### PR TITLE
feat: catalog & purchase management

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -15,6 +15,25 @@ return [
         // Health check endpoint.
         ['name' => 'health#index', 'url' => '/api/health', 'verb' => 'GET'],
 
+        // Catalog routes.
+        ['name' => 'catalog#search', 'url' => '/api/v1/catalog/search', 'verb' => 'GET'],
+        ['name' => 'catalog#import', 'url' => '/api/v1/catalogs/{id}/import', 'verb' => 'POST'],
+
+        // Order basket routes.
+        ['name' => 'orderBasket#submit', 'url' => '/api/v1/order-baskets/{id}/submit', 'verb' => 'POST'],
+
+        // Purchase order routes.
+        ['name' => 'purchaseOrder#submit', 'url' => '/api/v1/purchase-orders/{id}/submit', 'verb' => 'POST'],
+        ['name' => 'purchaseOrder#cancel', 'url' => '/api/v1/purchase-orders/{id}/cancel', 'verb' => 'POST'],
+        ['name' => 'purchaseOrder#sendReminder', 'url' => '/api/v1/purchase-orders/{id}/send-reminder', 'verb' => 'POST'],
+
+        // Goods receipt routes.
+        ['name' => 'goodsReceipt#create', 'url' => '/api/v1/goods-receipts', 'verb' => 'POST'],
+
+        // RFQ routes.
+        ['name' => 'rFQ#publish', 'url' => '/api/v1/rfqs/{id}/publish', 'verb' => 'POST'],
+        ['name' => 'rFQ#award', 'url' => '/api/v1/rfqs/{id}/award', 'verb' => 'POST'],
+
         // SPA catch-all — same controller as the index route; must use a distinct route name
         // (duplicate names replace the earlier route in Symfony, which breaks GET /).
         ['name' => 'dashboard#catchAll', 'url' => '/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+'], 'defaults' => ['path' => '']],

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\AppInfo;
 
 use OCA\Shillinq\Listener\DeepLinkRegistrationListener;
+use OCA\Shillinq\Repair\CreateDefaultConfiguration;
 use OCA\Shillinq\Repair\InitializeSettings;
 use OCA\OpenRegister\Event\DeepLinkRegistrationEvent;
 use OCP\AppFramework\App;
@@ -66,6 +67,9 @@ class Application extends App implements IBootstrap
 
         // Initialize register and schemas on install/upgrade.
         $context->registerRepairStep(InitializeSettings::class);
+
+        // Seed default catalog and purchase management data.
+        $context->registerRepairStep(CreateDefaultConfiguration::class);
 
     }//end register()
 

--- a/lib/BackgroundJob/OverdueDeliveryJob.php
+++ b/lib/BackgroundJob/OverdueDeliveryJob.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * Shillinq Overdue Delivery Background Job
+ *
+ * Timed background job that checks for purchase orders with overdue
+ * expected delivery dates and sends notifications to the creating user.
+ *
+ * @category BackgroundJob
+ * @package  OCA\Shillinq\BackgroundJob
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\BackgroundJob;
+
+use OCA\Shillinq\AppInfo\Application;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use OCP\Notification\IManager;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Timed background job that detects overdue purchase orders and notifies the creator.
+ *
+ * Runs once every 24 hours (86 400 seconds). For each purchase order whose
+ * expectedDeliveryDate is in the past and whose status is still submitted,
+ * acknowledged, or partially_received, a Nextcloud notification is created
+ * for the user identified by the createdBy field.
+ *
+ * Deduplication prevents the same notification from being sent more than once
+ * per calendar day per purchase order.
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-4.1
+ */
+class OverdueDeliveryJob extends TimedJob
+{
+
+    /**
+     * Statuses that qualify a purchase order as potentially overdue.
+     *
+     * @var array<string>
+     */
+    private const OVERDUE_STATUSES = [
+        'submitted',
+        'acknowledged',
+        'partially_received',
+    ];
+
+
+    /**
+     * Constructor for the OverdueDeliveryJob.
+     *
+     * @param ITimeFactory       $time                The time factory
+     * @param ContainerInterface $container            The DI container
+     * @param IManager           $notificationManager  The notification manager
+     * @param LoggerInterface    $logger               The logger
+     *
+     * @return void
+     */
+    public function __construct(
+        ITimeFactory $time,
+        private ContainerInterface $container,
+        private IManager $notificationManager,
+        private LoggerInterface $logger,
+    ) {
+        parent::__construct($time);
+        $this->setInterval(86400);
+    }//end __construct()
+
+
+    /**
+     * Execute the overdue delivery check.
+     *
+     * Queries all purchase orders with an expected delivery date in the past
+     * and a qualifying status, then creates a notification for each overdue
+     * order if one has not already been sent today.
+     *
+     * @param mixed $argument The job argument (unused)
+     *
+     * @return void
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-4.1
+     */
+    protected function run($argument): void
+    {
+        try {
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Exception $e) {
+            $this->logger->error('OverdueDeliveryJob: unable to get ObjectService', ['exception' => $e]);
+            return;
+        }
+
+        $now   = new \DateTime();
+        $today = $now->format('Y-m-d');
+
+        try {
+            $purchaseOrders = $objectService->findAll(
+                objectType: 'purchaseOrder',
+                filters: [
+                    'status' => self::OVERDUE_STATUSES,
+                ],
+            );
+        } catch (\Exception $e) {
+            $this->logger->error('OverdueDeliveryJob: failed to query purchase orders', ['exception' => $e]);
+            return;
+        }
+
+        foreach ($purchaseOrders as $po) {
+            $poData = is_array($po) ? $po : $po->jsonSerialize();
+
+            $expectedDate = $poData['expectedDeliveryDate'] ?? null;
+            if ($expectedDate === null) {
+                continue;
+            }
+
+            try {
+                $expectedDateTime = new \DateTime($expectedDate);
+            } catch (\Exception $e) {
+                $this->logger->warning('OverdueDeliveryJob: invalid date for PO', [
+                    'poNumber' => ($poData['poNumber'] ?? 'unknown'),
+                    'date'     => $expectedDate,
+                ]);
+                continue;
+            }
+
+            if ($expectedDateTime >= $now) {
+                continue;
+            }
+
+            $poNumber       = $poData['poNumber'] ?? 'unknown';
+            $createdBy      = $poData['createdBy'] ?? null;
+            $deduplicationKey = 'po-overdue-' . $poNumber . '-' . $today;
+
+            if ($createdBy === null) {
+                $this->logger->warning('OverdueDeliveryJob: no createdBy for PO', [
+                    'poNumber' => $poNumber,
+                ]);
+                continue;
+            }
+
+            // Check if notification already exists for today.
+            $existingNotification = $this->notificationManager->createNotification();
+            $existingNotification->setApp(Application::APP_ID)
+                ->setUser($createdBy)
+                ->setObject('purchaseOrder', $deduplicationKey);
+
+            if ($this->notificationManager->getCount($existingNotification) > 0) {
+                continue;
+            }
+
+            // Create notification.
+            $notification = $this->notificationManager->createNotification();
+            $notification->setApp(Application::APP_ID)
+                ->setUser($createdBy)
+                ->setDateTime($now)
+                ->setObject('purchaseOrder', $deduplicationKey)
+                ->setSubject(
+                    'overdue_delivery',
+                    [
+                        'poNumber' => $poNumber,
+                        'date'     => $expectedDate,
+                    ]
+                )
+                ->setMessage(
+                    'overdue_delivery',
+                    [
+                        'message' => "Purchase Order {$poNumber} is overdue — expected delivery was {$expectedDate}",
+                    ]
+                );
+
+            $this->notificationManager->notify($notification);
+
+            $this->logger->info('OverdueDeliveryJob: notification sent', [
+                'poNumber' => $poNumber,
+                'user'     => $createdBy,
+            ]);
+        }//end foreach
+    }//end run()
+}//end class

--- a/lib/BackgroundJob/OverdueDeliveryJob.php
+++ b/lib/BackgroundJob/OverdueDeliveryJob.php
@@ -20,7 +20,6 @@
 
 // SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
-
 declare(strict_types=1);
 
 namespace OCA\Shillinq\BackgroundJob;
@@ -59,14 +58,13 @@ class OverdueDeliveryJob extends TimedJob
         'partially_received',
     ];
 
-
     /**
      * Constructor for the OverdueDeliveryJob.
      *
      * @param ITimeFactory       $time                The time factory
-     * @param ContainerInterface $container            The DI container
-     * @param IManager           $notificationManager  The notification manager
-     * @param LoggerInterface    $logger               The logger
+     * @param ContainerInterface $container           The DI container
+     * @param IManager           $notificationManager The notification manager
+     * @param LoggerInterface    $logger              The logger
      *
      * @return void
      */
@@ -76,10 +74,9 @@ class OverdueDeliveryJob extends TimedJob
         private IManager $notificationManager,
         private LoggerInterface $logger,
     ) {
-        parent::__construct($time);
-        $this->setInterval(86400);
+        parent::__construct(time: $time);
+        $this->setInterval(seconds: 86400);
     }//end __construct()
-
 
     /**
      * Execute the overdue delivery check.
@@ -119,7 +116,11 @@ class OverdueDeliveryJob extends TimedJob
         }
 
         foreach ($purchaseOrders as $po) {
-            $poData = is_array($po) ? $po : $po->jsonSerialize();
+            if (is_array($po) === true) {
+                $poData = $po;
+            } else {
+                $poData = $po->jsonSerialize();
+            }
 
             $expectedDate = $poData['expectedDeliveryDate'] ?? null;
             if ($expectedDate === null) {
@@ -129,10 +130,13 @@ class OverdueDeliveryJob extends TimedJob
             try {
                 $expectedDateTime = new \DateTime($expectedDate);
             } catch (\Exception $e) {
-                $this->logger->warning('OverdueDeliveryJob: invalid date for PO', [
-                    'poNumber' => ($poData['poNumber'] ?? 'unknown'),
-                    'date'     => $expectedDate,
-                ]);
+                $this->logger->warning(
+                        'OverdueDeliveryJob: invalid date for PO',
+                        [
+                            'poNumber' => ($poData['poNumber'] ?? 'unknown'),
+                            'date'     => $expectedDate,
+                        ]
+                        );
                 continue;
             }
 
@@ -140,14 +144,17 @@ class OverdueDeliveryJob extends TimedJob
                 continue;
             }
 
-            $poNumber       = $poData['poNumber'] ?? 'unknown';
-            $createdBy      = $poData['createdBy'] ?? null;
-            $deduplicationKey = 'po-overdue-' . $poNumber . '-' . $today;
+            $poNumber         = $poData['poNumber'] ?? 'unknown';
+            $createdBy        = $poData['createdBy'] ?? null;
+            $deduplicationKey = 'po-overdue-'.$poNumber.'-'.$today;
 
             if ($createdBy === null) {
-                $this->logger->warning('OverdueDeliveryJob: no createdBy for PO', [
-                    'poNumber' => $poNumber,
-                ]);
+                $this->logger->warning(
+                        'OverdueDeliveryJob: no createdBy for PO',
+                        [
+                            'poNumber' => $poNumber,
+                        ]
+                        );
                 continue;
             }
 
@@ -183,10 +190,13 @@ class OverdueDeliveryJob extends TimedJob
 
             $this->notificationManager->notify($notification);
 
-            $this->logger->info('OverdueDeliveryJob: notification sent', [
-                'poNumber' => $poNumber,
-                'user'     => $createdBy,
-            ]);
+            $this->logger->info(
+                    'OverdueDeliveryJob: notification sent',
+                    [
+                        'poNumber' => $poNumber,
+                        'user'     => $createdBy,
+                    ]
+                    );
         }//end foreach
     }//end run()
 }//end class

--- a/lib/Controller/CatalogController.php
+++ b/lib/Controller/CatalogController.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * Shillinq Catalog Controller
+ *
+ * Controller for catalog search and import operations.
+ *
+ * @category Controller
+ * @package  OCA\Shillinq\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Controller;
+
+use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\CatalogSearchService;
+use OCA\Shillinq\Service\CatalogImportService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Controller for catalog search and CSV import operations.
+ *
+ * Provides endpoints for searching catalog items by query string and
+ * category, as well as importing catalog items from uploaded CSV files.
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.1
+ */
+class CatalogController extends Controller
+{
+
+    /**
+     * Constructor for the CatalogController.
+     *
+     * @param IRequest             $request        The request object
+     * @param CatalogSearchService $searchService  The catalog search service
+     * @param CatalogImportService $importService  The catalog import service
+     * @param ContainerInterface   $container       The DI container
+     * @param IUserSession         $userSession     The user session
+     * @param LoggerInterface      $logger          The logger
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private CatalogSearchService $searchService,
+        private CatalogImportService $importService,
+        private ContainerInterface $container,
+        private IUserSession $userSession,
+        private LoggerInterface $logger,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+    }//end __construct()
+
+
+    /**
+     * Search catalog items by query string and optional category.
+     *
+     * Reads the `q` and `categoryId` request parameters and delegates
+     * to the CatalogSearchService.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse The search results
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.1
+     */
+    public function search(): JSONResponse
+    {
+        try {
+            $query      = $this->request->getParam('q', '');
+            $categoryId = $this->request->getParam('categoryId', null);
+
+            $results = $this->searchService->search(
+                query: $query,
+                categoryId: $categoryId,
+            );
+
+            return new JSONResponse(data: $results);
+        } catch (\Exception $e) {
+            $this->logger->error('CatalogController::search failed', ['exception' => $e]);
+            return new JSONResponse(
+                data: ['error' => $e->getMessage()],
+                statusCode: 500,
+            );
+        }
+    }//end search()
+
+
+    /**
+     * Import catalog items from an uploaded CSV file.
+     *
+     * Validates that the catalog is not archived before proceeding.
+     * Returns 422 if the catalog has been archived.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @param string $id The catalog ID
+     *
+     * @return JSONResponse The import result
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.1
+     */
+    public function import(string $id): JSONResponse
+    {
+        try {
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+
+            // Verify catalog is not archived.
+            $catalog     = $objectService->findOne(objectType: 'catalog', id: $id);
+            $catalogData = is_array($catalog) ? $catalog : $catalog->jsonSerialize();
+
+            if (($catalogData['status'] ?? '') === 'archived') {
+                return new JSONResponse(
+                    data: ['error' => 'Cannot import into an archived catalog'],
+                    statusCode: 422,
+                );
+            }
+
+            // Read uploaded CSV file.
+            $file = $this->request->getUploadedFile('file');
+            if ($file === null || !isset($file['tmp_name'])) {
+                return new JSONResponse(
+                    data: ['error' => 'No CSV file uploaded'],
+                    statusCode: 400,
+                );
+            }
+
+            $result = $this->importService->import(
+                catalogId: $id,
+                filePath: $file['tmp_name'],
+            );
+
+            return new JSONResponse(data: $result);
+        } catch (\Exception $e) {
+            $this->logger->error('CatalogController::import failed', [
+                'catalogId' => $id,
+                'exception' => $e,
+            ]);
+            return new JSONResponse(
+                data: ['error' => $e->getMessage()],
+                statusCode: 500,
+            );
+        }
+    }//end import()
+}//end class

--- a/lib/Controller/CatalogController.php
+++ b/lib/Controller/CatalogController.php
@@ -19,7 +19,6 @@
 
 // SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
-
 declare(strict_types=1);
 
 namespace OCA\Shillinq\Controller;
@@ -44,16 +43,15 @@ use Psr\Log\LoggerInterface;
  */
 class CatalogController extends Controller
 {
-
     /**
      * Constructor for the CatalogController.
      *
-     * @param IRequest             $request        The request object
-     * @param CatalogSearchService $searchService  The catalog search service
-     * @param CatalogImportService $importService  The catalog import service
-     * @param ContainerInterface   $container       The DI container
-     * @param IUserSession         $userSession     The user session
-     * @param LoggerInterface      $logger          The logger
+     * @param IRequest             $request       The request object
+     * @param CatalogSearchService $searchService The catalog search service
+     * @param CatalogImportService $importService The catalog import service
+     * @param ContainerInterface   $container     The DI container
+     * @param IUserSession         $userSession   The user session
+     * @param LoggerInterface      $logger        The logger
      *
      * @return void
      */
@@ -68,17 +66,16 @@ class CatalogController extends Controller
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
 
-
     /**
      * Search catalog items by query string and optional category.
      *
      * Reads the `q` and `categoryId` request parameters and delegates
      * to the CatalogSearchService.
      *
+     * @return JSONResponse The search results
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
-     *
-     * @return JSONResponse The search results
      *
      * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.1
      */
@@ -89,7 +86,7 @@ class CatalogController extends Controller
             $categoryId = $this->request->getParam('categoryId', null);
 
             $results = $this->searchService->search(
-                query: $query,
+                term: $query,
                 categoryId: $categoryId,
             );
 
@@ -103,19 +100,18 @@ class CatalogController extends Controller
         }
     }//end search()
 
-
     /**
      * Import catalog items from an uploaded CSV file.
      *
      * Validates that the catalog is not archived before proceeding.
      * Returns 422 if the catalog has been archived.
      *
-     * @NoAdminRequired
-     * @NoCSRFRequired
-     *
      * @param string $id The catalog ID
      *
      * @return JSONResponse The import result
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
      *
      * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.1
      */
@@ -125,8 +121,12 @@ class CatalogController extends Controller
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
             // Verify catalog is not archived.
-            $catalog     = $objectService->findOne(objectType: 'catalog', id: $id);
-            $catalogData = is_array($catalog) ? $catalog : $catalog->jsonSerialize();
+            $catalog = $objectService->findOne(objectType: 'catalog', id: $id);
+            if (is_array($catalog) === true) {
+                $catalogData = $catalog;
+            } else {
+                $catalogData = $catalog->jsonSerialize();
+            }
 
             if (($catalogData['status'] ?? '') === 'archived') {
                 return new JSONResponse(
@@ -137,28 +137,36 @@ class CatalogController extends Controller
 
             // Read uploaded CSV file.
             $file = $this->request->getUploadedFile('file');
-            if ($file === null || !isset($file['tmp_name'])) {
+            if ($file === null || isset($file['tmp_name']) === false) {
                 return new JSONResponse(
                     data: ['error' => 'No CSV file uploaded'],
                     statusCode: 400,
                 );
             }
 
-            $result = $this->importService->import(
+            $csvStream = fopen($file['tmp_name'], 'r');
+            $result    = $this->importService->import(
                 catalogId: $id,
-                filePath: $file['tmp_name'],
+                csvStream: $csvStream,
             );
+
+            if (is_resource($csvStream) === true) {
+                fclose($csvStream);
+            }
 
             return new JSONResponse(data: $result);
         } catch (\Exception $e) {
-            $this->logger->error('CatalogController::import failed', [
-                'catalogId' => $id,
-                'exception' => $e,
-            ]);
+            $this->logger->error(
+                    'CatalogController::import failed',
+                    [
+                        'catalogId' => $id,
+                        'exception' => $e,
+                    ]
+                    );
             return new JSONResponse(
                 data: ['error' => $e->getMessage()],
                 statusCode: 500,
             );
-        }
+        }//end try
     }//end import()
 }//end class

--- a/lib/Controller/GoodsReceiptController.php
+++ b/lib/Controller/GoodsReceiptController.php
@@ -19,7 +19,6 @@
 
 // SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
-
 declare(strict_types=1);
 
 namespace OCA\Shillinq\Controller;
@@ -44,15 +43,14 @@ use Psr\Log\LoggerInterface;
  */
 class GoodsReceiptController extends Controller
 {
-
     /**
      * Constructor for the GoodsReceiptController.
      *
-     * @param IRequest                 $request         The request object
-     * @param ThreeWayMatchingService  $matchingService The three-way matching service
-     * @param ContainerInterface       $container        The DI container
-     * @param IUserSession             $userSession      The user session
-     * @param LoggerInterface          $logger           The logger
+     * @param IRequest                $request         The request object
+     * @param ThreeWayMatchingService $matchingService The three-way matching service
+     * @param ContainerInterface      $container       The DI container
+     * @param IUserSession            $userSession     The user session
+     * @param LoggerInterface         $logger          The logger
      *
      * @return void
      */
@@ -65,7 +63,6 @@ class GoodsReceiptController extends Controller
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
-
 
     /**
      * Create a goods receipt and trigger three-way matching.
@@ -101,8 +98,12 @@ class GoodsReceiptController extends Controller
             }
 
             // Validate PO is not closed.
-            $po     = $objectService->findOne(objectType: 'purchaseOrder', id: $purchaseOrderId);
-            $poData = is_array($po) ? $po : $po->jsonSerialize();
+            $po = $objectService->findOne(objectType: 'purchaseOrder', id: $purchaseOrderId);
+            if (is_array($po) === true) {
+                $poData = $po;
+            } else {
+                $poData = $po->jsonSerialize();
+            }
 
             if (($poData['status'] ?? '') === 'closed') {
                 return new JSONResponse(
@@ -112,38 +113,62 @@ class GoodsReceiptController extends Controller
             }
 
             // Create the GoodsReceipt object.
+            if ($user !== null) {
+                $receivedBy = $user->getUID();
+            } else {
+                $receivedBy = null;
+            }
+
             $goodsReceipt = $objectService->create(
                 objectType: 'goodsReceipt',
-                object: array_merge($receipt, [
-                    'receivedBy' => ($user !== null ? $user->getUID() : null),
-                    'receivedAt' => (new \DateTime())->format('c'),
-                    'status'     => 'received',
-                ]),
+                object: array_merge(
+                        $receipt,
+                        [
+                            'receivedBy' => $receivedBy,
+                            'receivedAt' => (new \DateTime())->format('c'),
+                            'status'     => 'received',
+                        ]
+                        ),
             );
 
-            $receiptData = is_array($goodsReceipt) ? $goodsReceipt : $goodsReceipt->jsonSerialize();
-            $receiptId   = $receiptData['id'] ?? $receiptData['uuid'] ?? null;
+            if (is_array($goodsReceipt) === true) {
+                $receiptData = $goodsReceipt;
+            } else {
+                $receiptData = $goodsReceipt->jsonSerialize();
+            }
+
+            $receiptId = $receiptData['id'] ?? $receiptData['uuid'] ?? null;
 
             // Create GoodsReceiptLine objects.
             $createdLines = [];
             foreach ($lines as $line) {
                 $createdLine = $objectService->create(
                     objectType: 'goodsReceiptLine',
-                    object: array_merge($line, [
-                        'goodsReceiptId' => $receiptId,
-                    ]),
+                    object: array_merge(
+                            $line,
+                            [
+                                'goodsReceiptId' => $receiptId,
+                            ]
+                            ),
                 );
-                $createdLines[] = is_array($createdLine) ? $createdLine : $createdLine->jsonSerialize();
+                if (is_array($createdLine) === true) {
+                    $createdLines[] = $createdLine;
+                } else {
+                    $createdLines[] = $createdLine->jsonSerialize();
+                }
             }
 
             // Run three-way matching.
             $matchResults = $this->matchingService->match(
                 purchaseOrderId: $purchaseOrderId,
-                goodsReceiptId: $receiptId,
             );
 
             // Determine and update PO status based on match results.
-            $newStatus = ($matchResults['fullyReceived'] ?? false) ? 'received' : 'partially_received';
+            if (($matchResults['fullyReceived'] ?? false) === true) {
+                $newStatus = 'received';
+            } else {
+                $newStatus = 'partially_received';
+            }
 
             $poData['status'] = $newStatus;
             $objectService->update(
@@ -152,18 +177,20 @@ class GoodsReceiptController extends Controller
                 object: $poData,
             );
 
-            return new JSONResponse(data: [
-                'goodsReceipt'   => $receiptData,
-                'lines'          => $createdLines,
-                'matchResults'   => $matchResults,
-                'purchaseOrderStatus' => $newStatus,
-            ]);
+            return new JSONResponse(
+                    data: [
+                        'goodsReceipt'        => $receiptData,
+                        'lines'               => $createdLines,
+                        'matchResults'        => $matchResults,
+                        'purchaseOrderStatus' => $newStatus,
+                    ]
+                    );
         } catch (\Exception $e) {
             $this->logger->error('GoodsReceiptController::create failed', ['exception' => $e]);
             return new JSONResponse(
                 data: ['error' => $e->getMessage()],
                 statusCode: 500,
             );
-        }
+        }//end try
     }//end create()
 }//end class

--- a/lib/Controller/GoodsReceiptController.php
+++ b/lib/Controller/GoodsReceiptController.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * Shillinq Goods Receipt Controller
+ *
+ * Controller for goods receipt creation and three-way matching.
+ *
+ * @category Controller
+ * @package  OCA\Shillinq\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Controller;
+
+use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\ThreeWayMatchingService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Controller for creating goods receipts and triggering three-way matching.
+ *
+ * Handles the creation of goods receipt records with their line items,
+ * validates that the associated purchase order is not closed, triggers
+ * three-way matching, and updates the purchase order status accordingly.
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.4
+ */
+class GoodsReceiptController extends Controller
+{
+
+    /**
+     * Constructor for the GoodsReceiptController.
+     *
+     * @param IRequest                 $request         The request object
+     * @param ThreeWayMatchingService  $matchingService The three-way matching service
+     * @param ContainerInterface       $container        The DI container
+     * @param IUserSession             $userSession      The user session
+     * @param LoggerInterface          $logger           The logger
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private ThreeWayMatchingService $matchingService,
+        private ContainerInterface $container,
+        private IUserSession $userSession,
+        private LoggerInterface $logger,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+    }//end __construct()
+
+
+    /**
+     * Create a goods receipt and trigger three-way matching.
+     *
+     * Reads the receipt and line items from the request body, validates
+     * the associated purchase order is not closed (returns 422 if it is),
+     * creates the GoodsReceipt and GoodsReceiptLine objects, runs
+     * three-way matching, and updates the purchase order status to
+     * partially_received or received.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse The created goods receipt with match results
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.4
+     */
+    public function create(): JSONResponse
+    {
+        try {
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+            $user          = $this->userSession->getUser();
+
+            $receipt = $this->request->getParam('receipt', []);
+            $lines   = $this->request->getParam('lines', []);
+
+            $purchaseOrderId = $receipt['purchaseOrderId'] ?? null;
+            if ($purchaseOrderId === null) {
+                return new JSONResponse(
+                    data: ['error' => 'purchaseOrderId is required'],
+                    statusCode: 400,
+                );
+            }
+
+            // Validate PO is not closed.
+            $po     = $objectService->findOne(objectType: 'purchaseOrder', id: $purchaseOrderId);
+            $poData = is_array($po) ? $po : $po->jsonSerialize();
+
+            if (($poData['status'] ?? '') === 'closed') {
+                return new JSONResponse(
+                    data: ['error' => 'Cannot create goods receipt for a closed purchase order'],
+                    statusCode: 422,
+                );
+            }
+
+            // Create the GoodsReceipt object.
+            $goodsReceipt = $objectService->create(
+                objectType: 'goodsReceipt',
+                object: array_merge($receipt, [
+                    'receivedBy' => ($user !== null ? $user->getUID() : null),
+                    'receivedAt' => (new \DateTime())->format('c'),
+                    'status'     => 'received',
+                ]),
+            );
+
+            $receiptData = is_array($goodsReceipt) ? $goodsReceipt : $goodsReceipt->jsonSerialize();
+            $receiptId   = $receiptData['id'] ?? $receiptData['uuid'] ?? null;
+
+            // Create GoodsReceiptLine objects.
+            $createdLines = [];
+            foreach ($lines as $line) {
+                $createdLine = $objectService->create(
+                    objectType: 'goodsReceiptLine',
+                    object: array_merge($line, [
+                        'goodsReceiptId' => $receiptId,
+                    ]),
+                );
+                $createdLines[] = is_array($createdLine) ? $createdLine : $createdLine->jsonSerialize();
+            }
+
+            // Run three-way matching.
+            $matchResults = $this->matchingService->match(
+                purchaseOrderId: $purchaseOrderId,
+                goodsReceiptId: $receiptId,
+            );
+
+            // Determine and update PO status based on match results.
+            $newStatus = ($matchResults['fullyReceived'] ?? false) ? 'received' : 'partially_received';
+
+            $poData['status'] = $newStatus;
+            $objectService->update(
+                objectType: 'purchaseOrder',
+                id: $purchaseOrderId,
+                object: $poData,
+            );
+
+            return new JSONResponse(data: [
+                'goodsReceipt'   => $receiptData,
+                'lines'          => $createdLines,
+                'matchResults'   => $matchResults,
+                'purchaseOrderStatus' => $newStatus,
+            ]);
+        } catch (\Exception $e) {
+            $this->logger->error('GoodsReceiptController::create failed', ['exception' => $e]);
+            return new JSONResponse(
+                data: ['error' => $e->getMessage()],
+                statusCode: 500,
+            );
+        }
+    }//end create()
+}//end class

--- a/lib/Controller/OrderBasketController.php
+++ b/lib/Controller/OrderBasketController.php
@@ -19,7 +19,6 @@
 
 // SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
-
 declare(strict_types=1);
 
 namespace OCA\Shillinq\Controller;
@@ -44,15 +43,14 @@ use Psr\Log\LoggerInterface;
  */
 class OrderBasketController extends Controller
 {
-
     /**
      * Constructor for the OrderBasketController.
      *
      * @param IRequest           $request      The request object
      * @param OrderLimitService  $limitService The order limit service
-     * @param ContainerInterface $container     The DI container
-     * @param IUserSession       $userSession   The user session
-     * @param LoggerInterface    $logger        The logger
+     * @param ContainerInterface $container    The DI container
+     * @param IUserSession       $userSession  The user session
+     * @param LoggerInterface    $logger       The logger
      *
      * @return void
      */
@@ -66,7 +64,6 @@ class OrderBasketController extends Controller
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
 
-
     /**
      * Submit an order basket for approval or auto-approval.
      *
@@ -75,12 +72,12 @@ class OrderBasketController extends Controller
      * or auto-approves the order by creating a PurchaseOrder draft.
      * Budget availability is also validated.
      *
-     * @NoAdminRequired
-     * @NoCSRFRequired
-     *
      * @param string $id The order basket ID
      *
      * @return JSONResponse The submission result
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
      *
      * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.2
      */
@@ -98,8 +95,12 @@ class OrderBasketController extends Controller
             }
 
             // Load the basket.
-            $basket     = $objectService->findOne(objectType: 'orderBasket', id: $id);
-            $basketData = is_array($basket) ? $basket : $basket->jsonSerialize();
+            $basket = $objectService->findOne(objectType: 'orderBasket', id: $id);
+            if (is_array($basket) === true) {
+                $basketData = $basket;
+            } else {
+                $basketData = $basket->jsonSerialize();
+            }
 
             // Set requisitionerId to authenticated user.
             $basketData['requisitionerId'] = $user->getUID();
@@ -107,7 +108,7 @@ class OrderBasketController extends Controller
             // Check order limits.
             $limitCheck = $this->limitService->check(
                 userId: $user->getUID(),
-                basket: $basketData,
+                basketTotal: (float) ($basketData['totalAmount'] ?? 0),
             );
 
             if ($limitCheck['requiresApproval'] === true) {
@@ -115,11 +116,11 @@ class OrderBasketController extends Controller
                 $approvalWorkflow = $objectService->create(
                     objectType: 'approvalWorkflow',
                     object: [
-                        'orderBasketId'  => $id,
+                        'orderBasketId'   => $id,
                         'requisitionerId' => $user->getUID(),
-                        'status'         => 'pending',
-                        'createdAt'      => (new \DateTime())->format('c'),
-                        'totalAmount'    => ($basketData['totalAmount'] ?? 0),
+                        'status'          => 'pending',
+                        'createdAt'       => (new \DateTime())->format('c'),
+                        'totalAmount'     => ($basketData['totalAmount'] ?? 0),
                     ],
                 );
 
@@ -131,26 +132,32 @@ class OrderBasketController extends Controller
                     object: $basketData,
                 );
 
-                return new JSONResponse(data: [
-                    'status'           => 'pending_approval',
-                    'approvalWorkflow' => is_array($approvalWorkflow)
-                        ? $approvalWorkflow
-                        : $approvalWorkflow->jsonSerialize(),
-                ]);
-            }
+                if (is_array($approvalWorkflow) === true) {
+                    $approvalWorkflowData = $approvalWorkflow;
+                } else {
+                    $approvalWorkflowData = $approvalWorkflow->jsonSerialize();
+                }
+
+                return new JSONResponse(
+                        data: [
+                            'status'           => 'pending_approval',
+                            'approvalWorkflow' => $approvalWorkflowData,
+                        ]
+                        );
+            }//end if
 
             // Auto-approve: create PurchaseOrder draft.
             $purchaseOrder = $objectService->create(
                 objectType: 'purchaseOrder',
                 object: [
-                    'orderBasketId'  => $id,
+                    'orderBasketId'   => $id,
                     'requisitionerId' => $user->getUID(),
-                    'status'         => 'draft',
-                    'createdBy'      => $user->getUID(),
-                    'createdAt'      => (new \DateTime())->format('c'),
-                    'items'          => ($basketData['items'] ?? []),
-                    'totalAmount'    => ($basketData['totalAmount'] ?? 0),
-                    'supplierId'     => ($basketData['supplierId'] ?? null),
+                    'status'          => 'draft',
+                    'createdBy'       => $user->getUID(),
+                    'createdAt'       => (new \DateTime())->format('c'),
+                    'items'           => ($basketData['items'] ?? []),
+                    'totalAmount'     => ($basketData['totalAmount'] ?? 0),
+                    'supplierId'      => ($basketData['supplierId'] ?? null),
                 ],
             );
 
@@ -162,21 +169,30 @@ class OrderBasketController extends Controller
                 object: $basketData,
             );
 
-            return new JSONResponse(data: [
-                'status'        => 'auto_approved',
-                'purchaseOrder' => is_array($purchaseOrder)
-                    ? $purchaseOrder
-                    : $purchaseOrder->jsonSerialize(),
-            ]);
+            if (is_array($purchaseOrder) === true) {
+                $purchaseOrderData = $purchaseOrder;
+            } else {
+                $purchaseOrderData = $purchaseOrder->jsonSerialize();
+            }
+
+            return new JSONResponse(
+                    data: [
+                        'status'        => 'auto_approved',
+                        'purchaseOrder' => $purchaseOrderData,
+                    ]
+                    );
         } catch (\Exception $e) {
-            $this->logger->error('OrderBasketController::submit failed', [
-                'basketId'  => $id,
-                'exception' => $e,
-            ]);
+            $this->logger->error(
+                    'OrderBasketController::submit failed',
+                    [
+                        'basketId'  => $id,
+                        'exception' => $e,
+                    ]
+                    );
             return new JSONResponse(
                 data: ['error' => $e->getMessage()],
                 statusCode: 500,
             );
-        }
+        }//end try
     }//end submit()
 }//end class

--- a/lib/Controller/OrderBasketController.php
+++ b/lib/Controller/OrderBasketController.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * Shillinq Order Basket Controller
+ *
+ * Controller for order basket submission and approval workflow.
+ *
+ * @category Controller
+ * @package  OCA\Shillinq\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Controller;
+
+use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\OrderLimitService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Controller for submitting order baskets for approval or auto-approval.
+ *
+ * Handles the submission of order baskets, including requisitioner assignment,
+ * order limit checks, budget validation, and routing through the approval
+ * workflow or auto-approval for orders within limits.
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.2
+ */
+class OrderBasketController extends Controller
+{
+
+    /**
+     * Constructor for the OrderBasketController.
+     *
+     * @param IRequest           $request      The request object
+     * @param OrderLimitService  $limitService The order limit service
+     * @param ContainerInterface $container     The DI container
+     * @param IUserSession       $userSession   The user session
+     * @param LoggerInterface    $logger        The logger
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private OrderLimitService $limitService,
+        private ContainerInterface $container,
+        private IUserSession $userSession,
+        private LoggerInterface $logger,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+    }//end __construct()
+
+
+    /**
+     * Submit an order basket for approval or auto-approval.
+     *
+     * Loads the basket, assigns the authenticated user as requisitioner,
+     * checks order limits, and either creates an ApprovalWorkflow object
+     * or auto-approves the order by creating a PurchaseOrder draft.
+     * Budget availability is also validated.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @param string $id The order basket ID
+     *
+     * @return JSONResponse The submission result
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.2
+     */
+    public function submit(string $id): JSONResponse
+    {
+        try {
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+            $user          = $this->userSession->getUser();
+
+            if ($user === null) {
+                return new JSONResponse(
+                    data: ['error' => 'Authentication required'],
+                    statusCode: 401,
+                );
+            }
+
+            // Load the basket.
+            $basket     = $objectService->findOne(objectType: 'orderBasket', id: $id);
+            $basketData = is_array($basket) ? $basket : $basket->jsonSerialize();
+
+            // Set requisitionerId to authenticated user.
+            $basketData['requisitionerId'] = $user->getUID();
+
+            // Check order limits.
+            $limitCheck = $this->limitService->check(
+                userId: $user->getUID(),
+                basket: $basketData,
+            );
+
+            if ($limitCheck['requiresApproval'] === true) {
+                // Create an ApprovalWorkflow object.
+                $approvalWorkflow = $objectService->create(
+                    objectType: 'approvalWorkflow',
+                    object: [
+                        'orderBasketId'  => $id,
+                        'requisitionerId' => $user->getUID(),
+                        'status'         => 'pending',
+                        'createdAt'      => (new \DateTime())->format('c'),
+                        'totalAmount'    => ($basketData['totalAmount'] ?? 0),
+                    ],
+                );
+
+                // Update basket status.
+                $basketData['status'] = 'pending_approval';
+                $objectService->update(
+                    objectType: 'orderBasket',
+                    id: $id,
+                    object: $basketData,
+                );
+
+                return new JSONResponse(data: [
+                    'status'           => 'pending_approval',
+                    'approvalWorkflow' => is_array($approvalWorkflow)
+                        ? $approvalWorkflow
+                        : $approvalWorkflow->jsonSerialize(),
+                ]);
+            }
+
+            // Auto-approve: create PurchaseOrder draft.
+            $purchaseOrder = $objectService->create(
+                objectType: 'purchaseOrder',
+                object: [
+                    'orderBasketId'  => $id,
+                    'requisitionerId' => $user->getUID(),
+                    'status'         => 'draft',
+                    'createdBy'      => $user->getUID(),
+                    'createdAt'      => (new \DateTime())->format('c'),
+                    'items'          => ($basketData['items'] ?? []),
+                    'totalAmount'    => ($basketData['totalAmount'] ?? 0),
+                    'supplierId'     => ($basketData['supplierId'] ?? null),
+                ],
+            );
+
+            // Update basket status.
+            $basketData['status'] = 'approved';
+            $objectService->update(
+                objectType: 'orderBasket',
+                id: $id,
+                object: $basketData,
+            );
+
+            return new JSONResponse(data: [
+                'status'        => 'auto_approved',
+                'purchaseOrder' => is_array($purchaseOrder)
+                    ? $purchaseOrder
+                    : $purchaseOrder->jsonSerialize(),
+            ]);
+        } catch (\Exception $e) {
+            $this->logger->error('OrderBasketController::submit failed', [
+                'basketId'  => $id,
+                'exception' => $e,
+            ]);
+            return new JSONResponse(
+                data: ['error' => $e->getMessage()],
+                statusCode: 500,
+            );
+        }
+    }//end submit()
+}//end class

--- a/lib/Controller/PurchaseOrderController.php
+++ b/lib/Controller/PurchaseOrderController.php
@@ -1,0 +1,274 @@
+<?php
+
+/**
+ * Shillinq Purchase Order Controller
+ *
+ * Controller for purchase order lifecycle operations including
+ * submission, cancellation, and delivery reminders.
+ *
+ * @category Controller
+ * @package  OCA\Shillinq\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Controller;
+
+use OCA\Shillinq\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+use OCP\Notification\IManager;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Controller for purchase order lifecycle management.
+ *
+ * Handles submission (status change + transmission timestamp),
+ * cancellation (with mandatory reason), and delivery reminder
+ * notifications for purchase orders.
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.3
+ */
+class PurchaseOrderController extends Controller
+{
+
+    /**
+     * Constructor for the PurchaseOrderController.
+     *
+     * @param IRequest           $request             The request object
+     * @param ContainerInterface $container             The DI container
+     * @param IManager           $notificationManager  The notification manager
+     * @param IUserSession       $userSession           The user session
+     * @param LoggerInterface    $logger                The logger
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private ContainerInterface $container,
+        private IManager $notificationManager,
+        private IUserSession $userSession,
+        private LoggerInterface $logger,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+    }//end __construct()
+
+
+    /**
+     * Submit a purchase order to the supplier.
+     *
+     * Changes the order status to "submitted", records the transmission
+     * timestamp, and sends a notification to the supplier.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @param string $id The purchase order ID
+     *
+     * @return JSONResponse The updated purchase order
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.3
+     */
+    public function submit(string $id): JSONResponse
+    {
+        try {
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+
+            $po     = $objectService->findOne(objectType: 'purchaseOrder', id: $id);
+            $poData = is_array($po) ? $po : $po->jsonSerialize();
+
+            // Update status and transmission timestamp.
+            $poData['status']        = 'submitted';
+            $poData['transmittedAt'] = (new \DateTime())->format('c');
+
+            $updated = $objectService->update(
+                objectType: 'purchaseOrder',
+                id: $id,
+                object: $poData,
+            );
+
+            // Send notification to supplier contact.
+            $supplierContact = $poData['supplierContactId'] ?? $poData['createdBy'] ?? null;
+            if ($supplierContact !== null) {
+                $notification = $this->notificationManager->createNotification();
+                $notification->setApp(Application::APP_ID)
+                    ->setUser($supplierContact)
+                    ->setDateTime(new \DateTime())
+                    ->setObject('purchaseOrder', 'po-submitted-' . $id)
+                    ->setSubject(
+                        'po_submitted',
+                        [
+                            'poNumber' => ($poData['poNumber'] ?? $id),
+                        ]
+                    );
+
+                $this->notificationManager->notify($notification);
+            }
+
+            return new JSONResponse(
+                data: is_array($updated) ? $updated : $updated->jsonSerialize(),
+            );
+        } catch (\Exception $e) {
+            $this->logger->error('PurchaseOrderController::submit failed', [
+                'purchaseOrderId' => $id,
+                'exception'       => $e,
+            ]);
+            return new JSONResponse(
+                data: ['error' => $e->getMessage()],
+                statusCode: 500,
+            );
+        }
+    }//end submit()
+
+
+    /**
+     * Cancel a purchase order with a mandatory reason.
+     *
+     * Requires a non-empty `reason` field in the request body.
+     * Returns 422 if the reason is missing or empty.
+     * Notifies the supplier of the cancellation.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @param string $id The purchase order ID
+     *
+     * @return JSONResponse The cancelled purchase order
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.3
+     */
+    public function cancel(string $id): JSONResponse
+    {
+        try {
+            $reason = $this->request->getParam('reason', '');
+
+            if (empty(trim($reason))) {
+                return new JSONResponse(
+                    data: ['error' => 'A cancellation reason is required'],
+                    statusCode: 422,
+                );
+            }
+
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+
+            $po     = $objectService->findOne(objectType: 'purchaseOrder', id: $id);
+            $poData = is_array($po) ? $po : $po->jsonSerialize();
+
+            $poData['status']             = 'cancelled';
+            $poData['cancellationReason'] = $reason;
+            $poData['cancelledAt']        = (new \DateTime())->format('c');
+
+            $updated = $objectService->update(
+                objectType: 'purchaseOrder',
+                id: $id,
+                object: $poData,
+            );
+
+            // Notify supplier of cancellation.
+            $supplierContact = $poData['supplierContactId'] ?? $poData['createdBy'] ?? null;
+            if ($supplierContact !== null) {
+                $notification = $this->notificationManager->createNotification();
+                $notification->setApp(Application::APP_ID)
+                    ->setUser($supplierContact)
+                    ->setDateTime(new \DateTime())
+                    ->setObject('purchaseOrder', 'po-cancelled-' . $id)
+                    ->setSubject(
+                        'po_cancelled',
+                        [
+                            'poNumber' => ($poData['poNumber'] ?? $id),
+                            'reason'   => $reason,
+                        ]
+                    );
+
+                $this->notificationManager->notify($notification);
+            }
+
+            return new JSONResponse(
+                data: is_array($updated) ? $updated : $updated->jsonSerialize(),
+            );
+        } catch (\Exception $e) {
+            $this->logger->error('PurchaseOrderController::cancel failed', [
+                'purchaseOrderId' => $id,
+                'exception'       => $e,
+            ]);
+            return new JSONResponse(
+                data: ['error' => $e->getMessage()],
+                statusCode: 500,
+            );
+        }
+    }//end cancel()
+
+
+    /**
+     * Send a delivery reminder notification to the supplier.
+     *
+     * Creates a Nextcloud notification reminding the supplier about
+     * the expected delivery for the given purchase order.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @param string $id The purchase order ID
+     *
+     * @return JSONResponse Confirmation of reminder sent
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.3
+     */
+    public function sendReminder(string $id): JSONResponse
+    {
+        try {
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+
+            $po     = $objectService->findOne(objectType: 'purchaseOrder', id: $id);
+            $poData = is_array($po) ? $po : $po->jsonSerialize();
+
+            $supplierContact = $poData['supplierContactId'] ?? $poData['createdBy'] ?? null;
+            if ($supplierContact === null) {
+                return new JSONResponse(
+                    data: ['error' => 'No supplier contact found for this purchase order'],
+                    statusCode: 422,
+                );
+            }
+
+            $notification = $this->notificationManager->createNotification();
+            $notification->setApp(Application::APP_ID)
+                ->setUser($supplierContact)
+                ->setDateTime(new \DateTime())
+                ->setObject('purchaseOrder', 'po-reminder-' . $id . '-' . date('Y-m-d'))
+                ->setSubject(
+                    'delivery_reminder',
+                    [
+                        'poNumber'             => ($poData['poNumber'] ?? $id),
+                        'expectedDeliveryDate' => ($poData['expectedDeliveryDate'] ?? 'unknown'),
+                    ]
+                );
+
+            $this->notificationManager->notify($notification);
+
+            return new JSONResponse(data: ['status' => 'reminder_sent']);
+        } catch (\Exception $e) {
+            $this->logger->error('PurchaseOrderController::sendReminder failed', [
+                'purchaseOrderId' => $id,
+                'exception'       => $e,
+            ]);
+            return new JSONResponse(
+                data: ['error' => $e->getMessage()],
+                statusCode: 500,
+            );
+        }
+    }//end sendReminder()
+}//end class

--- a/lib/Controller/PurchaseOrderController.php
+++ b/lib/Controller/PurchaseOrderController.php
@@ -20,7 +20,6 @@
 
 // SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
-
 declare(strict_types=1);
 
 namespace OCA\Shillinq\Controller;
@@ -45,15 +44,14 @@ use Psr\Log\LoggerInterface;
  */
 class PurchaseOrderController extends Controller
 {
-
     /**
      * Constructor for the PurchaseOrderController.
      *
      * @param IRequest           $request             The request object
-     * @param ContainerInterface $container             The DI container
-     * @param IManager           $notificationManager  The notification manager
-     * @param IUserSession       $userSession           The user session
-     * @param LoggerInterface    $logger                The logger
+     * @param ContainerInterface $container           The DI container
+     * @param IManager           $notificationManager The notification manager
+     * @param IUserSession       $userSession         The user session
+     * @param LoggerInterface    $logger              The logger
      *
      * @return void
      */
@@ -67,19 +65,18 @@ class PurchaseOrderController extends Controller
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
 
-
     /**
      * Submit a purchase order to the supplier.
      *
      * Changes the order status to "submitted", records the transmission
      * timestamp, and sends a notification to the supplier.
      *
-     * @NoAdminRequired
-     * @NoCSRFRequired
-     *
      * @param string $id The purchase order ID
      *
      * @return JSONResponse The updated purchase order
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
      *
      * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.3
      */
@@ -88,8 +85,12 @@ class PurchaseOrderController extends Controller
         try {
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
-            $po     = $objectService->findOne(objectType: 'purchaseOrder', id: $id);
-            $poData = is_array($po) ? $po : $po->jsonSerialize();
+            $po = $objectService->findOne(objectType: 'purchaseOrder', id: $id);
+            if (is_array($po) === true) {
+                $poData = $po;
+            } else {
+                $poData = $po->jsonSerialize();
+            }
 
             // Update status and transmission timestamp.
             $poData['status']        = 'submitted';
@@ -108,7 +109,7 @@ class PurchaseOrderController extends Controller
                 $notification->setApp(Application::APP_ID)
                     ->setUser($supplierContact)
                     ->setDateTime(new \DateTime())
-                    ->setObject('purchaseOrder', 'po-submitted-' . $id)
+                    ->setObject('purchaseOrder', 'po-submitted-'.$id)
                     ->setSubject(
                         'po_submitted',
                         [
@@ -119,21 +120,29 @@ class PurchaseOrderController extends Controller
                 $this->notificationManager->notify($notification);
             }
 
+            if (is_array($updated) === true) {
+                $updatedData = $updated;
+            } else {
+                $updatedData = $updated->jsonSerialize();
+            }
+
             return new JSONResponse(
-                data: is_array($updated) ? $updated : $updated->jsonSerialize(),
+                data: $updatedData,
             );
         } catch (\Exception $e) {
-            $this->logger->error('PurchaseOrderController::submit failed', [
-                'purchaseOrderId' => $id,
-                'exception'       => $e,
-            ]);
+            $this->logger->error(
+                    'PurchaseOrderController::submit failed',
+                    [
+                        'purchaseOrderId' => $id,
+                        'exception'       => $e,
+                    ]
+                    );
             return new JSONResponse(
                 data: ['error' => $e->getMessage()],
                 statusCode: 500,
             );
-        }
+        }//end try
     }//end submit()
-
 
     /**
      * Cancel a purchase order with a mandatory reason.
@@ -142,12 +151,12 @@ class PurchaseOrderController extends Controller
      * Returns 422 if the reason is missing or empty.
      * Notifies the supplier of the cancellation.
      *
-     * @NoAdminRequired
-     * @NoCSRFRequired
-     *
      * @param string $id The purchase order ID
      *
      * @return JSONResponse The cancelled purchase order
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
      *
      * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.3
      */
@@ -156,7 +165,7 @@ class PurchaseOrderController extends Controller
         try {
             $reason = $this->request->getParam('reason', '');
 
-            if (empty(trim($reason))) {
+            if (empty(trim($reason)) === true) {
                 return new JSONResponse(
                     data: ['error' => 'A cancellation reason is required'],
                     statusCode: 422,
@@ -165,10 +174,14 @@ class PurchaseOrderController extends Controller
 
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
-            $po     = $objectService->findOne(objectType: 'purchaseOrder', id: $id);
-            $poData = is_array($po) ? $po : $po->jsonSerialize();
+            $po = $objectService->findOne(objectType: 'purchaseOrder', id: $id);
+            if (is_array($po) === true) {
+                $poData = $po;
+            } else {
+                $poData = $po->jsonSerialize();
+            }
 
-            $poData['status']             = 'cancelled';
+            $poData['status'] = 'cancelled';
             $poData['cancellationReason'] = $reason;
             $poData['cancelledAt']        = (new \DateTime())->format('c');
 
@@ -185,7 +198,7 @@ class PurchaseOrderController extends Controller
                 $notification->setApp(Application::APP_ID)
                     ->setUser($supplierContact)
                     ->setDateTime(new \DateTime())
-                    ->setObject('purchaseOrder', 'po-cancelled-' . $id)
+                    ->setObject('purchaseOrder', 'po-cancelled-'.$id)
                     ->setSubject(
                         'po_cancelled',
                         [
@@ -197,21 +210,29 @@ class PurchaseOrderController extends Controller
                 $this->notificationManager->notify($notification);
             }
 
+            if (is_array($updated) === true) {
+                $updatedData = $updated;
+            } else {
+                $updatedData = $updated->jsonSerialize();
+            }
+
             return new JSONResponse(
-                data: is_array($updated) ? $updated : $updated->jsonSerialize(),
+                data: $updatedData,
             );
         } catch (\Exception $e) {
-            $this->logger->error('PurchaseOrderController::cancel failed', [
-                'purchaseOrderId' => $id,
-                'exception'       => $e,
-            ]);
+            $this->logger->error(
+                    'PurchaseOrderController::cancel failed',
+                    [
+                        'purchaseOrderId' => $id,
+                        'exception'       => $e,
+                    ]
+                    );
             return new JSONResponse(
                 data: ['error' => $e->getMessage()],
                 statusCode: 500,
             );
-        }
+        }//end try
     }//end cancel()
-
 
     /**
      * Send a delivery reminder notification to the supplier.
@@ -219,12 +240,12 @@ class PurchaseOrderController extends Controller
      * Creates a Nextcloud notification reminding the supplier about
      * the expected delivery for the given purchase order.
      *
-     * @NoAdminRequired
-     * @NoCSRFRequired
-     *
      * @param string $id The purchase order ID
      *
      * @return JSONResponse Confirmation of reminder sent
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
      *
      * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.3
      */
@@ -233,8 +254,12 @@ class PurchaseOrderController extends Controller
         try {
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
-            $po     = $objectService->findOne(objectType: 'purchaseOrder', id: $id);
-            $poData = is_array($po) ? $po : $po->jsonSerialize();
+            $po = $objectService->findOne(objectType: 'purchaseOrder', id: $id);
+            if (is_array($po) === true) {
+                $poData = $po;
+            } else {
+                $poData = $po->jsonSerialize();
+            }
 
             $supplierContact = $poData['supplierContactId'] ?? $poData['createdBy'] ?? null;
             if ($supplierContact === null) {
@@ -248,7 +273,7 @@ class PurchaseOrderController extends Controller
             $notification->setApp(Application::APP_ID)
                 ->setUser($supplierContact)
                 ->setDateTime(new \DateTime())
-                ->setObject('purchaseOrder', 'po-reminder-' . $id . '-' . date('Y-m-d'))
+                ->setObject('purchaseOrder', 'po-reminder-'.$id.'-'.date('Y-m-d'))
                 ->setSubject(
                     'delivery_reminder',
                     [
@@ -261,14 +286,17 @@ class PurchaseOrderController extends Controller
 
             return new JSONResponse(data: ['status' => 'reminder_sent']);
         } catch (\Exception $e) {
-            $this->logger->error('PurchaseOrderController::sendReminder failed', [
-                'purchaseOrderId' => $id,
-                'exception'       => $e,
-            ]);
+            $this->logger->error(
+                    'PurchaseOrderController::sendReminder failed',
+                    [
+                        'purchaseOrderId' => $id,
+                        'exception'       => $e,
+                    ]
+                    );
             return new JSONResponse(
                 data: ['error' => $e->getMessage()],
                 statusCode: 500,
             );
-        }
+        }//end try
     }//end sendReminder()
 }//end class

--- a/lib/Controller/RFQController.php
+++ b/lib/Controller/RFQController.php
@@ -20,7 +20,6 @@
 
 // SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
-
 declare(strict_types=1);
 
 namespace OCA\Shillinq\Controller;
@@ -45,15 +44,14 @@ use Psr\Log\LoggerInterface;
  */
 class RFQController extends Controller
 {
-
     /**
      * Constructor for the RFQController.
      *
      * @param IRequest           $request             The request object
-     * @param ContainerInterface $container             The DI container
-     * @param IManager           $notificationManager  The notification manager
-     * @param IUserSession       $userSession           The user session
-     * @param LoggerInterface    $logger                The logger
+     * @param ContainerInterface $container           The DI container
+     * @param IManager           $notificationManager The notification manager
+     * @param IUserSession       $userSession         The user session
+     * @param LoggerInterface    $logger              The logger
      *
      * @return void
      */
@@ -67,7 +65,6 @@ class RFQController extends Controller
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
 
-
     /**
      * Publish an RFQ to invited suppliers.
      *
@@ -76,12 +73,12 @@ class RFQController extends Controller
      * invited supplier profile IDs, and sends a notification to each
      * invited supplier.
      *
-     * @NoAdminRequired
-     * @NoCSRFRequired
-     *
      * @param string $id The RFQ ID
      *
      * @return JSONResponse The updated RFQ
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
      *
      * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.5
      */
@@ -91,12 +88,16 @@ class RFQController extends Controller
             $objectService      = $this->container->get('OCA\OpenRegister\Service\ObjectService');
             $supplierProfileIds = $this->request->getParam('supplierProfileIds', []);
 
-            $rfq     = $objectService->findOne(objectType: 'rfq', id: $id);
-            $rfqData = is_array($rfq) ? $rfq : $rfq->jsonSerialize();
+            $rfq = $objectService->findOne(objectType: 'rfq', id: $id);
+            if (is_array($rfq) === true) {
+                $rfqData = $rfq;
+            } else {
+                $rfqData = $rfq->jsonSerialize();
+            }
 
             // Update RFQ fields.
-            $rfqData['status']                  = 'published';
-            $rfqData['publishedAt']             = (new \DateTime())->format('c');
+            $rfqData['status']      = 'published';
+            $rfqData['publishedAt'] = (new \DateTime())->format('c');
             $rfqData['invitedSupplierProfileIds'] = $supplierProfileIds;
 
             $updated = $objectService->update(
@@ -112,9 +113,12 @@ class RFQController extends Controller
                         objectType: 'supplierProfile',
                         id: $supplierProfileId,
                     );
-                    $profileData  = is_array($supplierProfile)
-                        ? $supplierProfile
-                        : $supplierProfile->jsonSerialize();
+                    if (is_array($supplierProfile) === true) {
+                        $profileData = $supplierProfile;
+                    } else {
+                        $profileData = $supplierProfile->jsonSerialize();
+                    }
+
                     $contactUserId = $profileData['contactUserId'] ?? null;
 
                     if ($contactUserId !== null) {
@@ -122,7 +126,7 @@ class RFQController extends Controller
                         $notification->setApp(Application::APP_ID)
                             ->setUser($contactUserId)
                             ->setDateTime(new \DateTime())
-                            ->setObject('rfq', 'rfq-published-' . $id . '-' . $supplierProfileId)
+                            ->setObject('rfq', 'rfq-published-'.$id.'-'.$supplierProfileId)
                             ->setSubject(
                                 'rfq_published',
                                 [
@@ -134,28 +138,39 @@ class RFQController extends Controller
                         $this->notificationManager->notify($notification);
                     }
                 } catch (\Exception $e) {
-                    $this->logger->warning('RFQController::publish: failed to notify supplier', [
-                        'supplierProfileId' => $supplierProfileId,
-                        'exception'         => $e,
-                    ]);
-                }
+                    $this->logger->warning(
+                            'RFQController::publish: failed to notify supplier',
+                            [
+                                'supplierProfileId' => $supplierProfileId,
+                                'exception'         => $e,
+                            ]
+                            );
+                }//end try
             }//end foreach
 
+            if (is_array($updated) === true) {
+                $updatedData = $updated;
+            } else {
+                $updatedData = $updated->jsonSerialize();
+            }
+
             return new JSONResponse(
-                data: is_array($updated) ? $updated : $updated->jsonSerialize(),
+                data: $updatedData,
             );
         } catch (\Exception $e) {
-            $this->logger->error('RFQController::publish failed', [
-                'rfqId'     => $id,
-                'exception' => $e,
-            ]);
+            $this->logger->error(
+                    'RFQController::publish failed',
+                    [
+                        'rfqId'     => $id,
+                        'exception' => $e,
+                    ]
+                    );
             return new JSONResponse(
                 data: ['error' => $e->getMessage()],
                 statusCode: 500,
             );
-        }
+        }//end try
     }//end publish()
-
 
     /**
      * Award an RFQ to a selected supplier quote.
@@ -165,12 +180,12 @@ class RFQController extends Controller
      * quotes for this RFQ, and creates a purchase order draft from the
      * awarded quote data.
      *
-     * @NoAdminRequired
-     * @NoCSRFRequired
-     *
      * @param string $id The RFQ ID
      *
      * @return JSONResponse The award result including the created PO draft
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
      *
      * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.5
      */
@@ -181,7 +196,7 @@ class RFQController extends Controller
             $user            = $this->userSession->getUser();
             $supplierQuoteId = $this->request->getParam('supplierQuoteId');
 
-            if (empty($supplierQuoteId)) {
+            if (empty($supplierQuoteId) === true) {
                 return new JSONResponse(
                     data: ['error' => 'supplierQuoteId is required'],
                     statusCode: 400,
@@ -189,12 +204,16 @@ class RFQController extends Controller
             }
 
             // Update RFQ status to awarded.
-            $rfq     = $objectService->findOne(objectType: 'rfq', id: $id);
-            $rfqData = is_array($rfq) ? $rfq : $rfq->jsonSerialize();
+            $rfq = $objectService->findOne(objectType: 'rfq', id: $id);
+            if (is_array($rfq) === true) {
+                $rfqData = $rfq;
+            } else {
+                $rfqData = $rfq->jsonSerialize();
+            }
 
-            $rfqData['status']              = 'awarded';
-            $rfqData['awardedQuoteId']      = $supplierQuoteId;
-            $rfqData['awardedAt']           = (new \DateTime())->format('c');
+            $rfqData['status']         = 'awarded';
+            $rfqData['awardedQuoteId'] = $supplierQuoteId;
+            $rfqData['awardedAt']      = (new \DateTime())->format('c');
 
             $objectService->update(
                 objectType: 'rfq',
@@ -203,8 +222,12 @@ class RFQController extends Controller
             );
 
             // Accept the winning quote.
-            $winningQuote     = $objectService->findOne(objectType: 'supplierQuote', id: $supplierQuoteId);
-            $winningQuoteData = is_array($winningQuote) ? $winningQuote : $winningQuote->jsonSerialize();
+            $winningQuote = $objectService->findOne(objectType: 'supplierQuote', id: $supplierQuoteId);
+            if (is_array($winningQuote) === true) {
+                $winningQuoteData = $winningQuote;
+            } else {
+                $winningQuoteData = $winningQuote->jsonSerialize();
+            }
 
             $winningQuoteData['status'] = 'accepted';
             $objectService->update(
@@ -220,8 +243,13 @@ class RFQController extends Controller
             );
 
             foreach ($allQuotes as $quote) {
-                $quoteData = is_array($quote) ? $quote : $quote->jsonSerialize();
-                $quoteId   = $quoteData['id'] ?? $quoteData['uuid'] ?? null;
+                if (is_array($quote) === true) {
+                    $quoteData = $quote;
+                } else {
+                    $quoteData = $quote->jsonSerialize();
+                }
+
+                $quoteId = $quoteData['id'] ?? $quoteData['uuid'] ?? null;
 
                 if ($quoteId !== null && $quoteId !== $supplierQuoteId) {
                     $quoteData['status'] = 'rejected';
@@ -234,37 +262,52 @@ class RFQController extends Controller
             }
 
             // Create PurchaseOrder draft from the awarded quote.
+            if ($user !== null) {
+                $createdBy = $user->getUID();
+            } else {
+                $createdBy = null;
+            }
+
             $purchaseOrder = $objectService->create(
                 objectType: 'purchaseOrder',
                 object: [
-                    'rfqId'             => $id,
-                    'supplierQuoteId'   => $supplierQuoteId,
-                    'supplierId'        => ($winningQuoteData['supplierId'] ?? null),
-                    'status'            => 'draft',
-                    'createdBy'         => ($user !== null ? $user->getUID() : null),
-                    'createdAt'         => (new \DateTime())->format('c'),
-                    'items'             => ($winningQuoteData['items'] ?? []),
-                    'totalAmount'       => ($winningQuoteData['totalAmount'] ?? 0),
+                    'rfqId'           => $id,
+                    'supplierQuoteId' => $supplierQuoteId,
+                    'supplierId'      => ($winningQuoteData['supplierId'] ?? null),
+                    'status'          => 'draft',
+                    'createdBy'       => $createdBy,
+                    'createdAt'       => (new \DateTime())->format('c'),
+                    'items'           => ($winningQuoteData['items'] ?? []),
+                    'totalAmount'     => ($winningQuoteData['totalAmount'] ?? 0),
                 ],
             );
 
-            return new JSONResponse(data: [
-                'rfqId'         => $id,
-                'status'        => 'awarded',
-                'awardedQuote'  => $winningQuoteData,
-                'purchaseOrder' => is_array($purchaseOrder)
-                    ? $purchaseOrder
-                    : $purchaseOrder->jsonSerialize(),
-            ]);
+            if (is_array($purchaseOrder) === true) {
+                $purchaseOrderData = $purchaseOrder;
+            } else {
+                $purchaseOrderData = $purchaseOrder->jsonSerialize();
+            }
+
+            return new JSONResponse(
+                    data: [
+                        'rfqId'         => $id,
+                        'status'        => 'awarded',
+                        'awardedQuote'  => $winningQuoteData,
+                        'purchaseOrder' => $purchaseOrderData,
+                    ]
+                    );
         } catch (\Exception $e) {
-            $this->logger->error('RFQController::award failed', [
-                'rfqId'     => $id,
-                'exception' => $e,
-            ]);
+            $this->logger->error(
+                    'RFQController::award failed',
+                    [
+                        'rfqId'     => $id,
+                        'exception' => $e,
+                    ]
+                    );
             return new JSONResponse(
                 data: ['error' => $e->getMessage()],
                 statusCode: 500,
             );
-        }
+        }//end try
     }//end award()
 }//end class

--- a/lib/Controller/RFQController.php
+++ b/lib/Controller/RFQController.php
@@ -1,0 +1,270 @@
+<?php
+
+/**
+ * Shillinq RFQ Controller
+ *
+ * Controller for Request for Quotation lifecycle operations
+ * including publishing to suppliers and awarding quotes.
+ *
+ * @category Controller
+ * @package  OCA\Shillinq\Controller
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Controller;
+
+use OCA\Shillinq\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+use OCP\Notification\IManager;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Controller for Request for Quotation (RFQ) lifecycle management.
+ *
+ * Handles publishing RFQs to invited suppliers (with notifications)
+ * and awarding a selected supplier quote, which rejects competing
+ * quotes and creates a purchase order draft from the awarded quote.
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.5
+ */
+class RFQController extends Controller
+{
+
+    /**
+     * Constructor for the RFQController.
+     *
+     * @param IRequest           $request             The request object
+     * @param ContainerInterface $container             The DI container
+     * @param IManager           $notificationManager  The notification manager
+     * @param IUserSession       $userSession           The user session
+     * @param LoggerInterface    $logger                The logger
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private ContainerInterface $container,
+        private IManager $notificationManager,
+        private IUserSession $userSession,
+        private LoggerInterface $logger,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+    }//end __construct()
+
+
+    /**
+     * Publish an RFQ to invited suppliers.
+     *
+     * Reads supplierProfileIds from the request body, updates the RFQ
+     * status to "published" with a publishedAt timestamp, stores the
+     * invited supplier profile IDs, and sends a notification to each
+     * invited supplier.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @param string $id The RFQ ID
+     *
+     * @return JSONResponse The updated RFQ
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.5
+     */
+    public function publish(string $id): JSONResponse
+    {
+        try {
+            $objectService      = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+            $supplierProfileIds = $this->request->getParam('supplierProfileIds', []);
+
+            $rfq     = $objectService->findOne(objectType: 'rfq', id: $id);
+            $rfqData = is_array($rfq) ? $rfq : $rfq->jsonSerialize();
+
+            // Update RFQ fields.
+            $rfqData['status']                  = 'published';
+            $rfqData['publishedAt']             = (new \DateTime())->format('c');
+            $rfqData['invitedSupplierProfileIds'] = $supplierProfileIds;
+
+            $updated = $objectService->update(
+                objectType: 'rfq',
+                id: $id,
+                object: $rfqData,
+            );
+
+            // Send notifications to each invited supplier.
+            foreach ($supplierProfileIds as $supplierProfileId) {
+                try {
+                    $supplierProfile = $objectService->findOne(
+                        objectType: 'supplierProfile',
+                        id: $supplierProfileId,
+                    );
+                    $profileData  = is_array($supplierProfile)
+                        ? $supplierProfile
+                        : $supplierProfile->jsonSerialize();
+                    $contactUserId = $profileData['contactUserId'] ?? null;
+
+                    if ($contactUserId !== null) {
+                        $notification = $this->notificationManager->createNotification();
+                        $notification->setApp(Application::APP_ID)
+                            ->setUser($contactUserId)
+                            ->setDateTime(new \DateTime())
+                            ->setObject('rfq', 'rfq-published-' . $id . '-' . $supplierProfileId)
+                            ->setSubject(
+                                'rfq_published',
+                                [
+                                    'rfqId'    => $id,
+                                    'rfqTitle' => ($rfqData['title'] ?? $id),
+                                ]
+                            );
+
+                        $this->notificationManager->notify($notification);
+                    }
+                } catch (\Exception $e) {
+                    $this->logger->warning('RFQController::publish: failed to notify supplier', [
+                        'supplierProfileId' => $supplierProfileId,
+                        'exception'         => $e,
+                    ]);
+                }
+            }//end foreach
+
+            return new JSONResponse(
+                data: is_array($updated) ? $updated : $updated->jsonSerialize(),
+            );
+        } catch (\Exception $e) {
+            $this->logger->error('RFQController::publish failed', [
+                'rfqId'     => $id,
+                'exception' => $e,
+            ]);
+            return new JSONResponse(
+                data: ['error' => $e->getMessage()],
+                statusCode: 500,
+            );
+        }
+    }//end publish()
+
+
+    /**
+     * Award an RFQ to a selected supplier quote.
+     *
+     * Reads the supplierQuoteId from the request body, updates the RFQ
+     * status to "awarded", accepts the winning quote, rejects all other
+     * quotes for this RFQ, and creates a purchase order draft from the
+     * awarded quote data.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @param string $id The RFQ ID
+     *
+     * @return JSONResponse The award result including the created PO draft
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-5.5
+     */
+    public function award(string $id): JSONResponse
+    {
+        try {
+            $objectService   = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+            $user            = $this->userSession->getUser();
+            $supplierQuoteId = $this->request->getParam('supplierQuoteId');
+
+            if (empty($supplierQuoteId)) {
+                return new JSONResponse(
+                    data: ['error' => 'supplierQuoteId is required'],
+                    statusCode: 400,
+                );
+            }
+
+            // Update RFQ status to awarded.
+            $rfq     = $objectService->findOne(objectType: 'rfq', id: $id);
+            $rfqData = is_array($rfq) ? $rfq : $rfq->jsonSerialize();
+
+            $rfqData['status']              = 'awarded';
+            $rfqData['awardedQuoteId']      = $supplierQuoteId;
+            $rfqData['awardedAt']           = (new \DateTime())->format('c');
+
+            $objectService->update(
+                objectType: 'rfq',
+                id: $id,
+                object: $rfqData,
+            );
+
+            // Accept the winning quote.
+            $winningQuote     = $objectService->findOne(objectType: 'supplierQuote', id: $supplierQuoteId);
+            $winningQuoteData = is_array($winningQuote) ? $winningQuote : $winningQuote->jsonSerialize();
+
+            $winningQuoteData['status'] = 'accepted';
+            $objectService->update(
+                objectType: 'supplierQuote',
+                id: $supplierQuoteId,
+                object: $winningQuoteData,
+            );
+
+            // Reject all other quotes for this RFQ.
+            $allQuotes = $objectService->findAll(
+                objectType: 'supplierQuote',
+                filters: ['rfqId' => $id],
+            );
+
+            foreach ($allQuotes as $quote) {
+                $quoteData = is_array($quote) ? $quote : $quote->jsonSerialize();
+                $quoteId   = $quoteData['id'] ?? $quoteData['uuid'] ?? null;
+
+                if ($quoteId !== null && $quoteId !== $supplierQuoteId) {
+                    $quoteData['status'] = 'rejected';
+                    $objectService->update(
+                        objectType: 'supplierQuote',
+                        id: $quoteId,
+                        object: $quoteData,
+                    );
+                }
+            }
+
+            // Create PurchaseOrder draft from the awarded quote.
+            $purchaseOrder = $objectService->create(
+                objectType: 'purchaseOrder',
+                object: [
+                    'rfqId'             => $id,
+                    'supplierQuoteId'   => $supplierQuoteId,
+                    'supplierId'        => ($winningQuoteData['supplierId'] ?? null),
+                    'status'            => 'draft',
+                    'createdBy'         => ($user !== null ? $user->getUID() : null),
+                    'createdAt'         => (new \DateTime())->format('c'),
+                    'items'             => ($winningQuoteData['items'] ?? []),
+                    'totalAmount'       => ($winningQuoteData['totalAmount'] ?? 0),
+                ],
+            );
+
+            return new JSONResponse(data: [
+                'rfqId'         => $id,
+                'status'        => 'awarded',
+                'awardedQuote'  => $winningQuoteData,
+                'purchaseOrder' => is_array($purchaseOrder)
+                    ? $purchaseOrder
+                    : $purchaseOrder->jsonSerialize(),
+            ]);
+        } catch (\Exception $e) {
+            $this->logger->error('RFQController::award failed', [
+                'rfqId'     => $id,
+                'exception' => $e,
+            ]);
+            return new JSONResponse(
+                data: ['error' => $e->getMessage()],
+                statusCode: 500,
+            );
+        }
+    }//end award()
+}//end class

--- a/lib/Repair/CreateDefaultConfiguration.php
+++ b/lib/Repair/CreateDefaultConfiguration.php
@@ -19,7 +19,6 @@
 
 // SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
-
 declare(strict_types=1);
 
 namespace OCA\Shillinq\Repair;
@@ -96,7 +95,7 @@ class CreateDefaultConfiguration implements IRepairStep
         try {
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
         } catch (\Throwable $e) {
-            $output->warning('Could not obtain ObjectService: ' . $e->getMessage());
+            $output->warning('Could not obtain ObjectService: '.$e->getMessage());
             $this->logger->error(
                 'Shillinq: ObjectService not available for seeding',
                 ['exception' => $e->getMessage()]
@@ -108,7 +107,7 @@ class CreateDefaultConfiguration implements IRepairStep
             $this->seedAllData(objectService: $objectService, output: $output);
             $output->info('Default catalog-purchase-management data seeded successfully.');
         } catch (\Throwable $e) {
-            $output->warning('Error seeding default data: ' . $e->getMessage());
+            $output->warning('Error seeding default data: '.$e->getMessage());
             $this->logger->error(
                 'Shillinq: default data seeding failed',
                 ['exception' => $e->getMessage()]
@@ -342,7 +341,7 @@ class CreateDefaultConfiguration implements IRepairStep
                 objectService: $objectService,
                 schema: 'purchaseOrderLine',
                 uniqueField: 'purchaseOrderId',
-                uniqueValue: ($poId . '-' . ($penBlkId ?? '')),
+                uniqueValue: ($poId.'-'.($penBlkId ?? '')),
                 data: [
                     'purchaseOrderId' => $poId,
                     'productId'       => $penBlkId,
@@ -378,7 +377,7 @@ class CreateDefaultConfiguration implements IRepairStep
                 objectService: $objectService,
                 schema: 'supplierQuote',
                 uniqueField: 'rfqId',
-                uniqueValue: ($rfqId . '-' . $acmeId),
+                uniqueValue: ($rfqId.'-'.$acmeId),
                 data: [
                     'rfqId'             => $rfqId,
                     'supplierProfileId' => $acmeId,
@@ -394,7 +393,7 @@ class CreateDefaultConfiguration implements IRepairStep
                 objectService: $objectService,
                 schema: 'supplierQuote',
                 uniqueField: 'rfqId',
-                uniqueValue: ($rfqId . '-' . $betaId),
+                uniqueValue: ($rfqId.'-'.$betaId),
                 data: [
                     'rfqId'             => $rfqId,
                     'supplierProfileId' => $betaId,
@@ -460,7 +459,7 @@ class CreateDefaultConfiguration implements IRepairStep
             return $id;
         } catch (\Throwable $e) {
             $output->warning(
-                "Failed to seed {$schema} ({$uniqueField}={$uniqueValue}): " . $e->getMessage()
+                "Failed to seed {$schema} ({$uniqueField}={$uniqueValue}): ".$e->getMessage()
             );
             $this->logger->error(
                 "Shillinq: failed to seed {$schema}",
@@ -483,7 +482,7 @@ class CreateDefaultConfiguration implements IRepairStep
      * @param string|null $supplierId    The supplier profile object ID
      * @param IOutput     $output        The output interface for progress reporting
      *
-     * @return string|null The catalog item object ID or null on failure
+     * @return void
      *
      * @spec openspec/changes/catalog-purchase-management/tasks.md#task-2.2
      */
@@ -493,7 +492,7 @@ class CreateDefaultConfiguration implements IRepairStep
         string $productId,
         ?string $supplierId,
         IOutput $output,
-    ): ?string {
+    ): void {
         try {
             // Check for existing catalog item by composite key.
             $existing = $objectService->getObjects(
@@ -511,7 +510,7 @@ class CreateDefaultConfiguration implements IRepairStep
                 $output->info(
                     "Skipped existing catalogItem (catalogId={$catalogId}, productId={$productId}), id={$id}"
                 );
-                return $id;
+                return;
             }
 
             $data = [
@@ -532,11 +531,9 @@ class CreateDefaultConfiguration implements IRepairStep
             $output->info(
                 "Created catalogItem (catalogId={$catalogId}, productId={$productId}), id={$id}"
             );
-
-            return $id;
         } catch (\Throwable $e) {
             $output->warning(
-                'Failed to seed catalogItem: ' . $e->getMessage()
+                'Failed to seed catalogItem: '.$e->getMessage()
             );
             $this->logger->error(
                 'Shillinq: failed to seed catalogItem',
@@ -546,7 +543,6 @@ class CreateDefaultConfiguration implements IRepairStep
                     'exception' => $e->getMessage(),
                 ]
             );
-            return null;
         }//end try
     }//end seedCatalogItem()
 

--- a/lib/Repair/CreateDefaultConfiguration.php
+++ b/lib/Repair/CreateDefaultConfiguration.php
@@ -1,0 +1,589 @@
+<?php
+
+/**
+ * Shillinq Create Default Configuration Repair Step
+ *
+ * Repair step that seeds default catalog-purchase-management data on install/upgrade.
+ *
+ * @category Repair
+ * @package  OCA\Shillinq\Repair
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Repair;
+
+use OCA\Shillinq\Service\SettingsService;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Repair step that seeds default catalog and purchase management data.
+ *
+ * Seeds ProductCategory, Product, Catalog, CatalogItem, PurchaseOrder,
+ * PurchaseOrderLine, RFQ, and SupplierQuote objects idempotently via
+ * OpenRegister's ObjectService.
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-2.1
+ */
+class CreateDefaultConfiguration implements IRepairStep
+{
+    /**
+     * Constructor for CreateDefaultConfiguration.
+     *
+     * @param SettingsService    $settingsService The settings service
+     * @param ContainerInterface $container       The service container
+     * @param LoggerInterface    $logger          The logger interface
+     *
+     * @return void
+     */
+    public function __construct(
+        private SettingsService $settingsService,
+        private ContainerInterface $container,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Get the name of this repair step.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Seed default catalog and purchase management data for Shillinq';
+    }//end getName()
+
+    /**
+     * Run the repair step to seed default configuration data.
+     *
+     * Seeds ProductCategory, Product, Catalog, CatalogItem, PurchaseOrder,
+     * PurchaseOrderLine, RFQ, and SupplierQuote objects idempotently.
+     *
+     * @param IOutput $output The output interface for progress reporting
+     *
+     * @return void
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-2.1
+     */
+    public function run(IOutput $output): void
+    {
+        $output->info('Seeding default catalog-purchase-management data...');
+
+        if ($this->settingsService->isOpenRegisterAvailable() === false) {
+            $output->warning(
+                'OpenRegister is not installed or enabled. Skipping default data seeding.'
+            );
+            $this->logger->warning(
+                'Shillinq: OpenRegister not available, skipping default data seeding'
+            );
+            return;
+        }
+
+        try {
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Throwable $e) {
+            $output->warning('Could not obtain ObjectService: ' . $e->getMessage());
+            $this->logger->error(
+                'Shillinq: ObjectService not available for seeding',
+                ['exception' => $e->getMessage()]
+            );
+            return;
+        }
+
+        try {
+            $this->seedAllData(objectService: $objectService, output: $output);
+            $output->info('Default catalog-purchase-management data seeded successfully.');
+        } catch (\Throwable $e) {
+            $output->warning('Error seeding default data: ' . $e->getMessage());
+            $this->logger->error(
+                'Shillinq: default data seeding failed',
+                ['exception' => $e->getMessage()]
+            );
+        }//end try
+    }//end run()
+
+    /**
+     * Seed all default data in the correct order.
+     *
+     * Handles cross-entity reference resolution by seeding parent entities
+     * first and passing their IDs to child entities.
+     *
+     * @param object  $objectService The OpenRegister ObjectService
+     * @param IOutput $output        The output interface for progress reporting
+     *
+     * @return void
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-2.1
+     */
+    private function seedAllData(object $objectService, IOutput $output): void
+    {
+        // Seed root product categories.
+        $officeId = $this->seedObject(
+            objectService: $objectService,
+            schema: 'productCategory',
+            uniqueField: 'code',
+            uniqueValue: 'OFFICE',
+            data: [
+                'name' => 'Office & Facilities',
+                'code' => 'OFFICE',
+            ],
+            output: $output,
+        );
+
+        $itId = $this->seedObject(
+            objectService: $objectService,
+            schema: 'productCategory',
+            uniqueField: 'code',
+            uniqueValue: 'IT',
+            data: [
+                'name' => 'IT & Electronics',
+                'code' => 'IT',
+            ],
+            output: $output,
+        );
+
+        // Seed child product categories with parent references.
+        $officeSupId = $this->seedObject(
+            objectService: $objectService,
+            schema: 'productCategory',
+            uniqueField: 'code',
+            uniqueValue: 'OFFICE-SUP',
+            data: [
+                'name'             => 'Office Supplies',
+                'code'             => 'OFFICE-SUP',
+                'parentCategoryId' => $officeId,
+            ],
+            output: $output,
+        );
+
+        $itHwId = $this->seedObject(
+            objectService: $objectService,
+            schema: 'productCategory',
+            uniqueField: 'code',
+            uniqueValue: 'IT-HW',
+            data: [
+                'name'             => 'Computer Hardware',
+                'code'             => 'IT-HW',
+                'parentCategoryId' => $itId,
+            ],
+            output: $output,
+        );
+
+        // Seed products.
+        $paperA4Id = $this->seedObject(
+            objectService: $objectService,
+            schema: 'product',
+            uniqueField: 'sku',
+            uniqueValue: 'PAPER-A4-80',
+            data: [
+                'sku'           => 'PAPER-A4-80',
+                'name'          => 'A4 Copy Paper 80gsm (500 sheets)',
+                'unit'          => 'ream',
+                'purchasePrice' => 4.50,
+                'taxRate'       => 21,
+                'categoryId'    => $officeSupId,
+            ],
+            output: $output,
+        );
+
+        $penBlkId = $this->seedObject(
+            objectService: $objectService,
+            schema: 'product',
+            uniqueField: 'sku',
+            uniqueValue: 'PEN-BLK-10',
+            data: [
+                'sku'           => 'PEN-BLK-10',
+                'name'          => 'Black Ballpoint Pen (box of 10)',
+                'unit'          => 'box',
+                'purchasePrice' => 3.20,
+                'taxRate'       => 21,
+                'categoryId'    => $officeSupId,
+            ],
+            output: $output,
+        );
+
+        $laptopId = $this->seedObject(
+            objectService: $objectService,
+            schema: 'product',
+            uniqueField: 'sku',
+            uniqueValue: 'LAPTOP-15-STD',
+            data: [
+                'sku'           => 'LAPTOP-15-STD',
+                'name'          => 'Standard 15" Business Laptop',
+                'unit'          => 'piece',
+                'purchasePrice' => 850.00,
+                'taxRate'       => 21,
+                'categoryId'    => $itHwId,
+            ],
+            output: $output,
+        );
+
+        $mouseId = $this->seedObject(
+            objectService: $objectService,
+            schema: 'product',
+            uniqueField: 'sku',
+            uniqueValue: 'MOUSE-USB-STD',
+            data: [
+                'sku'           => 'MOUSE-USB-STD',
+                'name'          => 'USB Optical Mouse',
+                'unit'          => 'piece',
+                'purchasePrice' => 15.00,
+                'taxRate'       => 21,
+                'categoryId'    => $itHwId,
+            ],
+            output: $output,
+        );
+
+        // Seed catalog.
+        $catalogId = $this->seedObject(
+            objectService: $objectService,
+            schema: 'catalog',
+            uniqueField: 'name',
+            uniqueValue: 'Office Essentials 2026',
+            data: [
+                'name'              => 'Office Essentials 2026',
+                'status'            => 'active',
+                'effectiveFrom'     => '2026-01-01',
+                'effectiveTo'       => '2026-12-31',
+                'contractReference' => 'FW-2026-OFFICE',
+            ],
+            output: $output,
+        );
+
+        // Resolve supplier profile ID for Acme BV.
+        $acmeId = $this->resolveObjectId(
+            objectService: $objectService,
+            schema: 'supplierProfile',
+            field: 'companyName',
+            value: 'Acme BV',
+        );
+
+        // Resolve supplier profile ID for Beta Supplies BV.
+        $betaId = $this->resolveObjectId(
+            objectService: $objectService,
+            schema: 'supplierProfile',
+            field: 'companyName',
+            value: 'Beta Supplies BV',
+        );
+
+        // Seed catalog items (one per product, linked to catalog + Acme BV).
+        $productIds = [
+            $paperA4Id,
+            $penBlkId,
+            $laptopId,
+            $mouseId,
+        ];
+
+        foreach ($productIds as $productId) {
+            if ($productId === null || $catalogId === null) {
+                continue;
+            }
+
+            $this->seedCatalogItem(
+                objectService: $objectService,
+                catalogId: $catalogId,
+                productId: $productId,
+                supplierId: $acmeId,
+                output: $output,
+            );
+        }
+
+        // Seed purchase order.
+        $poId = $this->seedObject(
+            objectService: $objectService,
+            schema: 'purchaseOrder',
+            uniqueField: 'poNumber',
+            uniqueValue: 'PO-2026-00001',
+            data: [
+                'poNumber'             => 'PO-2026-00001',
+                'status'               => 'acknowledged',
+                'expectedDeliveryDate' => '2026-04-30',
+                'totalAmount'          => 50.00,
+                'currency'             => 'EUR',
+            ],
+            output: $output,
+        );
+
+        // Seed purchase order lines.
+        if ($poId !== null && $paperA4Id !== null) {
+            $this->seedObject(
+                objectService: $objectService,
+                schema: 'purchaseOrderLine',
+                uniqueField: 'purchaseOrderId',
+                uniqueValue: $poId,
+                data: [
+                    'purchaseOrderId' => $poId,
+                    'productId'       => $paperA4Id,
+                    'quantity'        => 5,
+                    'unit'            => 'ream',
+                    'unitPrice'       => 4.50,
+                    'lineTotal'       => 22.50,
+                ],
+                output: $output,
+            );
+        }
+
+        if ($poId !== null && $penBlkId !== null) {
+            $this->seedObject(
+                objectService: $objectService,
+                schema: 'purchaseOrderLine',
+                uniqueField: 'purchaseOrderId',
+                uniqueValue: ($poId . '-' . ($penBlkId ?? '')),
+                data: [
+                    'purchaseOrderId' => $poId,
+                    'productId'       => $penBlkId,
+                    'quantity'        => 5,
+                    'unit'            => 'box',
+                    'unitPrice'       => 3.20,
+                    'lineTotal'       => 16.00,
+                ],
+                output: $output,
+            );
+        }
+
+        // Seed RFQ.
+        $rfqId = $this->seedObject(
+            objectService: $objectService,
+            schema: 'rfq',
+            uniqueField: 'number',
+            uniqueValue: 'RFQ-2026-00001',
+            data: [
+                'number'  => 'RFQ-2026-00001',
+                'title'   => 'RFQ — IT Hardware Q3 2026',
+                'type'    => 'RFQ',
+                'status'  => 'evaluating',
+                'budget'  => 5000.00,
+                'dueDate' => '2026-05-15',
+            ],
+            output: $output,
+        );
+
+        // Seed supplier quotes.
+        if ($rfqId !== null && $acmeId !== null) {
+            $this->seedObject(
+                objectService: $objectService,
+                schema: 'supplierQuote',
+                uniqueField: 'rfqId',
+                uniqueValue: ($rfqId . '-' . $acmeId),
+                data: [
+                    'rfqId'             => $rfqId,
+                    'supplierProfileId' => $acmeId,
+                    'totalAmount'       => 4200.00,
+                    'status'            => 'submitted',
+                ],
+                output: $output,
+            );
+        }
+
+        if ($rfqId !== null && $betaId !== null) {
+            $this->seedObject(
+                objectService: $objectService,
+                schema: 'supplierQuote',
+                uniqueField: 'rfqId',
+                uniqueValue: ($rfqId . '-' . $betaId),
+                data: [
+                    'rfqId'             => $rfqId,
+                    'supplierProfileId' => $betaId,
+                    'totalAmount'       => 4650.00,
+                    'status'            => 'submitted',
+                ],
+                output: $output,
+            );
+        }
+    }//end seedAllData()
+
+    /**
+     * Seed a single object idempotently.
+     *
+     * Checks for an existing record by unique field before creating.
+     * Returns the object ID of the created or existing record.
+     *
+     * @param object  $objectService The OpenRegister ObjectService
+     * @param string  $schema        The schema name to seed into
+     * @param string  $uniqueField   The field to check for uniqueness
+     * @param string  $uniqueValue   The value that must be unique
+     * @param array   $data          The object data to seed
+     * @param IOutput $output        The output interface for progress reporting
+     *
+     * @return string|null The object ID or null on failure
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-2.1
+     */
+    private function seedObject(
+        object $objectService,
+        string $schema,
+        string $uniqueField,
+        string $uniqueValue,
+        array $data,
+        IOutput $output,
+    ): ?string {
+        try {
+            // Check for existing object by unique field.
+            $existing = $objectService->getObjects(
+                schema: $schema,
+                filters: [$uniqueField => $uniqueValue],
+                limit: 1,
+            );
+
+            if (empty($existing) === false) {
+                $existingObject = reset($existing);
+                $id = ($existingObject['id'] ?? null);
+                $output->info(
+                    "Skipped existing {$schema} ({$uniqueField}={$uniqueValue}), id={$id}"
+                );
+                return $id;
+            }
+
+            // Create the new object.
+            $result = $objectService->saveObject(
+                schema: $schema,
+                data: $data,
+            );
+
+            $id = ($result['id'] ?? null);
+            $output->info("Created {$schema} ({$uniqueField}={$uniqueValue}), id={$id}");
+
+            return $id;
+        } catch (\Throwable $e) {
+            $output->warning(
+                "Failed to seed {$schema} ({$uniqueField}={$uniqueValue}): " . $e->getMessage()
+            );
+            $this->logger->error(
+                "Shillinq: failed to seed {$schema}",
+                [
+                    'uniqueField' => $uniqueField,
+                    'uniqueValue' => $uniqueValue,
+                    'exception'   => $e->getMessage(),
+                ]
+            );
+            return null;
+        }//end try
+    }//end seedObject()
+
+    /**
+     * Seed a catalog item using composite key (catalogId + productId) for idempotency.
+     *
+     * @param object      $objectService The OpenRegister ObjectService
+     * @param string      $catalogId     The catalog object ID
+     * @param string      $productId     The product object ID
+     * @param string|null $supplierId    The supplier profile object ID
+     * @param IOutput     $output        The output interface for progress reporting
+     *
+     * @return string|null The catalog item object ID or null on failure
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-2.2
+     */
+    private function seedCatalogItem(
+        object $objectService,
+        string $catalogId,
+        string $productId,
+        ?string $supplierId,
+        IOutput $output,
+    ): ?string {
+        try {
+            // Check for existing catalog item by composite key.
+            $existing = $objectService->getObjects(
+                schema: 'catalogItem',
+                filters: [
+                    'catalogId' => $catalogId,
+                    'productId' => $productId,
+                ],
+                limit: 1,
+            );
+
+            if (empty($existing) === false) {
+                $existingObject = reset($existing);
+                $id = ($existingObject['id'] ?? null);
+                $output->info(
+                    "Skipped existing catalogItem (catalogId={$catalogId}, productId={$productId}), id={$id}"
+                );
+                return $id;
+            }
+
+            $data = [
+                'catalogId' => $catalogId,
+                'productId' => $productId,
+            ];
+
+            if ($supplierId !== null) {
+                $data['supplierProfileId'] = $supplierId;
+            }
+
+            $result = $objectService->saveObject(
+                schema: 'catalogItem',
+                data: $data,
+            );
+
+            $id = ($result['id'] ?? null);
+            $output->info(
+                "Created catalogItem (catalogId={$catalogId}, productId={$productId}), id={$id}"
+            );
+
+            return $id;
+        } catch (\Throwable $e) {
+            $output->warning(
+                'Failed to seed catalogItem: ' . $e->getMessage()
+            );
+            $this->logger->error(
+                'Shillinq: failed to seed catalogItem',
+                [
+                    'catalogId' => $catalogId,
+                    'productId' => $productId,
+                    'exception' => $e->getMessage(),
+                ]
+            );
+            return null;
+        }//end try
+    }//end seedCatalogItem()
+
+    /**
+     * Resolve an object ID by searching for it with a field filter.
+     *
+     * @param object $objectService The OpenRegister ObjectService
+     * @param string $schema        The schema to search
+     * @param string $field         The field to filter on
+     * @param string $value         The value to match
+     *
+     * @return string|null The object ID or null if not found
+     */
+    private function resolveObjectId(
+        object $objectService,
+        string $schema,
+        string $field,
+        string $value,
+    ): ?string {
+        try {
+            $results = $objectService->getObjects(
+                schema: $schema,
+                filters: [$field => $value],
+                limit: 1,
+            );
+
+            if (empty($results) === false) {
+                $object = reset($results);
+                return ($object['id'] ?? null);
+            }
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                "Shillinq: could not resolve {$schema} by {$field}={$value}",
+                ['exception' => $e->getMessage()]
+            );
+        }//end try
+
+        return null;
+    }//end resolveObjectId()
+}//end class

--- a/lib/Service/CatalogImportService.php
+++ b/lib/Service/CatalogImportService.php
@@ -1,11 +1,6 @@
 <?php
 
 /**
- * SPDX-License-Identifier: EUPL-1.2
- * Copyright (C) 2026 Conduction B.V.
- */
-
-/**
  * Shillinq Catalog Import Service
  *
  * Imports catalog items from CSV data, resolving products by SKU and
@@ -25,6 +20,8 @@
  * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.4
  */
 
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
 declare(strict_types=1);
 
 namespace OCA\Shillinq\Service;
@@ -119,7 +116,7 @@ class CatalogImportService
                     [
                         'row'     => 0,
                         'sku'     => '',
-                        'message' => 'Missing required columns: ' . implode(separator: ', ', array: $missingColumns),
+                        'message' => 'Missing required columns: '.implode(separator: ', ', array: $missingColumns),
                     ],
                 ],
             ];
@@ -155,7 +152,7 @@ class CatalogImportService
                 continue;
             }
 
-            $sku = trim((string) ($row[$columnMap['sku']] ?? ''));
+            $sku       = trim((string) ($row[$columnMap['sku']] ?? ''));
             $unitPrice = ($row[$columnMap['unit_price']] ?? '');
 
             if ($sku === '') {
@@ -177,7 +174,7 @@ class CatalogImportService
                 $errors[] = [
                     'row'     => $rowNumber,
                     'sku'     => $sku,
-                    'message' => 'Failed to look up product: ' . $e->getMessage(),
+                    'message' => 'Failed to look up product: '.$e->getMessage(),
                 ];
                 continue;
             }
@@ -186,7 +183,7 @@ class CatalogImportService
                 $errors[] = [
                     'row'     => $rowNumber,
                     'sku'     => $sku,
-                    'message' => 'Product not found for SKU: ' . $sku,
+                    'message' => 'Product not found for SKU: '.$sku,
                 ];
                 continue;
             }
@@ -198,7 +195,7 @@ class CatalogImportService
                 $errors[] = [
                     'row'     => $rowNumber,
                     'sku'     => $sku,
-                    'message' => 'Product has no ID for SKU: ' . $sku,
+                    'message' => 'Product has no ID for SKU: '.$sku,
                 ];
                 continue;
             }
@@ -234,10 +231,13 @@ class CatalogImportService
 
         // If fewer than 1 valid row, do not commit anything.
         if (count($validRows) < 1) {
-            $this->logger->info('CatalogImportService: no valid rows to import', [
-                'catalogId' => $catalogId,
-                'errors'    => count($errors),
-            ]);
+            $this->logger->info(
+                    'CatalogImportService: no valid rows to import',
+                    [
+                        'catalogId' => $catalogId,
+                        'errors'    => count($errors),
+                    ]
+                    );
 
             return [
                 'imported' => 0,
@@ -278,16 +278,19 @@ class CatalogImportService
                 $errors[] = [
                     'row'     => $validRow['rowNumber'],
                     'sku'     => $validRow['sku'],
-                    'message' => 'Failed to upsert catalog item: ' . $e->getMessage(),
+                    'message' => 'Failed to upsert catalog item: '.$e->getMessage(),
                 ];
-            }
+            }//end try
         }//end foreach
 
-        $this->logger->info('CatalogImportService: import completed', [
-            'catalogId' => $catalogId,
-            'imported'  => $imported,
-            'errors'    => count($errors),
-        ]);
+        $this->logger->info(
+                'CatalogImportService: import completed',
+                [
+                    'catalogId' => $catalogId,
+                    'imported'  => $imported,
+                    'errors'    => count($errors),
+                ]
+                );
 
         return [
             'imported' => $imported,

--- a/lib/Service/CatalogImportService.php
+++ b/lib/Service/CatalogImportService.php
@@ -1,0 +1,297 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ * Copyright (C) 2026 Conduction B.V.
+ */
+
+/**
+ * Shillinq Catalog Import Service
+ *
+ * Imports catalog items from CSV data, resolving products by SKU and
+ * upserting catalog item entries with pricing and availability metadata.
+ *
+ * @category Service
+ * @package  OCA\Shillinq\Service
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.4
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Service;
+
+use OCA\Shillinq\AppInfo\Application;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service for importing catalog items from CSV streams.
+ *
+ * Validates the CSV header, resolves products by SKU, and upserts catalog items
+ * (creates new or updates existing entries). Returns a summary of imported rows
+ * and per-row errors. If fewer than 1 valid row exists, no partial transaction
+ * is committed.
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.4
+ */
+class CatalogImportService
+{
+
+    /**
+     * Required CSV columns.
+     *
+     * @var array<string>
+     */
+    private const REQUIRED_COLUMNS = [
+        'sku',
+        'unit_price',
+    ];
+
+    /**
+     * Constructor for the CatalogImportService.
+     *
+     * @param ContainerInterface $container The service container
+     * @param LoggerInterface    $logger    The logger
+     *
+     * @return void
+     */
+    public function __construct(
+        private ContainerInterface $container,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Import catalog items from a CSV stream.
+     *
+     * Validates the header row for required columns (sku, unit_price).
+     * For each data row, resolves the product by SKU. If found, upserts a
+     * CatalogItem (creates if catalogId+productId combination does not exist;
+     * updates unitPrice, minimumOrderQuantity, leadTimeDays if it does).
+     * Optional columns: moq (minimumOrderQuantity), lead_time_days.
+     *
+     * If fewer than 1 valid row is found, no partial transaction is committed.
+     *
+     * @param string   $catalogId The catalog ID to import items into
+     * @param resource $csvStream A readable stream resource containing CSV data
+     *
+     * @return array{imported: int, errors: array<int,array{row: int, sku: string, message: string}>}
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.4
+     */
+    public function import(string $catalogId, $csvStream): array
+    {
+        $errors   = [];
+        $imported = 0;
+
+        // Read and validate header row.
+        $headerRow = fgetcsv(stream: $csvStream);
+        if ($headerRow === false || $headerRow === null) {
+            return [
+                'imported' => 0,
+                'errors'   => [
+                    [
+                        'row'     => 0,
+                        'sku'     => '',
+                        'message' => 'Missing required columns: sku, unit_price',
+                    ],
+                ],
+            ];
+        }
+
+        $headers = array_map(callback: 'trim', array: $headerRow);
+        $headers = array_map(callback: 'strtolower', array: $headers);
+
+        $missingColumns = array_diff(self::REQUIRED_COLUMNS, $headers);
+        if (empty($missingColumns) === false) {
+            return [
+                'imported' => 0,
+                'errors'   => [
+                    [
+                        'row'     => 0,
+                        'sku'     => '',
+                        'message' => 'Missing required columns: ' . implode(separator: ', ', array: $missingColumns),
+                    ],
+                ],
+            ];
+        }
+
+        // Build column index map.
+        $columnMap = array_flip($headers);
+
+        try {
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Throwable $e) {
+            $this->logger->error('CatalogImportService: unable to get ObjectService', ['exception' => $e->getMessage()]);
+            return [
+                'imported' => 0,
+                'errors'   => [
+                    [
+                        'row'     => 0,
+                        'sku'     => '',
+                        'message' => 'Internal error: ObjectService unavailable',
+                    ],
+                ],
+            ];
+        }
+
+        // Parse all data rows first to validate before committing.
+        $validRows = [];
+        $rowNumber = 0;
+
+        while (($row = fgetcsv(stream: $csvStream)) !== false) {
+            $rowNumber++;
+
+            if ($row === null || (count($row) === 1 && ($row[0] === null || trim($row[0]) === ''))) {
+                continue;
+            }
+
+            $sku = trim((string) ($row[$columnMap['sku']] ?? ''));
+            $unitPrice = ($row[$columnMap['unit_price']] ?? '');
+
+            if ($sku === '') {
+                $errors[] = [
+                    'row'     => $rowNumber,
+                    'sku'     => $sku,
+                    'message' => 'Empty SKU',
+                ];
+                continue;
+            }
+
+            // Resolve product by SKU.
+            try {
+                $products = $objectService->getObjects(
+                    objectType: 'product',
+                    filters: ['sku' => $sku],
+                );
+            } catch (\Throwable $e) {
+                $errors[] = [
+                    'row'     => $rowNumber,
+                    'sku'     => $sku,
+                    'message' => 'Failed to look up product: ' . $e->getMessage(),
+                ];
+                continue;
+            }
+
+            if (empty($products) === true) {
+                $errors[] = [
+                    'row'     => $rowNumber,
+                    'sku'     => $sku,
+                    'message' => 'Product not found for SKU: ' . $sku,
+                ];
+                continue;
+            }
+
+            $product   = reset($products);
+            $productId = ($product['id'] ?? null);
+
+            if ($productId === null) {
+                $errors[] = [
+                    'row'     => $rowNumber,
+                    'sku'     => $sku,
+                    'message' => 'Product has no ID for SKU: ' . $sku,
+                ];
+                continue;
+            }
+
+            $itemData = [
+                'catalogId' => $catalogId,
+                'productId' => $productId,
+                'unitPrice' => (float) $unitPrice,
+            ];
+
+            // Optional columns.
+            if (isset($columnMap['moq']) === true && isset($row[$columnMap['moq']]) === true) {
+                $moqValue = trim((string) $row[$columnMap['moq']]);
+                if ($moqValue !== '') {
+                    $itemData['minimumOrderQuantity'] = (int) $moqValue;
+                }
+            }
+
+            if (isset($columnMap['lead_time_days']) === true && isset($row[$columnMap['lead_time_days']]) === true) {
+                $leadTimeValue = trim((string) $row[$columnMap['lead_time_days']]);
+                if ($leadTimeValue !== '') {
+                    $itemData['leadTimeDays'] = (int) $leadTimeValue;
+                }
+            }
+
+            $validRows[] = [
+                'rowNumber' => $rowNumber,
+                'sku'       => $sku,
+                'productId' => $productId,
+                'data'      => $itemData,
+            ];
+        }//end while
+
+        // If fewer than 1 valid row, do not commit anything.
+        if (count($validRows) < 1) {
+            $this->logger->info('CatalogImportService: no valid rows to import', [
+                'catalogId' => $catalogId,
+                'errors'    => count($errors),
+            ]);
+
+            return [
+                'imported' => 0,
+                'errors'   => $errors,
+            ];
+        }
+
+        // Upsert valid rows.
+        foreach ($validRows as $validRow) {
+            try {
+                // Check if catalog item already exists for this catalog + product.
+                $existingItems = $objectService->getObjects(
+                    objectType: 'catalogItem',
+                    filters: [
+                        'catalogId' => $catalogId,
+                        'productId' => $validRow['productId'],
+                    ],
+                );
+
+                if (empty($existingItems) === false) {
+                    // Update existing catalog item.
+                    $existingItem = reset($existingItems);
+                    $objectService->updateObject(
+                        objectType: 'catalogItem',
+                        id: $existingItem['id'],
+                        data: $validRow['data'],
+                    );
+                } else {
+                    // Create new catalog item.
+                    $objectService->createObject(
+                        objectType: 'catalogItem',
+                        data: $validRow['data'],
+                    );
+                }
+
+                $imported++;
+            } catch (\Throwable $e) {
+                $errors[] = [
+                    'row'     => $validRow['rowNumber'],
+                    'sku'     => $validRow['sku'],
+                    'message' => 'Failed to upsert catalog item: ' . $e->getMessage(),
+                ];
+            }
+        }//end foreach
+
+        $this->logger->info('CatalogImportService: import completed', [
+            'catalogId' => $catalogId,
+            'imported'  => $imported,
+            'errors'    => count($errors),
+        ]);
+
+        return [
+            'imported' => $imported,
+            'errors'   => $errors,
+        ];
+    }//end import()
+}//end class

--- a/lib/Service/CatalogSearchService.php
+++ b/lib/Service/CatalogSearchService.php
@@ -1,11 +1,6 @@
 <?php
 
 /**
- * SPDX-License-Identifier: EUPL-1.2
- * Copyright (C) 2026 Conduction B.V.
- */
-
-/**
  * Shillinq Catalog Search Service
  *
  * Provides full-text and filtered search across active catalogs and products,
@@ -25,6 +20,8 @@
  * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.1
  */
 
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
 declare(strict_types=1);
 
 namespace OCA\Shillinq\Service;
@@ -44,7 +41,6 @@ use Psr\Log\LoggerInterface;
  */
 class CatalogSearchService
 {
-
     /**
      * Constructor for the CatalogSearchService.
      *
@@ -77,7 +73,7 @@ class CatalogSearchService
      *
      * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.1
      */
-    public function search(string $term, ?string $categoryId = null): array
+    public function search(string $term, ?string $categoryId=null): array
     {
         try {
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
@@ -102,7 +98,7 @@ class CatalogSearchService
         // Resolve allowed category IDs if filtering by category.
         $allowedCategoryIds = null;
         if ($categoryId !== null) {
-            $allowedCategoryIds = $this->getDescendantCategoryIds(
+            $allowedCategoryIds   = $this->getDescendantCategoryIds(
                 objectService: $objectService,
                 categoryId: $categoryId,
             );
@@ -188,10 +184,13 @@ class CatalogSearchService
             ];
         }//end foreach
 
-        $this->logger->info('CatalogSearchService: search completed', [
-            'term'    => $term,
-            'results' => count($results),
-        ]);
+        $this->logger->info(
+                'CatalogSearchService: search completed',
+                [
+                    'term'    => $term,
+                    'results' => count($results),
+                ]
+                );
 
         return $results;
     }//end search()
@@ -219,10 +218,13 @@ class CatalogSearchService
                 filters: ['parentCategoryId' => $categoryId],
             );
         } catch (\Throwable $e) {
-            $this->logger->debug('CatalogSearchService: failed to fetch child categories', [
-                'categoryId' => $categoryId,
-                'exception'  => $e->getMessage(),
-            ]);
+            $this->logger->debug(
+                    'CatalogSearchService: failed to fetch child categories',
+                    [
+                        'categoryId' => $categoryId,
+                        'exception'  => $e->getMessage(),
+                    ]
+                    );
             return [];
         }
 

--- a/lib/Service/CatalogSearchService.php
+++ b/lib/Service/CatalogSearchService.php
@@ -1,0 +1,247 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ * Copyright (C) 2026 Conduction B.V.
+ */
+
+/**
+ * Shillinq Catalog Search Service
+ *
+ * Provides full-text and filtered search across active catalogs and products,
+ * resolving category hierarchies for descendant matching.
+ *
+ * @category Service
+ * @package  OCA\Shillinq\Service
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.1
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Service;
+
+use OCA\Shillinq\AppInfo\Application;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service for searching catalog items across active catalogs and products.
+ *
+ * Joins catalog item, product, and catalog metadata to return enriched search
+ * results filtered by catalog validity period, product status, and optional
+ * category hierarchy.
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.1
+ */
+class CatalogSearchService
+{
+
+    /**
+     * Constructor for the CatalogSearchService.
+     *
+     * @param ContainerInterface $container The service container
+     * @param LoggerInterface    $logger    The logger
+     *
+     * @return void
+     */
+    public function __construct(
+        private ContainerInterface $container,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Search catalog items by term with optional category filtering.
+     *
+     * Queries catalogItem objects, joining product and catalog metadata.
+     * Only returns results from active catalogs within their validity period
+     * and with active products. When a categoryId is provided, matches the
+     * category and all its descendants via parentCategoryId traversal.
+     *
+     * @param string      $term       The search term to match against product names
+     * @param string|null $categoryId Optional category ID to filter by (includes descendants)
+     *
+     * @return array<int,array<string,mixed>> Array of result items with productName,
+     *                                        supplierName, unitPrice, currency,
+     *                                        catalogName, contractReference,
+     *                                        catalogItemId, productId
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.1
+     */
+    public function search(string $term, ?string $categoryId = null): array
+    {
+        try {
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Throwable $e) {
+            $this->logger->error('CatalogSearchService: unable to get ObjectService', ['exception' => $e->getMessage()]);
+            return [];
+        }
+
+        $today = (new \DateTime())->format('Y-m-d');
+
+        // Fetch all catalog items.
+        try {
+            $catalogItems = $objectService->getObjects(
+                objectType: 'catalogItem',
+                filters: [],
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error('CatalogSearchService: failed to fetch catalog items', ['exception' => $e->getMessage()]);
+            return [];
+        }
+
+        // Resolve allowed category IDs if filtering by category.
+        $allowedCategoryIds = null;
+        if ($categoryId !== null) {
+            $allowedCategoryIds = $this->getDescendantCategoryIds(
+                objectService: $objectService,
+                categoryId: $categoryId,
+            );
+            $allowedCategoryIds[] = $categoryId;
+        }
+
+        $results = [];
+
+        foreach ($catalogItems as $catalogItem) {
+            $productId = ($catalogItem['productId'] ?? null);
+            $catalogId = ($catalogItem['catalogId'] ?? null);
+
+            if ($productId === null || $catalogId === null) {
+                continue;
+            }
+
+            // Fetch the product.
+            try {
+                $product = $objectService->getObject(
+                    objectType: 'product',
+                    id: $productId,
+                );
+            } catch (\Throwable $e) {
+                $this->logger->debug('CatalogSearchService: product not found', ['productId' => $productId]);
+                continue;
+            }
+
+            // Filter: product must be active.
+            if (empty($product['active']) === true || $product['active'] !== true) {
+                continue;
+            }
+
+            // Filter: category matching (including descendants).
+            if ($allowedCategoryIds !== null) {
+                $productCategoryId = ($product['categoryId'] ?? null);
+                if ($productCategoryId === null || in_array($productCategoryId, $allowedCategoryIds, true) === false) {
+                    continue;
+                }
+            }
+
+            // Filter: search term against product name.
+            $productName = ($product['name'] ?? '');
+            if ($term !== '' && stripos($productName, $term) === false) {
+                continue;
+            }
+
+            // Fetch the catalog.
+            try {
+                $catalog = $objectService->getObject(
+                    objectType: 'catalog',
+                    id: $catalogId,
+                );
+            } catch (\Throwable $e) {
+                $this->logger->debug('CatalogSearchService: catalog not found', ['catalogId' => $catalogId]);
+                continue;
+            }
+
+            // Filter: catalog must be active.
+            if (($catalog['status'] ?? '') !== 'active') {
+                continue;
+            }
+
+            // Filter: catalog validity period.
+            $effectiveFrom = ($catalog['effectiveFrom'] ?? null);
+            $effectiveTo   = ($catalog['effectiveTo'] ?? null);
+            if ($effectiveFrom !== null && $effectiveFrom > $today) {
+                continue;
+            }
+
+            if ($effectiveTo !== null && $effectiveTo < $today) {
+                continue;
+            }
+
+            $results[] = [
+                'productName'       => $productName,
+                'supplierName'      => ($catalog['supplierName'] ?? ''),
+                'unitPrice'         => ($catalogItem['unitPrice'] ?? 0),
+                'currency'          => ($catalogItem['currency'] ?? 'EUR'),
+                'catalogName'       => ($catalog['name'] ?? ''),
+                'contractReference' => ($catalog['contractReference'] ?? ''),
+                'catalogItemId'     => ($catalogItem['id'] ?? ''),
+                'productId'         => $productId,
+            ];
+        }//end foreach
+
+        $this->logger->info('CatalogSearchService: search completed', [
+            'term'    => $term,
+            'results' => count($results),
+        ]);
+
+        return $results;
+    }//end search()
+
+    /**
+     * Recursively find all descendant category IDs for a given category.
+     *
+     * Traverses the category tree via parentCategoryId to collect all
+     * child categories at every depth level.
+     *
+     * @param object $objectService The OpenRegister object service
+     * @param string $categoryId    The parent category ID to find descendants for
+     *
+     * @return array<int,string> Array of descendant category IDs
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.1
+     */
+    private function getDescendantCategoryIds(object $objectService, string $categoryId): array
+    {
+        $descendants = [];
+
+        try {
+            $children = $objectService->getObjects(
+                objectType: 'category',
+                filters: ['parentCategoryId' => $categoryId],
+            );
+        } catch (\Throwable $e) {
+            $this->logger->debug('CatalogSearchService: failed to fetch child categories', [
+                'categoryId' => $categoryId,
+                'exception'  => $e->getMessage(),
+            ]);
+            return [];
+        }
+
+        foreach ($children as $child) {
+            $childId = ($child['id'] ?? null);
+            if ($childId === null) {
+                continue;
+            }
+
+            $descendants[] = $childId;
+            $descendants   = array_merge(
+                $descendants,
+                $this->getDescendantCategoryIds(
+                    objectService: $objectService,
+                    categoryId: $childId,
+                )
+            );
+        }//end foreach
+
+        return $descendants;
+    }//end getDescendantCategoryIds()
+}//end class

--- a/lib/Service/OrderLimitService.php
+++ b/lib/Service/OrderLimitService.php
@@ -1,11 +1,6 @@
 <?php
 
 /**
- * SPDX-License-Identifier: EUPL-1.2
- * Copyright (C) 2026 Conduction B.V.
- */
-
-/**
  * Shillinq Order Limit Service
  *
  * Checks per-user ordering limits against basket totals to determine
@@ -25,6 +20,8 @@
  * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.2
  */
 
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
 declare(strict_types=1);
 
 namespace OCA\Shillinq\Service;
@@ -43,7 +40,6 @@ use Psr\Log\LoggerInterface;
  */
 class OrderLimitService
 {
-
     /**
      * Constructor for the OrderLimitService.
      *
@@ -86,10 +82,13 @@ class OrderLimitService
 
         // No limit configured — approval is never required.
         if ($limitValue === '') {
-            $this->logger->debug('OrderLimitService: no limit configured for user', [
-                'userId'      => $userId,
-                'basketTotal' => $basketTotal,
-            ]);
+            $this->logger->debug(
+                    'OrderLimitService: no limit configured for user',
+                    [
+                        'userId'      => $userId,
+                        'basketTotal' => $basketTotal,
+                    ]
+                    );
 
             return [
                 'requiresApproval' => false,
@@ -101,12 +100,15 @@ class OrderLimitService
 
         $requiresApproval = ($basketTotal > $limit);
 
-        $this->logger->info('OrderLimitService: limit check performed', [
-            'userId'           => $userId,
-            'basketTotal'      => $basketTotal,
-            'limit'            => $limit,
-            'requiresApproval' => $requiresApproval,
-        ]);
+        $this->logger->info(
+                'OrderLimitService: limit check performed',
+                [
+                    'userId'           => $userId,
+                    'basketTotal'      => $basketTotal,
+                    'limit'            => $limit,
+                    'requiresApproval' => $requiresApproval,
+                ]
+                );
 
         return [
             'requiresApproval' => $requiresApproval,

--- a/lib/Service/OrderLimitService.php
+++ b/lib/Service/OrderLimitService.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ * Copyright (C) 2026 Conduction B.V.
+ */
+
+/**
+ * Shillinq Order Limit Service
+ *
+ * Checks per-user ordering limits against basket totals to determine
+ * whether approval is required before a purchase order can be placed.
+ *
+ * @category Service
+ * @package  OCA\Shillinq\Service
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Service;
+
+use OCA\Shillinq\AppInfo\Application;
+use OCP\IAppConfig;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service for checking per-user ordering limits against basket totals.
+ *
+ * Reads per-user or default ordering limits from application configuration
+ * and returns whether the given basket total requires approval.
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.2
+ */
+class OrderLimitService
+{
+
+    /**
+     * Constructor for the OrderLimitService.
+     *
+     * @param IAppConfig      $appConfig The app config interface
+     * @param LoggerInterface $logger    The logger
+     *
+     * @return void
+     */
+    public function __construct(
+        private IAppConfig $appConfig,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Check whether a basket total exceeds the user's ordering limit.
+     *
+     * Reads the per-user limit from AppSettings key `ordering.limitEur.{userId}`,
+     * falling back to `ordering.limitEur.default`. If no limit is configured,
+     * approval is never required.
+     *
+     * @param string $userId      The ID of the user placing the order
+     * @param float  $basketTotal The total value of the basket in EUR
+     *
+     * @return array{requiresApproval: bool, limit: float|null} Approval check result
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.2
+     */
+    public function check(string $userId, float $basketTotal): array
+    {
+        // Try per-user limit first.
+        $userLimitKey = "ordering.limitEur.{$userId}";
+        $limitValue   = $this->appConfig->getValueString(Application::APP_ID, $userLimitKey, '');
+
+        // Fall back to default limit.
+        if ($limitValue === '') {
+            $defaultLimitKey = 'ordering.limitEur.default';
+            $limitValue      = $this->appConfig->getValueString(Application::APP_ID, $defaultLimitKey, '');
+        }
+
+        // No limit configured — approval is never required.
+        if ($limitValue === '') {
+            $this->logger->debug('OrderLimitService: no limit configured for user', [
+                'userId'      => $userId,
+                'basketTotal' => $basketTotal,
+            ]);
+
+            return [
+                'requiresApproval' => false,
+                'limit'            => null,
+            ];
+        }
+
+        $limit = (float) $limitValue;
+
+        $requiresApproval = ($basketTotal > $limit);
+
+        $this->logger->info('OrderLimitService: limit check performed', [
+            'userId'           => $userId,
+            'basketTotal'      => $basketTotal,
+            'limit'            => $limit,
+            'requiresApproval' => $requiresApproval,
+        ]);
+
+        return [
+            'requiresApproval' => $requiresApproval,
+            'limit'            => $limit,
+        ];
+    }//end check()
+}//end class

--- a/lib/Service/ThreeWayMatchingService.php
+++ b/lib/Service/ThreeWayMatchingService.php
@@ -1,0 +1,254 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ * Copyright (C) 2026 Conduction B.V.
+ */
+
+/**
+ * Shillinq Three-Way Matching Service
+ *
+ * Performs three-way matching between purchase order lines, goods receipt lines,
+ * and invoice lines to detect quantity discrepancies.
+ *
+ * @category Service
+ * @package  OCA\Shillinq\Service
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.3
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Service;
+
+use OCA\Shillinq\AppInfo\Application;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Service for three-way matching of purchase orders, goods receipts, and invoices.
+ *
+ * For each purchase order line, compares the ordered quantity against received
+ * (from goods receipt lines) and invoiced (from invoice lines) quantities.
+ * Updates match status on each line and returns a discrepancy report.
+ * This operation is idempotent.
+ *
+ * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.3
+ */
+class ThreeWayMatchingService
+{
+
+    /**
+     * Constructor for the ThreeWayMatchingService.
+     *
+     * @param ContainerInterface $container The service container
+     * @param LoggerInterface    $logger    The logger
+     *
+     * @return void
+     */
+    public function __construct(
+        private ContainerInterface $container,
+        private LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Perform three-way matching for all lines of a purchase order.
+     *
+     * For each PurchaseOrderLine belonging to the given purchaseOrderId:
+     * - Sums receivedQuantity from all matching GoodsReceiptLine objects
+     * - Sums invoicedQuantity from all matching invoiceLine objects
+     * - Sets matchStatus to 'matched' when ordered == received == invoiced
+     * - Sets matchStatus to 'discrepancy' with a reason when values differ
+     * - Updates the PurchaseOrderLine with matchStatus, receivedQuantity, invoicedQuantity
+     *
+     * This method is idempotent: calling it multiple times yields the same result.
+     *
+     * @param string $purchaseOrderId The ID of the purchase order to match
+     *
+     * @return array<int,array<string,mixed>> Array of discrepancy report entries
+     *
+     * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.3
+     */
+    public function match(string $purchaseOrderId): array
+    {
+        try {
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        } catch (\Throwable $e) {
+            $this->logger->error('ThreeWayMatchingService: unable to get ObjectService', ['exception' => $e->getMessage()]);
+            return [];
+        }
+
+        // Fetch all purchase order lines for this order.
+        try {
+            $orderLines = $objectService->getObjects(
+                objectType: 'purchaseOrderLine',
+                filters: ['purchaseOrderId' => $purchaseOrderId],
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error('ThreeWayMatchingService: failed to fetch order lines', [
+                'purchaseOrderId' => $purchaseOrderId,
+                'exception'       => $e->getMessage(),
+            ]);
+            return [];
+        }
+
+        $discrepancies = [];
+
+        foreach ($orderLines as $orderLine) {
+            $lineId         = ($orderLine['id'] ?? null);
+            $orderedQuantity = (float) ($orderLine['quantity'] ?? 0);
+
+            if ($lineId === null) {
+                continue;
+            }
+
+            // Sum received quantities from goods receipt lines.
+            $receivedQuantity = $this->sumGoodsReceiptQuantity(
+                objectService: $objectService,
+                purchaseOrderLineId: $lineId,
+            );
+
+            // Sum invoiced quantities from invoice lines.
+            $invoicedQuantity = $this->sumInvoiceLineQuantity(
+                objectService: $objectService,
+                purchaseOrderLineId: $lineId,
+            );
+
+            // Determine match status.
+            $matchStatus = 'matched';
+            $reason      = '';
+
+            if ($orderedQuantity !== $receivedQuantity || $orderedQuantity !== $invoicedQuantity) {
+                $matchStatus = 'discrepancy';
+                $reasons     = [];
+
+                if ($orderedQuantity !== $receivedQuantity) {
+                    $reasons[] = "ordered={$orderedQuantity} received={$receivedQuantity}";
+                }
+
+                if ($orderedQuantity !== $invoicedQuantity) {
+                    $reasons[] = "ordered={$orderedQuantity} invoiced={$invoicedQuantity}";
+                }
+
+                if ($receivedQuantity !== $invoicedQuantity) {
+                    $reasons[] = "received={$receivedQuantity} invoiced={$invoicedQuantity}";
+                }
+
+                $reason = implode(separator: '; ', array: $reasons);
+            }
+
+            // Update the purchase order line with match results.
+            try {
+                $objectService->updateObject(
+                    objectType: 'purchaseOrderLine',
+                    id: $lineId,
+                    data: [
+                        'matchStatus'      => $matchStatus,
+                        'receivedQuantity'  => $receivedQuantity,
+                        'invoicedQuantity'  => $invoicedQuantity,
+                    ],
+                );
+            } catch (\Throwable $e) {
+                $this->logger->error('ThreeWayMatchingService: failed to update order line', [
+                    'lineId'    => $lineId,
+                    'exception' => $e->getMessage(),
+                ]);
+            }
+
+            // Add to discrepancy report if not matched.
+            if ($matchStatus === 'discrepancy') {
+                $discrepancies[] = [
+                    'purchaseOrderLineId' => $lineId,
+                    'orderedQuantity'     => $orderedQuantity,
+                    'receivedQuantity'    => $receivedQuantity,
+                    'invoicedQuantity'    => $invoicedQuantity,
+                    'matchStatus'         => $matchStatus,
+                    'reason'              => $reason,
+                ];
+            }
+        }//end foreach
+
+        $this->logger->info('ThreeWayMatchingService: matching completed', [
+            'purchaseOrderId' => $purchaseOrderId,
+            'totalLines'      => count($orderLines),
+            'discrepancies'   => count($discrepancies),
+        ]);
+
+        return $discrepancies;
+    }//end match()
+
+    /**
+     * Sum received quantities from goods receipt lines for a purchase order line.
+     *
+     * @param object $objectService       The OpenRegister object service
+     * @param string $purchaseOrderLineId The purchase order line ID
+     *
+     * @return float The total received quantity
+     */
+    private function sumGoodsReceiptQuantity(object $objectService, string $purchaseOrderLineId): float
+    {
+        $total = 0.0;
+
+        try {
+            $receiptLines = $objectService->getObjects(
+                objectType: 'goodsReceiptLine',
+                filters: ['purchaseOrderLineId' => $purchaseOrderLineId],
+            );
+
+            foreach ($receiptLines as $receiptLine) {
+                $total += (float) ($receiptLine['receivedQuantity'] ?? 0);
+            }
+        } catch (\Throwable $e) {
+            $this->logger->debug('ThreeWayMatchingService: failed to fetch goods receipt lines', [
+                'purchaseOrderLineId' => $purchaseOrderLineId,
+                'exception'           => $e->getMessage(),
+            ]);
+        }
+
+        return $total;
+    }//end sumGoodsReceiptQuantity()
+
+    /**
+     * Sum invoiced quantities from invoice lines for a purchase order line.
+     *
+     * Fetches linked invoice lines via OpenRegister relation using the
+     * 'invoiceLine' schema filtered by purchaseOrderLineId.
+     *
+     * @param object $objectService       The OpenRegister object service
+     * @param string $purchaseOrderLineId The purchase order line ID
+     *
+     * @return float The total invoiced quantity
+     */
+    private function sumInvoiceLineQuantity(object $objectService, string $purchaseOrderLineId): float
+    {
+        $total = 0.0;
+
+        try {
+            $invoiceLines = $objectService->getObjects(
+                objectType: 'invoiceLine',
+                filters: ['purchaseOrderLineId' => $purchaseOrderLineId],
+            );
+
+            foreach ($invoiceLines as $invoiceLine) {
+                $total += (float) ($invoiceLine['quantity'] ?? 0);
+            }
+        } catch (\Throwable $e) {
+            $this->logger->debug('ThreeWayMatchingService: no invoice lines found or fetch failed', [
+                'purchaseOrderLineId' => $purchaseOrderLineId,
+                'exception'           => $e->getMessage(),
+            ]);
+            // If none found, invoiced quantity is 0.
+        }
+
+        return $total;
+    }//end sumInvoiceLineQuantity()
+}//end class

--- a/lib/Service/ThreeWayMatchingService.php
+++ b/lib/Service/ThreeWayMatchingService.php
@@ -1,11 +1,6 @@
 <?php
 
 /**
- * SPDX-License-Identifier: EUPL-1.2
- * Copyright (C) 2026 Conduction B.V.
- */
-
-/**
  * Shillinq Three-Way Matching Service
  *
  * Performs three-way matching between purchase order lines, goods receipt lines,
@@ -25,6 +20,8 @@
  * @spec openspec/changes/catalog-purchase-management/tasks.md#task-3.3
  */
 
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
 declare(strict_types=1);
 
 namespace OCA\Shillinq\Service;
@@ -45,7 +42,6 @@ use Psr\Log\LoggerInterface;
  */
 class ThreeWayMatchingService
 {
-
     /**
      * Constructor for the ThreeWayMatchingService.
      *
@@ -94,17 +90,20 @@ class ThreeWayMatchingService
                 filters: ['purchaseOrderId' => $purchaseOrderId],
             );
         } catch (\Throwable $e) {
-            $this->logger->error('ThreeWayMatchingService: failed to fetch order lines', [
-                'purchaseOrderId' => $purchaseOrderId,
-                'exception'       => $e->getMessage(),
-            ]);
+            $this->logger->error(
+                    'ThreeWayMatchingService: failed to fetch order lines',
+                    [
+                        'purchaseOrderId' => $purchaseOrderId,
+                        'exception'       => $e->getMessage(),
+                    ]
+                    );
             return [];
         }
 
         $discrepancies = [];
 
         foreach ($orderLines as $orderLine) {
-            $lineId         = ($orderLine['id'] ?? null);
+            $lineId          = ($orderLine['id'] ?? null);
             $orderedQuantity = (float) ($orderLine['quantity'] ?? 0);
 
             if ($lineId === null) {
@@ -153,15 +152,18 @@ class ThreeWayMatchingService
                     id: $lineId,
                     data: [
                         'matchStatus'      => $matchStatus,
-                        'receivedQuantity'  => $receivedQuantity,
-                        'invoicedQuantity'  => $invoicedQuantity,
+                        'receivedQuantity' => $receivedQuantity,
+                        'invoicedQuantity' => $invoicedQuantity,
                     ],
                 );
             } catch (\Throwable $e) {
-                $this->logger->error('ThreeWayMatchingService: failed to update order line', [
-                    'lineId'    => $lineId,
-                    'exception' => $e->getMessage(),
-                ]);
+                $this->logger->error(
+                        'ThreeWayMatchingService: failed to update order line',
+                        [
+                            'lineId'    => $lineId,
+                            'exception' => $e->getMessage(),
+                        ]
+                        );
             }
 
             // Add to discrepancy report if not matched.
@@ -177,11 +179,14 @@ class ThreeWayMatchingService
             }
         }//end foreach
 
-        $this->logger->info('ThreeWayMatchingService: matching completed', [
-            'purchaseOrderId' => $purchaseOrderId,
-            'totalLines'      => count($orderLines),
-            'discrepancies'   => count($discrepancies),
-        ]);
+        $this->logger->info(
+                'ThreeWayMatchingService: matching completed',
+                [
+                    'purchaseOrderId' => $purchaseOrderId,
+                    'totalLines'      => count($orderLines),
+                    'discrepancies'   => count($discrepancies),
+                ]
+                );
 
         return $discrepancies;
     }//end match()
@@ -208,10 +213,13 @@ class ThreeWayMatchingService
                 $total += (float) ($receiptLine['receivedQuantity'] ?? 0);
             }
         } catch (\Throwable $e) {
-            $this->logger->debug('ThreeWayMatchingService: failed to fetch goods receipt lines', [
-                'purchaseOrderLineId' => $purchaseOrderLineId,
-                'exception'           => $e->getMessage(),
-            ]);
+            $this->logger->debug(
+                    'ThreeWayMatchingService: failed to fetch goods receipt lines',
+                    [
+                        'purchaseOrderLineId' => $purchaseOrderLineId,
+                        'exception'           => $e->getMessage(),
+                    ]
+                    );
         }
 
         return $total;
@@ -242,10 +250,13 @@ class ThreeWayMatchingService
                 $total += (float) ($invoiceLine['quantity'] ?? 0);
             }
         } catch (\Throwable $e) {
-            $this->logger->debug('ThreeWayMatchingService: no invoice lines found or fetch failed', [
-                'purchaseOrderLineId' => $purchaseOrderLineId,
-                'exception'           => $e->getMessage(),
-            ]);
+            $this->logger->debug(
+                    'ThreeWayMatchingService: no invoice lines found or fetch failed',
+                    [
+                        'purchaseOrderLineId' => $purchaseOrderLineId,
+                        'exception'           => $e->getMessage(),
+                    ]
+                    );
             // If none found, invoiced quantity is 0.
         }
 

--- a/lib/Settings/shillinq_register.json
+++ b/lib/Settings/shillinq_register.json
@@ -3,37 +3,711 @@
   "info": {
     "title": "Shillinq Register",
     "description": "Register containing all schemas for the Shillinq application.",
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "x-openregister": {
     "type": "application",
     "app": "shillinq",
     "openregister": "^v0.2.10",
-    "description": "Shillinq — replace with your app description"
+    "description": "Shillinq — complete open-source business administration suite"
   },
   "paths": {},
   "components": {
     "schemas": {
-      "example": {
-        "slug": "example",
-        "icon": "FileDocumentOutline",
+      "productCategory": {
+        "slug": "product-category",
+        "icon": "FolderOutline",
         "version": "0.1.0",
-        "title": "Example",
-        "description": "Example schema — replace with your app's actual schemas.",
+        "title": "Product Category",
+        "description": "Hierarchical product and service category supporting parent-child nesting.",
+        "x-schema-org": "schema:Thing",
         "type": "object",
         "required": [
-          "title"
+          "name"
         ],
         "properties": {
-          "title": {
+          "name": {
             "type": "string",
-            "description": "The title of the example object",
-            "example": "My example"
+            "description": "Category display name",
+            "example": "Office Supplies"
+          },
+          "code": {
+            "type": "string",
+            "description": "Short code for filtering (e.g. IT, OFFICE)",
+            "example": "OFFICE-SUP"
           },
           "description": {
             "type": "string",
-            "description": "An optional description",
-            "example": "This is an example"
+            "description": "Category description",
+            "example": "General office supplies"
+          },
+          "parentCategoryId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the parent ProductCategory; null for root nodes"
+          },
+          "active": {
+            "type": "boolean",
+            "description": "Whether the category is available for use",
+            "default": true
+          },
+          "sortOrder": {
+            "type": "integer",
+            "description": "Display order within a parent level",
+            "default": 0
+          }
+        }
+      },
+      "product": {
+        "slug": "product",
+        "icon": "PackageVariantClosed",
+        "version": "0.1.0",
+        "title": "Product",
+        "description": "Product or service item master with SKU, pricing, and category assignment.",
+        "x-schema-org": "schema:Product",
+        "type": "object",
+        "required": [
+          "sku",
+          "name"
+        ],
+        "properties": {
+          "sku": {
+            "type": "string",
+            "description": "Stock keeping unit; unique within the register",
+            "example": "PAPER-A4-80"
+          },
+          "name": {
+            "type": "string",
+            "description": "Product or service display name",
+            "example": "A4 Copy Paper 80gsm (500 sheets)"
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed description"
+          },
+          "unit": {
+            "type": "string",
+            "description": "Unit of measure (piece, kg, hour, litre, m², etc.)",
+            "default": "piece",
+            "example": "ream"
+          },
+          "active": {
+            "type": "boolean",
+            "description": "Whether the product is available for purchasing",
+            "default": true
+          },
+          "categoryId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the assigned ProductCategory"
+          },
+          "purchasePrice": {
+            "type": "number",
+            "description": "Default purchase price (may be overridden in CatalogItem)",
+            "example": 4.50
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO 4217 currency code for purchasePrice",
+            "default": "EUR",
+            "example": "EUR"
+          },
+          "taxRate": {
+            "type": "number",
+            "description": "Default VAT rate percentage",
+            "default": 21,
+            "example": 21
+          },
+          "leadTimeDays": {
+            "type": "integer",
+            "description": "Default supplier lead time in calendar days"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Internal notes"
+          }
+        }
+      },
+      "catalog": {
+        "slug": "catalog",
+        "icon": "BookOpenPageVariantOutline",
+        "version": "0.1.0",
+        "title": "Catalog",
+        "description": "Vendor catalog with negotiated pricing, effective date range, and lifecycle status.",
+        "x-schema-org": "schema:CreativeWork",
+        "type": "object",
+        "required": [
+          "name",
+          "status"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Catalog display name",
+            "example": "Office Essentials 2026"
+          },
+          "description": {
+            "type": "string",
+            "description": "Catalog scope and purpose"
+          },
+          "status": {
+            "type": "string",
+            "description": "Catalog lifecycle status",
+            "enum": ["draft", "active", "archived"],
+            "default": "draft",
+            "example": "active"
+          },
+          "supplierProfileId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the linked SupplierProfile"
+          },
+          "effectiveFrom": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date from which the catalog is valid"
+          },
+          "effectiveTo": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date after which the catalog expires"
+          },
+          "ownerId": {
+            "type": "string",
+            "description": "userId of the procurement manager who owns this catalog"
+          },
+          "contractReference": {
+            "type": "string",
+            "description": "Framework contract or agreement number",
+            "example": "FW-2026-OFFICE"
+          }
+        }
+      },
+      "catalogItem": {
+        "slug": "catalog-item",
+        "icon": "TagOutline",
+        "version": "0.1.0",
+        "title": "Catalog Item",
+        "description": "Links a Product to a Catalog with a negotiated unit price from a supplier.",
+        "x-schema-org": "schema:Offer",
+        "type": "object",
+        "required": [
+          "catalogId",
+          "productId",
+          "supplierProfileId",
+          "unitPrice"
+        ],
+        "properties": {
+          "catalogId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the parent Catalog"
+          },
+          "productId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the Product"
+          },
+          "supplierProfileId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the supplying SupplierProfile"
+          },
+          "unitPrice": {
+            "type": "number",
+            "description": "Negotiated unit price",
+            "example": 4.50
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO 4217 currency code",
+            "default": "EUR"
+          },
+          "minimumOrderQuantity": {
+            "type": "integer",
+            "description": "Minimum order quantity",
+            "default": 1
+          },
+          "leadTimeDays": {
+            "type": "integer",
+            "description": "Supplier lead time for this item (overrides Product default)"
+          },
+          "active": {
+            "type": "boolean",
+            "description": "Whether this item is orderable from this catalog",
+            "default": true
+          },
+          "notes": {
+            "type": "string",
+            "description": "Procurement notes"
+          }
+        }
+      },
+      "orderBasket": {
+        "slug": "order-basket",
+        "icon": "CartOutline",
+        "version": "0.1.0",
+        "title": "Order Basket",
+        "description": "Requisitioner shopping basket for catalog items with cost centre assignment.",
+        "x-schema-org": "schema:Order",
+        "type": "object",
+        "required": [
+          "requisitionerId",
+          "status"
+        ],
+        "properties": {
+          "requisitionerId": {
+            "type": "string",
+            "description": "userId of the requisitioner"
+          },
+          "status": {
+            "type": "string",
+            "description": "Basket lifecycle status",
+            "enum": ["open", "submitted", "approved", "rejected"],
+            "default": "open"
+          },
+          "costCentreId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the assigned Budget/cost centre"
+          },
+          "glAccountCode": {
+            "type": "string",
+            "description": "General ledger account code"
+          },
+          "totalAmount": {
+            "type": "number",
+            "description": "Running total (computed on save)",
+            "default": 0
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO 4217 currency code",
+            "default": "EUR"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Requisitioner notes"
+          },
+          "submittedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the basket was submitted for approval"
+          },
+          "approvedBy": {
+            "type": "string",
+            "description": "userId who approved the requisition"
+          },
+          "approvedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of approval decision"
+          }
+        }
+      },
+      "orderBasketLine": {
+        "slug": "order-basket-line",
+        "icon": "CartOutline",
+        "version": "0.1.0",
+        "title": "Order Basket Line",
+        "description": "Individual line item within an order basket.",
+        "x-schema-org": "schema:OrderItem",
+        "type": "object",
+        "required": [
+          "basketId",
+          "catalogItemId",
+          "quantity",
+          "unitPrice"
+        ],
+        "properties": {
+          "basketId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the parent OrderBasket"
+          },
+          "catalogItemId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the CatalogItem"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Ordered quantity",
+            "default": 1
+          },
+          "unitPrice": {
+            "type": "number",
+            "description": "Unit price at time of adding to basket (snapshot from CatalogItem)"
+          },
+          "lineTotal": {
+            "type": "number",
+            "description": "quantity × unitPrice (computed on save)"
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO 4217 currency code",
+            "default": "EUR"
+          }
+        }
+      },
+      "purchaseOrder": {
+        "slug": "purchase-order",
+        "icon": "ClipboardTextOutline",
+        "version": "0.1.0",
+        "title": "Purchase Order",
+        "description": "Purchase order sent to a supplier with sequential PO numbering and full lifecycle tracking.",
+        "x-schema-org": "schema:Order",
+        "type": "object",
+        "required": [
+          "poNumber",
+          "supplierProfileId",
+          "status",
+          "createdBy"
+        ],
+        "properties": {
+          "poNumber": {
+            "type": "string",
+            "description": "Auto-generated PO number (e.g. PO-2026-00001)",
+            "example": "PO-2026-00001"
+          },
+          "supplierProfileId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the SupplierProfile"
+          },
+          "status": {
+            "type": "string",
+            "description": "PO lifecycle status",
+            "enum": ["draft", "submitted", "acknowledged", "partially_received", "received", "invoiced", "closed", "cancelled"],
+            "default": "draft"
+          },
+          "orderBasketId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the originating OrderBasket"
+          },
+          "deliveryAddress": {
+            "type": "string",
+            "description": "Delivery address text"
+          },
+          "expectedDeliveryDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Expected delivery date"
+          },
+          "transmittedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when PO was sent to supplier"
+          },
+          "acknowledgedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when supplier acknowledged the PO"
+          },
+          "totalAmount": {
+            "type": "number",
+            "description": "PO total (computed from lines)"
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO 4217 currency code",
+            "default": "EUR"
+          },
+          "costCentreId": {
+            "type": "string",
+            "description": "Budget / cost centre reference"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "userId who created the PO"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Internal notes"
+          }
+        }
+      },
+      "purchaseOrderLine": {
+        "slug": "purchase-order-line",
+        "icon": "ClipboardTextOutline",
+        "version": "0.1.0",
+        "title": "Purchase Order Line",
+        "description": "Individual line item within a purchase order with three-way matching status.",
+        "x-schema-org": "schema:OrderItem",
+        "type": "object",
+        "required": [
+          "purchaseOrderId",
+          "productId",
+          "quantity",
+          "unitPrice"
+        ],
+        "properties": {
+          "purchaseOrderId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the parent PurchaseOrder"
+          },
+          "productId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the Product"
+          },
+          "description": {
+            "type": "string",
+            "description": "Line description (defaults to Product.name)"
+          },
+          "quantity": {
+            "type": "number",
+            "description": "Ordered quantity"
+          },
+          "unitPrice": {
+            "type": "number",
+            "description": "Agreed unit price"
+          },
+          "lineTotal": {
+            "type": "number",
+            "description": "quantity × unitPrice (computed on save)"
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO 4217 currency code",
+            "default": "EUR"
+          },
+          "matchStatus": {
+            "type": "string",
+            "description": "Three-way matching status",
+            "enum": ["pending", "matched", "discrepancy", "not_received"],
+            "default": "pending"
+          },
+          "receivedQuantity": {
+            "type": "number",
+            "description": "Cumulative quantity confirmed received",
+            "default": 0
+          },
+          "invoicedQuantity": {
+            "type": "number",
+            "description": "Cumulative quantity on matched invoices",
+            "default": 0
+          }
+        }
+      },
+      "goodsReceipt": {
+        "slug": "goods-receipt",
+        "icon": "TruckDeliveryOutline",
+        "version": "0.1.0",
+        "title": "Goods Receipt",
+        "description": "Confirmation of goods or services received against a purchase order.",
+        "x-schema-org": "schema:ReceiveAction",
+        "type": "object",
+        "required": [
+          "purchaseOrderId",
+          "receivedBy",
+          "receivedAt"
+        ],
+        "properties": {
+          "purchaseOrderId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the PurchaseOrder"
+          },
+          "receivedBy": {
+            "type": "string",
+            "description": "userId who confirmed receipt"
+          },
+          "receivedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of goods receipt"
+          },
+          "deliveryReference": {
+            "type": "string",
+            "description": "Supplier delivery note or tracking reference"
+          },
+          "notes": {
+            "type": "string",
+            "description": "General receipt notes"
+          },
+          "matchStatus": {
+            "type": "string",
+            "description": "Overall receipt matching status",
+            "enum": ["pending", "matched", "discrepancy"],
+            "default": "pending"
+          }
+        }
+      },
+      "goodsReceiptLine": {
+        "slug": "goods-receipt-line",
+        "icon": "TruckDeliveryOutline",
+        "version": "0.1.0",
+        "title": "Goods Receipt Line",
+        "description": "Per-line received quantity for a goods receipt.",
+        "x-schema-org": "schema:OrderItem",
+        "type": "object",
+        "required": [
+          "goodsReceiptId",
+          "purchaseOrderLineId",
+          "receivedQuantity"
+        ],
+        "properties": {
+          "goodsReceiptId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the parent GoodsReceipt"
+          },
+          "purchaseOrderLineId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the PurchaseOrderLine"
+          },
+          "receivedQuantity": {
+            "type": "number",
+            "description": "Actually received quantity"
+          },
+          "discrepancyNote": {
+            "type": "string",
+            "description": "Note explaining quantity or condition discrepancy"
+          }
+        }
+      },
+      "rFQ": {
+        "slug": "rfq",
+        "icon": "FileDocumentEditOutline",
+        "version": "0.1.0",
+        "title": "RFQ",
+        "description": "Request for Quotation for multi-supplier solicitation and evaluation.",
+        "x-schema-org": "schema:Quotation",
+        "type": "object",
+        "required": [
+          "number",
+          "title",
+          "createdBy"
+        ],
+        "properties": {
+          "number": {
+            "type": "string",
+            "description": "Unique RFQ number (auto-generated)",
+            "example": "RFQ-2026-00001"
+          },
+          "title": {
+            "type": "string",
+            "description": "RFQ title",
+            "example": "RFQ — IT Hardware Q3 2026"
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed RFQ description and requirements"
+          },
+          "type": {
+            "type": "string",
+            "description": "Solicitation type",
+            "enum": ["RFI", "RFP", "RFQ", "Auction"],
+            "default": "RFQ"
+          },
+          "status": {
+            "type": "string",
+            "description": "RFQ lifecycle status",
+            "enum": ["draft", "published", "evaluating", "awarded", "closed"],
+            "default": "draft"
+          },
+          "budget": {
+            "type": "number",
+            "description": "Budget envelope for this RFQ",
+            "example": 5000.00
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO 4217 currency code",
+            "default": "EUR"
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Deadline for supplier responses"
+          },
+          "publishedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when published to suppliers"
+          },
+          "awardedSupplierProfileId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the awarded SupplierProfile"
+          },
+          "awardedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of award"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "userId of the procurement officer"
+          },
+          "invitedSupplierProfileIds": {
+            "type": "array",
+            "description": "Array of SupplierProfile object IDs invited to respond",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          }
+        }
+      },
+      "supplierQuote": {
+        "slug": "supplier-quote",
+        "icon": "CurrencyEur",
+        "version": "0.1.0",
+        "title": "Supplier Quote",
+        "description": "A supplier's response to an RFQ with pricing and evaluation scoring.",
+        "x-schema-org": "schema:Offer",
+        "type": "object",
+        "required": [
+          "rfqId",
+          "supplierProfileId",
+          "status"
+        ],
+        "properties": {
+          "rfqId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the parent RFQ"
+          },
+          "supplierProfileId": {
+            "type": "string",
+            "description": "OpenRegister object ID of the quoting SupplierProfile"
+          },
+          "status": {
+            "type": "string",
+            "description": "Quote status",
+            "enum": ["submitted", "accepted", "rejected"],
+            "default": "submitted"
+          },
+          "totalAmount": {
+            "type": "number",
+            "description": "Supplier's total quoted price",
+            "example": 4200.00
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO 4217 currency code",
+            "default": "EUR"
+          },
+          "validUntil": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Quote validity deadline"
+          },
+          "notes": {
+            "type": "string",
+            "description": "Supplier's narrative or conditions"
+          },
+          "submittedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of quote submission"
+          },
+          "evaluationScore": {
+            "type": "number",
+            "description": "Numeric score assigned during evaluation"
+          },
+          "evaluationNotes": {
+            "type": "string",
+            "description": "Evaluator's notes"
+          },
+          "evaluatedBy": {
+            "type": "string",
+            "description": "userId of the evaluator"
+          },
+          "documentIds": {
+            "type": "array",
+            "description": "Array of Document object IDs attached to this quote",
+            "items": {
+              "type": "string"
+            },
+            "default": []
           }
         }
       }

--- a/openspec/changes/catalog-purchase-management/specs/catalog-purchase-management/spec.md
+++ b/openspec/changes/catalog-purchase-management/specs/catalog-purchase-management/spec.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: pr-created
 ---
 
 # Catalog & Purchase Management — Shillinq

--- a/openspec/changes/catalog-purchase-management/tasks.md
+++ b/openspec/changes/catalog-purchase-management/tasks.md
@@ -2,7 +2,7 @@
 
 ## 1. OpenRegister Schema Definitions
 
-- [ ] 1.1 Add `productCategory` schema to `lib/Settings/shillinq_register.json`
+- [x] 1.1 Add `productCategory` schema to `lib/Settings/shillinq_register.json`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-001`
   - **files**: `lib/Settings/shillinq_register.json`
   - **acceptance_criteria**:
@@ -10,28 +10,28 @@
     - THEN schema `productCategory` MUST be registered with `name` (required), `code`, `description`, `parentCategoryId`, `active` (boolean, default true), `sortOrder` (integer, default 0)
     - AND `x-schema-org` annotation MUST be `schema:Thing`
 
-- [ ] 1.2 Add `product` schema to `lib/Settings/shillinq_register.json`
+- [x] 1.2 Add `product` schema to `lib/Settings/shillinq_register.json`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-001`
   - **files**: `lib/Settings/shillinq_register.json`
   - **acceptance_criteria**:
     - THEN schema `product` MUST exist with `sku` (required), `name` (required), `description`, `unit` (default "piece"), `active` (boolean, default true), `categoryId`, `purchasePrice` (number), `currency` (default "EUR"), `taxRate` (number, default 21), `leadTimeDays` (integer), `notes`
     - AND `x-schema-org` MUST be `schema:Product`
 
-- [ ] 1.3 Add `catalog` schema to `lib/Settings/shillinq_register.json`
+- [x] 1.3 Add `catalog` schema to `lib/Settings/shillinq_register.json`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-002`
   - **files**: `lib/Settings/shillinq_register.json`
   - **acceptance_criteria**:
     - THEN schema `catalog` MUST exist with `name` (required), `description`, `status` (required, enum `["draft","active","archived"]`, default "draft"), `supplierProfileId`, `effectiveFrom` (datetime), `effectiveTo` (datetime), `ownerId`, `contractReference`
     - AND `x-schema-org` MUST be `schema:CreativeWork`
 
-- [ ] 1.4 Add `catalogItem` schema to `lib/Settings/shillinq_register.json`
+- [x] 1.4 Add `catalogItem` schema to `lib/Settings/shillinq_register.json`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-002`
   - **files**: `lib/Settings/shillinq_register.json`
   - **acceptance_criteria**:
     - THEN schema `catalogItem` MUST exist with `catalogId` (required), `productId` (required), `supplierProfileId` (required), `unitPrice` (required, number), `currency` (default "EUR"), `minimumOrderQuantity` (integer, default 1), `leadTimeDays` (integer), `active` (boolean, default true), `notes`
     - AND `x-schema-org` MUST be `schema:Offer`
 
-- [ ] 1.5 Add `orderBasket` and `orderBasketLine` schemas to `lib/Settings/shillinq_register.json`
+- [x] 1.5 Add `orderBasket` and `orderBasketLine` schemas to `lib/Settings/shillinq_register.json`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-003`
   - **files**: `lib/Settings/shillinq_register.json`
   - **acceptance_criteria**:
@@ -39,7 +39,7 @@
     - AND schema `orderBasketLine` MUST exist with `basketId` (required), `catalogItemId` (required), `quantity` (required, number), `unitPrice` (required, number), `lineTotal` (number), `currency` (default "EUR")
     - AND both MUST have `x-schema-org: schema:Order` and `schema:OrderItem` respectively
 
-- [ ] 1.6 Add `purchaseOrder` and `purchaseOrderLine` schemas to `lib/Settings/shillinq_register.json`
+- [x] 1.6 Add `purchaseOrder` and `purchaseOrderLine` schemas to `lib/Settings/shillinq_register.json`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-004`
   - **files**: `lib/Settings/shillinq_register.json`
   - **acceptance_criteria**:
@@ -47,7 +47,7 @@
     - AND schema `purchaseOrderLine` MUST exist with `purchaseOrderId` (required), `productId` (required), `description`, `quantity` (required, number), `unitPrice` (required, number), `lineTotal` (number), `currency` (default "EUR"), `matchStatus` (enum `["pending","matched","discrepancy","not_received"]`, default "pending"), `receivedQuantity` (number, default 0), `invoicedQuantity` (number, default 0)
     - AND `x-schema-org` MUST be `schema:Order` and `schema:OrderItem` respectively
 
-- [ ] 1.7 Add `goodsReceipt` and `goodsReceiptLine` schemas to `lib/Settings/shillinq_register.json`
+- [x] 1.7 Add `goodsReceipt` and `goodsReceiptLine` schemas to `lib/Settings/shillinq_register.json`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-005`
   - **files**: `lib/Settings/shillinq_register.json`
   - **acceptance_criteria**:
@@ -55,14 +55,14 @@
     - AND schema `goodsReceiptLine` MUST exist with `goodsReceiptId` (required), `purchaseOrderLineId` (required), `receivedQuantity` (required, number), `discrepancyNote`
     - AND `x-schema-org` MUST be `schema:ReceiveAction` and `schema:OrderItem` respectively
 
-- [ ] 1.8 Add `rFQ` schema to `lib/Settings/shillinq_register.json`
+- [x] 1.8 Add `rFQ` schema to `lib/Settings/shillinq_register.json`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-007`
   - **files**: `lib/Settings/shillinq_register.json`
   - **acceptance_criteria**:
     - THEN schema `rFQ` MUST exist with `number` (required), `title` (required), `description`, `type` (enum `["RFI","RFP","RFQ","Auction"]`, default "RFQ"), `status` (enum `["draft","published","evaluating","awarded","closed"]`, default "draft"), `budget` (number), `currency` (default "EUR"), `dueDate` (datetime), `publishedAt` (datetime), `awardedSupplierProfileId`, `awardedAt` (datetime), `createdBy` (required), `invitedSupplierProfileIds` (array, default [])
     - AND `x-schema-org` MUST be `schema:Quotation`
 
-- [ ] 1.9 Add `supplierQuote` schema to `lib/Settings/shillinq_register.json`
+- [x] 1.9 Add `supplierQuote` schema to `lib/Settings/shillinq_register.json`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-007`
   - **files**: `lib/Settings/shillinq_register.json`
   - **acceptance_criteria**:
@@ -71,7 +71,7 @@
 
 ## 2. Seed Data
 
-- [ ] 2.1 Add ProductCategory and Product seed objects to `lib/Repair/CreateDefaultConfiguration.php`
+- [x] 2.1 Add ProductCategory and Product seed objects to `lib/Repair/CreateDefaultConfiguration.php`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-009`
   - **files**: `lib/Repair/CreateDefaultConfiguration.php`
   - **acceptance_criteria**:
@@ -80,7 +80,7 @@
     - AND 4 Product objects MUST be created: PAPER-A4-80, PEN-BLK-10, LAPTOP-15-STD, MOUSE-USB-STD with the prices, units, and tax rates from the seed data table
     - AND idempotency key for ProductCategory MUST be `code`; for Product MUST be `sku`
 
-- [ ] 2.2 Add Catalog and CatalogItem seed objects to repair step
+- [x] 2.2 Add Catalog and CatalogItem seed objects to repair step
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-009`
   - **files**: `lib/Repair/CreateDefaultConfiguration.php`
   - **acceptance_criteria**:
@@ -88,7 +88,7 @@
     - AND 4 CatalogItem objects MUST be created linking each seed product to the catalog at seed purchase prices, linked to Acme BV SupplierProfile from supplier-management seed
     - AND idempotency key for CatalogItem MUST be composite `(catalogId, productId)`
 
-- [ ] 2.3 Add PurchaseOrder seed object to repair step
+- [x] 2.3 Add PurchaseOrder seed object to repair step
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-009`
   - **files**: `lib/Repair/CreateDefaultConfiguration.php`
   - **acceptance_criteria**:
@@ -96,7 +96,7 @@
     - AND 2 PurchaseOrderLines MUST be created: 5 reams PAPER-A4-80 (EUR 22.50) and 5 boxes PEN-BLK-10 (EUR 16.00), referencing Product IDs resolved at seed time
     - AND idempotency key for PurchaseOrder MUST be `poNumber`
 
-- [ ] 2.4 Add RFQ and SupplierQuote seed objects to repair step
+- [x] 2.4 Add RFQ and SupplierQuote seed objects to repair step
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-009`
   - **files**: `lib/Repair/CreateDefaultConfiguration.php`
   - **acceptance_criteria**:
@@ -106,7 +106,7 @@
 
 ## 3. Backend Services
 
-- [ ] 3.1 Create `lib/Service/CatalogSearchService.php`
+- [x] 3.1 Create `lib/Service/CatalogSearchService.php`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-002, #REQ-CAT-003`
   - **files**: `lib/Service/CatalogSearchService.php`
   - **acceptance_criteria**:
@@ -116,7 +116,7 @@
     - AND only items where the linked `Product.active` is `true` are returned
     - AND category filter applies to the product's `categoryId` AND all descendant category IDs (resolved via `ProductCategory.parentCategoryId` traversal)
 
-- [ ] 3.2 Create `lib/Service/OrderLimitService.php`
+- [x] 3.2 Create `lib/Service/OrderLimitService.php`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-003`
   - **files**: `lib/Service/OrderLimitService.php`
   - **acceptance_criteria**:
@@ -125,7 +125,7 @@
     - AND returns a boolean `requiresApproval` and the applicable limit amount
     - AND if no limit is configured, `requiresApproval` is always false
 
-- [ ] 3.3 Create `lib/Service/ThreeWayMatchingService.php`
+- [x] 3.3 Create `lib/Service/ThreeWayMatchingService.php`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-006`
   - **files**: `lib/Service/ThreeWayMatchingService.php`
   - **acceptance_criteria**:
@@ -137,7 +137,7 @@
     - AND MUST NOT modify any invoice or goods receipt objects; only `PurchaseOrderLine.matchStatus`, `receivedQuantity`, and `invoicedQuantity` are updated
     - AND the service is idempotent: calling it twice with unchanged data produces no further updates
 
-- [ ] 3.4 Create `lib/Service/CatalogImportService.php`
+- [x] 3.4 Create `lib/Service/CatalogImportService.php`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-002`
   - **files**: `lib/Service/CatalogImportService.php`
   - **acceptance_criteria**:
@@ -150,7 +150,7 @@
 
 ## 4. Background Jobs
 
-- [ ] 4.1 Create `lib/BackgroundJob/OverdueDeliveryJob.php`
+- [x] 4.1 Create `lib/BackgroundJob/OverdueDeliveryJob.php`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-008`
   - **files**: `lib/BackgroundJob/OverdueDeliveryJob.php`, `lib/AppInfo/Application.php`
   - **acceptance_criteria**:
@@ -162,7 +162,7 @@
 
 ## 5. Backend Controllers
 
-- [ ] 5.1 Create `lib/Controller/CatalogController.php`
+- [x] 5.1 Create `lib/Controller/CatalogController.php`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-002, #REQ-CAT-003`
   - **files**: `lib/Controller/CatalogController.php`, `appinfo/routes.php`
   - **acceptance_criteria**:
@@ -173,7 +173,7 @@
     - GIVEN `POST /api/v1/catalogs/{id}/import` is called for an archived catalog
     - THEN 422 is returned with "Cannot add items to an archived catalog."
 
-- [ ] 5.2 Create `lib/Controller/OrderBasketController.php`
+- [x] 5.2 Create `lib/Controller/OrderBasketController.php`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-003`
   - **files**: `lib/Controller/OrderBasketController.php`, `appinfo/routes.php`
   - **acceptance_criteria**:
@@ -182,7 +182,7 @@
     - AND `OrderBasket.requisitionerId` MUST always be set server-side to the authenticated userId; any client-supplied value is ignored
     - AND the budget check against the `Budget` entity for the selected `costCentreId` is performed; if available budget is insufficient, the response includes `{budgetWarning: true, deficit: N}` alongside the 200 success response
 
-- [ ] 5.3 Create `lib/Controller/PurchaseOrderController.php`
+- [x] 5.3 Create `lib/Controller/PurchaseOrderController.php`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-004`
   - **files**: `lib/Controller/PurchaseOrderController.php`, `appinfo/routes.php`
   - **acceptance_criteria**:
@@ -192,7 +192,7 @@
     - THEN reason is required; 422 if empty; status changes to `cancelled` and supplier is notified
     - GIVEN a new PO is created THEN `poNumber` is auto-generated in format `PO-{YYYY}-{NNNNN}` using the highest existing sequence number for the current year + 1
 
-- [ ] 5.4 Create `lib/Controller/GoodsReceiptController.php`
+- [x] 5.4 Create `lib/Controller/GoodsReceiptController.php`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-005`
   - **files**: `lib/Controller/GoodsReceiptController.php`, `appinfo/routes.php`
   - **acceptance_criteria**:
@@ -203,7 +203,7 @@
     - AND if all lines are fully received, `PurchaseOrder.status` changes to `received`
     - GIVEN the PO has `status: closed` THEN 422 is returned with "Cannot create a goods receipt for a closed purchase order."
 
-- [ ] 5.5 Create `lib/Controller/RFQController.php`
+- [x] 5.5 Create `lib/Controller/RFQController.php`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-007`
   - **files**: `lib/Controller/RFQController.php`, `appinfo/routes.php`
   - **acceptance_criteria**:
@@ -215,59 +215,59 @@
 
 ## 6. Pinia Stores
 
-- [ ] 6.1 Create `src/store/modules/productCategory.js`
+- [x] 6.1 Create `src/store/modules/productCategory.js`
   - **files**: `src/store/modules/productCategory.js`
   - **acceptance_criteria**:
     - THEN `useProductCategoryStore` MUST be created via `createObjectStore('productCategory')` and registered in `src/store/store.js`
 
-- [ ] 6.2 Create `src/store/modules/product.js`
+- [x] 6.2 Create `src/store/modules/product.js`
   - **files**: `src/store/modules/product.js`
   - **acceptance_criteria**:
     - THEN `useProductStore` MUST be created via `createObjectStore('product')` and registered in `src/store/store.js`
 
-- [ ] 6.3 Create `src/store/modules/catalog.js`
+- [x] 6.3 Create `src/store/modules/catalog.js`
   - **files**: `src/store/modules/catalog.js`
   - **acceptance_criteria**:
     - THEN `useCatalogStore` MUST be created via `createObjectStore('catalog')` and registered in `src/store/store.js`
 
-- [ ] 6.4 Create `src/store/modules/catalogItem.js`
+- [x] 6.4 Create `src/store/modules/catalogItem.js`
   - **files**: `src/store/modules/catalogItem.js`
   - **acceptance_criteria**:
     - THEN `useCatalogItemStore` MUST be created via `createObjectStore('catalogItem')` and registered in `src/store/store.js`
 
-- [ ] 6.5 Create `src/store/modules/orderBasket.js`
+- [x] 6.5 Create `src/store/modules/orderBasket.js`
   - **files**: `src/store/modules/orderBasket.js`
   - **acceptance_criteria**:
     - THEN `useOrderBasketStore` MUST be created via `createObjectStore('orderBasket')` and registered in `src/store/store.js`
 
-- [ ] 6.6 Create `src/store/modules/purchaseOrder.js`
+- [x] 6.6 Create `src/store/modules/purchaseOrder.js`
   - **files**: `src/store/modules/purchaseOrder.js`
   - **acceptance_criteria**:
     - THEN `usePurchaseOrderStore` MUST be created via `createObjectStore('purchaseOrder')` and registered in `src/store/store.js`
 
-- [ ] 6.7 Create `src/store/modules/goodsReceipt.js`
+- [x] 6.7 Create `src/store/modules/goodsReceipt.js`
   - **files**: `src/store/modules/goodsReceipt.js`
   - **acceptance_criteria**:
     - THEN `useGoodsReceiptStore` MUST be created via `createObjectStore('goodsReceipt')` and registered in `src/store/store.js`
 
-- [ ] 6.8 Create `src/store/modules/rFQ.js`
+- [x] 6.8 Create `src/store/modules/rFQ.js`
   - **files**: `src/store/modules/rFQ.js`
   - **acceptance_criteria**:
     - THEN `useRFQStore` MUST be created via `createObjectStore('rFQ')` and registered in `src/store/store.js`
 
-- [ ] 6.9 Create `src/store/modules/supplierQuote.js`
+- [x] 6.9 Create `src/store/modules/supplierQuote.js`
   - **files**: `src/store/modules/supplierQuote.js`
   - **acceptance_criteria**:
     - THEN `useSupplierQuoteStore` MUST be created via `createObjectStore('supplierQuote')` and registered in `src/store/store.js`
 
-- [ ] 6.10 Create `src/store/modules/supplier.js`
+- [x] 6.10 Create `src/store/modules/supplier.js`
   - **files**: `src/store/modules/supplier.js`
   - **acceptance_criteria**:
     - THEN `useSupplierStore` MUST be created via `createObjectStore('supplierProfile')` (referencing the supplier-management schema) and registered in `src/store/store.js`
 
 ## 7. Frontend Views — Product and Category
 
-- [ ] 7.1 Create `src/views/productCategory/ProductCategoryIndex.vue`, `ProductCategoryDetail.vue`, `ProductCategoryForm.vue`
+- [x] 7.1 Create `src/views/productCategory/ProductCategoryIndex.vue`, `ProductCategoryDetail.vue`, `ProductCategoryForm.vue`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-001`
   - **files**: `src/views/productCategory/ProductCategoryIndex.vue`, `src/views/productCategory/ProductCategoryDetail.vue`, `src/views/productCategory/ProductCategoryForm.vue`
   - **acceptance_criteria**:
@@ -275,7 +275,7 @@
     - GIVEN the detail renders THEN it uses `CnDetailPage` with tabs: Details, Products (listing `Product` objects where `categoryId` matches)
     - GIVEN the form opens THEN `parentCategoryId` uses a dropdown populated from existing categories
 
-- [ ] 7.2 Create `src/views/product/ProductIndex.vue`, `ProductDetail.vue`, `ProductForm.vue`
+- [x] 7.2 Create `src/views/product/ProductIndex.vue`, `ProductDetail.vue`, `ProductForm.vue`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-001`
   - **files**: `src/views/product/ProductIndex.vue`, `src/views/product/ProductDetail.vue`, `src/views/product/ProductForm.vue`
   - **acceptance_criteria**:
@@ -285,7 +285,7 @@
 
 ## 8. Frontend Views — Catalog
 
-- [ ] 8.1 Create `src/views/catalog/CatalogIndex.vue`, `CatalogDetail.vue`, `CatalogForm.vue`
+- [x] 8.1 Create `src/views/catalog/CatalogIndex.vue`, `CatalogDetail.vue`, `CatalogForm.vue`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-002`
   - **files**: `src/views/catalog/CatalogIndex.vue`, `src/views/catalog/CatalogDetail.vue`, `src/views/catalog/CatalogForm.vue`
   - **acceptance_criteria**:
@@ -293,7 +293,7 @@
     - GIVEN the detail renders THEN it uses `CnDetailPage` with tabs: Details, Items (CatalogItem list), Import (CSV upload panel via `CatalogImportPanel.vue`)
     - AND status transition buttons (Activate, Archive) MUST be shown per permitted roles; archived catalogs MUST show a read-only banner "This catalog is archived"
 
-- [ ] 8.2 Create `src/views/catalog/CatalogSearch.vue`
+- [x] 8.2 Create `src/views/catalog/CatalogSearch.vue`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-003`
   - **files**: `src/views/catalog/CatalogSearch.vue`
   - **acceptance_criteria**:
@@ -302,7 +302,7 @@
     - AND each result row shows: product name, supplier name, unit price + currency, catalog name, contract reference, and an "Add to basket" button with a quantity input
     - AND clicking "Add to basket" calls `useOrderBasketStore.addLine()` and updates the `OrderBasketPanel` badge count
 
-- [ ] 8.3 Create `src/components/CatalogImportPanel.vue`
+- [x] 8.3 Create `src/components/CatalogImportPanel.vue`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-002`
   - **files**: `src/components/CatalogImportPanel.vue`
   - **acceptance_criteria**:
@@ -311,7 +311,7 @@
 
 ## 9. Frontend Views — Order Basket
 
-- [ ] 9.1 Create `src/views/orderBasket/OrderBasketView.vue`
+- [x] 9.1 Create `src/views/orderBasket/OrderBasketView.vue`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-003`
   - **files**: `src/views/orderBasket/OrderBasketView.vue`
   - **acceptance_criteria**:
@@ -320,7 +320,7 @@
     - GIVEN the cost centre selector is used THEN only `Budget` objects the authenticated user is authorised to charge are shown
     - GIVEN submit is clicked THEN `POST /api/v1/order-baskets/{id}/submit` is called; if `budgetWarning: true` is returned, the warning banner is shown before the success message; if `requiresApproval: true`, the confirmation message reads "Your order has been sent for approval."
 
-- [ ] 9.2 Create `src/views/orderBasket/OrderBasketHistory.vue`
+- [x] 9.2 Create `src/views/orderBasket/OrderBasketHistory.vue`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-008`
   - **files**: `src/views/orderBasket/OrderBasketHistory.vue`
   - **acceptance_criteria**:
@@ -328,7 +328,7 @@
     - AND linked `PurchaseOrder.status` is shown per order: pending approval (amber), approved (blue), sent to supplier (blue), acknowledged (blue), overdue (red), delivered (green), invoiced (teal), closed (grey)
     - AND an "overdue" badge is shown for linked PurchaseOrders meeting the overdue criteria
 
-- [ ] 9.3 Create `src/components/OrderBasketPanel.vue`
+- [x] 9.3 Create `src/components/OrderBasketPanel.vue`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-003`
   - **files**: `src/components/OrderBasketPanel.vue`
   - **acceptance_criteria**:
@@ -337,7 +337,7 @@
 
 ## 10. Frontend Views — Purchase Order
 
-- [ ] 10.1 Create `src/views/purchaseOrder/PurchaseOrderIndex.vue`, `PurchaseOrderDetail.vue`, `PurchaseOrderForm.vue`
+- [x] 10.1 Create `src/views/purchaseOrder/PurchaseOrderIndex.vue`, `PurchaseOrderDetail.vue`, `PurchaseOrderForm.vue`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-004, #REQ-CAT-008`
   - **files**: `src/views/purchaseOrder/PurchaseOrderIndex.vue`, `src/views/purchaseOrder/PurchaseOrderDetail.vue`, `src/views/purchaseOrder/PurchaseOrderForm.vue`
   - **acceptance_criteria**:
@@ -349,7 +349,7 @@
 
 ## 11. Frontend Views — Goods Receipt
 
-- [ ] 11.1 Create `src/views/goodsReceipt/GoodsReceiptIndex.vue`, `GoodsReceiptDetail.vue`, `GoodsReceiptForm.vue`
+- [x] 11.1 Create `src/views/goodsReceipt/GoodsReceiptIndex.vue`, `GoodsReceiptDetail.vue`, `GoodsReceiptForm.vue`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-005`
   - **files**: `src/views/goodsReceipt/GoodsReceiptIndex.vue`, `src/views/goodsReceipt/GoodsReceiptDetail.vue`, `src/views/goodsReceipt/GoodsReceiptForm.vue`
   - **acceptance_criteria**:
@@ -357,7 +357,7 @@
     - AND a "Received quantity" validation MUST prevent values greater than the outstanding quantity (ordered − previously received) with message "Received quantity cannot exceed outstanding quantity of {N}"
     - GIVEN the form is submitted THEN `POST /api/v1/goods-receipts` is called; updated `matchStatus` values per line are reflected in the PO detail "Matching" tab immediately
 
-- [ ] 11.2 Create `src/components/ThreeWayMatchingPanel.vue`
+- [x] 11.2 Create `src/components/ThreeWayMatchingPanel.vue`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-006`
   - **files**: `src/components/ThreeWayMatchingPanel.vue`
   - **acceptance_criteria**:
@@ -368,7 +368,7 @@
 
 ## 12. Frontend Views — RFQ
 
-- [ ] 12.1 Create `src/views/rFQ/RFQIndex.vue`, `RFQDetail.vue`, `RFQForm.vue`
+- [x] 12.1 Create `src/views/rFQ/RFQIndex.vue`, `RFQDetail.vue`, `RFQForm.vue`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-007`
   - **files**: `src/views/rFQ/RFQIndex.vue`, `src/views/rFQ/RFQDetail.vue`, `src/views/rFQ/RFQForm.vue`
   - **acceptance_criteria**:
@@ -378,7 +378,7 @@
     - AND the Comparison tab renders `QuoteComparisonTable.vue`
     - AND an "Award" button on the Comparison tab calls `POST /api/v1/rfqs/{id}/award` with the selected quote ID; confirmation dialog shows "Awarding to {supplierName} will reject all other quotes. Continue?"
 
-- [ ] 12.2 Create `src/components/QuoteComparisonTable.vue`
+- [x] 12.2 Create `src/components/QuoteComparisonTable.vue`
   - **spec_ref**: `specs/catalog-purchase-management/spec.md#REQ-CAT-007`
   - **files**: `src/components/QuoteComparisonTable.vue`
   - **acceptance_criteria**:
@@ -389,7 +389,7 @@
 
 ## 13. Sidebar Navigation Update
 
-- [ ] 13.1 Add catalog and procurement sections to `src/components/ShillinqSidebar.vue`
+- [x] 13.1 Add catalog and procurement sections to `src/components/ShillinqSidebar.vue`
   - **files**: `src/components/ShillinqSidebar.vue`
   - **acceptance_criteria**:
     - GIVEN the sidebar renders THEN a "Catalog" section MUST be present with nav items: Catalog Search, My Basket, My Orders, Catalogs, Products, Categories

--- a/phpunit-unit.xml
+++ b/phpunit-unit.xml
@@ -28,14 +28,6 @@
         </exclude>
     </source>
 
-    <coverage>
-        <report>
-            <clover outputFile="coverage/clover.xml"/>
-            <html outputDirectory="coverage/html"/>
-            <text outputFile="php://stdout" showUncoveredFiles="false"/>
-        </report>
-    </coverage>
-
     <php>
         <env name="PHPUNIT_RUN" value="1"/>
         <env name="NEXTCLOUD_CONFIG_DIR" value="/var/www/html/config"/>

--- a/src/components/CatalogImportPanel.vue
+++ b/src/components/CatalogImportPanel.vue
@@ -1,0 +1,278 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-8.3 -->
+<template>
+	<div class="catalog-import-panel">
+		<h3>{{ t('shillinq', 'Import Catalog Items') }}</h3>
+
+		<p class="catalog-import-panel__description">
+			{{ t('shillinq', 'Upload a CSV file to import items into this catalog.') }}
+		</p>
+
+		<div class="catalog-import-panel__actions">
+			<NcButton type="secondary" @click="downloadTemplate">
+				<template #icon>
+					<DownloadIcon :size="20" />
+				</template>
+				{{ t('shillinq', 'Download template') }}
+			</NcButton>
+		</div>
+
+		<div class="catalog-import-panel__upload">
+			<label class="catalog-import-panel__file-label">
+				<FileUploadOutlineIcon :size="20" />
+				{{ selectedFile ? selectedFile.name : t('shillinq', 'Choose CSV file...') }}
+				<input
+					ref="fileInput"
+					type="file"
+					accept=".csv"
+					class="catalog-import-panel__file-input"
+					@change="onFileSelected">
+			</label>
+
+			<NcButton
+				type="primary"
+				:disabled="!selectedFile || importing"
+				@click="importFile">
+				<template v-if="importing" #icon>
+					<NcLoadingIcon :size="20" />
+				</template>
+				<template v-else #icon>
+					<UploadIcon :size="20" />
+				</template>
+				{{ t('shillinq', 'Import') }}
+			</NcButton>
+		</div>
+
+		<!-- Success message -->
+		<div v-if="importedCount !== null" class="catalog-import-panel__success">
+			<CheckCircleIcon :size="20" />
+			{{ t('shillinq', '{count} items imported successfully.', { count: importedCount }) }}
+		</div>
+
+		<!-- Error table -->
+		<div v-if="importErrors.length > 0" class="catalog-import-panel__errors">
+			<h4>{{ t('shillinq', 'Import Errors') }}</h4>
+			<table class="catalog-import-panel__error-table">
+				<thead>
+					<tr>
+						<th>{{ t('shillinq', 'Row') }}</th>
+						<th>{{ t('shillinq', 'SKU') }}</th>
+						<th>{{ t('shillinq', 'Error') }}</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr v-for="(error, index) in importErrors" :key="index">
+						<td>{{ error.row }}</td>
+						<td>{{ error.sku || '-' }}</td>
+						<td>{{ error.message }}</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcLoadingIcon } from '@nextcloud/vue'
+import { generateUrl } from '@nextcloud/router'
+import CheckCircleIcon from 'vue-material-design-icons/CheckCircle.vue'
+import DownloadIcon from 'vue-material-design-icons/Download.vue'
+import FileUploadOutlineIcon from 'vue-material-design-icons/FileUploadOutline.vue'
+import UploadIcon from 'vue-material-design-icons/Upload.vue'
+
+const CSV_TEMPLATE_HEADERS = [
+	'sku',
+	'productName',
+	'description',
+	'unitPrice',
+	'currency',
+	'unitOfMeasure',
+	'category',
+	'leadTimeDays',
+	'minimumOrderQuantity',
+]
+
+export default {
+	name: 'CatalogImportPanel',
+	components: {
+		NcButton,
+		NcLoadingIcon,
+		CheckCircleIcon,
+		DownloadIcon,
+		FileUploadOutlineIcon,
+		UploadIcon,
+	},
+
+	props: {
+		catalogId: {
+			type: String,
+			required: true,
+		},
+	},
+
+	emits: ['imported'],
+
+	data() {
+		return {
+			selectedFile: null,
+			importing: false,
+			importedCount: null,
+			importErrors: [],
+		}
+	},
+
+	methods: {
+		t(app, text, params) {
+			return t(app, text, params)
+		},
+
+		downloadTemplate() {
+			const csvContent = CSV_TEMPLATE_HEADERS.join(',') + '\n'
+				+ 'SKU-001,Example Product,Description,10.00,EUR,piece,General,5,1\n'
+			const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+			const url = URL.createObjectURL(blob)
+			const link = document.createElement('a')
+			link.href = url
+			link.download = 'catalog-import-template.csv'
+			link.click()
+			URL.revokeObjectURL(url)
+		},
+
+		onFileSelected(event) {
+			this.selectedFile = event.target.files[0] || null
+			this.importedCount = null
+			this.importErrors = []
+		},
+
+		async importFile() {
+			if (!this.selectedFile) return
+
+			this.importing = true
+			this.importedCount = null
+			this.importErrors = []
+
+			try {
+				const formData = new FormData()
+				formData.append('file', this.selectedFile)
+
+				const url = generateUrl(`/apps/shillinq/api/v1/catalogs/${this.catalogId}/import`)
+				const response = await fetch(url, {
+					method: 'POST',
+					headers: {
+						requesttoken: OC.requestToken,
+					},
+					body: formData,
+				})
+
+				const data = await response.json()
+
+				if (response.ok) {
+					this.importedCount = data.importedCount || 0
+					this.importErrors = data.errors || []
+					this.$emit('imported')
+				} else {
+					this.importErrors = data.errors || [
+						{ row: '-', sku: '-', message: data.message || 'Import failed' },
+					]
+				}
+			} catch (error) {
+				console.error('Import failed:', error)
+				this.importErrors = [
+					{ row: '-', sku: '-', message: error.message || 'Network error' },
+				]
+			} finally {
+				this.importing = false
+				this.selectedFile = null
+				if (this.$refs.fileInput) {
+					this.$refs.fileInput.value = ''
+				}
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.catalog-import-panel {
+	padding: 8px 0;
+}
+
+.catalog-import-panel h3 {
+	margin: 0 0 8px;
+	font-size: 18px;
+	font-weight: 600;
+}
+
+.catalog-import-panel__description {
+	margin: 0 0 12px;
+	color: var(--color-text-maxcontrast);
+}
+
+.catalog-import-panel__actions {
+	margin-bottom: 16px;
+}
+
+.catalog-import-panel__upload {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-bottom: 16px;
+}
+
+.catalog-import-panel__file-label {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 12px;
+	border: 1px dashed var(--color-border);
+	border-radius: var(--border-radius);
+	cursor: pointer;
+	color: var(--color-text-maxcontrast);
+}
+
+.catalog-import-panel__file-label:hover {
+	border-color: var(--color-primary);
+	color: var(--color-primary);
+}
+
+.catalog-import-panel__file-input {
+	display: none;
+}
+
+.catalog-import-panel__success {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 10px 16px;
+	background-color: var(--color-success-hover);
+	border-radius: var(--border-radius-large);
+	color: var(--color-success-text);
+	margin-bottom: 12px;
+}
+
+.catalog-import-panel__errors {
+	margin-top: 12px;
+}
+
+.catalog-import-panel__errors h4 {
+	margin: 0 0 8px;
+	color: var(--color-error);
+}
+
+.catalog-import-panel__error-table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.catalog-import-panel__error-table th,
+.catalog-import-panel__error-table td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.catalog-import-panel__error-table tr:nth-child(even) {
+	background-color: var(--color-background-dark);
+}
+</style>

--- a/src/components/OrderBasketPanel.vue
+++ b/src/components/OrderBasketPanel.vue
@@ -1,0 +1,231 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-9.3 -->
+<template>
+	<div class="basket-panel" :class="{ 'basket-panel--expanded': expanded }">
+		<button class="basket-panel__toggle" @click="expanded = !expanded">
+			<CartIcon :size="24" />
+			<span v-if="itemCount > 0" class="basket-panel__badge">
+				{{ itemCount }}
+			</span>
+			<span class="basket-panel__total">
+				{{ formatPrice(basketTotal) }}
+			</span>
+		</button>
+
+		<div v-if="expanded" class="basket-panel__dropdown">
+			<h4 class="basket-panel__title">
+				{{ t('shillinq', 'Your Basket') }}
+			</h4>
+
+			<div v-if="lines.length === 0" class="basket-panel__empty">
+				{{ t('shillinq', 'No items in basket') }}
+			</div>
+
+			<ul v-else class="basket-panel__lines">
+				<li v-for="line in lines" :key="line.id" class="basket-panel__line">
+					<span class="basket-panel__line-name">{{ line.productName }}</span>
+					<span class="basket-panel__line-qty">x{{ line.quantity }}</span>
+					<span class="basket-panel__line-price">
+						{{ formatPrice(line.quantity * line.unitPrice) }}
+					</span>
+				</li>
+			</ul>
+
+			<div class="basket-panel__footer">
+				<strong>{{ t('shillinq', 'Total') }}: {{ formatPrice(basketTotal) }}</strong>
+				<NcButton type="primary" :to="{ name: 'OrderBasket' }" @click="expanded = false">
+					{{ t('shillinq', 'Go to basket') }}
+				</NcButton>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcButton } from '@nextcloud/vue'
+import { generateUrl } from '@nextcloud/router'
+import CartIcon from 'vue-material-design-icons/Cart.vue'
+
+export default {
+	name: 'OrderBasketPanel',
+	components: {
+		NcButton,
+		CartIcon,
+	},
+
+	data() {
+		return {
+			expanded: false,
+			lines: [],
+			pollTimer: null,
+		}
+	},
+
+	computed: {
+		itemCount() {
+			return this.lines.reduce((sum, line) => sum + (line.quantity || 0), 0)
+		},
+		basketTotal() {
+			return this.lines.reduce(
+				(sum, line) => sum + (line.quantity || 0) * (line.unitPrice || 0),
+				0,
+			)
+		},
+	},
+
+	async created() {
+		await this.loadBasket()
+		this.pollTimer = setInterval(() => this.loadBasket(), 30000)
+	},
+
+	beforeDestroy() {
+		if (this.pollTimer) {
+			clearInterval(this.pollTimer)
+		}
+	},
+
+	methods: {
+		t(app, text) {
+			return t(app, text)
+		},
+
+		formatPrice(price) {
+			if (price == null) return '-'
+			return new Intl.NumberFormat('nl-NL', {
+				style: 'currency',
+				currency: 'EUR',
+			}).format(price)
+		},
+
+		async loadBasket() {
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/order-baskets/current')
+				const response = await fetch(url, {
+					headers: { requesttoken: OC.requestToken },
+				})
+				if (response.ok) {
+					const data = await response.json()
+					this.lines = data.lines || []
+				}
+			} catch (error) {
+				// Silently fail for the floating widget
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.basket-panel {
+	position: fixed;
+	bottom: 24px;
+	right: 24px;
+	z-index: 1000;
+}
+
+.basket-panel__toggle {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 10px 16px;
+	background-color: var(--color-primary);
+	color: var(--color-primary-text);
+	border: none;
+	border-radius: 24px;
+	cursor: pointer;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+	font-size: 14px;
+	font-weight: 600;
+}
+
+.basket-panel__toggle:hover {
+	opacity: 0.9;
+}
+
+.basket-panel__badge {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 20px;
+	height: 20px;
+	padding: 0 6px;
+	background-color: var(--color-error);
+	color: #fff;
+	border-radius: 10px;
+	font-size: 11px;
+	font-weight: 700;
+}
+
+.basket-panel__total {
+	font-size: 13px;
+}
+
+.basket-panel__dropdown {
+	position: absolute;
+	bottom: 56px;
+	right: 0;
+	width: 320px;
+	background-color: var(--color-main-background);
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-large);
+	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+	padding: 16px;
+}
+
+.basket-panel__title {
+	margin: 0 0 12px;
+	font-size: 16px;
+	font-weight: 600;
+}
+
+.basket-panel__empty {
+	color: var(--color-text-maxcontrast);
+	text-align: center;
+	padding: 12px 0;
+}
+
+.basket-panel__lines {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	max-height: 200px;
+	overflow-y: auto;
+}
+
+.basket-panel__line {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 6px 0;
+	border-bottom: 1px solid var(--color-border-dark);
+	font-size: 13px;
+}
+
+.basket-panel__line-name {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	margin-right: 8px;
+}
+
+.basket-panel__line-qty {
+	color: var(--color-text-maxcontrast);
+	margin-right: 8px;
+}
+
+.basket-panel__line-price {
+	font-weight: 600;
+	white-space: nowrap;
+}
+
+.basket-panel__footer {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-top: 12px;
+	padding-top: 8px;
+	border-top: 1px solid var(--color-border);
+}
+</style>

--- a/src/components/QuoteComparisonTable.vue
+++ b/src/components/QuoteComparisonTable.vue
@@ -1,0 +1,285 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-12.2 -->
+<template>
+	<div class="quote-comparison-table">
+		<NcLoadingIcon v-if="loading" />
+
+		<template v-else>
+			<table v-if="sortedQuotes.length" class="quote-comparison-table__table">
+				<thead>
+					<tr>
+						<th class="quote-comparison-table__sortable"
+							@click="toggleSort('supplierName')">
+							{{ t('shillinq', 'Supplier') }}
+							<span v-if="sortField === 'supplierName'">{{ sortAsc ? '▲' : '▼' }}</span>
+						</th>
+						<th class="quote-comparison-table__sortable"
+							@click="toggleSort('totalAmount')">
+							{{ t('shillinq', 'Total Amount') }}
+							<span v-if="sortField === 'totalAmount'">{{ sortAsc ? '▲' : '▼' }}</span>
+						</th>
+						<th>{{ t('shillinq', 'Currency') }}</th>
+						<th class="quote-comparison-table__sortable"
+							@click="toggleSort('validityDate')">
+							{{ t('shillinq', 'Validity Date') }}
+							<span v-if="sortField === 'validityDate'">{{ sortAsc ? '▲' : '▼' }}</span>
+						</th>
+						<th class="quote-comparison-table__sortable"
+							@click="toggleSort('evaluationScore')">
+							{{ t('shillinq', 'Evaluation Score') }}
+							<span v-if="sortField === 'evaluationScore'">{{ sortAsc ? '▲' : '▼' }}</span>
+						</th>
+						<th>{{ t('shillinq', 'Budget Variance') }}</th>
+						<th>{{ t('shillinq', 'Status') }}</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr v-for="quote in sortedQuotes"
+						:key="quote.id"
+						:class="{ 'quote-comparison-table__row--best': quote.isBestPrice }">
+						<td>
+							{{ quote.supplierName }}
+							<span v-if="quote.isBestPrice" class="quote-comparison-table__badge--best">
+								{{ t('shillinq', 'Best price') }}
+							</span>
+						</td>
+						<td>{{ formatCurrency(quote.totalAmount, quote.currency) }}</td>
+						<td>{{ quote.currency }}</td>
+						<td>{{ quote.validityDate }}</td>
+						<td>
+							<input v-model.number="quote.evaluationScore"
+								type="number"
+								min="0"
+								max="100"
+								step="1"
+								class="quote-comparison-table__score-input"
+								@change="updateScore(quote)" />
+						</td>
+						<td>
+							<span class="quote-comparison-table__variance"
+								:class="quote.budgetVariance > 0
+									? 'quote-comparison-table__variance--over'
+									: 'quote-comparison-table__variance--under'">
+								{{ formatVariance(quote.budgetVariance, quote.currency) }}
+							</span>
+						</td>
+						<td>
+							<span class="quote-comparison-table__status-chip"
+								:class="'quote-comparison-table__status-chip--' + quote.status">
+								{{ quote.status }}
+							</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+
+			<p v-else class="quote-comparison-table__empty">
+				{{ t('shillinq', 'No quotes to compare.') }}
+			</p>
+		</template>
+	</div>
+</template>
+
+<script>
+import { NcLoadingIcon } from '@nextcloud/vue'
+import { generateUrl } from '@nextcloud/router'
+import axios from '@nextcloud/axios'
+
+export default {
+	name: 'QuoteComparisonTable',
+	components: {
+		NcLoadingIcon,
+	},
+	props: {
+		rfqId: {
+			type: String,
+			required: true,
+		},
+	},
+	data() {
+		return {
+			loading: false,
+			quotes: [],
+			rfqBudget: 0,
+			sortField: 'totalAmount',
+			sortAsc: true,
+		}
+	},
+	computed: {
+		lowestAmount() {
+			if (!this.quotes.length) return null
+			return Math.min(...this.quotes.map((q) => q.totalAmount))
+		},
+		sortedQuotes() {
+			const enriched = this.quotes.map((quote) => ({
+				...quote,
+				isBestPrice: quote.totalAmount === this.lowestAmount,
+				budgetVariance: quote.totalAmount - this.rfqBudget,
+			}))
+
+			return [...enriched].sort((a, b) => {
+				let aVal = a[this.sortField]
+				let bVal = b[this.sortField]
+
+				if (typeof aVal === 'string') {
+					aVal = aVal.toLowerCase()
+					bVal = (bVal || '').toLowerCase()
+				}
+
+				if (aVal < bVal) return this.sortAsc ? -1 : 1
+				if (aVal > bVal) return this.sortAsc ? 1 : -1
+				return 0
+			})
+		},
+	},
+	watch: {
+		rfqId: {
+			immediate: true,
+			handler() {
+				this.fetchComparison()
+			},
+		},
+	},
+	methods: {
+		t,
+		async fetchComparison() {
+			this.loading = true
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/rfqs/{id}/comparison', {
+					id: this.rfqId,
+				})
+				const response = await axios.get(url)
+				this.quotes = response.data?.quotes || []
+				this.rfqBudget = response.data?.budget || 0
+			} catch (error) {
+				console.error('Failed to fetch comparison data:', error)
+			} finally {
+				this.loading = false
+			}
+		},
+		toggleSort(field) {
+			if (this.sortField === field) {
+				this.sortAsc = !this.sortAsc
+			} else {
+				this.sortField = field
+				this.sortAsc = true
+			}
+		},
+		formatCurrency(amount, currency) {
+			if (amount == null) return ''
+			return new Intl.NumberFormat(undefined, { style: 'currency', currency: currency || 'EUR' }).format(amount)
+		},
+		formatVariance(variance, currency) {
+			if (variance == null) return ''
+			const sign = variance >= 0 ? '+' : ''
+			return sign + new Intl.NumberFormat(undefined, {
+				style: 'currency',
+				currency: currency || 'EUR',
+			}).format(variance)
+		},
+		async updateScore(quote) {
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/rfqs/{rfqId}/quotes/{quoteId}', {
+					rfqId: this.rfqId,
+					quoteId: quote.id,
+				})
+				await axios.patch(url, { evaluationScore: quote.evaluationScore })
+			} catch (error) {
+				console.error('Failed to update evaluation score:', error)
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.quote-comparison-table__table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.quote-comparison-table__table th,
+.quote-comparison-table__table td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.quote-comparison-table__sortable {
+	cursor: pointer;
+	user-select: none;
+}
+
+.quote-comparison-table__sortable:hover {
+	color: var(--color-primary);
+}
+
+.quote-comparison-table__row--best {
+	background-color: var(--color-success-light, #e8f8e8);
+}
+
+.quote-comparison-table__badge--best {
+	display: inline-block;
+	margin-left: 8px;
+	padding: 2px 8px;
+	border-radius: 12px;
+	font-size: 11px;
+	font-weight: 700;
+	background-color: var(--color-success);
+	color: #fff;
+}
+
+.quote-comparison-table__score-input {
+	width: 70px;
+	padding: 4px 8px;
+	border: 1px solid var(--color-border);
+	border-radius: 4px;
+	text-align: center;
+}
+
+.quote-comparison-table__variance--over {
+	color: var(--color-error);
+	font-weight: 600;
+}
+
+.quote-comparison-table__variance--under {
+	color: var(--color-success);
+	font-weight: 600;
+}
+
+.quote-comparison-table__status-chip {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: capitalize;
+}
+
+.quote-comparison-table__status-chip--submitted {
+	background-color: var(--color-primary-light);
+	color: var(--color-primary);
+}
+
+.quote-comparison-table__status-chip--evaluated {
+	background-color: var(--color-warning-light, #fff8e1);
+	color: var(--color-warning);
+}
+
+.quote-comparison-table__status-chip--awarded {
+	background-color: var(--color-success-light, #e8f8e8);
+	color: var(--color-success);
+}
+
+.quote-comparison-table__status-chip--rejected {
+	background-color: var(--color-error-light, #fff0f0);
+	color: var(--color-error);
+}
+
+.quote-comparison-table__empty {
+	color: var(--color-text-maxcontrast);
+	text-align: center;
+	padding: 40px 0;
+}
+</style>

--- a/src/components/ThreeWayMatchingPanel.vue
+++ b/src/components/ThreeWayMatchingPanel.vue
@@ -1,0 +1,194 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-11.2 -->
+<template>
+	<div class="three-way-matching-panel">
+		<NcLoadingIcon v-if="loading" />
+
+		<template v-else>
+			<div v-if="allMatched" class="three-way-matching-panel__banner--success">
+				<Check :size="20" />
+				<span>{{ t('shillinq', 'All lines matched — ready for payment approval') }}</span>
+				<NcButton type="success" @click="approveForPayment">
+					{{ t('shillinq', 'Approve for payment') }}
+				</NcButton>
+			</div>
+
+			<table v-if="matchingLines.length" class="three-way-matching-panel__table">
+				<thead>
+					<tr>
+						<th>{{ t('shillinq', 'Product') }}</th>
+						<th>{{ t('shillinq', 'Ordered Qty') }}</th>
+						<th>{{ t('shillinq', 'Received Qty') }}</th>
+						<th>{{ t('shillinq', 'Invoiced Qty') }}</th>
+						<th>{{ t('shillinq', 'Match Status') }}</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr v-for="line in matchingLines"
+						:key="line.id"
+						:class="{ 'three-way-matching-panel__row--discrepancy': line.status === 'discrepancy' }">
+						<td>{{ line.productName }}</td>
+						<td>{{ line.orderedQuantity }}</td>
+						<td>{{ line.receivedQuantity }}</td>
+						<td>{{ line.invoicedQuantity }}</td>
+						<td>
+							<span class="three-way-matching-panel__chip"
+								:class="'three-way-matching-panel__chip--' + line.status">
+								{{ line.statusLabel }}
+							</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+
+			<p v-else class="three-way-matching-panel__empty">
+				{{ t('shillinq', 'No matching data available.') }}
+			</p>
+		</template>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcLoadingIcon } from '@nextcloud/vue'
+import { generateUrl } from '@nextcloud/router'
+import axios from '@nextcloud/axios'
+import Check from 'vue-material-design-icons/Check.vue'
+
+export default {
+	name: 'ThreeWayMatchingPanel',
+	components: {
+		NcButton,
+		NcLoadingIcon,
+		Check,
+	},
+	props: {
+		purchaseOrderId: {
+			type: String,
+			required: true,
+		},
+	},
+	data() {
+		return {
+			loading: false,
+			matchingLines: [],
+		}
+	},
+	computed: {
+		allMatched() {
+			return (
+				this.matchingLines.length > 0
+				&& this.matchingLines.every((line) => line.status === 'matched')
+			)
+		},
+	},
+	watch: {
+		purchaseOrderId: {
+			immediate: true,
+			handler() {
+				this.fetchMatchingData()
+			},
+		},
+	},
+	methods: {
+		t,
+		async fetchMatchingData() {
+			this.loading = true
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/purchase-orders/{id}/matching', {
+					id: this.purchaseOrderId,
+				})
+				const response = await axios.get(url)
+				this.matchingLines = (response.data?.lines || []).map((line) => {
+					const status = this.computeStatus(line)
+					return {
+						...line,
+						status,
+						statusLabel: status === 'matched'
+							? this.t('shillinq', 'Matched')
+							: this.t('shillinq', 'Discrepancy'),
+					}
+				})
+			} catch (error) {
+				console.error('Failed to fetch matching data:', error)
+			} finally {
+				this.loading = false
+			}
+		},
+		computeStatus(line) {
+			if (
+				line.orderedQuantity === line.receivedQuantity
+				&& line.receivedQuantity === line.invoicedQuantity
+			) {
+				return 'matched'
+			}
+			return 'discrepancy'
+		},
+		async approveForPayment() {
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/purchase-orders/{id}/approve-payment', {
+					id: this.purchaseOrderId,
+				})
+				await axios.post(url)
+			} catch (error) {
+				console.error('Failed to approve for payment:', error)
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.three-way-matching-panel__banner--success {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 12px 16px;
+	margin-bottom: 16px;
+	background-color: var(--color-success-light, #e8f8e8);
+	border: 1px solid var(--color-success);
+	border-radius: 8px;
+	color: var(--color-success);
+	font-weight: 600;
+}
+
+.three-way-matching-panel__table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.three-way-matching-panel__table th,
+.three-way-matching-panel__table td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.three-way-matching-panel__row--discrepancy {
+	background-color: var(--color-warning-light, #fff8e1);
+}
+
+.three-way-matching-panel__chip {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.three-way-matching-panel__chip--matched {
+	background-color: var(--color-success-light, #e8f8e8);
+	color: var(--color-success);
+}
+
+.three-way-matching-panel__chip--discrepancy {
+	background-color: var(--color-warning-light, #fff8e1);
+	color: var(--color-warning);
+}
+
+.three-way-matching-panel__empty {
+	color: var(--color-text-maxcontrast);
+	text-align: center;
+	padding: 40px 0;
+}
+</style>

--- a/src/navigation/MainMenu.vue
+++ b/src/navigation/MainMenu.vue
@@ -1,3 +1,8 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!--
+  @spec openspec/changes/catalog-purchase-management/tasks.md#task-13.1
+-->
 <template>
 	<NcAppNavigation>
 		<template #list>
@@ -9,6 +14,88 @@
 					<HomeIcon :size="20" />
 				</template>
 			</NcAppNavigationItem>
+
+			<NcAppNavigationCaption :name="t('shillinq', 'Catalog')" />
+
+			<NcAppNavigationItem
+				:name="t('shillinq', 'Catalog Search')"
+				:to="{ name: 'CatalogSearch' }">
+				<template #icon>
+					<MagnifyIcon :size="20" />
+				</template>
+			</NcAppNavigationItem>
+
+			<NcAppNavigationItem
+				:name="t('shillinq', 'My Basket')"
+				:to="{ name: 'OrderBasketView' }">
+				<template #icon>
+					<CartOutlineIcon :size="20" />
+				</template>
+				<template v-if="openBasketCount > 0" #counter>
+					<NcCounterBubble type="highlighted">
+						{{ openBasketCount }}
+					</NcCounterBubble>
+				</template>
+			</NcAppNavigationItem>
+
+			<NcAppNavigationItem
+				:name="t('shillinq', 'My Orders')"
+				:to="{ name: 'OrderBasketHistory' }">
+				<template #icon>
+					<ClipboardListOutlineIcon :size="20" />
+				</template>
+			</NcAppNavigationItem>
+
+			<NcAppNavigationItem
+				:name="t('shillinq', 'Catalogs')"
+				:to="{ name: 'CatalogIndex' }">
+				<template #icon>
+					<BookOpenPageVariantOutlineIcon :size="20" />
+				</template>
+			</NcAppNavigationItem>
+
+			<NcAppNavigationItem
+				:name="t('shillinq', 'Products')"
+				:to="{ name: 'ProductIndex' }">
+				<template #icon>
+					<PackageVariantClosedIcon :size="20" />
+				</template>
+			</NcAppNavigationItem>
+
+			<NcAppNavigationItem
+				:name="t('shillinq', 'Categories')"
+				:to="{ name: 'ProductCategoryIndex' }">
+				<template #icon>
+					<FolderOutlineIcon :size="20" />
+				</template>
+			</NcAppNavigationItem>
+
+			<NcAppNavigationCaption :name="t('shillinq', 'Procurement')" />
+
+			<NcAppNavigationItem
+				:name="t('shillinq', 'Purchase Orders')"
+				:to="{ name: 'PurchaseOrderIndex' }">
+				<template #icon>
+					<ClipboardTextOutlineIcon :size="20" />
+				</template>
+			</NcAppNavigationItem>
+
+			<NcAppNavigationItem
+				:name="t('shillinq', 'Goods Receipts')"
+				:to="{ name: 'GoodsReceiptIndex' }">
+				<template #icon>
+					<TruckDeliveryOutlineIcon :size="20" />
+				</template>
+			</NcAppNavigationItem>
+
+			<NcAppNavigationItem
+				:name="t('shillinq', 'RFQ')"
+				:to="{ name: 'RFQIndex' }">
+				<template #icon>
+					<FileDocumentEditOutlineIcon :size="20" />
+				</template>
+			</NcAppNavigationItem>
+
 			<NcAppNavigationItem
 				:name="t('shillinq', 'Documentation')"
 				@click="openLink('https://conduction.nl', '_blank')">
@@ -30,19 +117,46 @@
 </template>
 
 <script>
-import { NcAppNavigation, NcAppNavigationItem } from '@nextcloud/vue'
+import { NcAppNavigation, NcAppNavigationCaption, NcAppNavigationItem, NcCounterBubble } from '@nextcloud/vue'
+import BookOpenPageVariantOutlineIcon from 'vue-material-design-icons/BookOpenPageVariantOutline.vue'
 import BookOpenVariantOutline from 'vue-material-design-icons/BookOpenVariantOutline.vue'
+import CartOutlineIcon from 'vue-material-design-icons/CartOutline.vue'
+import ClipboardListOutlineIcon from 'vue-material-design-icons/ClipboardListOutline.vue'
+import ClipboardTextOutlineIcon from 'vue-material-design-icons/ClipboardTextOutline.vue'
 import CogIcon from 'vue-material-design-icons/Cog.vue'
+import FileDocumentEditOutlineIcon from 'vue-material-design-icons/FileDocumentEditOutline.vue'
+import FolderOutlineIcon from 'vue-material-design-icons/FolderOutline.vue'
 import HomeIcon from 'vue-material-design-icons/Home.vue'
+import MagnifyIcon from 'vue-material-design-icons/Magnify.vue'
+import PackageVariantClosedIcon from 'vue-material-design-icons/PackageVariantClosed.vue'
+import TruckDeliveryOutlineIcon from 'vue-material-design-icons/TruckDeliveryOutline.vue'
+import { useOrderBasketStore } from '../store/modules/orderBasket.js'
 
 export default {
 	name: 'MainMenu',
 	components: {
-		NcAppNavigation,
-		NcAppNavigationItem,
+		BookOpenPageVariantOutlineIcon,
 		BookOpenVariantOutline,
+		CartOutlineIcon,
+		ClipboardListOutlineIcon,
+		ClipboardTextOutlineIcon,
 		CogIcon,
+		FileDocumentEditOutlineIcon,
+		FolderOutlineIcon,
 		HomeIcon,
+		MagnifyIcon,
+		NcAppNavigation,
+		NcAppNavigationCaption,
+		NcAppNavigationItem,
+		NcCounterBubble,
+		PackageVariantClosedIcon,
+		TruckDeliveryOutlineIcon,
+	},
+	computed: {
+		openBasketCount() {
+			const store = useOrderBasketStore()
+			return store.getOpenBasketCount
+		},
 	},
 	methods: {
 		openLink(url, target = '_blank') {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,8 +1,27 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
 import Vue from 'vue'
 import Router from 'vue-router'
 import { generateUrl } from '@nextcloud/router'
 import Dashboard from '../views/Dashboard.vue'
 import AdminRoot from '../views/settings/AdminRoot.vue'
+import ProductCategoryIndex from '../views/productCategory/ProductCategoryIndex.vue'
+import ProductCategoryDetail from '../views/productCategory/ProductCategoryDetail.vue'
+import ProductIndex from '../views/product/ProductIndex.vue'
+import ProductDetail from '../views/product/ProductDetail.vue'
+import CatalogIndex from '../views/catalog/CatalogIndex.vue'
+import CatalogDetail from '../views/catalog/CatalogDetail.vue'
+import CatalogSearch from '../views/catalog/CatalogSearch.vue'
+import OrderBasketView from '../views/orderBasket/OrderBasketView.vue'
+import OrderBasketHistory from '../views/orderBasket/OrderBasketHistory.vue'
+import PurchaseOrderIndex from '../views/purchaseOrder/PurchaseOrderIndex.vue'
+import PurchaseOrderDetail from '../views/purchaseOrder/PurchaseOrderDetail.vue'
+import GoodsReceiptIndex from '../views/goodsReceipt/GoodsReceiptIndex.vue'
+import GoodsReceiptDetail from '../views/goodsReceipt/GoodsReceiptDetail.vue'
+import GoodsReceiptForm from '../views/goodsReceipt/GoodsReceiptForm.vue'
+import RFQIndex from '../views/rFQ/RFQIndex.vue'
+import RFQDetail from '../views/rFQ/RFQDetail.vue'
 
 Vue.use(Router)
 
@@ -10,8 +29,114 @@ export default new Router({
 	mode: 'history',
 	base: generateUrl('/apps/shillinq'),
 	routes: [
-		{ path: '/', name: 'Dashboard', component: Dashboard },
-		{ path: '/settings', name: 'Settings', component: AdminRoot },
+		{
+			path: '/',
+			name: 'Dashboard',
+			component: Dashboard,
+			meta: { breadcrumb: 'Dashboard' },
+		},
+		{
+			path: '/settings',
+			name: 'Settings',
+			component: AdminRoot,
+			meta: { breadcrumb: 'Settings' },
+		},
+		{
+			path: '/categories',
+			name: 'ProductCategoryIndex',
+			component: ProductCategoryIndex,
+			meta: { breadcrumb: 'Categories' },
+		},
+		{
+			path: '/categories/:categoryId',
+			name: 'ProductCategoryDetail',
+			component: ProductCategoryDetail,
+			meta: { breadcrumb: 'Category Detail' },
+		},
+		{
+			path: '/products',
+			name: 'ProductIndex',
+			component: ProductIndex,
+			meta: { breadcrumb: 'Products' },
+		},
+		{
+			path: '/products/:productId',
+			name: 'ProductDetail',
+			component: ProductDetail,
+			meta: { breadcrumb: 'Product Detail' },
+		},
+		{
+			path: '/catalogs',
+			name: 'CatalogIndex',
+			component: CatalogIndex,
+			meta: { breadcrumb: 'Catalogs' },
+		},
+		{
+			path: '/catalogs/:catalogId',
+			name: 'CatalogDetail',
+			component: CatalogDetail,
+			meta: { breadcrumb: 'Catalog Detail' },
+		},
+		{
+			path: '/catalog-search',
+			name: 'CatalogSearch',
+			component: CatalogSearch,
+			meta: { breadcrumb: 'Catalog Search' },
+		},
+		{
+			path: '/basket',
+			name: 'OrderBasketView',
+			component: OrderBasketView,
+			meta: { breadcrumb: 'My Basket' },
+		},
+		{
+			path: '/orders',
+			name: 'OrderBasketHistory',
+			component: OrderBasketHistory,
+			meta: { breadcrumb: 'My Orders' },
+		},
+		{
+			path: '/purchase-orders',
+			name: 'PurchaseOrderIndex',
+			component: PurchaseOrderIndex,
+			meta: { breadcrumb: 'Purchase Orders' },
+		},
+		{
+			path: '/purchase-orders/:purchaseOrderId',
+			name: 'PurchaseOrderDetail',
+			component: PurchaseOrderDetail,
+			meta: { breadcrumb: 'Purchase Order Detail' },
+		},
+		{
+			path: '/goods-receipts',
+			name: 'GoodsReceiptIndex',
+			component: GoodsReceiptIndex,
+			meta: { breadcrumb: 'Goods Receipts' },
+		},
+		{
+			path: '/goods-receipts/:goodsReceiptId',
+			name: 'GoodsReceiptDetail',
+			component: GoodsReceiptDetail,
+			meta: { breadcrumb: 'Goods Receipt Detail' },
+		},
+		{
+			path: '/goods-receipts/new/:purchaseOrderId',
+			name: 'GoodsReceiptForm',
+			component: GoodsReceiptForm,
+			meta: { breadcrumb: 'New Goods Receipt' },
+		},
+		{
+			path: '/rfqs',
+			name: 'RFQIndex',
+			component: RFQIndex,
+			meta: { breadcrumb: 'RFQ' },
+		},
+		{
+			path: '/rfqs/:rfqId',
+			name: 'RFQDetail',
+			component: RFQDetail,
+			meta: { breadcrumb: 'RFQ Detail' },
+		},
 		{ path: '*', redirect: '/' },
 	],
 })

--- a/src/store/modules/catalog.js
+++ b/src/store/modules/catalog.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+import { createObjectStore } from '@conduction/nextcloud-vue'
+
+/**
+ * Catalog store.
+ *
+ * @see openspec/changes/catalog-purchase-management/tasks.md#task-6.3
+ */
+export const useCatalogStore = createObjectStore('catalog')

--- a/src/store/modules/catalogItem.js
+++ b/src/store/modules/catalogItem.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+import { createObjectStore } from '@conduction/nextcloud-vue'
+
+/**
+ * Catalog item store.
+ *
+ * @see openspec/changes/catalog-purchase-management/tasks.md#task-6.4
+ */
+export const useCatalogItemStore = createObjectStore('catalogItem')

--- a/src/store/modules/goodsReceipt.js
+++ b/src/store/modules/goodsReceipt.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+import { createObjectStore } from '@conduction/nextcloud-vue'
+
+/**
+ * Goods receipt store.
+ *
+ * @see openspec/changes/catalog-purchase-management/tasks.md#task-6.7
+ */
+export const useGoodsReceiptStore = createObjectStore('goodsReceipt')

--- a/src/store/modules/orderBasket.js
+++ b/src/store/modules/orderBasket.js
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+import { createObjectStore } from '@conduction/nextcloud-vue'
+
+/**
+ * Order basket store.
+ *
+ * @see openspec/changes/catalog-purchase-management/tasks.md#task-6.5
+ */
+export const useOrderBasketStore = createObjectStore('orderBasket', {
+	plugins: [
+		(store) => {
+			store.getOpenBasketCount = () => {
+				return store.objectList.filter((item) => item.status === 'open').length
+			}
+		},
+	],
+})

--- a/src/store/modules/product.js
+++ b/src/store/modules/product.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+import { createObjectStore } from '@conduction/nextcloud-vue'
+
+/**
+ * Product store.
+ *
+ * @see openspec/changes/catalog-purchase-management/tasks.md#task-6.2
+ */
+export const useProductStore = createObjectStore('product')

--- a/src/store/modules/productCategory.js
+++ b/src/store/modules/productCategory.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+import { createObjectStore } from '@conduction/nextcloud-vue'
+
+/**
+ * Product category store.
+ *
+ * @see openspec/changes/catalog-purchase-management/tasks.md#task-6.1
+ */
+export const useProductCategoryStore = createObjectStore('productCategory')

--- a/src/store/modules/purchaseOrder.js
+++ b/src/store/modules/purchaseOrder.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+import { createObjectStore } from '@conduction/nextcloud-vue'
+
+/**
+ * Purchase order store.
+ *
+ * @see openspec/changes/catalog-purchase-management/tasks.md#task-6.6
+ */
+export const usePurchaseOrderStore = createObjectStore('purchaseOrder')

--- a/src/store/modules/rFQ.js
+++ b/src/store/modules/rFQ.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+import { createObjectStore } from '@conduction/nextcloud-vue'
+
+/**
+ * RFQ store.
+ *
+ * @see openspec/changes/catalog-purchase-management/tasks.md#task-6.8
+ */
+export const useRFQStore = createObjectStore('rFQ')

--- a/src/store/modules/supplier.js
+++ b/src/store/modules/supplier.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+import { createObjectStore } from '@conduction/nextcloud-vue'
+
+/**
+ * Supplier store.
+ *
+ * @see openspec/changes/catalog-purchase-management/tasks.md#task-6.10
+ */
+export const useSupplierStore = createObjectStore('supplierProfile')

--- a/src/store/modules/supplierQuote.js
+++ b/src/store/modules/supplierQuote.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+import { createObjectStore } from '@conduction/nextcloud-vue'
+
+/**
+ * Supplier quote store.
+ *
+ * @see openspec/changes/catalog-purchase-management/tasks.md#task-6.9
+ */
+export const useSupplierQuoteStore = createObjectStore('supplierQuote')

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,19 +1,39 @@
-import { generateUrl } from '@nextcloud/router'
-import { useObjectStore } from './modules/object.js'
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+
+import { useObjectStore } from '@conduction/nextcloud-vue'
 import { useSettingsStore } from './modules/settings.js'
+import { useProductCategoryStore } from './modules/productCategory.js'
+import { useProductStore } from './modules/product.js'
+import { useCatalogStore } from './modules/catalog.js'
+import { useCatalogItemStore } from './modules/catalogItem.js'
+import { useOrderBasketStore } from './modules/orderBasket.js'
+import { usePurchaseOrderStore } from './modules/purchaseOrder.js'
+import { useGoodsReceiptStore } from './modules/goodsReceipt.js'
+import { useRFQStore } from './modules/rFQ.js'
+import { useSupplierQuoteStore } from './modules/supplierQuote.js'
+import { useSupplierStore } from './modules/supplier.js'
 
 export async function initializeStores() {
 	const settingsStore = useSettingsStore()
 	const objectStore = useObjectStore()
-
-	objectStore.configure({
-		baseUrl: generateUrl('/apps/openregister/api/objects'),
-		schemaBaseUrl: generateUrl('/apps/openregister/api/schemas'),
-	})
 
 	await settingsStore.fetchSettings()
 
 	return { settingsStore, objectStore }
 }
 
-export { useObjectStore, useSettingsStore }
+export {
+	useObjectStore,
+	useSettingsStore,
+	useProductCategoryStore,
+	useProductStore,
+	useCatalogStore,
+	useCatalogItemStore,
+	useOrderBasketStore,
+	usePurchaseOrderStore,
+	useGoodsReceiptStore,
+	useRFQStore,
+	useSupplierQuoteStore,
+	useSupplierStore,
+}

--- a/src/views/catalog/CatalogDetail.vue
+++ b/src/views/catalog/CatalogDetail.vue
@@ -1,0 +1,359 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-8.1 -->
+<template>
+	<div class="catalog-detail">
+		<NcLoadingIcon v-if="loading" :size="44" />
+
+		<template v-else-if="catalog">
+			<div v-if="catalog.status === 'archived'" class="catalog-detail__banner catalog-detail__banner--archived">
+				<LockIcon :size="20" />
+				{{ t('shillinq', 'This catalog is archived and read-only.') }}
+			</div>
+
+			<header class="catalog-detail__header">
+				<div>
+					<h2>{{ catalog.name }}</h2>
+					<span :class="'catalog-detail__status--' + catalog.status">
+						{{ catalog.status }}
+					</span>
+				</div>
+				<div class="catalog-detail__actions">
+					<NcButton
+						v-if="catalog.status === 'draft'"
+						type="primary"
+						@click="transitionStatus('active')">
+						<template #icon>
+							<CheckIcon :size="20" />
+						</template>
+						{{ t('shillinq', 'Activate') }}
+					</NcButton>
+					<NcButton
+						v-if="catalog.status === 'active'"
+						type="secondary"
+						@click="transitionStatus('archived')">
+						<template #icon>
+							<ArchiveIcon :size="20" />
+						</template>
+						{{ t('shillinq', 'Archive') }}
+					</NcButton>
+					<NcButton
+						v-if="catalog.status !== 'archived'"
+						@click="showEditDialog = true">
+						<template #icon>
+							<PencilIcon :size="20" />
+						</template>
+						{{ t('shillinq', 'Edit') }}
+					</NcButton>
+				</div>
+			</header>
+
+			<div class="catalog-detail__tabs">
+				<NcButton
+					v-for="tab in tabs"
+					:key="tab.id"
+					:type="activeTab === tab.id ? 'primary' : 'tertiary'"
+					@click="activeTab = tab.id">
+					{{ tab.label }}
+				</NcButton>
+			</div>
+
+			<!-- Details tab -->
+			<div v-if="activeTab === 'details'" class="catalog-detail__section">
+				<table class="catalog-detail__properties">
+					<tr>
+						<th>{{ t('shillinq', 'Description') }}</th>
+						<td>{{ catalog.description || '-' }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Supplier Profile') }}</th>
+						<td>{{ catalog.supplierProfileId || '-' }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Effective From') }}</th>
+						<td>{{ catalog.effectiveFrom || '-' }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Effective To') }}</th>
+						<td>{{ catalog.effectiveTo || '-' }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Owner') }}</th>
+						<td>{{ catalog.ownerId || '-' }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Contract Reference') }}</th>
+						<td>{{ catalog.contractReference || '-' }}</td>
+					</tr>
+				</table>
+			</div>
+
+			<!-- Items tab -->
+			<div v-if="activeTab === 'items'" class="catalog-detail__section">
+				<NcEmptyContent
+					v-if="catalogItems.length === 0"
+					:name="t('shillinq', 'No items yet')"
+					:description="t('shillinq', 'Add items to this catalog via the Import tab or the API.')">
+					<template #icon>
+						<PackageVariantClosedIcon :size="64" />
+					</template>
+				</NcEmptyContent>
+
+				<table v-else class="catalog-detail__items-table">
+					<thead>
+						<tr>
+							<th>{{ t('shillinq', 'SKU') }}</th>
+							<th>{{ t('shillinq', 'Product Name') }}</th>
+							<th>{{ t('shillinq', 'Unit Price') }}</th>
+							<th>{{ t('shillinq', 'Currency') }}</th>
+							<th>{{ t('shillinq', 'Category') }}</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="item in catalogItems" :key="item.id">
+							<td>{{ item.sku }}</td>
+							<td>{{ item.productName }}</td>
+							<td>{{ item.unitPrice }}</td>
+							<td>{{ item.currency }}</td>
+							<td>{{ item.category || '-' }}</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<!-- Import tab -->
+			<div v-if="activeTab === 'import'" class="catalog-detail__section">
+				<CatalogImportPanel
+					v-if="catalog.status !== 'archived'"
+					:catalog-id="catalog.id"
+					@imported="loadCatalogItems" />
+				<p v-else>
+					{{ t('shillinq', 'Import is disabled for archived catalogs.') }}
+				</p>
+			</div>
+		</template>
+
+		<NcEmptyContent
+			v-else
+			:name="t('shillinq', 'Catalog not found')">
+			<template #icon>
+				<AlertCircleOutlineIcon :size="64" />
+			</template>
+		</NcEmptyContent>
+
+		<CatalogForm
+			v-if="showEditDialog"
+			:catalog="catalog"
+			@close="showEditDialog = false"
+			@saved="onCatalogSaved" />
+	</div>
+</template>
+
+<script>
+import { NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import { generateUrl } from '@nextcloud/router'
+import AlertCircleOutlineIcon from 'vue-material-design-icons/AlertCircleOutline.vue'
+import ArchiveIcon from 'vue-material-design-icons/Archive.vue'
+import CheckIcon from 'vue-material-design-icons/Check.vue'
+import LockIcon from 'vue-material-design-icons/Lock.vue'
+import PackageVariantClosedIcon from 'vue-material-design-icons/PackageVariantClosed.vue'
+import PencilIcon from 'vue-material-design-icons/Pencil.vue'
+import CatalogForm from './CatalogForm.vue'
+import CatalogImportPanel from '../../components/CatalogImportPanel.vue'
+
+export default {
+	name: 'CatalogDetail',
+	components: {
+		NcButton,
+		NcEmptyContent,
+		NcLoadingIcon,
+		AlertCircleOutlineIcon,
+		ArchiveIcon,
+		CheckIcon,
+		LockIcon,
+		PackageVariantClosedIcon,
+		PencilIcon,
+		CatalogForm,
+		CatalogImportPanel,
+	},
+
+	data() {
+		return {
+			loading: false,
+			catalog: null,
+			catalogItems: [],
+			activeTab: 'details',
+			showEditDialog: false,
+		}
+	},
+
+	computed: {
+		tabs() {
+			return [
+				{ id: 'details', label: this.t('shillinq', 'Details') },
+				{ id: 'items', label: this.t('shillinq', 'Items') },
+				{ id: 'import', label: this.t('shillinq', 'Import') },
+			]
+		},
+	},
+
+	async created() {
+		await this.loadCatalog()
+		await this.loadCatalogItems()
+	},
+
+	methods: {
+		t(app, text) {
+			return t(app, text)
+		},
+
+		async loadCatalog() {
+			this.loading = true
+			try {
+				const id = this.$route.params.id
+				const url = generateUrl(`/apps/shillinq/api/v1/catalogs/${id}`)
+				const response = await fetch(url, {
+					headers: { requesttoken: OC.requestToken },
+				})
+				if (response.ok) {
+					this.catalog = await response.json()
+				}
+			} catch (error) {
+				console.error('Failed to load catalog:', error)
+			} finally {
+				this.loading = false
+			}
+		},
+
+		async loadCatalogItems() {
+			try {
+				const id = this.$route.params.id
+				const url = generateUrl(`/apps/shillinq/api/v1/catalogs/${id}/items`)
+				const response = await fetch(url, {
+					headers: { requesttoken: OC.requestToken },
+				})
+				if (response.ok) {
+					const data = await response.json()
+					this.catalogItems = data.results || data
+				}
+			} catch (error) {
+				console.error('Failed to load catalog items:', error)
+			}
+		},
+
+		async transitionStatus(newStatus) {
+			try {
+				const url = generateUrl(`/apps/shillinq/api/v1/catalogs/${this.catalog.id}`)
+				const response = await fetch(url, {
+					method: 'PUT',
+					headers: {
+						'Content-Type': 'application/json',
+						requesttoken: OC.requestToken,
+					},
+					body: JSON.stringify({ status: newStatus }),
+				})
+				if (response.ok) {
+					this.catalog = await response.json()
+				}
+			} catch (error) {
+				console.error('Failed to update catalog status:', error)
+			}
+		},
+
+		async onCatalogSaved() {
+			this.showEditDialog = false
+			await this.loadCatalog()
+		},
+	},
+}
+</script>
+
+<style scoped>
+.catalog-detail {
+	padding: 8px 16px 24px;
+	max-width: 1200px;
+}
+
+.catalog-detail__banner {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 10px 16px;
+	border-radius: var(--border-radius-large);
+	margin-bottom: 16px;
+}
+
+.catalog-detail__banner--archived {
+	background-color: var(--color-background-dark);
+	color: var(--color-text-maxcontrast);
+}
+
+.catalog-detail__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+	margin-bottom: 16px;
+}
+
+.catalog-detail__header h2 {
+	margin: 0 0 4px;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.catalog-detail__actions {
+	display: flex;
+	gap: 8px;
+}
+
+.catalog-detail__status--draft {
+	color: var(--color-text-maxcontrast);
+	font-style: italic;
+}
+
+.catalog-detail__status--active {
+	color: var(--color-success);
+	font-weight: 600;
+}
+
+.catalog-detail__status--archived {
+	color: var(--color-text-maxcontrast);
+	text-decoration: line-through;
+}
+
+.catalog-detail__tabs {
+	display: flex;
+	gap: 4px;
+	margin-bottom: 16px;
+	border-bottom: 1px solid var(--color-border);
+	padding-bottom: 8px;
+}
+
+.catalog-detail__section {
+	margin-top: 8px;
+}
+
+.catalog-detail__properties th {
+	padding: 8px 16px 8px 0;
+	text-align: left;
+	color: var(--color-text-maxcontrast);
+	white-space: nowrap;
+	vertical-align: top;
+}
+
+.catalog-detail__properties td {
+	padding: 8px 0;
+}
+
+.catalog-detail__items-table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.catalog-detail__items-table th,
+.catalog-detail__items-table td {
+	padding: 10px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+</style>

--- a/src/views/catalog/CatalogForm.vue
+++ b/src/views/catalog/CatalogForm.vue
@@ -1,0 +1,240 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-8.1 -->
+<template>
+	<NcDialog
+		:name="isEditing ? t('shillinq', 'Edit Catalog') : t('shillinq', 'New Catalog')"
+		size="normal"
+		@closing="$emit('close')">
+		<form class="catalog-form" @submit.prevent="save">
+			<div class="catalog-form__field">
+				<label for="catalog-name">{{ t('shillinq', 'Name') }} *</label>
+				<NcTextField
+					id="catalog-name"
+					v-model="form.name"
+					:label="t('shillinq', 'Catalog name')"
+					required />
+			</div>
+
+			<div class="catalog-form__field">
+				<label for="catalog-description">{{ t('shillinq', 'Description') }}</label>
+				<NcTextArea
+					id="catalog-description"
+					v-model="form.description"
+					:label="t('shillinq', 'Description')" />
+			</div>
+
+			<div class="catalog-form__field">
+				<label for="catalog-status">{{ t('shillinq', 'Status') }}</label>
+				<NcSelect
+					id="catalog-status"
+					v-model="form.status"
+					:options="statusOptions"
+					:placeholder="t('shillinq', 'Select status')" />
+			</div>
+
+			<div class="catalog-form__field">
+				<label for="catalog-supplier">{{ t('shillinq', 'Supplier Profile') }}</label>
+				<NcSelect
+					id="catalog-supplier"
+					v-model="form.supplierProfileId"
+					:options="supplierOptions"
+					:placeholder="t('shillinq', 'Select supplier')"
+					label="name"
+					track-by="id" />
+			</div>
+
+			<div class="catalog-form__row">
+				<div class="catalog-form__field">
+					<label for="catalog-from">{{ t('shillinq', 'Effective From') }}</label>
+					<NcTextField
+						id="catalog-from"
+						v-model="form.effectiveFrom"
+						type="date"
+						:label="t('shillinq', 'Start date')" />
+				</div>
+				<div class="catalog-form__field">
+					<label for="catalog-to">{{ t('shillinq', 'Effective To') }}</label>
+					<NcTextField
+						id="catalog-to"
+						v-model="form.effectiveTo"
+						type="date"
+						:label="t('shillinq', 'End date')" />
+				</div>
+			</div>
+
+			<div class="catalog-form__field">
+				<label for="catalog-owner">{{ t('shillinq', 'Owner') }}</label>
+				<NcTextField
+					id="catalog-owner"
+					v-model="form.ownerId"
+					:label="t('shillinq', 'Owner ID')" />
+			</div>
+
+			<div class="catalog-form__field">
+				<label for="catalog-contract">{{ t('shillinq', 'Contract Reference') }}</label>
+				<NcTextField
+					id="catalog-contract"
+					v-model="form.contractReference"
+					:label="t('shillinq', 'Contract reference')" />
+			</div>
+
+			<div class="catalog-form__actions">
+				<NcButton type="tertiary" @click="$emit('close')">
+					{{ t('shillinq', 'Cancel') }}
+				</NcButton>
+				<NcButton type="primary" native-type="submit" :disabled="saving">
+					<template v-if="saving" #icon>
+						<NcLoadingIcon :size="20" />
+					</template>
+					{{ isEditing ? t('shillinq', 'Save') : t('shillinq', 'Create') }}
+				</NcButton>
+			</div>
+		</form>
+	</NcDialog>
+</template>
+
+<script>
+import { NcButton, NcDialog, NcLoadingIcon, NcSelect, NcTextArea, NcTextField } from '@nextcloud/vue'
+import { generateUrl } from '@nextcloud/router'
+
+export default {
+	name: 'CatalogForm',
+	components: {
+		NcButton,
+		NcDialog,
+		NcLoadingIcon,
+		NcSelect,
+		NcTextArea,
+		NcTextField,
+	},
+
+	props: {
+		catalog: {
+			type: Object,
+			default: null,
+		},
+	},
+
+	emits: ['close', 'saved'],
+
+	data() {
+		return {
+			saving: false,
+			supplierOptions: [],
+			statusOptions: ['draft', 'active', 'archived'],
+			form: {
+				name: '',
+				description: '',
+				status: 'draft',
+				supplierProfileId: null,
+				effectiveFrom: '',
+				effectiveTo: '',
+				ownerId: '',
+				contractReference: '',
+			},
+		}
+	},
+
+	computed: {
+		isEditing() {
+			return !!this.catalog
+		},
+	},
+
+	created() {
+		if (this.catalog) {
+			this.form = {
+				name: this.catalog.name || '',
+				description: this.catalog.description || '',
+				status: this.catalog.status || 'draft',
+				supplierProfileId: this.catalog.supplierProfileId || null,
+				effectiveFrom: this.catalog.effectiveFrom || '',
+				effectiveTo: this.catalog.effectiveTo || '',
+				ownerId: this.catalog.ownerId || '',
+				contractReference: this.catalog.contractReference || '',
+			}
+		}
+		this.loadSuppliers()
+	},
+
+	methods: {
+		t(app, text) {
+			return t(app, text)
+		},
+
+		async loadSuppliers() {
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/supplier-profiles')
+				const response = await fetch(url, {
+					headers: { requesttoken: OC.requestToken },
+				})
+				if (response.ok) {
+					const data = await response.json()
+					this.supplierOptions = data.results || data
+				}
+			} catch (error) {
+				console.error('Failed to load suppliers:', error)
+			}
+		},
+
+		async save() {
+			this.saving = true
+			try {
+				const isEdit = this.isEditing
+				const url = isEdit
+					? generateUrl(`/apps/shillinq/api/v1/catalogs/${this.catalog.id}`)
+					: generateUrl('/apps/shillinq/api/v1/catalogs')
+				const response = await fetch(url, {
+					method: isEdit ? 'PUT' : 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						requesttoken: OC.requestToken,
+					},
+					body: JSON.stringify(this.form),
+				})
+				if (response.ok) {
+					this.$emit('saved')
+				}
+			} catch (error) {
+				console.error('Failed to save catalog:', error)
+			} finally {
+				this.saving = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.catalog-form {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 8px 0;
+}
+
+.catalog-form__field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	flex: 1;
+}
+
+.catalog-form__field label {
+	font-weight: 600;
+	font-size: 14px;
+}
+
+.catalog-form__row {
+	display: flex;
+	gap: 12px;
+}
+
+.catalog-form__actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 8px;
+}
+</style>

--- a/src/views/catalog/CatalogIndex.vue
+++ b/src/views/catalog/CatalogIndex.vue
@@ -1,0 +1,211 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-8.1 -->
+<template>
+	<div class="catalog-index">
+		<header class="catalog-index__header">
+			<h2>{{ t('shillinq', 'Catalogs') }}</h2>
+			<NcButton type="primary" @click="showNewDialog = true">
+				<template #icon>
+					<PlusIcon :size="20" />
+				</template>
+				{{ t('shillinq', 'New Catalog') }}
+			</NcButton>
+		</header>
+
+		<div class="catalog-index__filters">
+			<NcButton
+				v-for="chip in statusChips"
+				:key="chip.value"
+				:type="activeStatus === chip.value ? 'primary' : 'secondary'"
+				@click="filterByStatus(chip.value)">
+				{{ chip.label }}
+			</NcButton>
+		</div>
+
+		<NcLoadingIcon v-if="loading" :size="44" />
+
+		<NcEmptyContent
+			v-else-if="filteredCatalogs.length === 0"
+			:name="t('shillinq', 'No catalogs found')"
+			:description="t('shillinq', 'Create a new catalog or change the active filter.')">
+			<template #icon>
+				<BookOpenVariantOutline :size="64" />
+			</template>
+		</NcEmptyContent>
+
+		<table v-else class="catalog-index__table">
+			<thead>
+				<tr>
+					<th>{{ t('shillinq', 'Name') }}</th>
+					<th>{{ t('shillinq', 'Status') }}</th>
+					<th>{{ t('shillinq', 'Effective From') }}</th>
+					<th>{{ t('shillinq', 'Effective To') }}</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr
+					v-for="catalog in filteredCatalogs"
+					:key="catalog.id"
+					class="catalog-index__row"
+					@click="goToDetail(catalog.id)">
+					<td>{{ catalog.name }}</td>
+					<td>
+						<span :class="'catalog-index__badge--' + catalog.status">
+							{{ catalog.status }}
+						</span>
+					</td>
+					<td>{{ catalog.effectiveFrom || '-' }}</td>
+					<td>{{ catalog.effectiveTo || '-' }}</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<CatalogForm
+			v-if="showNewDialog"
+			@close="showNewDialog = false"
+			@saved="onCatalogSaved" />
+	</div>
+</template>
+
+<script>
+import { NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import BookOpenVariantOutline from 'vue-material-design-icons/BookOpenVariantOutline.vue'
+import PlusIcon from 'vue-material-design-icons/Plus.vue'
+import CatalogForm from './CatalogForm.vue'
+import { useObjectStore } from '../../store/modules/object.js'
+
+export default {
+	name: 'CatalogIndex',
+	components: {
+		NcButton,
+		NcEmptyContent,
+		NcLoadingIcon,
+		BookOpenVariantOutline,
+		PlusIcon,
+		CatalogForm,
+	},
+
+	data() {
+		return {
+			loading: false,
+			activeStatus: null,
+			showNewDialog: false,
+			catalogs: [],
+		}
+	},
+
+	computed: {
+		statusChips() {
+			return [
+				{ label: this.t('shillinq', 'All'), value: null },
+				{ label: this.t('shillinq', 'Draft'), value: 'draft' },
+				{ label: this.t('shillinq', 'Active'), value: 'active' },
+				{ label: this.t('shillinq', 'Archived'), value: 'archived' },
+			]
+		},
+		filteredCatalogs() {
+			if (!this.activeStatus) {
+				return this.catalogs
+			}
+			return this.catalogs.filter((c) => c.status === this.activeStatus)
+		},
+	},
+
+	async created() {
+		await this.loadCatalogs()
+	},
+
+	methods: {
+		t(app, text) {
+			return t(app, text)
+		},
+
+		filterByStatus(status) {
+			this.activeStatus = status
+		},
+
+		goToDetail(id) {
+			this.$router.push({ name: 'CatalogDetail', params: { id } })
+		},
+
+		async loadCatalogs() {
+			this.loading = true
+			try {
+				const objectStore = useObjectStore()
+				this.catalogs = await objectStore.fetchObjects('catalog')
+			} catch (error) {
+				console.error('Failed to load catalogs:', error)
+			} finally {
+				this.loading = false
+			}
+		},
+
+		async onCatalogSaved() {
+			this.showNewDialog = false
+			await this.loadCatalogs()
+		},
+	},
+}
+</script>
+
+<style scoped>
+.catalog-index {
+	padding: 8px 16px 24px;
+	max-width: 1200px;
+}
+
+.catalog-index__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 16px;
+}
+
+.catalog-index__header h2 {
+	margin: 0;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.catalog-index__filters {
+	display: flex;
+	gap: 8px;
+	margin-bottom: 16px;
+}
+
+.catalog-index__table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.catalog-index__table th,
+.catalog-index__table td {
+	padding: 10px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.catalog-index__row {
+	cursor: pointer;
+}
+
+.catalog-index__row:hover {
+	background-color: var(--color-background-hover);
+}
+
+.catalog-index__badge--draft {
+	color: var(--color-text-maxcontrast);
+	font-style: italic;
+}
+
+.catalog-index__badge--active {
+	color: var(--color-success);
+	font-weight: 600;
+}
+
+.catalog-index__badge--archived {
+	color: var(--color-text-maxcontrast);
+	text-decoration: line-through;
+}
+</style>

--- a/src/views/catalog/CatalogSearch.vue
+++ b/src/views/catalog/CatalogSearch.vue
@@ -1,0 +1,288 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-8.2 -->
+<template>
+	<div class="catalog-search">
+		<header class="catalog-search__header">
+			<h2>{{ t('shillinq', 'Catalog Search') }}</h2>
+		</header>
+
+		<div class="catalog-search__controls">
+			<NcTextField
+				v-model="searchQuery"
+				:label="t('shillinq', 'Search products...')"
+				class="catalog-search__input"
+				@input="onSearchInput" />
+
+			<NcSelect
+				v-model="selectedCategory"
+				:options="categories"
+				:placeholder="t('shillinq', 'All categories')"
+				class="catalog-search__category"
+				@input="onSearchInput" />
+		</div>
+
+		<NcLoadingIcon v-if="loading" :size="44" />
+
+		<NcEmptyContent
+			v-else-if="results.length === 0 && hasSearched"
+			:name="t('shillinq', 'No results')"
+			:description="t('shillinq', 'Try adjusting your search terms or category filter.')">
+			<template #icon>
+				<MagnifyIcon :size="64" />
+			</template>
+		</NcEmptyContent>
+
+		<div v-else class="catalog-search__results">
+			<div
+				v-for="item in results"
+				:key="item.id"
+				class="catalog-search__result-card">
+				<div class="catalog-search__result-info">
+					<h3>{{ item.productName }}</h3>
+					<p class="catalog-search__supplier">
+						{{ item.supplierName }}
+					</p>
+					<p class="catalog-search__price">
+						{{ formatPrice(item.unitPrice, item.currency) }}
+					</p>
+					<p class="catalog-search__meta">
+						{{ t('shillinq', 'Catalog') }}: {{ item.catalogName }}
+						<template v-if="item.contractReference">
+							&middot; {{ item.contractReference }}
+						</template>
+					</p>
+				</div>
+				<div class="catalog-search__result-actions">
+					<NcTextField
+						v-model.number="item._quantity"
+						type="number"
+						:label="t('shillinq', 'Qty')"
+						min="1"
+						class="catalog-search__qty-input" />
+					<NcButton type="primary" @click="addToBasket(item)">
+						<template #icon>
+							<CartPlusIcon :size="20" />
+						</template>
+						{{ t('shillinq', 'Add to basket') }}
+					</NcButton>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcEmptyContent, NcLoadingIcon, NcSelect, NcTextField } from '@nextcloud/vue'
+import { generateUrl } from '@nextcloud/router'
+import CartPlusIcon from 'vue-material-design-icons/CartPlus.vue'
+import MagnifyIcon from 'vue-material-design-icons/Magnify.vue'
+
+export default {
+	name: 'CatalogSearch',
+	components: {
+		NcButton,
+		NcEmptyContent,
+		NcLoadingIcon,
+		NcSelect,
+		NcTextField,
+		CartPlusIcon,
+		MagnifyIcon,
+	},
+
+	data() {
+		return {
+			searchQuery: '',
+			selectedCategory: null,
+			categories: [],
+			results: [],
+			loading: false,
+			hasSearched: false,
+			debounceTimer: null,
+		}
+	},
+
+	async created() {
+		await this.loadCategories()
+	},
+
+	beforeDestroy() {
+		if (this.debounceTimer) {
+			clearTimeout(this.debounceTimer)
+		}
+	},
+
+	methods: {
+		t(app, text) {
+			return t(app, text)
+		},
+
+		onSearchInput() {
+			if (this.debounceTimer) {
+				clearTimeout(this.debounceTimer)
+			}
+			this.debounceTimer = setTimeout(() => {
+				this.performSearch()
+			}, 300)
+		},
+
+		async performSearch() {
+			if (!this.searchQuery && !this.selectedCategory) {
+				this.results = []
+				this.hasSearched = false
+				return
+			}
+
+			this.loading = true
+			this.hasSearched = true
+			try {
+				const url = new URL(
+					generateUrl('/apps/shillinq/api/v1/catalog/search'),
+					window.location.origin,
+				)
+				if (this.searchQuery) {
+					url.searchParams.set('q', this.searchQuery)
+				}
+				if (this.selectedCategory) {
+					url.searchParams.set('category', this.selectedCategory)
+				}
+
+				const response = await fetch(url.toString(), {
+					headers: { requesttoken: OC.requestToken },
+				})
+				if (response.ok) {
+					const data = await response.json()
+					this.results = (data.results || data).map((item) => ({
+						...item,
+						_quantity: 1,
+					}))
+				}
+			} catch (error) {
+				console.error('Catalog search failed:', error)
+			} finally {
+				this.loading = false
+			}
+		},
+
+		async loadCategories() {
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/catalog/categories')
+				const response = await fetch(url, {
+					headers: { requesttoken: OC.requestToken },
+				})
+				if (response.ok) {
+					this.categories = await response.json()
+				}
+			} catch (error) {
+				console.error('Failed to load categories:', error)
+			}
+		},
+
+		formatPrice(price, currency) {
+			if (price == null) return '-'
+			const cur = currency || 'EUR'
+			return new Intl.NumberFormat('nl-NL', {
+				style: 'currency',
+				currency: cur,
+			}).format(price)
+		},
+
+		async addToBasket(item) {
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/order-baskets/current/lines')
+				const response = await fetch(url, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						requesttoken: OC.requestToken,
+					},
+					body: JSON.stringify({
+						catalogItemId: item.id,
+						quantity: item._quantity || 1,
+					}),
+				})
+				if (response.ok) {
+					this.$emit('basket-updated')
+				}
+			} catch (error) {
+				console.error('Failed to add item to basket:', error)
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.catalog-search {
+	padding: 8px 16px 24px;
+	max-width: 1200px;
+}
+
+.catalog-search__header h2 {
+	margin: 0 0 16px;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.catalog-search__controls {
+	display: flex;
+	gap: 12px;
+	margin-bottom: 16px;
+}
+
+.catalog-search__input {
+	flex: 2;
+}
+
+.catalog-search__category {
+	flex: 1;
+}
+
+.catalog-search__results {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.catalog-search__result-card {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 12px 16px;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-large);
+}
+
+.catalog-search__result-info h3 {
+	margin: 0 0 4px;
+	font-size: 16px;
+}
+
+.catalog-search__supplier {
+	margin: 0;
+	color: var(--color-text-maxcontrast);
+	font-size: 13px;
+}
+
+.catalog-search__price {
+	margin: 4px 0;
+	font-weight: 600;
+	font-size: 15px;
+}
+
+.catalog-search__meta {
+	margin: 0;
+	color: var(--color-text-maxcontrast);
+	font-size: 12px;
+}
+
+.catalog-search__result-actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.catalog-search__qty-input {
+	width: 70px;
+}
+</style>

--- a/src/views/goodsReceipt/GoodsReceiptDetail.vue
+++ b/src/views/goodsReceipt/GoodsReceiptDetail.vue
@@ -1,0 +1,170 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-11.1 -->
+<template>
+	<div class="goods-receipt-detail">
+		<NcLoadingIcon v-if="loading" />
+
+		<template v-else-if="receipt">
+			<header class="goods-receipt-detail__header">
+				<h2>{{ t('shillinq', 'Goods Receipt') }}: {{ receipt.receiptNumber }}</h2>
+			</header>
+
+			<table class="goods-receipt-detail__properties">
+				<tr>
+					<th>{{ t('shillinq', 'Receipt Number') }}</th>
+					<td>{{ receipt.receiptNumber }}</td>
+				</tr>
+				<tr>
+					<th>{{ t('shillinq', 'Purchase Order') }}</th>
+					<td>
+						<a href="#" @click.prevent="navigateToPO">
+							{{ receipt.poNumber }}
+						</a>
+					</td>
+				</tr>
+				<tr>
+					<th>{{ t('shillinq', 'Received Date') }}</th>
+					<td>{{ receipt.receivedDate }}</td>
+				</tr>
+				<tr>
+					<th>{{ t('shillinq', 'Received By') }}</th>
+					<td>{{ receipt.receivedBy }}</td>
+				</tr>
+				<tr>
+					<th>{{ t('shillinq', 'Notes') }}</th>
+					<td>{{ receipt.notes }}</td>
+				</tr>
+			</table>
+
+			<h3>{{ t('shillinq', 'Receipt Lines') }}</h3>
+
+			<table v-if="receipt.lines && receipt.lines.length" class="goods-receipt-detail__lines-table">
+				<thead>
+					<tr>
+						<th>{{ t('shillinq', 'Product') }}</th>
+						<th>{{ t('shillinq', 'Ordered Qty') }}</th>
+						<th>{{ t('shillinq', 'Received Qty') }}</th>
+						<th>{{ t('shillinq', 'Discrepancy Note') }}</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr v-for="line in receipt.lines" :key="line.id">
+						<td>{{ line.productName }}</td>
+						<td>{{ line.orderedQuantity }}</td>
+						<td>{{ line.receivedQuantity }}</td>
+						<td>{{ line.discrepancyNote }}</td>
+					</tr>
+				</tbody>
+			</table>
+
+			<p v-else class="goods-receipt-detail__empty">
+				{{ t('shillinq', 'No receipt lines.') }}
+			</p>
+		</template>
+
+		<p v-else class="goods-receipt-detail__empty">
+			{{ t('shillinq', 'Goods receipt not found.') }}
+		</p>
+	</div>
+</template>
+
+<script>
+import { NcLoadingIcon } from '@nextcloud/vue'
+import { useGoodsReceiptStore } from '../../store/modules/goodsReceipt.js'
+
+export default {
+	name: 'GoodsReceiptDetail',
+	components: {
+		NcLoadingIcon,
+	},
+	data() {
+		return {
+			loading: false,
+		}
+	},
+	computed: {
+		goodsReceiptStore() {
+			return useGoodsReceiptStore()
+		},
+		receipt() {
+			return this.goodsReceiptStore.current || null
+		},
+	},
+	mounted() {
+		this.fetchReceipt()
+	},
+	methods: {
+		t,
+		async fetchReceipt() {
+			this.loading = true
+			try {
+				await this.goodsReceiptStore.fetchOne(this.$route.params.id)
+			} finally {
+				this.loading = false
+			}
+		},
+		navigateToPO() {
+			if (this.receipt?.purchaseOrderId) {
+				this.$router.push({
+					name: 'purchaseOrderDetail',
+					params: { id: this.receipt.purchaseOrderId },
+				})
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.goods-receipt-detail {
+	padding: 8px 4px 24px;
+	max-width: 1200px;
+}
+
+.goods-receipt-detail__header {
+	margin-bottom: 16px;
+}
+
+.goods-receipt-detail__header h2 {
+	margin: 0;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.goods-receipt-detail__properties {
+	width: 100%;
+	max-width: 600px;
+	margin-bottom: 24px;
+}
+
+.goods-receipt-detail__properties th {
+	text-align: left;
+	padding: 6px 16px 6px 0;
+	color: var(--color-text-maxcontrast);
+	white-space: nowrap;
+	width: 180px;
+}
+
+.goods-receipt-detail__properties td {
+	padding: 6px 0;
+}
+
+.goods-receipt-detail__lines-table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.goods-receipt-detail__lines-table th,
+.goods-receipt-detail__lines-table td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.goods-receipt-detail__empty {
+	color: var(--color-text-maxcontrast);
+	text-align: center;
+	padding: 40px 0;
+}
+</style>

--- a/src/views/goodsReceipt/GoodsReceiptForm.vue
+++ b/src/views/goodsReceipt/GoodsReceiptForm.vue
@@ -1,0 +1,253 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-11.1 -->
+<template>
+	<div class="goods-receipt-form">
+		<NcLoadingIcon v-if="loading" />
+
+		<template v-else>
+			<header class="goods-receipt-form__header">
+				<h2>{{ t('shillinq', 'Record Goods Receipt') }}</h2>
+				<p v-if="purchaseOrder" class="goods-receipt-form__subtitle">
+					{{ t('shillinq', 'For Purchase Order:') }} {{ purchaseOrder.poNumber }}
+				</p>
+			</header>
+
+			<form class="goods-receipt-form__form" @submit.prevent="submit">
+				<table v-if="lines.length" class="goods-receipt-form__table">
+					<thead>
+						<tr>
+							<th>{{ t('shillinq', 'Product') }}</th>
+							<th>{{ t('shillinq', 'Ordered Qty') }}</th>
+							<th>{{ t('shillinq', 'Previously Received') }}</th>
+							<th>{{ t('shillinq', 'Outstanding') }}</th>
+							<th>{{ t('shillinq', 'Received Qty') }} *</th>
+							<th>{{ t('shillinq', 'Discrepancy Note') }}</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="(line, index) in lines" :key="line.purchaseOrderLineId">
+							<td>{{ line.productName }}</td>
+							<td>{{ line.orderedQuantity }}</td>
+							<td>{{ line.previouslyReceived }}</td>
+							<td>{{ line.outstanding }}</td>
+							<td>
+								<input v-model.number="line.receivedQuantity"
+									type="number"
+									min="0"
+									:max="line.outstanding"
+									class="goods-receipt-form__qty-input"
+									required
+									@input="validateLine(index)" />
+								<span v-if="line.error" class="goods-receipt-form__error">
+									{{ line.error }}
+								</span>
+							</td>
+							<td>
+								<input v-model="line.discrepancyNote"
+									type="text"
+									class="goods-receipt-form__note-input"
+									:placeholder="t('shillinq', 'Optional note...')" />
+							</td>
+						</tr>
+					</tbody>
+				</table>
+
+				<p v-else class="goods-receipt-form__empty">
+					{{ t('shillinq', 'No outstanding lines to receive.') }}
+				</p>
+
+				<div class="goods-receipt-form__actions">
+					<NcButton type="tertiary" @click="$router.back()">
+						{{ t('shillinq', 'Cancel') }}
+					</NcButton>
+					<NcButton type="primary"
+						native-type="submit"
+						:disabled="saving || !isValid">
+						<template #icon>
+							<NcLoadingIcon v-if="saving" :size="20" />
+						</template>
+						{{ t('shillinq', 'Submit Goods Receipt') }}
+					</NcButton>
+				</div>
+			</form>
+		</template>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcLoadingIcon } from '@nextcloud/vue'
+import { generateUrl } from '@nextcloud/router'
+import axios from '@nextcloud/axios'
+import { usePurchaseOrderStore } from '../../store/modules/purchaseOrder.js'
+
+export default {
+	name: 'GoodsReceiptForm',
+	components: {
+		NcButton,
+		NcLoadingIcon,
+	},
+	data() {
+		return {
+			loading: false,
+			saving: false,
+			purchaseOrder: null,
+			lines: [],
+		}
+	},
+	computed: {
+		purchaseOrderStore() {
+			return usePurchaseOrderStore()
+		},
+		isValid() {
+			return (
+				this.lines.length > 0
+				&& this.lines.every((line) => !line.error && line.receivedQuantity >= 0)
+				&& this.lines.some((line) => line.receivedQuantity > 0)
+			)
+		},
+	},
+	mounted() {
+		this.loadPurchaseOrder()
+	},
+	methods: {
+		t,
+		async loadPurchaseOrder() {
+			this.loading = true
+			try {
+				const purchaseOrderId = this.$route.query.purchaseOrderId
+				if (!purchaseOrderId) {
+					console.error('No purchaseOrderId provided')
+					return
+				}
+				await this.purchaseOrderStore.fetchOne(purchaseOrderId)
+				this.purchaseOrder = this.purchaseOrderStore.current
+
+				if (this.purchaseOrder?.lines) {
+					this.lines = this.purchaseOrder.lines.map((poLine) => {
+						const outstanding = poLine.quantity - (poLine.receivedQuantity || 0)
+						return {
+							purchaseOrderLineId: poLine.id,
+							productName: poLine.productName,
+							orderedQuantity: poLine.quantity,
+							previouslyReceived: poLine.receivedQuantity || 0,
+							outstanding,
+							receivedQuantity: 0,
+							discrepancyNote: '',
+							error: '',
+						}
+					})
+				}
+			} finally {
+				this.loading = false
+			}
+		},
+		validateLine(index) {
+			const line = this.lines[index]
+			if (line.receivedQuantity < 0) {
+				line.error = this.t('shillinq', 'Quantity cannot be negative.')
+			} else if (line.receivedQuantity > line.outstanding) {
+				line.error = this.t('shillinq', 'Cannot exceed outstanding quantity ({outstanding}).', {
+					outstanding: line.outstanding,
+				})
+			} else {
+				line.error = ''
+			}
+		},
+		async submit() {
+			if (!this.isValid || this.saving) return
+			this.saving = true
+			try {
+				const payload = {
+					purchaseOrderId: this.purchaseOrder.id,
+					lines: this.lines
+						.filter((line) => line.receivedQuantity > 0)
+						.map((line) => ({
+							purchaseOrderLineId: line.purchaseOrderLineId,
+							receivedQuantity: line.receivedQuantity,
+							discrepancyNote: line.discrepancyNote || null,
+						})),
+				}
+				const url = generateUrl('/apps/shillinq/api/v1/goods-receipts')
+				await axios.post(url, payload)
+				this.$router.push({
+					name: 'purchaseOrderDetail',
+					params: { id: this.purchaseOrder.id },
+				})
+			} catch (error) {
+				console.error('Failed to submit goods receipt:', error)
+			} finally {
+				this.saving = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.goods-receipt-form {
+	padding: 8px 4px 24px;
+	max-width: 1200px;
+}
+
+.goods-receipt-form__header {
+	margin-bottom: 16px;
+}
+
+.goods-receipt-form__header h2 {
+	margin: 0 0 4px;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.goods-receipt-form__subtitle {
+	margin: 0;
+	color: var(--color-text-maxcontrast);
+}
+
+.goods-receipt-form__table {
+	width: 100%;
+	border-collapse: collapse;
+	margin-bottom: 20px;
+}
+
+.goods-receipt-form__table th,
+.goods-receipt-form__table td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.goods-receipt-form__qty-input {
+	width: 80px;
+	padding: 4px 8px;
+	border: 1px solid var(--color-border);
+	border-radius: 4px;
+}
+
+.goods-receipt-form__note-input {
+	width: 100%;
+	padding: 4px 8px;
+	border: 1px solid var(--color-border);
+	border-radius: 4px;
+}
+
+.goods-receipt-form__error {
+	display: block;
+	color: var(--color-error);
+	font-size: 12px;
+	margin-top: 2px;
+}
+
+.goods-receipt-form__actions {
+	display: flex;
+	gap: 8px;
+	justify-content: flex-end;
+}
+
+.goods-receipt-form__empty {
+	color: var(--color-text-maxcontrast);
+	text-align: center;
+	padding: 40px 0;
+}
+</style>

--- a/src/views/goodsReceipt/GoodsReceiptIndex.vue
+++ b/src/views/goodsReceipt/GoodsReceiptIndex.vue
@@ -1,0 +1,125 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-11.1 -->
+<template>
+	<div class="goods-receipt-index">
+		<header class="goods-receipt-index__header">
+			<h2>{{ t('shillinq', 'Goods Receipts') }}</h2>
+		</header>
+
+		<NcLoadingIcon v-if="loading" />
+
+		<table v-else-if="receipts.length" class="goods-receipt-index__table">
+			<thead>
+				<tr>
+					<th>{{ t('shillinq', 'Receipt Number') }}</th>
+					<th>{{ t('shillinq', 'PO Number') }}</th>
+					<th>{{ t('shillinq', 'Received Date') }}</th>
+					<th>{{ t('shillinq', 'Received By') }}</th>
+					<th>{{ t('shillinq', 'Lines') }}</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr v-for="receipt in receipts"
+					:key="receipt.id"
+					class="goods-receipt-index__row"
+					@click="navigateToDetail(receipt.id)">
+					<td>{{ receipt.receiptNumber }}</td>
+					<td>{{ receipt.poNumber }}</td>
+					<td>{{ receipt.receivedDate }}</td>
+					<td>{{ receipt.receivedBy }}</td>
+					<td>{{ receipt.lineCount }}</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<p v-else class="goods-receipt-index__empty">
+			{{ t('shillinq', 'No goods receipts found.') }}
+		</p>
+	</div>
+</template>
+
+<script>
+import { NcLoadingIcon } from '@nextcloud/vue'
+import { useGoodsReceiptStore } from '../../store/modules/goodsReceipt.js'
+
+export default {
+	name: 'GoodsReceiptIndex',
+	components: {
+		NcLoadingIcon,
+	},
+	data() {
+		return {
+			loading: false,
+		}
+	},
+	computed: {
+		goodsReceiptStore() {
+			return useGoodsReceiptStore()
+		},
+		receipts() {
+			return this.goodsReceiptStore.items || []
+		},
+	},
+	mounted() {
+		this.fetchReceipts()
+	},
+	methods: {
+		t,
+		async fetchReceipts() {
+			this.loading = true
+			try {
+				await this.goodsReceiptStore.fetchAll()
+			} finally {
+				this.loading = false
+			}
+		},
+		navigateToDetail(id) {
+			this.$router.push({ name: 'goodsReceiptDetail', params: { id } })
+		},
+	},
+}
+</script>
+
+<style scoped>
+.goods-receipt-index {
+	padding: 8px 4px 24px;
+	max-width: 1200px;
+}
+
+.goods-receipt-index__header {
+	margin-bottom: 16px;
+}
+
+.goods-receipt-index__header h2 {
+	margin: 0;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.goods-receipt-index__table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.goods-receipt-index__table th,
+.goods-receipt-index__table td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.goods-receipt-index__row {
+	cursor: pointer;
+}
+
+.goods-receipt-index__row:hover {
+	background-color: var(--color-background-hover);
+}
+
+.goods-receipt-index__empty {
+	color: var(--color-text-maxcontrast);
+	text-align: center;
+	padding: 40px 0;
+}
+</style>

--- a/src/views/orderBasket/OrderBasketHistory.vue
+++ b/src/views/orderBasket/OrderBasketHistory.vue
@@ -1,0 +1,200 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-9.2 -->
+<template>
+	<div class="basket-history">
+		<header class="basket-history__header">
+			<h2>{{ t('shillinq', 'Order History') }}</h2>
+		</header>
+
+		<NcLoadingIcon v-if="loading" :size="44" />
+
+		<NcEmptyContent
+			v-else-if="baskets.length === 0"
+			:name="t('shillinq', 'No order history')"
+			:description="t('shillinq', 'Submitted baskets will appear here.')">
+			<template #icon>
+				<HistoryIcon :size="64" />
+			</template>
+		</NcEmptyContent>
+
+		<table v-else class="basket-history__table">
+			<thead>
+				<tr>
+					<th>{{ t('shillinq', 'Submitted') }}</th>
+					<th>{{ t('shillinq', 'Items') }}</th>
+					<th>{{ t('shillinq', 'Total') }}</th>
+					<th>{{ t('shillinq', 'Basket Status') }}</th>
+					<th>{{ t('shillinq', 'PO Status') }}</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr v-for="basket in baskets" :key="basket.id">
+					<td>{{ formatDate(basket.submittedAt) }}</td>
+					<td>{{ basket.lineCount || (basket.lines && basket.lines.length) || 0 }}</td>
+					<td>{{ formatPrice(basket.total, basket.currency) }}</td>
+					<td>{{ basket.status }}</td>
+					<td>
+						<span
+							v-if="basket.purchaseOrderStatus"
+							:class="'basket-history__po-badge basket-history__po-badge--' + poStatusColor(basket.purchaseOrderStatus)">
+							{{ basket.purchaseOrderStatus }}
+						</span>
+						<span v-else class="basket-history__po-badge basket-history__po-badge--grey">
+							{{ t('shillinq', 'n/a') }}
+						</span>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</template>
+
+<script>
+import { NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import { generateUrl } from '@nextcloud/router'
+import HistoryIcon from 'vue-material-design-icons/History.vue'
+
+const PO_STATUS_COLORS = {
+	pending: 'amber',
+	approved: 'blue',
+	submitted: 'blue',
+	acknowledged: 'blue',
+	overdue: 'red',
+	delivered: 'green',
+	invoiced: 'teal',
+	closed: 'grey',
+}
+
+export default {
+	name: 'OrderBasketHistory',
+	components: {
+		NcEmptyContent,
+		NcLoadingIcon,
+		HistoryIcon,
+	},
+
+	data() {
+		return {
+			loading: false,
+			baskets: [],
+		}
+	},
+
+	async created() {
+		await this.loadHistory()
+	},
+
+	methods: {
+		t(app, text) {
+			return t(app, text)
+		},
+
+		poStatusColor(status) {
+			return PO_STATUS_COLORS[status] || 'grey'
+		},
+
+		formatDate(dateStr) {
+			if (!dateStr) return '-'
+			return new Date(dateStr).toLocaleDateString('nl-NL', {
+				year: 'numeric',
+				month: 'short',
+				day: 'numeric',
+				hour: '2-digit',
+				minute: '2-digit',
+			})
+		},
+
+		formatPrice(price, currency) {
+			if (price == null) return '-'
+			const cur = currency || 'EUR'
+			return new Intl.NumberFormat('nl-NL', {
+				style: 'currency',
+				currency: cur,
+			}).format(price)
+		},
+
+		async loadHistory() {
+			this.loading = true
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/order-baskets?exclude_status=open&sort=-submittedAt')
+				const response = await fetch(url, {
+					headers: { requesttoken: OC.requestToken },
+				})
+				if (response.ok) {
+					const data = await response.json()
+					this.baskets = data.results || data
+				}
+			} catch (error) {
+				console.error('Failed to load basket history:', error)
+			} finally {
+				this.loading = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.basket-history {
+	padding: 8px 16px 24px;
+	max-width: 1200px;
+}
+
+.basket-history__header h2 {
+	margin: 0 0 16px;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.basket-history__table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.basket-history__table th,
+.basket-history__table td {
+	padding: 10px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.basket-history__po-badge {
+	display: inline-block;
+	padding: 2px 10px;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: capitalize;
+}
+
+.basket-history__po-badge--amber {
+	background-color: #fff3cd;
+	color: #856404;
+}
+
+.basket-history__po-badge--blue {
+	background-color: #cce5ff;
+	color: #004085;
+}
+
+.basket-history__po-badge--red {
+	background-color: #f8d7da;
+	color: #721c24;
+}
+
+.basket-history__po-badge--green {
+	background-color: #d4edda;
+	color: #155724;
+}
+
+.basket-history__po-badge--teal {
+	background-color: #d1ecf1;
+	color: #0c5460;
+}
+
+.basket-history__po-badge--grey {
+	background-color: #e2e3e5;
+	color: #383d41;
+}
+</style>

--- a/src/views/orderBasket/OrderBasketView.vue
+++ b/src/views/orderBasket/OrderBasketView.vue
@@ -1,0 +1,382 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-9.1 -->
+<template>
+	<div class="order-basket">
+		<header class="order-basket__header">
+			<h2>{{ t('shillinq', 'Order Basket') }}</h2>
+		</header>
+
+		<NcLoadingIcon v-if="loading" :size="44" />
+
+		<NcEmptyContent
+			v-else-if="lines.length === 0"
+			:name="t('shillinq', 'Your basket is empty')"
+			:description="t('shillinq', 'Search the catalog to add items.')">
+			<template #icon>
+				<CartOutlineIcon :size="64" />
+			</template>
+			<template #action>
+				<NcButton type="primary" :to="{ name: 'CatalogSearch' }">
+					{{ t('shillinq', 'Search Catalog') }}
+				</NcButton>
+			</template>
+		</NcEmptyContent>
+
+		<template v-else>
+			<!-- Budget warning -->
+			<div v-if="budgetWarning" class="order-basket__warning">
+				<AlertIcon :size="20" />
+				{{ budgetWarning }}
+			</div>
+
+			<!-- Approval message -->
+			<div v-if="approvalMessage" class="order-basket__approval">
+				<CheckCircleIcon :size="20" />
+				{{ approvalMessage }}
+			</div>
+
+			<table class="order-basket__table">
+				<thead>
+					<tr>
+						<th>{{ t('shillinq', 'Product') }}</th>
+						<th>{{ t('shillinq', 'Quantity') }}</th>
+						<th>{{ t('shillinq', 'Unit Price') }}</th>
+						<th>{{ t('shillinq', 'Line Total') }}</th>
+						<th />
+					</tr>
+				</thead>
+				<tbody>
+					<tr v-for="line in lines" :key="line.id">
+						<td>{{ line.productName }}</td>
+						<td>
+							<NcTextField
+								v-model.number="line.quantity"
+								type="number"
+								min="1"
+								class="order-basket__qty"
+								:label="t('shillinq', 'Quantity')"
+								@input="onQuantityChange(line)" />
+						</td>
+						<td>{{ formatPrice(line.unitPrice, line.currency) }}</td>
+						<td class="order-basket__line-total">
+							{{ formatPrice(lineTotal(line), line.currency) }}
+						</td>
+						<td>
+							<NcButton
+								type="tertiary"
+								:aria-label="t('shillinq', 'Remove')"
+								@click="removeLine(line)">
+								<template #icon>
+									<DeleteIcon :size="20" />
+								</template>
+							</NcButton>
+						</td>
+					</tr>
+				</tbody>
+				<tfoot>
+					<tr>
+						<td colspan="3" class="order-basket__total-label">
+							<strong>{{ t('shillinq', 'Total') }}</strong>
+						</td>
+						<td class="order-basket__total-value">
+							<strong>{{ formatPrice(basketTotal, defaultCurrency) }}</strong>
+						</td>
+						<td />
+					</tr>
+				</tfoot>
+			</table>
+
+			<div class="order-basket__footer">
+				<div class="order-basket__cost-centre">
+					<label for="cost-centre">{{ t('shillinq', 'Cost Centre') }}</label>
+					<NcSelect
+						id="cost-centre"
+						v-model="selectedCostCentre"
+						:options="costCentres"
+						:placeholder="t('shillinq', 'Select cost centre')"
+						label="name"
+						track-by="id" />
+				</div>
+
+				<NcButton
+					type="primary"
+					:disabled="submitting || !selectedCostCentre"
+					@click="submitBasket">
+					<template v-if="submitting" #icon>
+						<NcLoadingIcon :size="20" />
+					</template>
+					<template v-else #icon>
+						<SendIcon :size="20" />
+					</template>
+					{{ t('shillinq', 'Submit Order') }}
+				</NcButton>
+			</div>
+		</template>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcEmptyContent, NcLoadingIcon, NcSelect, NcTextField } from '@nextcloud/vue'
+import { generateUrl } from '@nextcloud/router'
+import AlertIcon from 'vue-material-design-icons/Alert.vue'
+import CartOutlineIcon from 'vue-material-design-icons/CartOutline.vue'
+import CheckCircleIcon from 'vue-material-design-icons/CheckCircle.vue'
+import DeleteIcon from 'vue-material-design-icons/Delete.vue'
+import SendIcon from 'vue-material-design-icons/Send.vue'
+
+export default {
+	name: 'OrderBasketView',
+	components: {
+		NcButton,
+		NcEmptyContent,
+		NcLoadingIcon,
+		NcSelect,
+		NcTextField,
+		AlertIcon,
+		CartOutlineIcon,
+		CheckCircleIcon,
+		DeleteIcon,
+		SendIcon,
+	},
+
+	data() {
+		return {
+			loading: false,
+			submitting: false,
+			basketId: null,
+			lines: [],
+			costCentres: [],
+			selectedCostCentre: null,
+			budgetWarning: null,
+			approvalMessage: null,
+			defaultCurrency: 'EUR',
+		}
+	},
+
+	computed: {
+		basketTotal() {
+			return this.lines.reduce((sum, line) => sum + this.lineTotal(line), 0)
+		},
+	},
+
+	async created() {
+		await Promise.all([
+			this.loadBasket(),
+			this.loadCostCentres(),
+		])
+	},
+
+	methods: {
+		t(app, text, params) {
+			return t(app, text, params)
+		},
+
+		lineTotal(line) {
+			return (line.quantity || 0) * (line.unitPrice || 0)
+		},
+
+		formatPrice(price, currency) {
+			if (price == null) return '-'
+			const cur = currency || 'EUR'
+			return new Intl.NumberFormat('nl-NL', {
+				style: 'currency',
+				currency: cur,
+			}).format(price)
+		},
+
+		onQuantityChange(line) {
+			if (line.quantity < 1) {
+				line.quantity = 1
+			}
+		},
+
+		async loadBasket() {
+			this.loading = true
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/order-baskets/current')
+				const response = await fetch(url, {
+					headers: { requesttoken: OC.requestToken },
+				})
+				if (response.ok) {
+					const data = await response.json()
+					this.basketId = data.id
+					this.lines = data.lines || []
+				}
+			} catch (error) {
+				console.error('Failed to load basket:', error)
+			} finally {
+				this.loading = false
+			}
+		},
+
+		async loadCostCentres() {
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/cost-centres')
+				const response = await fetch(url, {
+					headers: { requesttoken: OC.requestToken },
+				})
+				if (response.ok) {
+					const data = await response.json()
+					this.costCentres = data.results || data
+				}
+			} catch (error) {
+				console.error('Failed to load cost centres:', error)
+			}
+		},
+
+		async removeLine(line) {
+			try {
+				const url = generateUrl(
+					`/apps/shillinq/api/v1/order-baskets/${this.basketId}/lines/${line.id}`,
+				)
+				const response = await fetch(url, {
+					method: 'DELETE',
+					headers: { requesttoken: OC.requestToken },
+				})
+				if (response.ok) {
+					this.lines = this.lines.filter((l) => l.id !== line.id)
+				}
+			} catch (error) {
+				console.error('Failed to remove line:', error)
+			}
+		},
+
+		async submitBasket() {
+			if (!this.basketId || !this.selectedCostCentre) return
+
+			this.submitting = true
+			this.budgetWarning = null
+			this.approvalMessage = null
+
+			try {
+				const url = generateUrl(
+					`/apps/shillinq/api/v1/order-baskets/${this.basketId}/submit`,
+				)
+				const response = await fetch(url, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						requesttoken: OC.requestToken,
+					},
+					body: JSON.stringify({
+						costCentreId: this.selectedCostCentre.id,
+						lines: this.lines.map((l) => ({
+							id: l.id,
+							quantity: l.quantity,
+						})),
+					}),
+				})
+
+				const data = await response.json()
+
+				if (response.ok) {
+					if (data.budgetWarning) {
+						this.budgetWarning = data.budgetWarning
+					}
+					if (data.requiresApproval) {
+						this.approvalMessage = t(
+							'shillinq',
+							'Your order has been sent for approval.',
+						)
+					} else {
+						this.approvalMessage = t(
+							'shillinq',
+							'Your order has been submitted successfully.',
+						)
+					}
+					await this.loadBasket()
+				}
+			} catch (error) {
+				console.error('Failed to submit basket:', error)
+			} finally {
+				this.submitting = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.order-basket {
+	padding: 8px 16px 24px;
+	max-width: 1200px;
+}
+
+.order-basket__header h2 {
+	margin: 0 0 16px;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.order-basket__warning {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 10px 16px;
+	background-color: var(--color-warning-hover);
+	border-radius: var(--border-radius-large);
+	color: var(--color-warning-text);
+	margin-bottom: 12px;
+}
+
+.order-basket__approval {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 10px 16px;
+	background-color: var(--color-success-hover);
+	border-radius: var(--border-radius-large);
+	color: var(--color-success-text);
+	margin-bottom: 12px;
+}
+
+.order-basket__table {
+	width: 100%;
+	border-collapse: collapse;
+	margin-bottom: 16px;
+}
+
+.order-basket__table th,
+.order-basket__table td {
+	padding: 10px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.order-basket__qty {
+	width: 80px;
+}
+
+.order-basket__line-total {
+	font-weight: 600;
+}
+
+.order-basket__total-label {
+	text-align: right;
+	padding-right: 12px;
+}
+
+.order-basket__total-value {
+	font-size: 16px;
+}
+
+.order-basket__footer {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-end;
+	gap: 16px;
+}
+
+.order-basket__cost-centre {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	min-width: 250px;
+}
+
+.order-basket__cost-centre label {
+	font-weight: 600;
+	font-size: 14px;
+}
+</style>

--- a/src/views/product/ProductDetail.vue
+++ b/src/views/product/ProductDetail.vue
@@ -1,0 +1,336 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-7.2 -->
+<template>
+	<div class="product-detail">
+		<NcLoadingIcon v-if="isLoading" :size="44" />
+
+		<template v-else-if="product">
+			<header class="product-detail__header">
+				<NcButton type="tertiary" @click="goBack">
+					<template #icon>
+						<ArrowLeft :size="20" />
+					</template>
+					{{ t('shillinq', 'Back to products') }}
+				</NcButton>
+				<h2>{{ product.name }}</h2>
+				<NcButton type="secondary" @click="showForm = true">
+					<template #icon>
+						<Pencil :size="20" />
+					</template>
+					{{ t('shillinq', 'Edit') }}
+				</NcButton>
+			</header>
+
+			<div class="product-detail__tabs">
+				<NcButton
+					:type="activeTab === 'details' ? 'primary' : 'secondary'"
+					@click="activeTab = 'details'">
+					{{ t('shillinq', 'Details') }}
+				</NcButton>
+				<NcButton
+					:type="activeTab === 'catalogs' ? 'primary' : 'secondary'"
+					@click="activeTab = 'catalogs'">
+					{{ t('shillinq', 'Catalogs') }}
+				</NcButton>
+				<NcButton
+					:type="activeTab === 'orders' ? 'primary' : 'secondary'"
+					@click="activeTab = 'orders'">
+					{{ t('shillinq', 'Orders') }}
+				</NcButton>
+			</div>
+
+			<!-- Details tab -->
+			<div v-if="activeTab === 'details'" class="product-detail__content">
+				<dl class="product-detail__properties">
+					<dt>{{ t('shillinq', 'SKU') }}</dt>
+					<dd>{{ product.sku }}</dd>
+
+					<dt>{{ t('shillinq', 'Name') }}</dt>
+					<dd>{{ product.name }}</dd>
+
+					<dt>{{ t('shillinq', 'Description') }}</dt>
+					<dd>{{ product.description || '-' }}</dd>
+
+					<dt>{{ t('shillinq', 'Unit') }}</dt>
+					<dd>{{ product.unit || '-' }}</dd>
+
+					<dt>{{ t('shillinq', 'Category') }}</dt>
+					<dd>{{ categoryName }}</dd>
+
+					<dt>{{ t('shillinq', 'Purchase Price') }}</dt>
+					<dd>{{ formatPrice(product.purchasePrice, product.currency) }}</dd>
+
+					<dt>{{ t('shillinq', 'Currency') }}</dt>
+					<dd>{{ product.currency || 'EUR' }}</dd>
+
+					<dt>{{ t('shillinq', 'Tax Rate') }}</dt>
+					<dd>{{ product.taxRate != null ? product.taxRate + '%' : '-' }}</dd>
+
+					<dt>{{ t('shillinq', 'Lead Time (Days)') }}</dt>
+					<dd>{{ product.leadTimeDays ?? '-' }}</dd>
+
+					<dt>{{ t('shillinq', 'Active') }}</dt>
+					<dd>{{ product.active ? t('shillinq', 'Yes') : t('shillinq', 'No') }}</dd>
+
+					<dt>{{ t('shillinq', 'Notes') }}</dt>
+					<dd>{{ product.notes || '-' }}</dd>
+				</dl>
+			</div>
+
+			<!-- Catalogs tab -->
+			<div v-if="activeTab === 'catalogs'" class="product-detail__content">
+				<NcLoadingIcon v-if="catalogItemsLoading" :size="32" />
+				<table v-else-if="filteredCatalogItems.length" class="product-detail__table">
+					<thead>
+						<tr>
+							<th>{{ t('shillinq', 'Catalog') }}</th>
+							<th>{{ t('shillinq', 'Price') }}</th>
+							<th>{{ t('shillinq', 'Active') }}</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="item in filteredCatalogItems" :key="item.id">
+							<td>{{ item.catalogId }}</td>
+							<td>{{ formatPrice(item.price, item.currency) }}</td>
+							<td>
+								<CheckCircle v-if="item.active" :size="20" class="icon--success" />
+								<CloseCircle v-else :size="20" class="icon--muted" />
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				<NcEmptyContent v-else :name="t('shillinq', 'Not listed in any catalog')">
+					<template #icon>
+						<BookOpenPageVariantOutline :size="64" />
+					</template>
+				</NcEmptyContent>
+			</div>
+
+			<!-- Orders tab -->
+			<div v-if="activeTab === 'orders'" class="product-detail__content">
+				<NcLoadingIcon v-if="purchaseOrdersLoading" :size="32" />
+				<table v-else-if="filteredOrderLines.length" class="product-detail__table">
+					<thead>
+						<tr>
+							<th>{{ t('shillinq', 'Order') }}</th>
+							<th>{{ t('shillinq', 'Quantity') }}</th>
+							<th>{{ t('shillinq', 'Unit Price') }}</th>
+							<th>{{ t('shillinq', 'Total') }}</th>
+							<th>{{ t('shillinq', 'Status') }}</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="line in filteredOrderLines" :key="line.id">
+							<td>{{ line.purchaseOrderId }}</td>
+							<td>{{ line.quantity }}</td>
+							<td>{{ formatPrice(line.unitPrice, line.currency) }}</td>
+							<td>{{ formatPrice(line.totalPrice, line.currency) }}</td>
+							<td>{{ line.status || '-' }}</td>
+						</tr>
+					</tbody>
+				</table>
+				<NcEmptyContent v-else :name="t('shillinq', 'No orders for this product')">
+					<template #icon>
+						<ClipboardTextOutline :size="64" />
+					</template>
+				</NcEmptyContent>
+			</div>
+		</template>
+
+		<NcEmptyContent v-else :name="t('shillinq', 'Product not found')">
+			<template #icon>
+				<PackageVariantClosed :size="64" />
+			</template>
+		</NcEmptyContent>
+
+		<ProductForm
+			v-if="showForm"
+			:product="product"
+			@close="showForm = false"
+			@saved="onSaved" />
+	</div>
+</template>
+
+<script>
+import { NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import ArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
+import BookOpenPageVariantOutline from 'vue-material-design-icons/BookOpenPageVariantOutline.vue'
+import CheckCircle from 'vue-material-design-icons/CheckCircle.vue'
+import ClipboardTextOutline from 'vue-material-design-icons/ClipboardTextOutline.vue'
+import CloseCircle from 'vue-material-design-icons/CloseCircle.vue'
+import PackageVariantClosed from 'vue-material-design-icons/PackageVariantClosed.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
+import { useProductStore } from '../../store/modules/product.js'
+import { useProductCategoryStore } from '../../store/modules/productCategory.js'
+import { useCatalogItemStore } from '../../store/modules/catalogItem.js'
+import { usePurchaseOrderStore } from '../../store/modules/purchaseOrder.js'
+import ProductForm from './ProductForm.vue'
+
+export default {
+	name: 'ProductDetail',
+	components: {
+		NcButton,
+		NcEmptyContent,
+		NcLoadingIcon,
+		ArrowLeft,
+		BookOpenPageVariantOutline,
+		CheckCircle,
+		ClipboardTextOutline,
+		CloseCircle,
+		PackageVariantClosed,
+		Pencil,
+		ProductForm,
+	},
+	data() {
+		return {
+			activeTab: 'details',
+			showForm: false,
+		}
+	},
+	computed: {
+		productStore() {
+			return useProductStore()
+		},
+		productCategoryStore() {
+			return useProductCategoryStore()
+		},
+		catalogItemStore() {
+			return useCatalogItemStore()
+		},
+		purchaseOrderStore() {
+			return usePurchaseOrderStore()
+		},
+		productId() {
+			return this.$route.params.productId
+		},
+		product() {
+			return this.productStore.objectItem
+		},
+		isLoading() {
+			return this.productStore.isLoading
+		},
+		catalogItemsLoading() {
+			return this.catalogItemStore.isLoading
+		},
+		purchaseOrdersLoading() {
+			return this.purchaseOrderStore.isLoading
+		},
+		categoryName() {
+			if (!this.product?.categoryId) return '-'
+			const category = (this.productCategoryStore.objectList || []).find(
+				(c) => c.id === this.product.categoryId,
+			)
+			return category ? category.name : this.product.categoryId
+		},
+		filteredCatalogItems() {
+			return (this.catalogItemStore.objectList || []).filter(
+				(item) => item.productId === this.productId,
+			)
+		},
+		filteredOrderLines() {
+			return (this.purchaseOrderStore.objectList || []).filter(
+				(line) => line.productId === this.productId,
+			)
+		},
+	},
+	watch: {
+		productId: {
+			handler(id) {
+				if (id) {
+					this.loadData(id)
+				}
+			},
+			immediate: true,
+		},
+	},
+	methods: {
+		async loadData(id) {
+			await Promise.all([
+				this.productStore.fetchOne(id),
+				this.productCategoryStore.fetchAll(),
+				this.catalogItemStore.fetchAll(),
+				this.purchaseOrderStore.fetchAll(),
+			])
+		},
+		goBack() {
+			this.$router.push({ name: 'ProductIndex' })
+		},
+		formatPrice(price, currency) {
+			if (price == null) return '-'
+			return `${currency || 'EUR'} ${Number(price).toFixed(2)}`
+		},
+		onSaved() {
+			this.showForm = false
+			this.productStore.fetchOne(this.productId)
+		},
+	},
+}
+</script>
+
+<style scoped>
+.product-detail {
+	padding: 8px 4px 24px;
+	max-width: 1200px;
+}
+
+.product-detail__header {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-bottom: 20px;
+}
+
+.product-detail__header h2 {
+	margin: 0;
+	font-size: 22px;
+	font-weight: 600;
+	flex: 1;
+}
+
+.product-detail__tabs {
+	display: flex;
+	gap: 8px;
+	margin-bottom: 16px;
+}
+
+.product-detail__properties {
+	display: grid;
+	grid-template-columns: 200px 1fr;
+	gap: 8px 16px;
+}
+
+.product-detail__properties dt {
+	font-weight: 600;
+	color: var(--color-text-maxcontrast);
+}
+
+.product-detail__properties dd {
+	margin: 0;
+}
+
+.product-detail__table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.product-detail__table th,
+.product-detail__table td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.product-detail__table th {
+	font-weight: 600;
+	color: var(--color-text-maxcontrast);
+}
+
+.icon--success {
+	color: var(--color-success);
+}
+
+.icon--muted {
+	color: var(--color-text-maxcontrast);
+}
+</style>

--- a/src/views/product/ProductForm.vue
+++ b/src/views/product/ProductForm.vue
@@ -1,0 +1,288 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-7.2 -->
+<template>
+	<NcDialog
+		:name="isEdit ? t('shillinq', 'Edit Product') : t('shillinq', 'New Product')"
+		size="normal"
+		@closing="$emit('close')">
+		<form class="product-form" @submit.prevent="save">
+			<div class="product-form__field">
+				<label for="product-sku">{{ t('shillinq', 'SKU') }} *</label>
+				<input
+					id="product-sku"
+					v-model="form.sku"
+					type="text"
+					required
+					:placeholder="t('shillinq', 'Unique product SKU')">
+				<p class="product-form__hint">
+					{{ t('shillinq', 'SKU must be unique across all products.') }}
+				</p>
+			</div>
+
+			<div class="product-form__field">
+				<label for="product-name">{{ t('shillinq', 'Name') }} *</label>
+				<input
+					id="product-name"
+					v-model="form.name"
+					type="text"
+					required
+					:placeholder="t('shillinq', 'Product name')">
+			</div>
+
+			<div class="product-form__field">
+				<label for="product-description">{{ t('shillinq', 'Description') }}</label>
+				<textarea
+					id="product-description"
+					v-model="form.description"
+					rows="3"
+					:placeholder="t('shillinq', 'Product description')" />
+			</div>
+
+			<div class="product-form__field">
+				<label for="product-unit">{{ t('shillinq', 'Unit') }}</label>
+				<input
+					id="product-unit"
+					v-model="form.unit"
+					type="text"
+					:placeholder="t('shillinq', 'e.g. pcs, kg, liter')">
+			</div>
+
+			<div class="product-form__field">
+				<label for="product-category">{{ t('shillinq', 'Category') }}</label>
+				<select id="product-category" v-model="form.categoryId">
+					<option :value="null">
+						{{ t('shillinq', 'No category') }}
+					</option>
+					<option
+						v-for="cat in categories"
+						:key="cat.id"
+						:value="cat.id">
+						{{ cat.name }}
+					</option>
+				</select>
+			</div>
+
+			<div class="product-form__row">
+				<div class="product-form__field">
+					<label for="product-price">{{ t('shillinq', 'Purchase Price') }}</label>
+					<input
+						id="product-price"
+						v-model.number="form.purchasePrice"
+						type="number"
+						step="0.01"
+						min="0"
+						:placeholder="t('shillinq', '0.00')">
+				</div>
+
+				<div class="product-form__field">
+					<label for="product-currency">{{ t('shillinq', 'Currency') }}</label>
+					<input
+						id="product-currency"
+						v-model="form.currency"
+						type="text"
+						maxlength="3"
+						:placeholder="t('shillinq', 'EUR')">
+				</div>
+			</div>
+
+			<div class="product-form__row">
+				<div class="product-form__field">
+					<label for="product-tax-rate">{{ t('shillinq', 'Tax Rate (%)') }}</label>
+					<input
+						id="product-tax-rate"
+						v-model.number="form.taxRate"
+						type="number"
+						step="0.01"
+						min="0"
+						max="100"
+						:placeholder="t('shillinq', '0')">
+				</div>
+
+				<div class="product-form__field">
+					<label for="product-lead-time">{{ t('shillinq', 'Lead Time (Days)') }}</label>
+					<input
+						id="product-lead-time"
+						v-model.number="form.leadTimeDays"
+						type="number"
+						min="0"
+						:placeholder="t('shillinq', '0')">
+				</div>
+			</div>
+
+			<div class="product-form__field product-form__field--inline">
+				<input
+					id="product-active"
+					v-model="form.active"
+					type="checkbox">
+				<label for="product-active">{{ t('shillinq', 'Active') }}</label>
+			</div>
+
+			<div class="product-form__field">
+				<label for="product-notes">{{ t('shillinq', 'Notes') }}</label>
+				<textarea
+					id="product-notes"
+					v-model="form.notes"
+					rows="2"
+					:placeholder="t('shillinq', 'Additional notes')" />
+			</div>
+
+			<div class="product-form__actions">
+				<NcButton type="secondary" @click="$emit('close')">
+					{{ t('shillinq', 'Cancel') }}
+				</NcButton>
+				<NcButton
+					type="primary"
+					native-type="submit"
+					:disabled="saving || !form.sku || !form.name">
+					{{ saving ? t('shillinq', 'Saving...') : t('shillinq', 'Save') }}
+				</NcButton>
+			</div>
+		</form>
+	</NcDialog>
+</template>
+
+<script>
+import { NcButton, NcDialog } from '@nextcloud/vue'
+import { useProductStore } from '../../store/modules/product.js'
+import { useProductCategoryStore } from '../../store/modules/productCategory.js'
+
+export default {
+	name: 'ProductForm',
+	components: {
+		NcButton,
+		NcDialog,
+	},
+	props: {
+		product: {
+			type: Object,
+			default: null,
+		},
+	},
+	emits: ['close', 'saved'],
+	data() {
+		return {
+			form: {
+				sku: '',
+				name: '',
+				description: '',
+				unit: '',
+				active: true,
+				categoryId: null,
+				purchasePrice: null,
+				currency: 'EUR',
+				taxRate: null,
+				leadTimeDays: null,
+				notes: '',
+			},
+			saving: false,
+		}
+	},
+	computed: {
+		productStore() {
+			return useProductStore()
+		},
+		productCategoryStore() {
+			return useProductCategoryStore()
+		},
+		isEdit() {
+			return !!this.product?.id
+		},
+		categories() {
+			return this.productCategoryStore.objectList || []
+		},
+	},
+	created() {
+		if (this.product) {
+			this.form = {
+				sku: this.product.sku || '',
+				name: this.product.name || '',
+				description: this.product.description || '',
+				unit: this.product.unit || '',
+				active: this.product.active !== false,
+				categoryId: this.product.categoryId || null,
+				purchasePrice: this.product.purchasePrice ?? null,
+				currency: this.product.currency || 'EUR',
+				taxRate: this.product.taxRate ?? null,
+				leadTimeDays: this.product.leadTimeDays ?? null,
+				notes: this.product.notes || '',
+			}
+		}
+		this.productCategoryStore.fetchAll()
+	},
+	methods: {
+		async save() {
+			this.saving = true
+			try {
+				const data = { ...this.form }
+				if (this.isEdit) {
+					await this.productStore.save({ ...data, id: this.product.id })
+				} else {
+					await this.productStore.save(data)
+				}
+				this.$emit('saved')
+			} catch (error) {
+				console.error('Failed to save product:', error)
+			} finally {
+				this.saving = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.product-form {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 8px 0;
+}
+
+.product-form__field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	flex: 1;
+}
+
+.product-form__field label {
+	font-weight: 600;
+}
+
+.product-form__field--inline {
+	flex-direction: row;
+	align-items: center;
+	gap: 8px;
+}
+
+.product-form__row {
+	display: flex;
+	gap: 12px;
+}
+
+.product-form__hint {
+	margin: 0;
+	font-size: 12px;
+	color: var(--color-text-maxcontrast);
+}
+
+.product-form__field input[type="text"],
+.product-form__field input[type="number"],
+.product-form__field textarea,
+.product-form__field select {
+	width: 100%;
+	padding: 8px;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+}
+
+.product-form__actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 8px;
+}
+</style>

--- a/src/views/product/ProductIndex.vue
+++ b/src/views/product/ProductIndex.vue
@@ -1,0 +1,252 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-7.2 -->
+<template>
+	<div class="product-index">
+		<header class="product-index__header">
+			<h2>{{ t('shillinq', 'Products') }}</h2>
+			<NcButton type="primary" @click="showForm = true">
+				<template #icon>
+					<Plus :size="20" />
+				</template>
+				{{ t('shillinq', 'New Product') }}
+			</NcButton>
+		</header>
+
+		<div class="product-index__filters">
+			<NcButton
+				:type="filterActive === null ? 'primary' : 'secondary'"
+				@click="filterActive = null">
+				{{ t('shillinq', 'All') }}
+			</NcButton>
+			<NcButton
+				:type="filterActive === true ? 'primary' : 'secondary'"
+				@click="filterActive = true">
+				<template #icon>
+					<CheckCircle :size="20" />
+				</template>
+				{{ t('shillinq', 'Active') }}
+			</NcButton>
+			<NcButton
+				:type="filterActive === false ? 'primary' : 'secondary'"
+				@click="filterActive = false">
+				<template #icon>
+					<CloseCircle :size="20" />
+				</template>
+				{{ t('shillinq', 'Inactive') }}
+			</NcButton>
+
+			<select
+				v-model="filterCategoryId"
+				class="product-index__category-filter">
+				<option :value="null">
+					{{ t('shillinq', 'All categories') }}
+				</option>
+				<option
+					v-for="cat in categories"
+					:key="cat.id"
+					:value="cat.id">
+					{{ cat.name }}
+				</option>
+			</select>
+		</div>
+
+		<NcLoadingIcon v-if="isLoading" :size="44" />
+
+		<table v-else-if="filteredProducts.length" class="product-index__table">
+			<thead>
+				<tr>
+					<th>{{ t('shillinq', 'SKU') }}</th>
+					<th>{{ t('shillinq', 'Name') }}</th>
+					<th>{{ t('shillinq', 'Unit') }}</th>
+					<th>{{ t('shillinq', 'Category') }}</th>
+					<th>{{ t('shillinq', 'Purchase Price') }}</th>
+					<th>{{ t('shillinq', 'Active') }}</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr
+					v-for="product in filteredProducts"
+					:key="product.id"
+					class="product-index__row"
+					@click="navigateToDetail(product)">
+					<td>{{ product.sku }}</td>
+					<td>{{ product.name }}</td>
+					<td>{{ product.unit }}</td>
+					<td>{{ getCategoryName(product.categoryId) }}</td>
+					<td>{{ formatPrice(product.purchasePrice, product.currency) }}</td>
+					<td>
+						<CheckCircle v-if="product.active" :size="20" class="icon--success" />
+						<CloseCircle v-else :size="20" class="icon--muted" />
+					</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<NcEmptyContent v-else :name="t('shillinq', 'No products found')">
+			<template #icon>
+				<PackageVariantClosed :size="64" />
+			</template>
+			<template #action>
+				<NcButton type="primary" @click="showForm = true">
+					{{ t('shillinq', 'Create your first product') }}
+				</NcButton>
+			</template>
+		</NcEmptyContent>
+
+		<ProductForm
+			v-if="showForm"
+			@close="showForm = false"
+			@saved="onSaved" />
+	</div>
+</template>
+
+<script>
+import { NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import CheckCircle from 'vue-material-design-icons/CheckCircle.vue'
+import CloseCircle from 'vue-material-design-icons/CloseCircle.vue'
+import PackageVariantClosed from 'vue-material-design-icons/PackageVariantClosed.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import { useProductStore } from '../../store/modules/product.js'
+import { useProductCategoryStore } from '../../store/modules/productCategory.js'
+import ProductForm from './ProductForm.vue'
+
+export default {
+	name: 'ProductIndex',
+	components: {
+		NcButton,
+		NcEmptyContent,
+		NcLoadingIcon,
+		CheckCircle,
+		CloseCircle,
+		PackageVariantClosed,
+		Plus,
+		ProductForm,
+	},
+	data() {
+		return {
+			showForm: false,
+			filterActive: null,
+			filterCategoryId: null,
+		}
+	},
+	computed: {
+		productStore() {
+			return useProductStore()
+		},
+		productCategoryStore() {
+			return useProductCategoryStore()
+		},
+		products() {
+			return this.productStore.objectList || []
+		},
+		categories() {
+			return this.productCategoryStore.objectList || []
+		},
+		isLoading() {
+			return this.productStore.isLoading
+		},
+		filteredProducts() {
+			let result = this.products
+			if (this.filterActive !== null) {
+				result = result.filter((p) => p.active === this.filterActive)
+			}
+			if (this.filterCategoryId !== null) {
+				result = result.filter((p) => p.categoryId === this.filterCategoryId)
+			}
+			return result
+		},
+	},
+	mounted() {
+		this.productStore.fetchAll()
+		this.productCategoryStore.fetchAll()
+	},
+	methods: {
+		navigateToDetail(product) {
+			this.$router.push({ name: 'ProductDetail', params: { productId: product.id } })
+		},
+		getCategoryName(categoryId) {
+			if (!categoryId) return '-'
+			const category = this.categories.find((c) => c.id === categoryId)
+			return category ? category.name : categoryId
+		},
+		formatPrice(price, currency) {
+			if (price == null) return '-'
+			return `${currency || 'EUR'} ${Number(price).toFixed(2)}`
+		},
+		onSaved() {
+			this.showForm = false
+			this.productStore.fetchAll()
+		},
+	},
+}
+</script>
+
+<style scoped>
+.product-index {
+	padding: 8px 4px 24px;
+	max-width: 1200px;
+}
+
+.product-index__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 20px;
+}
+
+.product-index__header h2 {
+	margin: 0;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.product-index__filters {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	margin-bottom: 16px;
+	flex-wrap: wrap;
+}
+
+.product-index__category-filter {
+	padding: 8px;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+}
+
+.product-index__table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.product-index__table th,
+.product-index__table td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.product-index__table th {
+	font-weight: 600;
+	color: var(--color-text-maxcontrast);
+}
+
+.product-index__row {
+	cursor: pointer;
+}
+
+.product-index__row:hover {
+	background-color: var(--color-background-hover);
+}
+
+.icon--success {
+	color: var(--color-success);
+}
+
+.icon--muted {
+	color: var(--color-text-maxcontrast);
+}
+</style>

--- a/src/views/productCategory/ProductCategoryDetail.vue
+++ b/src/views/productCategory/ProductCategoryDetail.vue
@@ -1,0 +1,284 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-7.1 -->
+<template>
+	<div class="product-category-detail">
+		<NcLoadingIcon v-if="isLoading" :size="44" />
+
+		<template v-else-if="category">
+			<header class="product-category-detail__header">
+				<NcButton type="tertiary" @click="goBack">
+					<template #icon>
+						<ArrowLeft :size="20" />
+					</template>
+					{{ t('shillinq', 'Back to categories') }}
+				</NcButton>
+				<h2>{{ category.name }}</h2>
+				<NcButton type="secondary" @click="showForm = true">
+					<template #icon>
+						<Pencil :size="20" />
+					</template>
+					{{ t('shillinq', 'Edit') }}
+				</NcButton>
+			</header>
+
+			<div class="product-category-detail__tabs">
+				<NcButton
+					:type="activeTab === 'details' ? 'primary' : 'secondary'"
+					@click="activeTab = 'details'">
+					{{ t('shillinq', 'Details') }}
+				</NcButton>
+				<NcButton
+					:type="activeTab === 'products' ? 'primary' : 'secondary'"
+					@click="activeTab = 'products'">
+					{{ t('shillinq', 'Products') }}
+				</NcButton>
+			</div>
+
+			<!-- Details tab -->
+			<div v-if="activeTab === 'details'" class="product-category-detail__content">
+				<dl class="product-category-detail__properties">
+					<dt>{{ t('shillinq', 'Name') }}</dt>
+					<dd>{{ category.name }}</dd>
+
+					<dt>{{ t('shillinq', 'Code') }}</dt>
+					<dd>{{ category.code || '-' }}</dd>
+
+					<dt>{{ t('shillinq', 'Description') }}</dt>
+					<dd>{{ category.description || '-' }}</dd>
+
+					<dt>{{ t('shillinq', 'Parent Category') }}</dt>
+					<dd>{{ parentCategoryName }}</dd>
+
+					<dt>{{ t('shillinq', 'Active') }}</dt>
+					<dd>{{ category.active ? t('shillinq', 'Yes') : t('shillinq', 'No') }}</dd>
+
+					<dt>{{ t('shillinq', 'Sort Order') }}</dt>
+					<dd>{{ category.sortOrder ?? '-' }}</dd>
+				</dl>
+			</div>
+
+			<!-- Products tab -->
+			<div v-if="activeTab === 'products'" class="product-category-detail__content">
+				<NcLoadingIcon v-if="productsLoading" :size="32" />
+				<table v-else-if="filteredProducts.length" class="product-category-detail__table">
+					<thead>
+						<tr>
+							<th>{{ t('shillinq', 'SKU') }}</th>
+							<th>{{ t('shillinq', 'Name') }}</th>
+							<th>{{ t('shillinq', 'Unit') }}</th>
+							<th>{{ t('shillinq', 'Purchase Price') }}</th>
+							<th>{{ t('shillinq', 'Active') }}</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr
+							v-for="product in filteredProducts"
+							:key="product.id"
+							class="product-category-detail__row"
+							@click="navigateToProduct(product)">
+							<td>{{ product.sku }}</td>
+							<td>{{ product.name }}</td>
+							<td>{{ product.unit }}</td>
+							<td>{{ product.purchasePrice }}</td>
+							<td>
+								<CheckCircle v-if="product.active" :size="20" class="icon--success" />
+								<CloseCircle v-else :size="20" class="icon--muted" />
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				<NcEmptyContent v-else :name="t('shillinq', 'No products in this category')">
+					<template #icon>
+						<PackageVariantClosed :size="64" />
+					</template>
+				</NcEmptyContent>
+			</div>
+		</template>
+
+		<NcEmptyContent v-else :name="t('shillinq', 'Category not found')">
+			<template #icon>
+				<FolderOutline :size="64" />
+			</template>
+		</NcEmptyContent>
+
+		<ProductCategoryForm
+			v-if="showForm"
+			:category="category"
+			@close="showForm = false"
+			@saved="onSaved" />
+	</div>
+</template>
+
+<script>
+import { NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import ArrowLeft from 'vue-material-design-icons/ArrowLeft.vue'
+import CheckCircle from 'vue-material-design-icons/CheckCircle.vue'
+import CloseCircle from 'vue-material-design-icons/CloseCircle.vue'
+import FolderOutline from 'vue-material-design-icons/FolderOutline.vue'
+import PackageVariantClosed from 'vue-material-design-icons/PackageVariantClosed.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
+import { useProductCategoryStore } from '../../store/modules/productCategory.js'
+import { useProductStore } from '../../store/modules/product.js'
+import ProductCategoryForm from './ProductCategoryForm.vue'
+
+export default {
+	name: 'ProductCategoryDetail',
+	components: {
+		NcButton,
+		NcEmptyContent,
+		NcLoadingIcon,
+		ArrowLeft,
+		CheckCircle,
+		CloseCircle,
+		FolderOutline,
+		PackageVariantClosed,
+		Pencil,
+		ProductCategoryForm,
+	},
+	data() {
+		return {
+			activeTab: 'details',
+			showForm: false,
+		}
+	},
+	computed: {
+		productCategoryStore() {
+			return useProductCategoryStore()
+		},
+		productStore() {
+			return useProductStore()
+		},
+		categoryId() {
+			return this.$route.params.categoryId
+		},
+		category() {
+			return this.productCategoryStore.objectItem
+		},
+		isLoading() {
+			return this.productCategoryStore.isLoading
+		},
+		productsLoading() {
+			return this.productStore.isLoading
+		},
+		filteredProducts() {
+			return (this.productStore.objectList || []).filter(
+				(product) => product.categoryId === this.categoryId,
+			)
+		},
+		parentCategoryName() {
+			if (!this.category?.parentCategoryId) {
+				return t('shillinq', 'None')
+			}
+			const parent = (this.productCategoryStore.objectList || []).find(
+				(c) => c.id === this.category.parentCategoryId,
+			)
+			return parent ? parent.name : this.category.parentCategoryId
+		},
+	},
+	watch: {
+		categoryId: {
+			handler(id) {
+				if (id) {
+					this.loadData(id)
+				}
+			},
+			immediate: true,
+		},
+	},
+	methods: {
+		async loadData(id) {
+			await Promise.all([
+				this.productCategoryStore.fetchOne(id),
+				this.productCategoryStore.fetchAll(),
+				this.productStore.fetchAll(),
+			])
+		},
+		goBack() {
+			this.$router.push({ name: 'ProductCategoryIndex' })
+		},
+		navigateToProduct(product) {
+			this.$router.push({ name: 'ProductDetail', params: { productId: product.id } })
+		},
+		onSaved() {
+			this.showForm = false
+			this.productCategoryStore.fetchOne(this.categoryId)
+		},
+	},
+}
+</script>
+
+<style scoped>
+.product-category-detail {
+	padding: 8px 4px 24px;
+	max-width: 1200px;
+}
+
+.product-category-detail__header {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-bottom: 20px;
+}
+
+.product-category-detail__header h2 {
+	margin: 0;
+	font-size: 22px;
+	font-weight: 600;
+	flex: 1;
+}
+
+.product-category-detail__tabs {
+	display: flex;
+	gap: 8px;
+	margin-bottom: 16px;
+}
+
+.product-category-detail__properties {
+	display: grid;
+	grid-template-columns: 200px 1fr;
+	gap: 8px 16px;
+}
+
+.product-category-detail__properties dt {
+	font-weight: 600;
+	color: var(--color-text-maxcontrast);
+}
+
+.product-category-detail__properties dd {
+	margin: 0;
+}
+
+.product-category-detail__table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.product-category-detail__table th,
+.product-category-detail__table td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.product-category-detail__table th {
+	font-weight: 600;
+	color: var(--color-text-maxcontrast);
+}
+
+.product-category-detail__row {
+	cursor: pointer;
+}
+
+.product-category-detail__row:hover {
+	background-color: var(--color-background-hover);
+}
+
+.icon--success {
+	color: var(--color-success);
+}
+
+.icon--muted {
+	color: var(--color-text-maxcontrast);
+}
+</style>

--- a/src/views/productCategory/ProductCategoryForm.vue
+++ b/src/views/productCategory/ProductCategoryForm.vue
@@ -1,0 +1,207 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-7.1 -->
+<template>
+	<NcDialog
+		:name="isEdit ? t('shillinq', 'Edit Category') : t('shillinq', 'New Category')"
+		size="normal"
+		@closing="$emit('close')">
+		<form class="product-category-form" @submit.prevent="save">
+			<div class="product-category-form__field">
+				<label for="category-name">{{ t('shillinq', 'Name') }} *</label>
+				<input
+					id="category-name"
+					v-model="form.name"
+					type="text"
+					required
+					:placeholder="t('shillinq', 'Category name')">
+			</div>
+
+			<div class="product-category-form__field">
+				<label for="category-code">{{ t('shillinq', 'Code') }}</label>
+				<input
+					id="category-code"
+					v-model="form.code"
+					type="text"
+					:placeholder="t('shillinq', 'Category code')">
+			</div>
+
+			<div class="product-category-form__field">
+				<label for="category-description">{{ t('shillinq', 'Description') }}</label>
+				<textarea
+					id="category-description"
+					v-model="form.description"
+					rows="3"
+					:placeholder="t('shillinq', 'Category description')" />
+			</div>
+
+			<div class="product-category-form__field">
+				<label for="category-parent">{{ t('shillinq', 'Parent Category') }}</label>
+				<select id="category-parent" v-model="form.parentCategoryId">
+					<option :value="null">
+						{{ t('shillinq', 'None (top-level)') }}
+					</option>
+					<option
+						v-for="cat in availableParents"
+						:key="cat.id"
+						:value="cat.id">
+						{{ cat.name }}
+					</option>
+				</select>
+			</div>
+
+			<div class="product-category-form__field product-category-form__field--inline">
+				<input
+					id="category-active"
+					v-model="form.active"
+					type="checkbox">
+				<label for="category-active">{{ t('shillinq', 'Active') }}</label>
+			</div>
+
+			<div class="product-category-form__field">
+				<label for="category-sort-order">{{ t('shillinq', 'Sort Order') }}</label>
+				<input
+					id="category-sort-order"
+					v-model.number="form.sortOrder"
+					type="number"
+					min="0"
+					:placeholder="t('shillinq', '0')">
+			</div>
+
+			<div class="product-category-form__actions">
+				<NcButton type="secondary" @click="$emit('close')">
+					{{ t('shillinq', 'Cancel') }}
+				</NcButton>
+				<NcButton
+					type="primary"
+					native-type="submit"
+					:disabled="saving || !form.name">
+					{{ saving ? t('shillinq', 'Saving...') : t('shillinq', 'Save') }}
+				</NcButton>
+			</div>
+		</form>
+	</NcDialog>
+</template>
+
+<script>
+import { NcButton, NcDialog } from '@nextcloud/vue'
+import { useProductCategoryStore } from '../../store/modules/productCategory.js'
+
+export default {
+	name: 'ProductCategoryForm',
+	components: {
+		NcButton,
+		NcDialog,
+	},
+	props: {
+		category: {
+			type: Object,
+			default: null,
+		},
+	},
+	emits: ['close', 'saved'],
+	data() {
+		return {
+			form: {
+				name: '',
+				code: '',
+				description: '',
+				parentCategoryId: null,
+				active: true,
+				sortOrder: 0,
+			},
+			saving: false,
+		}
+	},
+	computed: {
+		productCategoryStore() {
+			return useProductCategoryStore()
+		},
+		isEdit() {
+			return !!this.category?.id
+		},
+		availableParents() {
+			const categories = this.productCategoryStore.objectList || []
+			if (this.isEdit) {
+				return categories.filter((c) => c.id !== this.category.id)
+			}
+			return categories
+		},
+	},
+	created() {
+		if (this.category) {
+			this.form = {
+				name: this.category.name || '',
+				code: this.category.code || '',
+				description: this.category.description || '',
+				parentCategoryId: this.category.parentCategoryId || null,
+				active: this.category.active !== false,
+				sortOrder: this.category.sortOrder || 0,
+			}
+		}
+		this.productCategoryStore.fetchAll()
+	},
+	methods: {
+		async save() {
+			this.saving = true
+			try {
+				const data = { ...this.form }
+				if (this.isEdit) {
+					await this.productCategoryStore.save({ ...data, id: this.category.id })
+				} else {
+					await this.productCategoryStore.save(data)
+				}
+				this.$emit('saved')
+			} catch (error) {
+				console.error('Failed to save category:', error)
+			} finally {
+				this.saving = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.product-category-form {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 8px 0;
+}
+
+.product-category-form__field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.product-category-form__field label {
+	font-weight: 600;
+}
+
+.product-category-form__field--inline {
+	flex-direction: row;
+	align-items: center;
+	gap: 8px;
+}
+
+.product-category-form__field input[type="text"],
+.product-category-form__field input[type="number"],
+.product-category-form__field textarea,
+.product-category-form__field select {
+	width: 100%;
+	padding: 8px;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+}
+
+.product-category-form__actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 8px;
+}
+</style>

--- a/src/views/productCategory/ProductCategoryIndex.vue
+++ b/src/views/productCategory/ProductCategoryIndex.vue
@@ -1,0 +1,211 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-7.1 -->
+<template>
+	<div class="product-category-index">
+		<header class="product-category-index__header">
+			<h2>{{ t('shillinq', 'Product Categories') }}</h2>
+			<div class="product-category-index__actions">
+				<NcButton type="secondary" @click="toggleView">
+					<template #icon>
+						<FileTreeOutline v-if="viewMode === 'flat'" :size="20" />
+						<FormatListBulleted v-else :size="20" />
+					</template>
+					{{ viewMode === 'flat' ? t('shillinq', 'Tree view') : t('shillinq', 'Flat view') }}
+				</NcButton>
+				<NcButton type="primary" @click="showForm = true">
+					<template #icon>
+						<Plus :size="20" />
+					</template>
+					{{ t('shillinq', 'New Category') }}
+				</NcButton>
+			</div>
+		</header>
+
+		<NcLoadingIcon v-if="isLoading" :size="44" />
+
+		<table v-else-if="categories.length" class="product-category-index__table">
+			<thead>
+				<tr>
+					<th>{{ t('shillinq', 'Name') }}</th>
+					<th>{{ t('shillinq', 'Code') }}</th>
+					<th>{{ t('shillinq', 'Description') }}</th>
+					<th>{{ t('shillinq', 'Active') }}</th>
+					<th>{{ t('shillinq', 'Sort Order') }}</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr
+					v-for="category in displayedCategories"
+					:key="category.id"
+					class="product-category-index__row"
+					@click="navigateToDetail(category)">
+					<td>
+						<span v-if="viewMode === 'tree'" :style="{ paddingLeft: (category._depth || 0) * 20 + 'px' }">
+							{{ category.name }}
+						</span>
+						<span v-else>{{ category.name }}</span>
+					</td>
+					<td>{{ category.code }}</td>
+					<td>{{ category.description }}</td>
+					<td>
+						<CheckCircle v-if="category.active" :size="20" class="icon--success" />
+						<CloseCircle v-else :size="20" class="icon--muted" />
+					</td>
+					<td>{{ category.sortOrder }}</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<NcEmptyContent v-else :name="t('shillinq', 'No categories found')">
+			<template #icon>
+				<FolderOutline :size="64" />
+			</template>
+			<template #action>
+				<NcButton type="primary" @click="showForm = true">
+					{{ t('shillinq', 'Create your first category') }}
+				</NcButton>
+			</template>
+		</NcEmptyContent>
+
+		<ProductCategoryForm
+			v-if="showForm"
+			@close="showForm = false"
+			@saved="onSaved" />
+	</div>
+</template>
+
+<script>
+import { NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import CheckCircle from 'vue-material-design-icons/CheckCircle.vue'
+import CloseCircle from 'vue-material-design-icons/CloseCircle.vue'
+import FileTreeOutline from 'vue-material-design-icons/FileTreeOutline.vue'
+import FolderOutline from 'vue-material-design-icons/FolderOutline.vue'
+import FormatListBulleted from 'vue-material-design-icons/FormatListBulleted.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import { useProductCategoryStore } from '../../store/modules/productCategory.js'
+import ProductCategoryForm from './ProductCategoryForm.vue'
+
+export default {
+	name: 'ProductCategoryIndex',
+	components: {
+		NcButton,
+		NcEmptyContent,
+		NcLoadingIcon,
+		CheckCircle,
+		CloseCircle,
+		FileTreeOutline,
+		FolderOutline,
+		FormatListBulleted,
+		Plus,
+		ProductCategoryForm,
+	},
+	data() {
+		return {
+			showForm: false,
+			viewMode: 'flat',
+		}
+	},
+	computed: {
+		productCategoryStore() {
+			return useProductCategoryStore()
+		},
+		categories() {
+			return this.productCategoryStore.objectList || []
+		},
+		isLoading() {
+			return this.productCategoryStore.isLoading
+		},
+		displayedCategories() {
+			if (this.viewMode === 'tree') {
+				return this.buildTree(this.categories)
+			}
+			return [...this.categories].sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0))
+		},
+	},
+	mounted() {
+		this.productCategoryStore.fetchAll()
+	},
+	methods: {
+		toggleView() {
+			this.viewMode = this.viewMode === 'flat' ? 'tree' : 'flat'
+		},
+		navigateToDetail(category) {
+			this.$router.push({ name: 'ProductCategoryDetail', params: { categoryId: category.id } })
+		},
+		onSaved() {
+			this.showForm = false
+			this.productCategoryStore.fetchAll()
+		},
+		buildTree(categories, parentId = null, depth = 0) {
+			const result = []
+			const children = categories
+				.filter((c) => (c.parentCategoryId || null) === parentId)
+				.sort((a, b) => (a.sortOrder || 0) - (b.sortOrder || 0))
+			for (const child of children) {
+				result.push({ ...child, _depth: depth })
+				result.push(...this.buildTree(categories, child.id, depth + 1))
+			}
+			return result
+		},
+	},
+}
+</script>
+
+<style scoped>
+.product-category-index {
+	padding: 8px 4px 24px;
+	max-width: 1200px;
+}
+
+.product-category-index__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 20px;
+}
+
+.product-category-index__header h2 {
+	margin: 0;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.product-category-index__actions {
+	display: flex;
+	gap: 8px;
+}
+
+.product-category-index__table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.product-category-index__table th,
+.product-category-index__table td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.product-category-index__table th {
+	font-weight: 600;
+	color: var(--color-text-maxcontrast);
+}
+
+.product-category-index__row {
+	cursor: pointer;
+}
+
+.product-category-index__row:hover {
+	background-color: var(--color-background-hover);
+}
+
+.icon--success {
+	color: var(--color-success);
+}
+
+.icon--muted {
+	color: var(--color-text-maxcontrast);
+}
+</style>

--- a/src/views/purchaseOrder/PurchaseOrderDetail.vue
+++ b/src/views/purchaseOrder/PurchaseOrderDetail.vue
@@ -1,0 +1,463 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-10.1 -->
+<template>
+	<div class="purchase-order-detail">
+		<NcLoadingIcon v-if="loading" />
+
+		<template v-else-if="order">
+			<header class="purchase-order-detail__header">
+				<h2>{{ t('shillinq', 'Purchase Order') }}: {{ order.poNumber }}</h2>
+				<span class="purchase-order-detail__status-chip"
+					:class="'purchase-order-detail__status-chip--' + order.status">
+					{{ order.status }}
+				</span>
+				<span v-if="isOverdue" class="purchase-order-detail__badge--overdue">
+					{{ t('shillinq', 'Overdue') }}
+				</span>
+			</header>
+
+			<div class="purchase-order-detail__tabs">
+				<NcButton v-for="tab in tabs"
+					:key="tab.id"
+					:type="activeTab === tab.id ? 'primary' : 'tertiary'"
+					@click="activeTab = tab.id">
+					{{ tab.label }}
+				</NcButton>
+			</div>
+
+			<!-- Details tab -->
+			<div v-if="activeTab === 'details'" class="purchase-order-detail__panel">
+				<table class="purchase-order-detail__properties">
+					<tr>
+						<th>{{ t('shillinq', 'PO Number') }}</th>
+						<td>{{ order.poNumber }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Supplier') }}</th>
+						<td>{{ order.supplierName }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Delivery Address') }}</th>
+						<td>{{ order.deliveryAddress }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Expected Delivery') }}</th>
+						<td>{{ order.expectedDeliveryDate }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Cost Centre') }}</th>
+						<td>{{ order.costCentreName || order.costCentreId }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Total Amount') }}</th>
+						<td>{{ formatCurrency(order.totalAmount, order.currency) }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Notes') }}</th>
+						<td>{{ order.notes }}</td>
+					</tr>
+				</table>
+
+				<div class="purchase-order-detail__actions">
+					<NcButton v-if="order.status === 'draft'"
+						type="primary"
+						@click="transitionStatus('submitted')">
+						<template #icon>
+							<Send :size="20" />
+						</template>
+						{{ t('shillinq', 'Submit to Supplier') }}
+					</NcButton>
+
+					<NcButton v-if="order.status === 'submitted' || order.status === 'acknowledged'"
+						type="error"
+						@click="showCancelDialog = true">
+						<template #icon>
+							<Cancel :size="20" />
+						</template>
+						{{ t('shillinq', 'Cancel') }}
+					</NcButton>
+
+					<NcButton v-if="order.status === 'received' || order.status === 'invoiced'"
+						type="primary"
+						@click="transitionStatus('closed')">
+						<template #icon>
+							<Check :size="20" />
+						</template>
+						{{ t('shillinq', 'Close') }}
+					</NcButton>
+
+					<NcButton v-if="isOverdue"
+						type="warning"
+						@click="sendDeliveryReminder">
+						<template #icon>
+							<Bell :size="20" />
+						</template>
+						{{ t('shillinq', 'Send delivery reminder') }}
+					</NcButton>
+				</div>
+			</div>
+
+			<!-- Lines tab -->
+			<div v-if="activeTab === 'lines'" class="purchase-order-detail__panel">
+				<table v-if="order.lines && order.lines.length" class="purchase-order-detail__lines-table">
+					<thead>
+						<tr>
+							<th>{{ t('shillinq', 'Product') }}</th>
+							<th>{{ t('shillinq', 'Quantity') }}</th>
+							<th>{{ t('shillinq', 'Unit Price') }}</th>
+							<th>{{ t('shillinq', 'Line Total') }}</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="line in order.lines" :key="line.id">
+							<td>{{ line.productName }}</td>
+							<td>{{ line.quantity }}</td>
+							<td>{{ formatCurrency(line.unitPrice, order.currency) }}</td>
+							<td>{{ formatCurrency(line.lineTotal, order.currency) }}</td>
+						</tr>
+					</tbody>
+				</table>
+				<p v-else class="purchase-order-detail__empty">
+					{{ t('shillinq', 'No lines on this purchase order.') }}
+				</p>
+			</div>
+
+			<!-- Receipts tab -->
+			<div v-if="activeTab === 'receipts'" class="purchase-order-detail__panel">
+				<NcButton type="primary" @click="navigateToCreateReceipt">
+					<template #icon>
+						<Plus :size="20" />
+					</template>
+					{{ t('shillinq', 'Record Goods Receipt') }}
+				</NcButton>
+
+				<table v-if="receipts.length" class="purchase-order-detail__receipts-table">
+					<thead>
+						<tr>
+							<th>{{ t('shillinq', 'Receipt Number') }}</th>
+							<th>{{ t('shillinq', 'Received Date') }}</th>
+							<th>{{ t('shillinq', 'Received By') }}</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="receipt in receipts"
+							:key="receipt.id"
+							class="purchase-order-detail__row--clickable"
+							@click="navigateToReceipt(receipt.id)">
+							<td>{{ receipt.receiptNumber }}</td>
+							<td>{{ receipt.receivedDate }}</td>
+							<td>{{ receipt.receivedBy }}</td>
+						</tr>
+					</tbody>
+				</table>
+				<p v-else class="purchase-order-detail__empty">
+					{{ t('shillinq', 'No goods receipts recorded yet.') }}
+				</p>
+			</div>
+
+			<!-- Matching tab -->
+			<div v-if="activeTab === 'matching'" class="purchase-order-detail__panel">
+				<ThreeWayMatchingPanel :purchase-order-id="order.id" />
+			</div>
+
+			<!-- Documents tab -->
+			<div v-if="activeTab === 'documents'" class="purchase-order-detail__panel">
+				<p class="purchase-order-detail__empty">
+					{{ t('shillinq', 'Documents will be displayed here.') }}
+				</p>
+			</div>
+
+			<!-- Cancel reason dialog -->
+			<NcDialog v-if="showCancelDialog"
+				:name="t('shillinq', 'Cancel Purchase Order')"
+				@close="showCancelDialog = false">
+				<p>{{ t('shillinq', 'Please provide a reason for cancellation:') }}</p>
+				<textarea v-model="cancelReason"
+					class="purchase-order-detail__cancel-reason"
+					:placeholder="t('shillinq', 'Cancellation reason...')" />
+				<template #actions>
+					<NcButton type="tertiary" @click="showCancelDialog = false">
+						{{ t('shillinq', 'Keep Order') }}
+					</NcButton>
+					<NcButton type="error"
+						:disabled="!cancelReason.trim()"
+						@click="confirmCancel">
+						{{ t('shillinq', 'Confirm Cancellation') }}
+					</NcButton>
+				</template>
+			</NcDialog>
+		</template>
+
+		<p v-else class="purchase-order-detail__empty">
+			{{ t('shillinq', 'Purchase order not found.') }}
+		</p>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcDialog, NcLoadingIcon } from '@nextcloud/vue'
+import { generateUrl } from '@nextcloud/router'
+import Bell from 'vue-material-design-icons/Bell.vue'
+import Cancel from 'vue-material-design-icons/Cancel.vue'
+import Check from 'vue-material-design-icons/Check.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import Send from 'vue-material-design-icons/Send.vue'
+import { usePurchaseOrderStore } from '../../store/modules/purchaseOrder.js'
+import { useGoodsReceiptStore } from '../../store/modules/goodsReceipt.js'
+import ThreeWayMatchingPanel from '../../components/ThreeWayMatchingPanel.vue'
+
+export default {
+	name: 'PurchaseOrderDetail',
+	components: {
+		NcButton,
+		NcDialog,
+		NcLoadingIcon,
+		Bell,
+		Cancel,
+		Check,
+		Plus,
+		Send,
+		ThreeWayMatchingPanel,
+	},
+	data() {
+		return {
+			loading: false,
+			activeTab: 'details',
+			showCancelDialog: false,
+			cancelReason: '',
+			tabs: [
+				{ id: 'details', label: this.t('shillinq', 'Details') },
+				{ id: 'lines', label: this.t('shillinq', 'Lines') },
+				{ id: 'receipts', label: this.t('shillinq', 'Receipts') },
+				{ id: 'matching', label: this.t('shillinq', 'Matching') },
+				{ id: 'documents', label: this.t('shillinq', 'Documents') },
+			],
+		}
+	},
+	computed: {
+		purchaseOrderStore() {
+			return usePurchaseOrderStore()
+		},
+		goodsReceiptStore() {
+			return useGoodsReceiptStore()
+		},
+		order() {
+			return this.purchaseOrderStore.current || null
+		},
+		receipts() {
+			return this.goodsReceiptStore.items || []
+		},
+		isOverdue() {
+			if (!this.order || !this.order.expectedDeliveryDate) return false
+			if (this.order.status === 'closed' || this.order.status === 'cancelled') return false
+			return new Date(this.order.expectedDeliveryDate) < new Date()
+		},
+	},
+	mounted() {
+		this.fetchOrder()
+	},
+	methods: {
+		t,
+		async fetchOrder() {
+			this.loading = true
+			try {
+				const id = this.$route.params.id
+				await this.purchaseOrderStore.fetchOne(id)
+				await this.goodsReceiptStore.fetchAll({ purchaseOrderId: id })
+			} finally {
+				this.loading = false
+			}
+		},
+		formatCurrency(amount, currency) {
+			if (amount == null) return ''
+			return new Intl.NumberFormat(undefined, { style: 'currency', currency: currency || 'EUR' }).format(amount)
+		},
+		async transitionStatus(newStatus) {
+			try {
+				await this.purchaseOrderStore.updateStatus(this.order.id, newStatus)
+				await this.fetchOrder()
+			} catch (error) {
+				console.error('Failed to transition status:', error)
+			}
+		},
+		async confirmCancel() {
+			try {
+				await this.purchaseOrderStore.updateStatus(this.order.id, 'cancelled', {
+					reason: this.cancelReason.trim(),
+				})
+				this.showCancelDialog = false
+				this.cancelReason = ''
+				await this.fetchOrder()
+			} catch (error) {
+				console.error('Failed to cancel order:', error)
+			}
+		},
+		async sendDeliveryReminder() {
+			try {
+				await this.purchaseOrderStore.sendReminder(this.order.id)
+			} catch (error) {
+				console.error('Failed to send reminder:', error)
+			}
+		},
+		navigateToCreateReceipt() {
+			this.$router.push({
+				name: 'goodsReceiptCreate',
+				query: { purchaseOrderId: this.order.id },
+			})
+		},
+		navigateToReceipt(id) {
+			this.$router.push({ name: 'goodsReceiptDetail', params: { id } })
+		},
+	},
+}
+</script>
+
+<style scoped>
+.purchase-order-detail {
+	padding: 8px 4px 24px;
+	max-width: 1200px;
+}
+
+.purchase-order-detail__header {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-bottom: 16px;
+}
+
+.purchase-order-detail__header h2 {
+	margin: 0;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.purchase-order-detail__status-chip {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: capitalize;
+}
+
+.purchase-order-detail__status-chip--draft {
+	background-color: var(--color-background-dark);
+	color: var(--color-text-maxcontrast);
+}
+
+.purchase-order-detail__status-chip--submitted {
+	background-color: var(--color-primary-light);
+	color: var(--color-primary);
+}
+
+.purchase-order-detail__status-chip--acknowledged {
+	background-color: var(--color-info-light, #e8f4fd);
+	color: var(--color-info, #0082c9);
+}
+
+.purchase-order-detail__status-chip--received {
+	background-color: var(--color-success-light, #e8f8e8);
+	color: var(--color-success);
+}
+
+.purchase-order-detail__status-chip--invoiced {
+	background-color: var(--color-warning-light, #fff8e1);
+	color: var(--color-warning);
+}
+
+.purchase-order-detail__status-chip--closed {
+	background-color: var(--color-success-light, #e8f8e8);
+	color: var(--color-success);
+}
+
+.purchase-order-detail__status-chip--cancelled {
+	background-color: var(--color-error-light, #fff0f0);
+	color: var(--color-error);
+}
+
+.purchase-order-detail__badge--overdue {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 12px;
+	font-size: 11px;
+	font-weight: 700;
+	background-color: var(--color-error);
+	color: #fff;
+}
+
+.purchase-order-detail__tabs {
+	display: flex;
+	gap: 4px;
+	margin-bottom: 16px;
+	border-bottom: 1px solid var(--color-border);
+	padding-bottom: 8px;
+}
+
+.purchase-order-detail__panel {
+	padding: 16px 0;
+}
+
+.purchase-order-detail__properties {
+	width: 100%;
+	max-width: 600px;
+	margin-bottom: 20px;
+}
+
+.purchase-order-detail__properties th {
+	text-align: left;
+	padding: 6px 16px 6px 0;
+	color: var(--color-text-maxcontrast);
+	white-space: nowrap;
+	width: 180px;
+}
+
+.purchase-order-detail__properties td {
+	padding: 6px 0;
+}
+
+.purchase-order-detail__actions {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.purchase-order-detail__lines-table,
+.purchase-order-detail__receipts-table {
+	width: 100%;
+	border-collapse: collapse;
+	margin-top: 12px;
+}
+
+.purchase-order-detail__lines-table th,
+.purchase-order-detail__lines-table td,
+.purchase-order-detail__receipts-table th,
+.purchase-order-detail__receipts-table td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.purchase-order-detail__row--clickable {
+	cursor: pointer;
+}
+
+.purchase-order-detail__row--clickable:hover {
+	background-color: var(--color-background-hover);
+}
+
+.purchase-order-detail__cancel-reason {
+	width: 100%;
+	min-height: 80px;
+	padding: 8px;
+	border: 1px solid var(--color-border);
+	border-radius: 4px;
+	resize: vertical;
+}
+
+.purchase-order-detail__empty {
+	color: var(--color-text-maxcontrast);
+	text-align: center;
+	padding: 40px 0;
+}
+</style>

--- a/src/views/purchaseOrder/PurchaseOrderDetail.vue
+++ b/src/views/purchaseOrder/PurchaseOrderDetail.vue
@@ -197,7 +197,6 @@
 
 <script>
 import { NcButton, NcDialog, NcLoadingIcon } from '@nextcloud/vue'
-import { generateUrl } from '@nextcloud/router'
 import Bell from 'vue-material-design-icons/Bell.vue'
 import Cancel from 'vue-material-design-icons/Cancel.vue'
 import Check from 'vue-material-design-icons/Check.vue'

--- a/src/views/purchaseOrder/PurchaseOrderForm.vue
+++ b/src/views/purchaseOrder/PurchaseOrderForm.vue
@@ -1,0 +1,189 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-10.1 -->
+<template>
+	<NcDialog :name="t('shillinq', 'New Purchase Order')"
+		size="normal"
+		@close="$emit('close')">
+		<form class="purchase-order-form" @submit.prevent="submit">
+			<div class="purchase-order-form__field">
+				<label>{{ t('shillinq', 'PO Number') }}</label>
+				<input type="text"
+					:value="form.poNumber || t('shillinq', 'Auto-generated')"
+					disabled
+					class="purchase-order-form__input purchase-order-form__input--readonly" />
+			</div>
+
+			<div class="purchase-order-form__field">
+				<label>{{ t('shillinq', 'Supplier') }} *</label>
+				<select v-model="form.supplierProfileId"
+					class="purchase-order-form__input"
+					required>
+					<option value="" disabled>
+						{{ t('shillinq', 'Select a supplier...') }}
+					</option>
+					<option v-for="supplier in suppliers"
+						:key="supplier.id"
+						:value="supplier.id">
+						{{ supplier.name }}
+					</option>
+				</select>
+			</div>
+
+			<div class="purchase-order-form__field">
+				<label>{{ t('shillinq', 'Delivery Address') }} *</label>
+				<textarea v-model="form.deliveryAddress"
+					class="purchase-order-form__input"
+					required
+					rows="3"
+					:placeholder="t('shillinq', 'Enter delivery address...')" />
+			</div>
+
+			<div class="purchase-order-form__field">
+				<label>{{ t('shillinq', 'Expected Delivery Date') }} *</label>
+				<input v-model="form.expectedDeliveryDate"
+					type="date"
+					class="purchase-order-form__input"
+					required />
+			</div>
+
+			<div class="purchase-order-form__field">
+				<label>{{ t('shillinq', 'Cost Centre') }}</label>
+				<select v-model="form.costCentreId"
+					class="purchase-order-form__input">
+					<option value="">
+						{{ t('shillinq', 'None') }}
+					</option>
+					<option v-for="centre in costCentres"
+						:key="centre.id"
+						:value="centre.id">
+						{{ centre.name }}
+					</option>
+				</select>
+			</div>
+
+			<div class="purchase-order-form__field">
+				<label>{{ t('shillinq', 'Notes') }}</label>
+				<textarea v-model="form.notes"
+					class="purchase-order-form__input"
+					rows="3"
+					:placeholder="t('shillinq', 'Optional notes...')" />
+			</div>
+		</form>
+
+		<template #actions>
+			<NcButton type="tertiary" @click="$emit('close')">
+				{{ t('shillinq', 'Cancel') }}
+			</NcButton>
+			<NcButton type="primary"
+				:disabled="saving || !isValid"
+				@click="submit">
+				<template #icon>
+					<NcLoadingIcon v-if="saving" :size="20" />
+				</template>
+				{{ t('shillinq', 'Create Purchase Order') }}
+			</NcButton>
+		</template>
+	</NcDialog>
+</template>
+
+<script>
+import { NcButton, NcDialog, NcLoadingIcon } from '@nextcloud/vue'
+import { usePurchaseOrderStore } from '../../store/modules/purchaseOrder.js'
+
+export default {
+	name: 'PurchaseOrderForm',
+	components: {
+		NcButton,
+		NcDialog,
+		NcLoadingIcon,
+	},
+	emits: ['close', 'saved'],
+	data() {
+		return {
+			saving: false,
+			suppliers: [],
+			costCentres: [],
+			form: {
+				poNumber: '',
+				supplierProfileId: '',
+				deliveryAddress: '',
+				expectedDeliveryDate: '',
+				costCentreId: '',
+				notes: '',
+			},
+		}
+	},
+	computed: {
+		purchaseOrderStore() {
+			return usePurchaseOrderStore()
+		},
+		isValid() {
+			return (
+				this.form.supplierProfileId
+				&& this.form.deliveryAddress.trim()
+				&& this.form.expectedDeliveryDate
+			)
+		},
+	},
+	mounted() {
+		this.loadFormData()
+	},
+	methods: {
+		t,
+		async loadFormData() {
+			try {
+				this.suppliers = await this.purchaseOrderStore.fetchSuppliers?.() || []
+				this.costCentres = await this.purchaseOrderStore.fetchCostCentres?.() || []
+			} catch (error) {
+				console.error('Failed to load form data:', error)
+			}
+		},
+		async submit() {
+			if (!this.isValid || this.saving) return
+			this.saving = true
+			try {
+				await this.purchaseOrderStore.create(this.form)
+				this.$emit('saved')
+			} catch (error) {
+				console.error('Failed to create purchase order:', error)
+			} finally {
+				this.saving = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.purchase-order-form {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	padding: 8px 0;
+}
+
+.purchase-order-form__field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.purchase-order-form__field label {
+	font-weight: 600;
+	font-size: 14px;
+}
+
+.purchase-order-form__input {
+	padding: 8px;
+	border: 1px solid var(--color-border);
+	border-radius: 4px;
+	font-size: 14px;
+}
+
+.purchase-order-form__input--readonly {
+	background-color: var(--color-background-dark);
+	color: var(--color-text-maxcontrast);
+	cursor: not-allowed;
+}
+</style>

--- a/src/views/purchaseOrder/PurchaseOrderIndex.vue
+++ b/src/views/purchaseOrder/PurchaseOrderIndex.vue
@@ -1,0 +1,259 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-10.1 -->
+<template>
+	<div class="purchase-order-index">
+		<header class="purchase-order-index__header">
+			<h2>{{ t('shillinq', 'Purchase Orders') }}</h2>
+			<NcButton type="primary" @click="showCreateDialog = true">
+				<template #icon>
+					<Plus :size="20" />
+				</template>
+				{{ t('shillinq', 'New Purchase Order') }}
+			</NcButton>
+		</header>
+
+		<div class="purchase-order-index__filters">
+			<NcButton v-for="status in statusFilters"
+				:key="status.value"
+				:type="activeStatus === status.value ? 'primary' : 'secondary'"
+				@click="activeStatus = status.value">
+				{{ status.label }}
+			</NcButton>
+		</div>
+
+		<NcLoadingIcon v-if="loading" />
+
+		<table v-else-if="filteredOrders.length" class="purchase-order-index__table">
+			<thead>
+				<tr>
+					<th>{{ t('shillinq', 'PO Number') }}</th>
+					<th>{{ t('shillinq', 'Supplier') }}</th>
+					<th>{{ t('shillinq', 'Status') }}</th>
+					<th>{{ t('shillinq', 'Expected Delivery') }}</th>
+					<th>{{ t('shillinq', 'Total') }}</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr v-for="order in filteredOrders"
+					:key="order.id"
+					class="purchase-order-index__row"
+					:class="{ 'purchase-order-index__row--overdue': isOverdue(order) }"
+					@click="navigateToDetail(order.id)">
+					<td>{{ order.poNumber }}</td>
+					<td>{{ order.supplierName }}</td>
+					<td>
+						<span class="purchase-order-index__status-chip"
+							:class="'purchase-order-index__status-chip--' + order.status">
+							{{ order.status }}
+						</span>
+						<span v-if="isOverdue(order)" class="purchase-order-index__badge--overdue">
+							{{ t('shillinq', 'Overdue') }}
+						</span>
+					</td>
+					<td>{{ order.expectedDeliveryDate }}</td>
+					<td>{{ formatCurrency(order.totalAmount, order.currency) }}</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<p v-else class="purchase-order-index__empty">
+			{{ t('shillinq', 'No purchase orders found.') }}
+		</p>
+
+		<PurchaseOrderForm v-if="showCreateDialog"
+			@close="showCreateDialog = false"
+			@saved="onOrderCreated" />
+	</div>
+</template>
+
+<script>
+import { NcButton, NcLoadingIcon } from '@nextcloud/vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import { usePurchaseOrderStore } from '../../store/modules/purchaseOrder.js'
+import PurchaseOrderForm from './PurchaseOrderForm.vue'
+
+export default {
+	name: 'PurchaseOrderIndex',
+	components: {
+		NcButton,
+		NcLoadingIcon,
+		Plus,
+		PurchaseOrderForm,
+	},
+	data() {
+		return {
+			loading: false,
+			showCreateDialog: false,
+			activeStatus: 'all',
+			statusFilters: [
+				{ value: 'all', label: this.t('shillinq', 'All') },
+				{ value: 'draft', label: this.t('shillinq', 'Draft') },
+				{ value: 'submitted', label: this.t('shillinq', 'Submitted') },
+				{ value: 'acknowledged', label: this.t('shillinq', 'Acknowledged') },
+				{ value: 'received', label: this.t('shillinq', 'Received') },
+				{ value: 'invoiced', label: this.t('shillinq', 'Invoiced') },
+				{ value: 'closed', label: this.t('shillinq', 'Closed') },
+				{ value: 'cancelled', label: this.t('shillinq', 'Cancelled') },
+			],
+		}
+	},
+	computed: {
+		purchaseOrderStore() {
+			return usePurchaseOrderStore()
+		},
+		orders() {
+			return this.purchaseOrderStore.items || []
+		},
+		filteredOrders() {
+			if (this.activeStatus === 'all') {
+				return this.orders
+			}
+			return this.orders.filter((o) => o.status === this.activeStatus)
+		},
+	},
+	mounted() {
+		this.fetchOrders()
+	},
+	methods: {
+		t,
+		async fetchOrders() {
+			this.loading = true
+			try {
+				await this.purchaseOrderStore.fetchAll()
+			} finally {
+				this.loading = false
+			}
+		},
+		isOverdue(order) {
+			if (!order.expectedDeliveryDate || order.status === 'closed' || order.status === 'cancelled') {
+				return false
+			}
+			return new Date(order.expectedDeliveryDate) < new Date()
+		},
+		formatCurrency(amount, currency) {
+			if (amount == null) return ''
+			return new Intl.NumberFormat(undefined, { style: 'currency', currency: currency || 'EUR' }).format(amount)
+		},
+		navigateToDetail(id) {
+			this.$router.push({ name: 'purchaseOrderDetail', params: { id } })
+		},
+		onOrderCreated() {
+			this.showCreateDialog = false
+			this.fetchOrders()
+		},
+	},
+}
+</script>
+
+<style scoped>
+.purchase-order-index {
+	padding: 8px 4px 24px;
+	max-width: 1200px;
+}
+
+.purchase-order-index__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 16px;
+}
+
+.purchase-order-index__header h2 {
+	margin: 0;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.purchase-order-index__filters {
+	display: flex;
+	gap: 8px;
+	margin-bottom: 16px;
+	flex-wrap: wrap;
+}
+
+.purchase-order-index__table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.purchase-order-index__table th,
+.purchase-order-index__table td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.purchase-order-index__row {
+	cursor: pointer;
+}
+
+.purchase-order-index__row:hover {
+	background-color: var(--color-background-hover);
+}
+
+.purchase-order-index__row--overdue {
+	background-color: var(--color-error-light, #fff0f0);
+}
+
+.purchase-order-index__status-chip {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: capitalize;
+}
+
+.purchase-order-index__status-chip--draft {
+	background-color: var(--color-background-dark);
+	color: var(--color-text-maxcontrast);
+}
+
+.purchase-order-index__status-chip--submitted {
+	background-color: var(--color-primary-light);
+	color: var(--color-primary);
+}
+
+.purchase-order-index__status-chip--acknowledged {
+	background-color: var(--color-info-light, #e8f4fd);
+	color: var(--color-info, #0082c9);
+}
+
+.purchase-order-index__status-chip--received {
+	background-color: var(--color-success-light, #e8f8e8);
+	color: var(--color-success);
+}
+
+.purchase-order-index__status-chip--invoiced {
+	background-color: var(--color-warning-light, #fff8e1);
+	color: var(--color-warning);
+}
+
+.purchase-order-index__status-chip--closed {
+	background-color: var(--color-success-light, #e8f8e8);
+	color: var(--color-success);
+}
+
+.purchase-order-index__status-chip--cancelled {
+	background-color: var(--color-error-light, #fff0f0);
+	color: var(--color-error);
+}
+
+.purchase-order-index__badge--overdue {
+	display: inline-block;
+	margin-left: 8px;
+	padding: 2px 8px;
+	border-radius: 12px;
+	font-size: 11px;
+	font-weight: 700;
+	background-color: var(--color-error);
+	color: #fff;
+}
+
+.purchase-order-index__empty {
+	color: var(--color-text-maxcontrast);
+	text-align: center;
+	padding: 40px 0;
+}
+</style>

--- a/src/views/rFQ/RFQDetail.vue
+++ b/src/views/rFQ/RFQDetail.vue
@@ -172,7 +172,7 @@ import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 import Send from 'vue-material-design-icons/Send.vue'
 import Trophy from 'vue-material-design-icons/Trophy.vue'
-import { useRfqStore } from '../../store/modules/rfq.js'
+import { useRFQStore } from '../../store/modules/rFQ.js'
 import QuoteComparisonTable from '../../components/QuoteComparisonTable.vue'
 
 export default {
@@ -203,7 +203,7 @@ export default {
 	},
 	computed: {
 		rfqStore() {
-			return useRfqStore()
+			return useRFQStore()
 		},
 		rfq() {
 			return this.rfqStore.current || null

--- a/src/views/rFQ/RFQDetail.vue
+++ b/src/views/rFQ/RFQDetail.vue
@@ -1,0 +1,426 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-12.1 -->
+<template>
+	<div class="rfq-detail">
+		<NcLoadingIcon v-if="loading" />
+
+		<template v-else-if="rfq">
+			<header class="rfq-detail__header">
+				<h2>{{ t('shillinq', 'RFQ') }}: {{ rfq.number }}</h2>
+				<span class="rfq-detail__status-chip"
+					:class="'rfq-detail__status-chip--' + rfq.status">
+					{{ rfq.status }}
+				</span>
+			</header>
+
+			<div class="rfq-detail__tabs">
+				<NcButton v-for="tab in tabs"
+					:key="tab.id"
+					:type="activeTab === tab.id ? 'primary' : 'tertiary'"
+					@click="activeTab = tab.id">
+					{{ tab.label }}
+				</NcButton>
+			</div>
+
+			<!-- Details tab -->
+			<div v-if="activeTab === 'details'" class="rfq-detail__panel">
+				<table class="rfq-detail__properties">
+					<tr>
+						<th>{{ t('shillinq', 'Number') }}</th>
+						<td>{{ rfq.number }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Title') }}</th>
+						<td>{{ rfq.title }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Description') }}</th>
+						<td>{{ rfq.description }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Type') }}</th>
+						<td>{{ rfq.type }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Budget') }}</th>
+						<td>{{ formatCurrency(rfq.budget, rfq.currency) }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Currency') }}</th>
+						<td>{{ rfq.currency }}</td>
+					</tr>
+					<tr>
+						<th>{{ t('shillinq', 'Due Date') }}</th>
+						<td>{{ rfq.dueDate }}</td>
+					</tr>
+				</table>
+			</div>
+
+			<!-- Suppliers tab -->
+			<div v-if="activeTab === 'suppliers'" class="rfq-detail__panel">
+				<div class="rfq-detail__supplier-actions">
+					<input v-model="supplierSearch"
+						type="text"
+						class="rfq-detail__supplier-search"
+						:placeholder="t('shillinq', 'Search suppliers...')" />
+					<NcButton v-if="rfq.status === 'draft'"
+						type="primary"
+						@click="publishAndInvite">
+						<template #icon>
+							<Send :size="20" />
+						</template>
+						{{ t('shillinq', 'Publish & Invite') }}
+					</NcButton>
+				</div>
+
+				<table v-if="invitedSuppliers.length" class="rfq-detail__suppliers-table">
+					<thead>
+						<tr>
+							<th>{{ t('shillinq', 'Supplier') }}</th>
+							<th>{{ t('shillinq', 'Invited Date') }}</th>
+							<th>{{ t('shillinq', 'Response') }}</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="supplier in invitedSuppliers" :key="supplier.id">
+							<td>{{ supplier.name }}</td>
+							<td>{{ supplier.invitedDate }}</td>
+							<td>
+								<span class="rfq-detail__response-chip"
+									:class="'rfq-detail__response-chip--' + supplier.responseStatus">
+									{{ supplier.responseStatus }}
+								</span>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				<p v-else class="rfq-detail__empty">
+					{{ t('shillinq', 'No suppliers invited yet.') }}
+				</p>
+			</div>
+
+			<!-- Quotes tab -->
+			<div v-if="activeTab === 'quotes'" class="rfq-detail__panel">
+				<table v-if="quotes.length" class="rfq-detail__quotes-table">
+					<thead>
+						<tr>
+							<th>{{ t('shillinq', 'Supplier') }}</th>
+							<th>{{ t('shillinq', 'Total Amount') }}</th>
+							<th>{{ t('shillinq', 'Validity Date') }}</th>
+							<th>{{ t('shillinq', 'Status') }}</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="quote in quotes" :key="quote.id">
+							<td>{{ quote.supplierName }}</td>
+							<td>{{ formatCurrency(quote.totalAmount, quote.currency) }}</td>
+							<td>{{ quote.validityDate }}</td>
+							<td>
+								<span class="rfq-detail__status-chip"
+									:class="'rfq-detail__status-chip--' + quote.status">
+									{{ quote.status }}
+								</span>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				<p v-else class="rfq-detail__empty">
+					{{ t('shillinq', 'No quotes received yet.') }}
+				</p>
+			</div>
+
+			<!-- Comparison tab -->
+			<div v-if="activeTab === 'comparison'" class="rfq-detail__panel">
+				<QuoteComparisonTable :rfq-id="rfq.id" />
+
+				<div v-if="rfq.status === 'evaluating'" class="rfq-detail__award-actions">
+					<NcButton type="primary" @click="showAwardDialog = true">
+						<template #icon>
+							<Trophy :size="20" />
+						</template>
+						{{ t('shillinq', 'Award') }}
+					</NcButton>
+				</div>
+			</div>
+
+			<!-- Award confirmation dialog -->
+			<NcDialog v-if="showAwardDialog"
+				:name="t('shillinq', 'Award RFQ')"
+				@close="showAwardDialog = false">
+				<p>{{ t('shillinq', 'Are you sure you want to award this RFQ? This action cannot be undone.') }}</p>
+				<template #actions>
+					<NcButton type="tertiary" @click="showAwardDialog = false">
+						{{ t('shillinq', 'Cancel') }}
+					</NcButton>
+					<NcButton type="primary" @click="confirmAward">
+						{{ t('shillinq', 'Confirm Award') }}
+					</NcButton>
+				</template>
+			</NcDialog>
+		</template>
+
+		<p v-else class="rfq-detail__empty">
+			{{ t('shillinq', 'RFQ not found.') }}
+		</p>
+	</div>
+</template>
+
+<script>
+import { NcButton, NcDialog, NcLoadingIcon } from '@nextcloud/vue'
+import { generateUrl } from '@nextcloud/router'
+import axios from '@nextcloud/axios'
+import Send from 'vue-material-design-icons/Send.vue'
+import Trophy from 'vue-material-design-icons/Trophy.vue'
+import { useRfqStore } from '../../store/modules/rfq.js'
+import QuoteComparisonTable from '../../components/QuoteComparisonTable.vue'
+
+export default {
+	name: 'RFQDetail',
+	components: {
+		NcButton,
+		NcDialog,
+		NcLoadingIcon,
+		Send,
+		Trophy,
+		QuoteComparisonTable,
+	},
+	data() {
+		return {
+			loading: false,
+			activeTab: 'details',
+			supplierSearch: '',
+			showAwardDialog: false,
+			invitedSuppliers: [],
+			quotes: [],
+			tabs: [
+				{ id: 'details', label: this.t('shillinq', 'Details') },
+				{ id: 'suppliers', label: this.t('shillinq', 'Suppliers') },
+				{ id: 'quotes', label: this.t('shillinq', 'Quotes') },
+				{ id: 'comparison', label: this.t('shillinq', 'Comparison') },
+			],
+		}
+	},
+	computed: {
+		rfqStore() {
+			return useRfqStore()
+		},
+		rfq() {
+			return this.rfqStore.current || null
+		},
+	},
+	mounted() {
+		this.fetchRfq()
+	},
+	methods: {
+		t,
+		async fetchRfq() {
+			this.loading = true
+			try {
+				const id = this.$route.params.id
+				await this.rfqStore.fetchOne(id)
+				await this.fetchSuppliers()
+				await this.fetchQuotes()
+			} finally {
+				this.loading = false
+			}
+		},
+		async fetchSuppliers() {
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/rfqs/{id}/suppliers', {
+					id: this.$route.params.id,
+				})
+				const response = await axios.get(url)
+				this.invitedSuppliers = response.data?.results || []
+			} catch (error) {
+				console.error('Failed to fetch suppliers:', error)
+			}
+		},
+		async fetchQuotes() {
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/rfqs/{id}/quotes', {
+					id: this.$route.params.id,
+				})
+				const response = await axios.get(url)
+				this.quotes = response.data?.results || []
+			} catch (error) {
+				console.error('Failed to fetch quotes:', error)
+			}
+		},
+		formatCurrency(amount, currency) {
+			if (amount == null) return ''
+			return new Intl.NumberFormat(undefined, { style: 'currency', currency: currency || 'EUR' }).format(amount)
+		},
+		async publishAndInvite() {
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/rfqs/{id}/publish', {
+					id: this.rfq.id,
+				})
+				await axios.post(url)
+				await this.fetchRfq()
+			} catch (error) {
+				console.error('Failed to publish and invite:', error)
+			}
+		},
+		async confirmAward() {
+			try {
+				const url = generateUrl('/apps/shillinq/api/v1/rfqs/{id}/award', {
+					id: this.rfq.id,
+				})
+				await axios.post(url)
+				this.showAwardDialog = false
+				await this.fetchRfq()
+			} catch (error) {
+				console.error('Failed to award RFQ:', error)
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.rfq-detail {
+	padding: 8px 4px 24px;
+	max-width: 1200px;
+}
+
+.rfq-detail__header {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-bottom: 16px;
+}
+
+.rfq-detail__header h2 {
+	margin: 0;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.rfq-detail__status-chip {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: capitalize;
+}
+
+.rfq-detail__status-chip--draft {
+	background-color: var(--color-background-dark);
+	color: var(--color-text-maxcontrast);
+}
+
+.rfq-detail__status-chip--published {
+	background-color: var(--color-primary-light);
+	color: var(--color-primary);
+}
+
+.rfq-detail__status-chip--evaluating {
+	background-color: var(--color-warning-light, #fff8e1);
+	color: var(--color-warning);
+}
+
+.rfq-detail__status-chip--awarded {
+	background-color: var(--color-success-light, #e8f8e8);
+	color: var(--color-success);
+}
+
+.rfq-detail__status-chip--closed {
+	background-color: var(--color-background-dark);
+	color: var(--color-text-maxcontrast);
+}
+
+.rfq-detail__tabs {
+	display: flex;
+	gap: 4px;
+	margin-bottom: 16px;
+	border-bottom: 1px solid var(--color-border);
+	padding-bottom: 8px;
+}
+
+.rfq-detail__panel {
+	padding: 16px 0;
+}
+
+.rfq-detail__properties {
+	width: 100%;
+	max-width: 600px;
+}
+
+.rfq-detail__properties th {
+	text-align: left;
+	padding: 6px 16px 6px 0;
+	color: var(--color-text-maxcontrast);
+	white-space: nowrap;
+	width: 150px;
+}
+
+.rfq-detail__properties td {
+	padding: 6px 0;
+}
+
+.rfq-detail__supplier-actions {
+	display: flex;
+	gap: 12px;
+	align-items: center;
+	margin-bottom: 16px;
+}
+
+.rfq-detail__supplier-search {
+	flex: 1;
+	max-width: 400px;
+	padding: 8px;
+	border: 1px solid var(--color-border);
+	border-radius: 4px;
+}
+
+.rfq-detail__suppliers-table,
+.rfq-detail__quotes-table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.rfq-detail__suppliers-table th,
+.rfq-detail__suppliers-table td,
+.rfq-detail__quotes-table th,
+.rfq-detail__quotes-table td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.rfq-detail__response-chip {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: capitalize;
+}
+
+.rfq-detail__response-chip--pending {
+	background-color: var(--color-background-dark);
+	color: var(--color-text-maxcontrast);
+}
+
+.rfq-detail__response-chip--accepted {
+	background-color: var(--color-success-light, #e8f8e8);
+	color: var(--color-success);
+}
+
+.rfq-detail__response-chip--declined {
+	background-color: var(--color-error-light, #fff0f0);
+	color: var(--color-error);
+}
+
+.rfq-detail__award-actions {
+	margin-top: 16px;
+}
+
+.rfq-detail__empty {
+	color: var(--color-text-maxcontrast);
+	text-align: center;
+	padding: 40px 0;
+}
+</style>

--- a/src/views/rFQ/RFQForm.vue
+++ b/src/views/rFQ/RFQForm.vue
@@ -1,0 +1,176 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-12.1 -->
+<template>
+	<NcDialog :name="t('shillinq', 'New Request for Quotation')"
+		size="normal"
+		@close="$emit('close')">
+		<form class="rfq-form" @submit.prevent="submit">
+			<div class="rfq-form__field">
+				<label>{{ t('shillinq', 'Number') }}</label>
+				<input type="text"
+					:value="form.number || t('shillinq', 'Auto-generated')"
+					disabled
+					class="rfq-form__input rfq-form__input--readonly" />
+			</div>
+
+			<div class="rfq-form__field">
+				<label>{{ t('shillinq', 'Title') }} *</label>
+				<input v-model="form.title"
+					type="text"
+					class="rfq-form__input"
+					required
+					:placeholder="t('shillinq', 'Enter RFQ title...')" />
+			</div>
+
+			<div class="rfq-form__field">
+				<label>{{ t('shillinq', 'Description') }}</label>
+				<textarea v-model="form.description"
+					class="rfq-form__input"
+					rows="4"
+					:placeholder="t('shillinq', 'Describe what you are requesting...')" />
+			</div>
+
+			<div class="rfq-form__field">
+				<label>{{ t('shillinq', 'Type') }} *</label>
+				<select v-model="form.type"
+					class="rfq-form__input"
+					required>
+					<option value="" disabled>
+						{{ t('shillinq', 'Select type...') }}
+					</option>
+					<option value="rfq">{{ t('shillinq', 'RFQ — Request for Quotation') }}</option>
+					<option value="rfi">{{ t('shillinq', 'RFI — Request for Information') }}</option>
+					<option value="rfp">{{ t('shillinq', 'RFP — Request for Proposal') }}</option>
+				</select>
+			</div>
+
+			<div class="rfq-form__field">
+				<label>{{ t('shillinq', 'Budget') }}</label>
+				<input v-model.number="form.budget"
+					type="number"
+					min="0"
+					step="0.01"
+					class="rfq-form__input"
+					:placeholder="t('shillinq', '0.00')" />
+			</div>
+
+			<div class="rfq-form__field">
+				<label>{{ t('shillinq', 'Currency') }}</label>
+				<select v-model="form.currency"
+					class="rfq-form__input">
+					<option value="EUR">EUR</option>
+					<option value="USD">USD</option>
+					<option value="GBP">GBP</option>
+				</select>
+			</div>
+
+			<div class="rfq-form__field">
+				<label>{{ t('shillinq', 'Due Date') }} *</label>
+				<input v-model="form.dueDate"
+					type="date"
+					class="rfq-form__input"
+					required />
+			</div>
+		</form>
+
+		<template #actions>
+			<NcButton type="tertiary" @click="$emit('close')">
+				{{ t('shillinq', 'Cancel') }}
+			</NcButton>
+			<NcButton type="primary"
+				:disabled="saving || !isValid"
+				@click="submit">
+				<template #icon>
+					<NcLoadingIcon v-if="saving" :size="20" />
+				</template>
+				{{ t('shillinq', 'Create RFQ') }}
+			</NcButton>
+		</template>
+	</NcDialog>
+</template>
+
+<script>
+import { NcButton, NcDialog, NcLoadingIcon } from '@nextcloud/vue'
+import { useRfqStore } from '../../store/modules/rfq.js'
+
+export default {
+	name: 'RFQForm',
+	components: {
+		NcButton,
+		NcDialog,
+		NcLoadingIcon,
+	},
+	emits: ['close', 'saved'],
+	data() {
+		return {
+			saving: false,
+			form: {
+				number: '',
+				title: '',
+				description: '',
+				type: '',
+				budget: null,
+				currency: 'EUR',
+				dueDate: '',
+			},
+		}
+	},
+	computed: {
+		rfqStore() {
+			return useRfqStore()
+		},
+		isValid() {
+			return this.form.title.trim() && this.form.type && this.form.dueDate
+		},
+	},
+	methods: {
+		t,
+		async submit() {
+			if (!this.isValid || this.saving) return
+			this.saving = true
+			try {
+				await this.rfqStore.create(this.form)
+				this.$emit('saved')
+			} catch (error) {
+				console.error('Failed to create RFQ:', error)
+			} finally {
+				this.saving = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.rfq-form {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	padding: 8px 0;
+}
+
+.rfq-form__field {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.rfq-form__field label {
+	font-weight: 600;
+	font-size: 14px;
+}
+
+.rfq-form__input {
+	padding: 8px;
+	border: 1px solid var(--color-border);
+	border-radius: 4px;
+	font-size: 14px;
+}
+
+.rfq-form__input--readonly {
+	background-color: var(--color-background-dark);
+	color: var(--color-text-maxcontrast);
+	cursor: not-allowed;
+}
+</style>

--- a/src/views/rFQ/RFQForm.vue
+++ b/src/views/rFQ/RFQForm.vue
@@ -92,7 +92,7 @@
 
 <script>
 import { NcButton, NcDialog, NcLoadingIcon } from '@nextcloud/vue'
-import { useRfqStore } from '../../store/modules/rfq.js'
+import { useRFQStore } from '../../store/modules/rFQ.js'
 
 export default {
 	name: 'RFQForm',
@@ -118,7 +118,7 @@ export default {
 	},
 	computed: {
 		rfqStore() {
-			return useRfqStore()
+			return useRFQStore()
 		},
 		isValid() {
 			return this.form.title.trim() && this.form.type && this.form.dueDate

--- a/src/views/rFQ/RFQIndex.vue
+++ b/src/views/rFQ/RFQIndex.vue
@@ -82,7 +82,7 @@
 <script>
 import { NcButton, NcLoadingIcon } from '@nextcloud/vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
-import { useRfqStore } from '../../store/modules/rfq.js'
+import { useRFQStore } from '../../store/modules/rFQ.js'
 import RFQForm from './RFQForm.vue'
 
 export default {
@@ -117,7 +117,7 @@ export default {
 	},
 	computed: {
 		rfqStore() {
-			return useRfqStore()
+			return useRFQStore()
 		},
 		rfqs() {
 			return this.rfqStore.items || []

--- a/src/views/rFQ/RFQIndex.vue
+++ b/src/views/rFQ/RFQIndex.vue
@@ -1,0 +1,270 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+<!-- @spec openspec/changes/catalog-purchase-management/tasks.md#task-12.1 -->
+<template>
+	<div class="rfq-index">
+		<header class="rfq-index__header">
+			<h2>{{ t('shillinq', 'Requests for Quotation') }}</h2>
+			<NcButton type="primary" @click="showCreateDialog = true">
+				<template #icon>
+					<Plus :size="20" />
+				</template>
+				{{ t('shillinq', 'New RFQ') }}
+			</NcButton>
+		</header>
+
+		<div class="rfq-index__filters">
+			<div class="rfq-index__filter-group">
+				<span class="rfq-index__filter-label">{{ t('shillinq', 'Type:') }}</span>
+				<NcButton v-for="typeFilter in typeFilters"
+					:key="typeFilter.value"
+					:type="activeType === typeFilter.value ? 'primary' : 'secondary'"
+					@click="activeType = typeFilter.value">
+					{{ typeFilter.label }}
+				</NcButton>
+			</div>
+			<div class="rfq-index__filter-group">
+				<span class="rfq-index__filter-label">{{ t('shillinq', 'Status:') }}</span>
+				<NcButton v-for="status in statusFilters"
+					:key="status.value"
+					:type="activeStatus === status.value ? 'primary' : 'secondary'"
+					@click="activeStatus = status.value">
+					{{ status.label }}
+				</NcButton>
+			</div>
+		</div>
+
+		<NcLoadingIcon v-if="loading" />
+
+		<table v-else-if="filteredRfqs.length" class="rfq-index__table">
+			<thead>
+				<tr>
+					<th>{{ t('shillinq', 'Number') }}</th>
+					<th>{{ t('shillinq', 'Title') }}</th>
+					<th>{{ t('shillinq', 'Type') }}</th>
+					<th>{{ t('shillinq', 'Status') }}</th>
+					<th>{{ t('shillinq', 'Budget') }}</th>
+					<th>{{ t('shillinq', 'Due Date') }}</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr v-for="rfq in filteredRfqs"
+					:key="rfq.id"
+					class="rfq-index__row"
+					@click="navigateToDetail(rfq.id)">
+					<td>{{ rfq.number }}</td>
+					<td>{{ rfq.title }}</td>
+					<td>
+						<span class="rfq-index__type-chip">{{ rfq.type }}</span>
+					</td>
+					<td>
+						<span class="rfq-index__status-chip"
+							:class="'rfq-index__status-chip--' + rfq.status">
+							{{ rfq.status }}
+						</span>
+					</td>
+					<td>{{ formatCurrency(rfq.budget, rfq.currency) }}</td>
+					<td>{{ rfq.dueDate }}</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<p v-else class="rfq-index__empty">
+			{{ t('shillinq', 'No RFQs found.') }}
+		</p>
+
+		<RFQForm v-if="showCreateDialog"
+			@close="showCreateDialog = false"
+			@saved="onRfqCreated" />
+	</div>
+</template>
+
+<script>
+import { NcButton, NcLoadingIcon } from '@nextcloud/vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+import { useRfqStore } from '../../store/modules/rfq.js'
+import RFQForm from './RFQForm.vue'
+
+export default {
+	name: 'RFQIndex',
+	components: {
+		NcButton,
+		NcLoadingIcon,
+		Plus,
+		RFQForm,
+	},
+	data() {
+		return {
+			loading: false,
+			showCreateDialog: false,
+			activeType: 'all',
+			activeStatus: 'all',
+			typeFilters: [
+				{ value: 'all', label: this.t('shillinq', 'All') },
+				{ value: 'rfq', label: this.t('shillinq', 'RFQ') },
+				{ value: 'rfi', label: this.t('shillinq', 'RFI') },
+				{ value: 'rfp', label: this.t('shillinq', 'RFP') },
+			],
+			statusFilters: [
+				{ value: 'all', label: this.t('shillinq', 'All') },
+				{ value: 'draft', label: this.t('shillinq', 'Draft') },
+				{ value: 'published', label: this.t('shillinq', 'Published') },
+				{ value: 'evaluating', label: this.t('shillinq', 'Evaluating') },
+				{ value: 'awarded', label: this.t('shillinq', 'Awarded') },
+				{ value: 'closed', label: this.t('shillinq', 'Closed') },
+			],
+		}
+	},
+	computed: {
+		rfqStore() {
+			return useRfqStore()
+		},
+		rfqs() {
+			return this.rfqStore.items || []
+		},
+		filteredRfqs() {
+			return this.rfqs.filter((rfq) => {
+				if (this.activeType !== 'all' && rfq.type !== this.activeType) return false
+				if (this.activeStatus !== 'all' && rfq.status !== this.activeStatus) return false
+				return true
+			})
+		},
+	},
+	mounted() {
+		this.fetchRfqs()
+	},
+	methods: {
+		t,
+		async fetchRfqs() {
+			this.loading = true
+			try {
+				await this.rfqStore.fetchAll()
+			} finally {
+				this.loading = false
+			}
+		},
+		formatCurrency(amount, currency) {
+			if (amount == null) return ''
+			return new Intl.NumberFormat(undefined, { style: 'currency', currency: currency || 'EUR' }).format(amount)
+		},
+		navigateToDetail(id) {
+			this.$router.push({ name: 'rfqDetail', params: { id } })
+		},
+		onRfqCreated() {
+			this.showCreateDialog = false
+			this.fetchRfqs()
+		},
+	},
+}
+</script>
+
+<style scoped>
+.rfq-index {
+	padding: 8px 4px 24px;
+	max-width: 1200px;
+}
+
+.rfq-index__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 16px;
+}
+
+.rfq-index__header h2 {
+	margin: 0;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.rfq-index__filters {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	margin-bottom: 16px;
+}
+
+.rfq-index__filter-group {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	flex-wrap: wrap;
+}
+
+.rfq-index__filter-label {
+	font-weight: 600;
+	font-size: 14px;
+	color: var(--color-text-maxcontrast);
+}
+
+.rfq-index__table {
+	width: 100%;
+	border-collapse: collapse;
+}
+
+.rfq-index__table th,
+.rfq-index__table td {
+	padding: 8px 12px;
+	text-align: left;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.rfq-index__row {
+	cursor: pointer;
+}
+
+.rfq-index__row:hover {
+	background-color: var(--color-background-hover);
+}
+
+.rfq-index__type-chip {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+	background-color: var(--color-background-dark);
+	color: var(--color-text-maxcontrast);
+}
+
+.rfq-index__status-chip {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: capitalize;
+}
+
+.rfq-index__status-chip--draft {
+	background-color: var(--color-background-dark);
+	color: var(--color-text-maxcontrast);
+}
+
+.rfq-index__status-chip--published {
+	background-color: var(--color-primary-light);
+	color: var(--color-primary);
+}
+
+.rfq-index__status-chip--evaluating {
+	background-color: var(--color-warning-light, #fff8e1);
+	color: var(--color-warning);
+}
+
+.rfq-index__status-chip--awarded {
+	background-color: var(--color-success-light, #e8f8e8);
+	color: var(--color-success);
+}
+
+.rfq-index__status-chip--closed {
+	background-color: var(--color-background-dark);
+	color: var(--color-text-maxcontrast);
+}
+
+.rfq-index__empty {
+	color: var(--color-text-maxcontrast);
+	text-align: center;
+	padding: 40px 0;
+}
+</style>

--- a/tests/bootstrap-unit.php
+++ b/tests/bootstrap-unit.php
@@ -8,6 +8,13 @@ define('PHPUNIT_RUN', 1);
 // Include Composer's autoloader.
 require_once __DIR__ . '/../vendor/autoload.php';
 
+// Register OCP and NCU namespaces from the nextcloud/ocp package so that
+// unit tests can mock Nextcloud interfaces without a full NC environment.
+$ocpLoader = new \Composer\Autoload\ClassLoader();
+$ocpLoader->addPsr4('OCP\\', __DIR__ . '/../vendor/nextcloud/ocp/OCP');
+$ocpLoader->addPsr4('NCU\\', __DIR__ . '/../vendor/nextcloud/ocp/NCU');
+$ocpLoader->register(true);
+
 // Bootstrap Nextcloud — since we run inside the Docker container,
 // the full environment (including \OC::$server) is available.
 if (file_exists(__DIR__ . '/../../../lib/base.php')) {


### PR DESCRIPTION
Closes #46

## Summary
Implements the full catalog and purchase management module for Shillinq, adding product/service item management, vendor catalogs with negotiated pricing, requisitioner basket checkout, RFQ management, purchase order lifecycle, goods receipt confirmation, and three-way matching. All entities are OpenRegister schemas.

## Spec Reference
- Issue: #46
- Spec: `openspec/changes/catalog-purchase-management/design.md`

## Changes
- `lib/Settings/shillinq_register.json` — 11 new OpenRegister schemas
- `lib/Service/` — CatalogSearchService, OrderLimitService, ThreeWayMatchingService, CatalogImportService
- `lib/BackgroundJob/OverdueDeliveryJob.php` — Daily overdue PO notifications
- `lib/Controller/` — CatalogController, OrderBasketController, PurchaseOrderController, GoodsReceiptController, RFQController
- `lib/Repair/CreateDefaultConfiguration.php` — Idempotent seed data
- `appinfo/routes.php` — All new API routes
- `src/store/modules/*.js` — 10 Pinia stores
- `src/views/**/*.vue` — All entity views (Index, Detail, Form)
- `src/components/*.vue` — CatalogImportPanel, OrderBasketPanel, QuoteComparisonTable, ThreeWayMatchingPanel
- `src/navigation/MainMenu.vue` — Catalog and Procurement nav sections
- `src/router/index.js` — All new routes

## Test Coverage
- `composer lint` — passes
- `composer phpcs` — passes
- `composer psalm` — passes