### PR TITLE
chore(docs): @conduction/docusaurus-preset 2.6.1

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "shillinq-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^1.5.1",
+        "@conduction/docusaurus-preset": "^2.6.1",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
         "@docusaurus/theme-mermaid": "^3.7.0",
@@ -2012,9 +2012,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.5.1.tgz",
-      "integrity": "sha512-xKcq6OHKvKMHopqP7PzOjviyLe5D91Za9qpY2teMiLN9jOOfbhM1lvv/dK+o7N+kK0ATolM7rOZOHNZwfIIaNQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-2.6.1.tgz",
+      "integrity": "sha512-hOkS2XAj3p1wfaZWjvIqKzwC5cbTSLUPm+DJxUp7TePbnU37kaHGegjLjfVOnQ312G8an+0M5VWIhmg/YhRVyA==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^1.5.1",
+    "@conduction/docusaurus-preset": "^2.6.1",
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
     "@docusaurus/theme-mermaid": "^3.7.0",


### PR DESCRIPTION
Bumps the docs preset from ^1.x to ^2.6.1 (latest published). Build verified locally; no 2.x adaptation needed.