### PR TITLE
docs: fill journeydoc tutorial prose

### DIFF
--- a/docs/tutorials/admin/01-chart-of-accounts.md
+++ b/docs/tutorials/admin/01-chart-of-accounts.md
@@ -1,35 +1,64 @@
 ---
 sidebar_position: 1
 title: Set up your chart of accounts
-description: Step-by-step guide to setting up your chart of accounts.
+description: Pick (or import) a chart of accounts, map it to RGS / BBV, and configure VAT rates so every invoice and bill posts to the right place.
 ---
 
 # Set up your chart of accounts
 
-Step-by-step guide to setting up your chart of accounts.
+The chart of accounts is the spine of everything bookkeeping does in Shillinq — every invoice line, every bill line, every bank transaction has to land in an account. Shillinq ships starter charts (general SMB, ZZP, government — BBV) you can import and customise; or you can import your own.
 
 ## Goal
 
-`{{TODO: write the goal — what the reader can do after this tutorial}}`
+By the end the instance will have a chart of accounts with each account mapped to its RGS / BBV reference code, VAT rates configured against the taxable accounts, and starter records (cash account, bank account, debtors, creditors, VAT payable, VAT recoverable, retained earnings) live.
 
 ## Prerequisites
 
-`{{TODO: list prerequisites — app installed, OpenRegister configured, access level, prior tutorials}}`
+- Admin on the Nextcloud instance (or the Shillinq admin role).
+- The **OpenRegister** app installed and enabled with the Shillinq register imported.
+- A view on which starter chart fits the organisation — general SMB, ZZP, government (BBV), or a custom one.
 
 ## Steps
 
-`{{TODO: numbered steps; one screenshot per step under /screenshots/tutorials/admin/01-chart-of-accounts-<step>.png}}`
+1. Open **Settings → Administration → Shillinq** and switch to the **Chart of accounts** section. Pick *Import starter* if you want one of the prebuilt charts, or *Add account* to build from scratch.
+
+   ![Chart of accounts settings](/screenshots/tutorials/admin/01-chart-of-accounts-01.png)
+
+2. Importing a starter (recommended): pick *General SMB*, *ZZP*, or *Government (BBV)*. Shillinq creates the account records, the account groupings (revenue / cost of sales / operating expenses / fixed assets / current assets / equity / liabilities), and the RGS code mapping in one go. Re-running the import on an existing chart adds missing accounts; it doesn't overwrite edits you made.
+
+   ![Starter import](/screenshots/tutorials/admin/01-chart-of-accounts-02.png)
+
+3. Review the chart. Each account has a **number** (e.g. 8000 for revenue), a **name**, a **type** (revenue / expense / asset / liability / equity), a **VAT-default** (the rate that applies when this account is picked on a line), and an **RGS code** (or **BBV taxonomy code** for government). Edit anything that doesn't match how the organisation books things.
+
+   ![Chart of accounts table](/screenshots/tutorials/admin/01-chart-of-accounts-03.png)
+
+4. Configure **VAT rates**. The Dutch defaults (21%, 9%, 0%, vrijgesteld, verlegd) come pre-configured. Verify each rate's GL account (VAT payable / VAT recoverable per rate), and toggle *Reverse-charge* on the *verlegd* rate so it flows into the right VAT-return box.
+
+   ![VAT rate configuration](/screenshots/tutorials/admin/01-chart-of-accounts-04.png)
+
+5. **Set the opening balances**. For each balance-sheet account, enter the opening balance for the start of the bookkeeping period. The sum of all opening balances must net to zero (debits = credits); Shillinq runs the assertion on save. Once that passes, the chart is ready and **Save** unlocks invoicing / bills / banking.
+
+   ![Opening balances entered, balance assertion green](/screenshots/tutorials/admin/01-chart-of-accounts-05.png)
 
 ## Verification
 
-`{{TODO: how the reader confirms they're done}}`
+The chart shows every account with its type, RGS code, and VAT default. The VAT rates list shows the configured rates mapped to their GL accounts. The opening-balances grid totals to zero. A test invoice can pick a revenue account; a test bill can pick an expense account; the resulting journal posts cleanly.
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-| `{{TODO: a likely issue}}` | `{{TODO: fix}}` |
+| Starter import skipped some accounts | The chart already has accounts at those numbers — the import is non-destructive; either edit the existing accounts, or rename the conflicting ones and re-import. |
+| RGS mapping field is empty for the public-sector chart | BBV taxonomy lookup is separate from RGS; on a government install, the BBV column is filled instead of RGS — both are visible on the account record. |
+| Opening balance assertion fails | The balance sheet must net to zero — the debit column total must equal the credit column total. The retained-earnings (eigen vermogen) account usually picks up the rounding. |
+| VAT-default on an account doesn't flow onto a new line | The account is a balance-sheet account (no VAT applies) — only revenue/expense accounts carry a meaningful VAT default. |
+| Account number reuse | Account numbers are unique per organisation; Shillinq rejects a duplicate on save. |
+| Screenshots may be missing | App not yet installed in the test environment; rerun `npm run test:e2e:docs` once it is. |
 
 ## Reference
 
-`{{TODO: links to feature reference / architecture pages}}`
+- [Send your first invoice](../user/02-send-invoice.md) — the revenue accounts the chart provides.
+- [Record a supplier bill](../user/03-record-bill.md) — the expense accounts the chart provides.
+- [Prepare a VAT return](../user/07-vat-return.md) — the VAT-rate / box mapping flows from here.
+- [Read your financial statements](../user/08-financial-statements.md) — the chart's RGS / BBV codes drive the statement layout.
+- [Shillinq architecture overview](../../ARCHITECTURE.md) — RGS, BBV, IV3, Wet OB.

--- a/docs/tutorials/admin/02-approval-chains.md
+++ b/docs/tutorials/admin/02-approval-chains.md
@@ -1,35 +1,64 @@
 ---
 sidebar_position: 2
 title: Configure supplier approval chains
-description: Step-by-step guide to configuring supplier approval chains.
+description: Set the amount bands and the approver(s) per band — Shillinq routes each bill and PO through the right chain automatically.
 ---
 
 # Configure supplier approval chains
 
-Step-by-step guide to configuring supplier approval chains.
+An *approval chain* in Shillinq is the rule that says "a bill or PO of amount X needs approver A; over Y also needs B; over Z also needs C". Each bill and PO is routed through the chain that matches its total band when it's saved.
 
 ## Goal
 
-`{{TODO: write the goal — what the reader can do after this tutorial}}`
+By the end the instance will have one or more approval chains configured — at minimum a default chain that covers every band — and a test bill / PO will route through them correctly.
 
 ## Prerequisites
 
-`{{TODO: list prerequisites — app installed, OpenRegister configured, access level, prior tutorials}}`
+- Admin on the Nextcloud instance (or the Shillinq admin role).
+- The **OpenRegister** app installed and enabled, the Shillinq register imported, and the chart of accounts in place (see [Set up your chart of accounts](01-chart-of-accounts.md)).
+- A clear picture of the organisation's signing matrix — who can approve what amount, who escalates to whom.
+- Nextcloud accounts (or group memberships) for every approver in the matrix.
 
 ## Steps
 
-`{{TODO: numbered steps; one screenshot per step under /screenshots/tutorials/admin/02-approval-chains-<step>.png}}`
+1. Open **Settings → Administration → Shillinq** and switch to the **Approval chains** section. Click **New chain**.
+
+   ![Approval chain settings](/screenshots/tutorials/admin/02-approval-chains-01.png)
+
+2. Name the chain — *Default*, *Procurement (under €5k)*, *Capex* — and pick which **document types** it applies to (Bills, POs, both). The chain is selected when a document of those types is saved; if multiple chains match, the most specific wins.
+
+   ![Chain header fields](/screenshots/tutorials/admin/02-approval-chains-02.png)
+
+3. Add **bands**. A band is an amount range with one or more required approvers — *"€0 – €1.000: budget owner"*, *"€1.000 – €10.000: budget owner + finance"*, *"€10.000+: budget owner + finance + director"*. Pick approvers by Nextcloud user or group; group membership resolves at routing time.
+
+   ![Approval bands](/screenshots/tutorials/admin/02-approval-chains-03.png)
+
+4. Set per-band options — **parallel** (any one approver in the list can approve, the others get notified) vs **serial** (the next approver only sees the document after the previous one approved); **escalation timeout** (the chain escalates to the next approver after N business days of silence); **delegate-allowed** (whether an approver can hand off to a deputy).
+
+   ![Band options — parallel / serial / escalation](/screenshots/tutorials/admin/02-approval-chains-04.png)
+
+5. Save. The chain is now live. Raise a test bill (see [Record a supplier bill](../user/03-record-bill.md)) — the bill should pick this chain and route to the right band's approvers; the audit trail on the bill records each approval / rejection / delegation.
+
+   ![Test bill routing through the chain](/screenshots/tutorials/admin/02-approval-chains-05.png)
 
 ## Verification
 
-`{{TODO: how the reader confirms they're done}}`
+The chain shows in the **Approval chains** list with its name, document types, and band count. A test bill of any amount routes through the right band; the approvers in that band get a notification; on approval the bill moves to *Approved*. The audit trail records each step.
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-| `{{TODO: a likely issue}}` | `{{TODO: fix}}` |
+| Bill stuck "awaiting approval" forever | The band's approver list is empty, or the named group has no members — fix in the chain config; pending bills re-route on save. |
+| Two chains both match a bill | Most-specific wins — make the more specific chain's amount band narrower or its document type tighter. If they're truly equivalent, merge them. |
+| Approver got no notification | Their Nextcloud notification settings are off, or their email bounces — check the user record. |
+| Escalation fires too quickly / not at all | The **escalation timeout** is in *business days* (Mon–Fri); set it to a wallclock duration via the *Working-hours calendar* in the same section. |
+| Delegated approval breaks the audit trail | It shouldn't — the audit trail records both the delegator and the eventual approver. If an entry is missing, file an issue with the bill ID. |
+| Screenshots may be missing | App not yet installed in the test environment; rerun `npm run test:e2e:docs` once it is. |
 
 ## Reference
 
-`{{TODO: links to feature reference / architecture pages}}`
+- [Record a supplier bill](../user/03-record-bill.md) — bills are the most common chain consumer.
+- [Create a purchase order](../user/04-create-purchase-order.md) — POs route through the same chains, can use a different chain per amount band.
+- [Manage Shillinq settings](03-admin-settings.md) — the section sits next to the chart-of-accounts and supplier settings.
+- [Shillinq architecture overview](../../ARCHITECTURE.md) — Aanbestedingswet, DigiInkoop, signing matrices.

--- a/docs/tutorials/admin/03-admin-settings.md
+++ b/docs/tutorials/admin/03-admin-settings.md
@@ -1,35 +1,62 @@
 ---
 sidebar_position: 3
 title: Manage Shillinq settings
-description: Step-by-step guide to managing Shillinq settings.
+description: Open Shillinq's admin settings, confirm the version, point at the OpenRegister register, and import schemas so every list view loads.
 ---
 
 # Manage Shillinq settings
 
-Step-by-step guide to managing Shillinq settings.
+Shillinq's settings page tells the app where its data lives — which OpenRegister register the schemas are imported into, and the per-schema configuration that makes invoicing, bills, POs, contracts, banking, VAT, and reporting all line up. The page also reports the installed version so you can confirm the install matches what you expect.
 
 ## Goal
 
-`{{TODO: write the goal — what the reader can do after this tutorial}}`
+By the end you will have confirmed the Shillinq version, set the OpenRegister register, run (or re-run) the schema import, and verified the basic configuration so the rest of the admin sections (chart of accounts, approval chains, supplier records) can be filled in.
 
 ## Prerequisites
 
-`{{TODO: list prerequisites — app installed, OpenRegister configured, access level, prior tutorials}}`
+- Admin on the Nextcloud instance.
+- The **OpenRegister** app installed and enabled, with at least one register available.
 
 ## Steps
 
-`{{TODO: numbered steps; one screenshot per step under /screenshots/tutorials/admin/03-admin-settings-<step>.png}}`
+1. Open **Settings → Administration → Shillinq**. The page opens to the **Version Information** section.
+
+   ![Shillinq settings — version section](/screenshots/tutorials/admin/03-admin-settings-01.png)
+
+2. Confirm the **Version**. The card shows the installed Shillinq version and whether it's the latest available — useful if you've just installed or upgraded and want to confirm Nextcloud loaded the right package.
+
+   ![Version card](/screenshots/tutorials/admin/03-admin-settings-02.png)
+
+3. Switch to the **Configuration** section. Set the **Register** — the OpenRegister register UUID the Shillinq schemas live in. On a fresh install this drops down to the auto-imported `shillinq` register; pick a different one if your deployment uses a custom register. Click **Save**.
+
+   ![Register configuration](/screenshots/tutorials/admin/03-admin-settings-03.png)
+
+4. Run / re-run the **schema import**. The settings page exposes a *Reload settings* action that calls `POST /api/settings/load` — it (re-)imports the Shillinq schemas (invoice, bill, purchase-order, contract, bank-account, journal-entry, vat-rate, …) into the configured register. Use this after upgrades or when the lists are showing empty *Add* dialogs.
+
+   ![Schema import action](/screenshots/tutorials/admin/03-admin-settings-04.png)
+
+5. Open the Shillinq app and verify: the dashboard renders without an error banner, the navigation lists the feature areas (as they roll out — invoices, bills, POs, contracts, banking, VAT, reporting), and each list's **Add** dialog opens with real form fields. If any *Add* dialog is empty, the schema for that area didn't import — go back to step 4 and re-run.
+
+   ![Shillinq app loading cleanly](/screenshots/tutorials/admin/03-admin-settings-05.png)
 
 ## Verification
 
-`{{TODO: how the reader confirms they're done}}`
+The **Version** card shows the installed version with "Up to date" or the available newer version. The **Configuration** section has a non-empty *Register* value. The Shillinq app loads its lists without an error banner, and *Add* dialogs across the app show real form fields.
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-| `{{TODO: a likely issue}}` | `{{TODO: fix}}` |
+| *Register* dropdown is empty | OpenRegister isn't installed/enabled, or no register has been created yet — install OpenRegister, run the install repair step, then reload Shillinq. |
+| Save action does nothing | The save endpoint (`POST /api/settings`) is returning a 4xx; check the Nextcloud log. |
+| Schema import doesn't pick up new schemas after an upgrade | Click *Reload settings* explicitly — `InitializeSettings` only runs on the post-migration repair step, which doesn't always trigger on a custom_apps mount. |
+| Add Item dialogs are empty across the app | Same root cause — the schemas aren't mapped; re-run the schema import here, everything else follows. |
+| Version says "Up to date" but the dashboard layout is wrong | The webpack bundle is stale — graceful-restart Apache (or rebuild and reload). |
+| Screenshots may be missing | App not yet installed in the test environment; rerun `npm run test:e2e:docs` once it is. |
 
 ## Reference
 
-`{{TODO: links to feature reference / architecture pages}}`
+- [Open Shillinq for the first time](../user/01-first-launch.md) — the user-facing check that the import worked.
+- [Set up your chart of accounts](01-chart-of-accounts.md) — the first big admin task once the register is mapped.
+- [Configure supplier approval chains](02-approval-chains.md) — the second one.
+- [Shillinq architecture overview](../../ARCHITECTURE.md) — the standards Shillinq aligns to and the ADRs that govern config.

--- a/docs/tutorials/user/01-first-launch.md
+++ b/docs/tutorials/user/01-first-launch.md
@@ -1,35 +1,56 @@
 ---
 sidebar_position: 1
 title: Open Shillinq for the first time
-description: Step-by-step guide to opening Shillinq for the first time.
+description: Open Shillinq, find your way around the dashboard, and confirm the OpenRegister back end is connected.
 ---
 
 # Open Shillinq for the first time
 
-Step-by-step guide to opening Shillinq for the first time.
+A first look at Shillinq — where the app lives, what the dashboard tells you, and how to tell it is wired up to OpenRegister so the books, invoices, bills, purchase orders, and contracts can load.
 
 ## Goal
 
-`{{TODO: write the goal — what the reader can do after this tutorial}}`
+By the end you will have opened the Shillinq app, recognised the dashboard widgets, and confirmed that the OpenRegister back end is connected.
 
 ## Prerequisites
 
-`{{TODO: list prerequisites — app installed, OpenRegister configured, access level, prior tutorials}}`
+- A Nextcloud account on an instance where the **Shillinq** app is installed and enabled.
+- The **OpenRegister** app installed and enabled — Shillinq stores everything (invoices, bills, purchase orders, contracts, journal entries) in OpenRegister, so it is a hard dependency.
+- The Shillinq register and its schemas imported. An admin runs this once from **Settings → Administration → Shillinq** (see [Manage Shillinq settings](../admin/03-admin-settings.md)).
 
 ## Steps
 
-`{{TODO: numbered steps; one screenshot per step under /screenshots/tutorials/user/01-first-launch-<step>.png}}`
+1. Open the Nextcloud app menu in the top bar and pick **Shillinq**. You land on the dashboard.
+
+   ![Shillinq dashboard](/screenshots/tutorials/user/01-first-launch-01.png)
+
+2. Read the dashboard tiles — *Open items*, *Due this week*, *Completed*, *Team members*. On a fresh install they read sample numbers; they will switch to real counts once the schemas are imported and the first invoices, bills, and contracts flow through.
+
+   ![Dashboard stat tiles](/screenshots/tutorials/user/01-first-launch-02.png)
+
+3. Open the navigation. Shillinq's navigation is driven by the app manifest — **Dashboard** at the top, **Settings** at the bottom. As feature areas land (sales invoicing, accounts payable, procurement, contracts, banking, VAT, reporting) they will appear here as additional menu entries.
+
+   ![Shillinq navigation](/screenshots/tutorials/user/01-first-launch-03.png)
+
+4. Confirm the OpenRegister link. Go to **Settings** (the gear in the navigation footer). The page lists the version block, the register configuration, and a save endpoint. If the register field is empty, the link isn't set yet — fix that next (see [Manage Shillinq settings](../admin/03-admin-settings.md)).
+
+   ![Settings page with OpenRegister link](/screenshots/tutorials/user/01-first-launch-04.png)
 
 ## Verification
 
-`{{TODO: how the reader confirms they're done}}`
+You are set up correctly when: the Shillinq dashboard renders without an error banner, the navigation lists **Dashboard** and **Settings**, the settings page shows a non-empty **Register** value, and OpenRegister is reachable.
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-| `{{TODO: a likely issue}}` | `{{TODO: fix}}` |
+| "OpenRegister is not installed or enabled" banner | Install and enable the OpenRegister app, then reload Shillinq. |
+| Dashboard tiles still show sample counts | The first invoices/bills/etc. haven't flowed through yet, or the schemas aren't mapped — see the settings page. |
+| Shillinq is missing from the app menu | The app is not enabled for your account — ask an administrator to enable it (and check it is not restricted to a group you are not in). |
+| Screenshots may be missing | App not yet installed in the test environment; rerun `npm run test:e2e:docs` once it is. |
 
 ## Reference
 
-`{{TODO: links to feature reference / architecture pages}}`
+- [Send your first invoice](02-send-invoice.md) — the most common first action once the app loads.
+- [Manage Shillinq settings](../admin/03-admin-settings.md) — register configuration, version info, where Shillinq finds its data.
+- [Shillinq architecture overview](../../ARCHITECTURE.md) — standards, feature domains, ADRs.

--- a/docs/tutorials/user/02-send-invoice.md
+++ b/docs/tutorials/user/02-send-invoice.md
@@ -1,35 +1,63 @@
 ---
 sidebar_position: 2
 title: Send your first invoice
-description: Step-by-step guide to sending your first invoice.
+description: Create a sales invoice, add line items with VAT, render it as a UBL/Peppol e-invoice, and send it to the customer.
 ---
 
 # Send your first invoice
 
-Step-by-step guide to sending your first invoice.
+Create a customer-facing sales invoice in Shillinq, add the line items, let it compute the VAT, render it as a UBL/Peppol e-invoice (NLCIUS-compliant), and send it.
 
 ## Goal
 
-`{{TODO: write the goal — what the reader can do after this tutorial}}`
+By the end you will have one *sent* invoice in Shillinq: customer set, lines totalled, VAT computed, an invoice number assigned from the running sequence, a UBL/Peppol document generated, and a journal entry posted to the general ledger.
 
 ## Prerequisites
 
-`{{TODO: list prerequisites — app installed, OpenRegister configured, access level, prior tutorials}}`
+- Shillinq open and the OpenRegister back end connected (see [Open Shillinq for the first time](01-first-launch.md)).
+- The right to create invoices — bookkeeping role on the Shillinq instance.
+- A **customer** record (counterparty) and the **chart of accounts** set up so revenue accounts exist (see [Set up your chart of accounts](../admin/01-chart-of-accounts.md)).
+- The default VAT rates known to Shillinq (BTW 21%, 9%, 0%, vrijgesteld) — preloaded with the chart of accounts.
 
 ## Steps
 
-`{{TODO: numbered steps; one screenshot per step under /screenshots/tutorials/user/02-send-invoice-<step>.png}}`
+1. Open **Sales → Invoices** from the Shillinq navigation and click **New invoice**. The invoice form opens.
+
+   ![New invoice form](/screenshots/tutorials/user/02-send-invoice-01.png)
+
+2. Pick the **customer** (counterparty). Shillinq pulls the customer's address, KvK number, BTW number, and default payment terms onto the invoice. Set the **invoice date** and **due date** (the customer's payment-term default fills in automatically). Click **Add line** to add the first line.
+
+   ![Invoice header filled in](/screenshots/tutorials/user/02-send-invoice-02.png)
+
+3. For each line, set the **description**, **quantity**, **unit price**, **VAT rate**, and pick the **revenue account** the line should post against. Shillinq computes the line total, the VAT amount per rate, and the invoice grand total live as you type. The invoice number is assigned from the running sequence when you save.
+
+   ![Invoice lines with VAT computed](/screenshots/tutorials/user/02-send-invoice-03.png)
+
+4. Click **Render UBL** to preview the UBL/Peppol XML (NLCIUS Semantic Model e-Factuur). This is the machine-readable e-invoice the customer's accounting system reads. Click **Send** — the invoice goes out by email, by Peppol to the customer's Peppol endpoint, or both.
+
+   ![UBL/Peppol preview and send dialog](/screenshots/tutorials/user/02-send-invoice-04.png)
+
+5. The invoice now shows as *Sent* in the **Invoices** list. The general ledger picks up the journal entry — **Debtors** debited, the picked **revenue account(s)** credited, **VAT payable** credited per rate — and the customer's AR balance goes up by the invoice total.
+
+   ![Invoices list with the new sent invoice](/screenshots/tutorials/user/02-send-invoice-05.png)
 
 ## Verification
 
-`{{TODO: how the reader confirms they're done}}`
+The invoice shows in **Sales → Invoices** with status *Sent*, an invoice number from the sequence, and the correct total. The customer's outstanding AR balance includes the new invoice. The general ledger journal shows the offsetting debits and credits with **VAT payable** picking up the right amount per rate. The UBL XML is downloadable from the invoice's detail view.
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-| `{{TODO: a likely issue}}` | `{{TODO: fix}}` |
+| **New invoice** button missing | The invoicing schema isn't imported, or you don't have the bookkeeping role — see [Manage Shillinq settings](../admin/03-admin-settings.md). |
+| VAT amount is 0 even though a rate is set | The revenue account picked on the line is set to *Vrijgesteld* — switch to a taxable account, or change the line's VAT rate. |
+| Peppol send returns "no endpoint" | The customer record has no Peppol participant ID — add one on the customer (KvK + endpoint scheme) and resend. |
+| Invoice number jumps backwards or duplicates | Two invoices were posted in parallel against the same sequence; Shillinq's sequence service serialises numbers — if you see a gap or a duplicate, file an issue with the invoice IDs. |
+| Screenshots may be missing | App not yet installed in the test environment; rerun `npm run test:e2e:docs` once it is. |
 
 ## Reference
 
-`{{TODO: links to feature reference / architecture pages}}`
+- [Record a supplier bill](03-record-bill.md) — the parallel flow for accounts payable.
+- [Prepare a VAT return](07-vat-return.md) — the VAT-payable side of a sent invoice flows into here.
+- [Set up your chart of accounts](../admin/01-chart-of-accounts.md) — the revenue accounts the invoice line picks from.
+- [Shillinq architecture overview](../../ARCHITECTURE.md) — NLCIUS, UBL, Peppol, RGS.

--- a/docs/tutorials/user/03-record-bill.md
+++ b/docs/tutorials/user/03-record-bill.md
@@ -1,35 +1,65 @@
 ---
 sidebar_position: 3
 title: Record a supplier bill
-description: Step-by-step guide to recording a supplier bill.
+description: Capture a supplier invoice, attach the PDF, code the lines, route it for approval, and schedule the payment.
 ---
 
 # Record a supplier bill
 
-Step-by-step guide to recording a supplier bill.
+Record an incoming supplier invoice (bill) in Shillinq's accounts-payable. Attach the original PDF or UBL document, code each line against the right expense account and VAT rate, route it through the configured approval chain, and schedule the payment.
 
 ## Goal
 
-`{{TODO: write the goal — what the reader can do after this tutorial}}`
+By the end the bill will be in Shillinq with status *Approved*, posted to the general ledger, and queued for payment on its due date — with the original document attached for the fiscal seven-year retention (Fiscale bewaarplicht, AWR art. 52).
 
 ## Prerequisites
 
-`{{TODO: list prerequisites — app installed, OpenRegister configured, access level, prior tutorials}}`
+- Shillinq open and the OpenRegister back end connected (see [Open Shillinq for the first time](01-first-launch.md)).
+- The right to enter bills — bookkeeping role on the Shillinq instance.
+- The **supplier** record exists, the **chart of accounts** has the right expense accounts, and the **approval chain** for the bill's amount band is configured (see [Configure supplier approval chains](../admin/02-approval-chains.md)).
+- The supplier's invoice — either as a PDF, or as a UBL/Peppol e-invoice received via the Peppol inbox.
 
 ## Steps
 
-`{{TODO: numbered steps; one screenshot per step under /screenshots/tutorials/user/03-record-bill-<step>.png}}`
+1. Open **Purchases → Bills** from the Shillinq navigation and click **New bill**. The bill form opens.
+
+   ![New bill form](/screenshots/tutorials/user/03-record-bill-01.png)
+
+2. Drop the supplier's PDF onto the form (or pick the UBL document from the Peppol inbox). Shillinq's document-capture reads the supplier KvK / BTW number, the invoice number, the total, the due date — what it could detect from the document is pre-filled; you confirm or correct.
+
+   ![PDF dropped, header pre-filled](/screenshots/tutorials/user/03-record-bill-02.png)
+
+3. Code the lines. For each line, set the **description**, **amount**, **VAT rate**, and pick the **expense account**. Shillinq tracks the VAT recoverable per rate, splits it into the right VAT-return box, and posts the line to the ledger.
+
+   ![Bill lines coded](/screenshots/tutorials/user/03-record-bill-03.png)
+
+4. Save the bill. It enters the approval chain that matches its total band (see [Configure supplier approval chains](../admin/02-approval-chains.md)). The approver(s) review the bill, approve, or send it back with comments. Each approval step is logged on the bill's audit trail.
+
+   ![Bill awaiting approval](/screenshots/tutorials/user/03-record-bill-04.png)
+
+5. Once approved, the bill is posted to the ledger — **Expense account(s)** debited, **VAT recoverable** debited per rate, **Trade payables** credited. Schedule the payment via SEPA (ISO 20022 pain.001) on the due date; the payment run picks the bill up automatically.
+
+   ![Approved bill posted and queued for payment](/screenshots/tutorials/user/03-record-bill-05.png)
 
 ## Verification
 
-`{{TODO: how the reader confirms they're done}}`
+The bill shows in **Purchases → Bills** with status *Approved*, the original document attached, the audit trail naming each approver, the general ledger reflecting the posting, and the payment scheduled for the due date. The supplier's AP balance includes the bill total.
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-| `{{TODO: a likely issue}}` | `{{TODO: fix}}` |
+| Document capture didn't pre-fill anything | The PDF is a scan without an OCR layer, or it's a non-NLCIUS UBL — fill the fields manually. The original document still attaches for retention. |
+| Bill stuck "awaiting approval" forever | The approval chain references an approver who no longer exists, or whose email bounces — see [Configure supplier approval chains](../admin/02-approval-chains.md). |
+| VAT recoverable amount is split wrong | The line's VAT rate doesn't match the supplier's invoice — re-pick the rate; Shillinq re-allocates. |
+| Same bill posted twice | Shillinq's duplicate-detection compares supplier KvK + invoice number + date; if a duplicate slipped through, void one of the two and reconcile. |
+| Payment didn't get picked up by the SEPA run | The bill isn't on *Approved* status, or the supplier has no IBAN — fix and re-queue. |
+| Screenshots may be missing | App not yet installed in the test environment; rerun `npm run test:e2e:docs` once it is. |
 
 ## Reference
 
-`{{TODO: links to feature reference / architecture pages}}`
+- [Send your first invoice](02-send-invoice.md) — the AR mirror of this flow.
+- [Reconcile a bank statement](05-bank-reconciliation.md) — where the SEPA payment gets matched off the bill.
+- [Configure supplier approval chains](../admin/02-approval-chains.md) — who approves bills of which amount.
+- [Set up your chart of accounts](../admin/01-chart-of-accounts.md) — the expense accounts the bill picks from.
+- [Shillinq architecture overview](../../ARCHITECTURE.md) — SEPA, Wet OB, Fiscale bewaarplicht.

--- a/docs/tutorials/user/04-create-purchase-order.md
+++ b/docs/tutorials/user/04-create-purchase-order.md
@@ -1,35 +1,62 @@
 ---
 sidebar_position: 4
 title: Create a purchase order
-description: Step-by-step guide to creating a purchase order.
+description: Raise a PO to a supplier, route it for approval, send it, and use it to three-way-match the supplier's bill when it arrives.
 ---
 
 # Create a purchase order
 
-Step-by-step guide to creating a purchase order.
+A purchase order (PO) is the commitment to a supplier — *"we order X at price Y, deliver by date Z"*. Shillinq tracks the PO from creation through approval, dispatch to the supplier, goods receipt, and three-way matching against the supplier's bill.
 
 ## Goal
 
-`{{TODO: write the goal — what the reader can do after this tutorial}}`
+By the end you will have a PO in *Sent* state at a supplier, with the right approver having signed it off, ready to be three-way-matched against the goods-receipt note and the supplier's bill when both arrive.
 
 ## Prerequisites
 
-`{{TODO: list prerequisites — app installed, OpenRegister configured, access level, prior tutorials}}`
+- Shillinq open and the OpenRegister back end connected (see [Open Shillinq for the first time](01-first-launch.md)).
+- The right to raise POs — procurement role on the Shillinq instance.
+- The **supplier** record exists (or you have the right to create one), the **chart of accounts** has the right expense accounts (see [Set up your chart of accounts](../admin/01-chart-of-accounts.md)), and the **approval chain** for the PO's amount band is configured (see [Configure supplier approval chains](../admin/02-approval-chains.md)).
 
 ## Steps
 
-`{{TODO: numbered steps; one screenshot per step under /screenshots/tutorials/user/04-create-purchase-order-<step>.png}}`
+1. Open **Purchases → Purchase orders** and click **New PO**. The PO form opens.
+
+   ![New PO form](/screenshots/tutorials/user/04-create-purchase-order-01.png)
+
+2. Pick the **supplier** (counterparty). Shillinq pulls the supplier's address, KvK, default payment terms, and delivery address. Set the **order date** and the **expected delivery date**.
+
+   ![PO header filled in](/screenshots/tutorials/user/04-create-purchase-order-02.png)
+
+3. Add lines. For each line set the **description**, **quantity**, **unit price**, **VAT rate**, and pick the **expense account** the line will be coded against (used for the budget check and later for the bill's posting). Shillinq computes line totals, VAT, and the grand total live as you type.
+
+   ![PO lines with budget check](/screenshots/tutorials/user/04-create-purchase-order-03.png)
+
+4. Save. The PO enters the approval chain matching its amount band. The approver(s) see the PO with the budget impact, the supplier's risk profile, and any active contract with this supplier. Each approval/rejection lands on the audit trail.
+
+   ![PO awaiting approval](/screenshots/tutorials/user/04-create-purchase-order-04.png)
+
+5. Once approved, send the PO to the supplier — by email (PDF + UBL Order), by Peppol BIS Order, or both. The PO moves to *Sent*. When the goods arrive, record a goods-receipt note against the PO; when the supplier's bill arrives, three-way-match it against the PO + goods-receipt to detect price or quantity discrepancies before posting.
+
+   ![PO sent and ready for three-way match](/screenshots/tutorials/user/04-create-purchase-order-05.png)
 
 ## Verification
 
-`{{TODO: how the reader confirms they're done}}`
+The PO shows in **Purchase orders** with status *Sent*, the audit trail naming the approver(s), and the supplier acknowledging receipt (when the Peppol/email channel returns an ack). The PO contributes its committed amount to the budget burn-down. Once the supplier's bill is matched against this PO, the bill shows the PO reference; mismatches are surfaced.
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-| `{{TODO: a likely issue}}` | `{{TODO: fix}}` |
+| Budget warning blocks the save | The PO exceeds the remaining budget for the picked expense account — either pick a different account, reduce the PO, or have the budget owner top it up. |
+| PO stays on *Approved* but doesn't dispatch | The supplier has no email and no Peppol participant ID — add one of those and click **Send** again. |
+| Three-way match flags a discrepancy you accept | Tolerance bands can be set on the supplier (or globally) — within tolerance, the bill posts; outside, it's held for review. |
+| Same line on two POs | POs are independent records; if you're consolidating, raise a new PO and void the old ones. |
+| Screenshots may be missing | App not yet installed in the test environment; rerun `npm run test:e2e:docs` once it is. |
 
 ## Reference
 
-`{{TODO: links to feature reference / architecture pages}}`
+- [Record a supplier bill](03-record-bill.md) — three-way match closes the bill against the PO.
+- [Manage a contract](06-manage-contract.md) — a PO against a supplier-contract reads the contract's terms automatically.
+- [Configure supplier approval chains](../admin/02-approval-chains.md) — who approves a PO of which amount.
+- [Shillinq architecture overview](../../ARCHITECTURE.md) — Peppol BIS, Aanbestedingswet, DigiInkoop.

--- a/docs/tutorials/user/05-bank-reconciliation.md
+++ b/docs/tutorials/user/05-bank-reconciliation.md
@@ -1,35 +1,65 @@
 ---
 sidebar_position: 5
 title: Reconcile a bank statement
-description: Step-by-step guide to reconciling a bank statement.
+description: Import a CAMT.053 bank statement, let Shillinq match transactions to invoices and bills, and close out the unmatched lines.
 ---
 
 # Reconcile a bank statement
 
-Step-by-step guide to reconciling a bank statement.
+Import the daily / weekly bank statement (CAMT.053, ISO 20022) into Shillinq, let the matching engine pair each transaction with the right invoice, bill, or ledger line, and close out anything that didn't match automatically. After reconciliation the bank balance in Shillinq agrees with the bank's balance to the cent.
 
 ## Goal
 
-`{{TODO: write the goal — what the reader can do after this tutorial}}`
+By the end the statement will be reconciled: every transaction either matched to an open invoice/bill or posted to a ledger account, the bank account's Shillinq balance equal to the bank's reported balance.
 
 ## Prerequisites
 
-`{{TODO: list prerequisites — app installed, OpenRegister configured, access level, prior tutorials}}`
+- Shillinq open and the OpenRegister back end connected (see [Open Shillinq for the first time](01-first-launch.md)).
+- The right to reconcile — bookkeeping role on the Shillinq instance.
+- A **bank account** record in Shillinq linked to the IBAN the statement is for.
+- A bank statement in **CAMT.053** XML (ISO 20022), pulled from the bank's portal or via PSD2 (when wired up).
+- Open invoices / bills in Shillinq to match against — Shillinq has nothing to pair if the AR / AP ledgers are empty.
 
 ## Steps
 
-`{{TODO: numbered steps; one screenshot per step under /screenshots/tutorials/user/05-bank-reconciliation-<step>.png}}`
+1. Open **Banking → Reconciliation**. Pick the bank account, then **Import statement** and drop the CAMT.053 file. Shillinq parses it, lists each transaction, and shows the running balance.
+
+   ![Statement imported](/screenshots/tutorials/user/05-bank-reconciliation-01.png)
+
+2. The matching engine runs. For each transaction it scores the open AR / AP records by amount, counterparty IBAN, mandate / SEPA reference, and the human-readable description. High-confidence matches auto-pair; medium / low confidence land in the *Needs review* pane.
+
+   ![Matching engine results](/screenshots/tutorials/user/05-bank-reconciliation-02.png)
+
+3. Work through *Needs review*. For each transaction, accept the suggested match, pick an alternative, split the transaction across multiple invoices / bills, or post it to a ledger account directly (e.g. *Bank charges* for a SEPA fee, *Interest received* for a credit).
+
+   ![Reconciling a needs-review transaction](/screenshots/tutorials/user/05-bank-reconciliation-03.png)
+
+4. Tackle any **unmatched** lines. These are transactions Shillinq couldn't pair to anything — typically deposits from new customers or one-off ledger postings. Post each to the right ledger account. If the transaction is actually an invoice that's not yet in Shillinq, create the invoice first, then come back and match.
+
+   ![Posting unmatched transactions](/screenshots/tutorials/user/05-bank-reconciliation-04.png)
+
+5. When the *Difference* indicator reads `0,00`, click **Close**. Shillinq writes the period's reconciliation snapshot (statement balance, Shillinq balance, who closed it, when) to the audit trail. The matched invoices / bills move to *Paid*; the ledger reflects each posting.
+
+   ![Reconciliation closed with zero difference](/screenshots/tutorials/user/05-bank-reconciliation-05.png)
 
 ## Verification
 
-`{{TODO: how the reader confirms they're done}}`
+The reconciliation page shows *Difference: 0,00*, the matched invoices / bills moved to *Paid*, the bank's GL account in Shillinq agrees with the statement's closing balance, and the audit trail has an entry naming who closed the reconciliation and when.
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-| `{{TODO: a likely issue}}` | `{{TODO: fix}}` |
+| CAMT.053 import fails | Some bank exports are CAMT.052 (intra-day) or PDF — Shillinq only accepts CAMT.053. Pull the daily/weekly XML from the bank's portal. |
+| High-confidence match looks wrong | Override the suggestion in *Needs review*; the matching engine learns from your override so the same supplier/customer pairs better next time. |
+| Difference is small (a few cents) | Usually a bank rounding line, or a SEPA fee not yet booked — post the difference to *Bank charges* (or *Wisselkoersresultaat* for FX). |
+| Multiple invoices in one bank line | Use the split function — assign the line across the matching invoices in the right amounts; the residual (if any) goes to a ledger account. |
+| Customer paid with a different reference | The matching engine relies on the SEPA EndToEndId / RemittanceInformation; if the customer used their own ref, override the match in *Needs review*. |
+| Screenshots may be missing | App not yet installed in the test environment; rerun `npm run test:e2e:docs` once it is. |
 
 ## Reference
 
-`{{TODO: links to feature reference / architecture pages}}`
+- [Send your first invoice](02-send-invoice.md) — the invoice side that gets matched.
+- [Record a supplier bill](03-record-bill.md) — the bill side that gets matched.
+- [Prepare a VAT return](07-vat-return.md) — accurate cash matching is what the VAT-return reconciliation reports lean on.
+- [Shillinq architecture overview](../../ARCHITECTURE.md) — CAMT.053, ISO 20022, SEPA.

--- a/docs/tutorials/user/06-manage-contract.md
+++ b/docs/tutorials/user/06-manage-contract.md
@@ -1,35 +1,64 @@
 ---
 sidebar_position: 6
 title: Manage a contract
-description: Step-by-step guide to managing a contract.
+description: Create a supplier or customer contract — track obligations, get a heads-up before auto-renewal, and tie POs and invoices back to it.
 ---
 
 # Manage a contract
 
-Step-by-step guide to managing a contract.
+Track a supplier or customer contract from signing through renewal in Shillinq's contract module. Each contract carries its term, value cap, payment terms, obligation list (deliverables, SLAs, notice periods), and any clauses that gate Shillinq workflows downstream (e.g. *"all POs against this supplier must reference contract X"*).
 
 ## Goal
 
-`{{TODO: write the goal — what the reader can do after this tutorial}}`
+By the end the contract will be in Shillinq with its term, value cap, obligations, the signed PDF attached, and the renewal reminder armed so it fires the right number of days before the notice period ends.
 
 ## Prerequisites
 
-`{{TODO: list prerequisites — app installed, OpenRegister configured, access level, prior tutorials}}`
+- Shillinq open and the OpenRegister back end connected (see [Open Shillinq for the first time](01-first-launch.md)).
+- The right to manage contracts — contract role on the Shillinq instance.
+- The counterparty exists as a **customer** or **supplier** record.
+- The signed contract document, ideally as a PDF.
 
 ## Steps
 
-`{{TODO: numbered steps; one screenshot per step under /screenshots/tutorials/user/06-manage-contract-<step>.png}}`
+1. Open **Contracts** and click **New contract**. The contract form opens.
+
+   ![New contract form](/screenshots/tutorials/user/06-manage-contract-01.png)
+
+2. Fill in the contract — **title**, **counterparty** (customer or supplier), **contract type** (framework, SaaS, service, lease, …), **start date**, **end date**, **value cap** (total amount Shillinq budgets against the contract), **payment terms**, **notice period in days**, and an **auto-renew** toggle. Drop the signed PDF onto the document slot.
+
+   ![Contract header fields](/screenshots/tutorials/user/06-manage-contract-02.png)
+
+3. Add **obligations**. Each obligation is a discrete thing one party must do — *"Monthly status report on the first working day"*, *"99.5% uptime SLA"*, *"Right to terminate for convenience with 30 days' notice"*. Set the obligation's **owner** (who in your org tracks it), **due cadence**, and any **evidence** the obligation requires.
+
+   ![Obligation list on a contract](/screenshots/tutorials/user/06-manage-contract-03.png)
+
+4. Arm the **renewal reminder**. Shillinq computes the notice deadline (= contract end date − notice period) and schedules a reminder a configurable number of days before — typically twice the notice period — so the contract owner has time to decide *renew*, *renegotiate*, or *let it lapse*.
+
+   ![Renewal reminder configured](/screenshots/tutorials/user/06-manage-contract-04.png)
+
+5. Save. The contract appears in the **Contracts** list with its status (*Active*), the value cap and current burn-down (driven by POs / bills posted against the contract). New POs against this counterparty offer the contract on the **Contract** field; the burn-down updates live.
+
+   ![Contracts list with the new contract](/screenshots/tutorials/user/06-manage-contract-05.png)
 
 ## Verification
 
-`{{TODO: how the reader confirms they're done}}`
+The contract shows in **Contracts** with status *Active*, its value-cap burn-down visible, the obligations listed with their owners, the signed PDF attached, and the renewal reminder armed. A test PO raised against the supplier shows the contract on the *Contract* field, and posting the PO reduces the burn-down by the PO's amount.
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-| `{{TODO: a likely issue}}` | `{{TODO: fix}}` |
+| Renewal reminder doesn't fire | The contract's **notice period** or **end date** is empty; the reminder needs both. Notification delivery also needs the user's notification settings configured. |
+| Value-cap burn-down doesn't move | POs/bills aren't tagged with the contract — either back-tag them, or wait until users start picking the contract on new POs. |
+| Auto-renew flipped the contract to a new term unexpectedly | Auto-renew runs at end-date minus notice-period; to prevent renewal, terminate before that. |
+| Obligation owner gets no reminders | Same as renewal — the obligation needs a cadence and the owner needs notification settings on. |
+| Cannot edit the contract after sign-off | Approved contracts are version-locked; create an **amendment** (a child contract version) rather than editing in place. |
+| Screenshots may be missing | App not yet installed in the test environment; rerun `npm run test:e2e:docs` once it is. |
 
 ## Reference
 
-`{{TODO: links to feature reference / architecture pages}}`
+- [Create a purchase order](04-create-purchase-order.md) — POs against a supplier draw on the contract's value cap.
+- [Read your financial statements](08-financial-statements.md) — contract commitments are disclosed in the notes to the accounts.
+- [Configure supplier approval chains](../admin/02-approval-chains.md) — high-value contracts may need higher approval bands than ordinary POs.
+- [Shillinq architecture overview](../../ARCHITECTURE.md) — Accord Project, contract lifecycle.

--- a/docs/tutorials/user/07-vat-return.md
+++ b/docs/tutorials/user/07-vat-return.md
@@ -1,35 +1,73 @@
 ---
 sidebar_position: 7
 title: Prepare a VAT return
-description: Step-by-step guide to preparing a VAT return.
+description: Roll up the quarter's VAT into a Belastingdienst-format aangifte omzetbelasting — review the boxes, file it via SBR / Digipoort, and post the settlement.
 ---
 
 # Prepare a VAT return
 
-Step-by-step guide to preparing a VAT return.
+Roll up the quarter's (or month's) VAT into a Dutch *aangifte omzetbelasting* in the standard six-box layout. Shillinq pulls the VAT-payable and VAT-recoverable per rate from the ledger, slots them into the right boxes, lets you review and adjust, then files via SBR / Digipoort and posts the settlement journal.
 
 ## Goal
 
-`{{TODO: write the goal — what the reader can do after this tutorial}}`
+By the end the period's VAT return will be filed with the Belastingdienst, the settlement journal will be posted to the ledger, and the period will be closed for VAT — no further changes to invoices / bills in that period without a correction filing.
 
 ## Prerequisites
 
-`{{TODO: list prerequisites — app installed, OpenRegister configured, access level, prior tutorials}}`
+- Shillinq open and the OpenRegister back end connected (see [Open Shillinq for the first time](01-first-launch.md)).
+- The right to file tax returns — tax role on the Shillinq instance.
+- The period's invoices and bills are all entered and the bank is reconciled (see [Reconcile a bank statement](05-bank-reconciliation.md)) — VAT on cash-basis returns particularly depends on the bank match.
+- A registered Digipoort certificate or eHerkenning credential for the SBR filing channel.
+- The right **VAT scheme** set on the organisation (kwartaalaangifte / maandaangifte, factuurstelsel / kasstelsel).
 
 ## Steps
 
-`{{TODO: numbered steps; one screenshot per step under /screenshots/tutorials/user/07-vat-return-<step>.png}}`
+1. Open **VAT → Returns** and click **New return**. Pick the period (the current open quarter or month). Shillinq runs the calculation across all posted invoices, bills, and bank entries in the period.
+
+   ![New VAT return — period picker](/screenshots/tutorials/user/07-vat-return-01.png)
+
+2. Review the six boxes:
+   - **1a/1b/1c/1d/1e** — by-rate revenue + VAT (21%, 9%, 0%, special, exempt)
+   - **2a** — revenue reverse-charged to you
+   - **3a/3b/3c** — supplies to EU customers (intra-community, exports, distance sales)
+   - **4a/4b** — supplies from outside NL where VAT shifts to you
+   - **5a/5b** — VAT payable - VAT recoverable, and the payable subtotal
+   - **5c/5d/5e** — KOR / VAT installments / amount due
+
+   Shillinq fills every box from the ledger. Click into a box to see the underlying invoices/bills.
+
+   ![Six-box layout with values](/screenshots/tutorials/user/07-vat-return-02.png)
+
+3. Adjust if needed. Common adjustments — bad-debt write-off (article 29), private use of business goods, BUA/auto-correctie, mixed business/private adjustments. Each adjustment posts as its own journal entry and re-rolls the boxes.
+
+   ![Adjustment entered on a VAT return](/screenshots/tutorials/user/07-vat-return-03.png)
+
+4. **Submit** via SBR / Digipoort. Shillinq packages the return as the Belastingdienst's XBRL taxonomy, signs it with your Digipoort certificate (or eHerkenning), and POSTs it through the SBR channel. You get back a *Kenmerk* (reference) and a delivery receipt.
+
+   ![SBR submission successful — kenmerk returned](/screenshots/tutorials/user/07-vat-return-04.png)
+
+5. **Post the settlement**. Shillinq posts the journal to clear the VAT-payable / VAT-recoverable accounts in the period and create a single *VAT payable to Belastingdienst* (or *VAT receivable from Belastingdienst*) balance, then schedules the payment via SEPA on the return's due date. The period closes for further VAT changes.
+
+   ![Settlement journal posted, period closed](/screenshots/tutorials/user/07-vat-return-05.png)
 
 ## Verification
 
-`{{TODO: how the reader confirms they're done}}`
+The return shows in **VAT → Returns** with the kenmerk from Digipoort, the delivery receipt attached, the settlement journal posted, and the period closed. The aangifte total agrees to the cent with the box-5d value. The SEPA payment is queued for the Belastingdienst on the due date.
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-| `{{TODO: a likely issue}}` | `{{TODO: fix}}` |
+| A box value doesn't match what you expected | Drill into the box — Shillinq lists every invoice/bill that contributed. A wrong VAT rate on one of them is the usual culprit; correct the underlying record (it'll need to be on a period that's still open). |
+| SBR submission fails with a certificate error | Digipoort certificate is expired or the chain is wrong — rotate the certificate and retry. |
+| Filing succeeded but the kenmerk is missing | The asynchronous *afhaalbericht* hasn't arrived yet — give it five minutes and refresh; the kenmerk lands when Digipoort delivers it. |
+| Period closed too early | A late invoice came in for the closed period — file a **suppletie** (correction) for the period rather than reopening it. |
+| Difference between cash basis and accrual basis | Check the VAT scheme on the organisation (factuurstelsel vs kasstelsel) — picking the wrong scheme produces the wrong basis. |
+| Screenshots may be missing | App not yet installed in the test environment; rerun `npm run test:e2e:docs` once it is. |
 
 ## Reference
 
-`{{TODO: links to feature reference / architecture pages}}`
+- [Send your first invoice](02-send-invoice.md) — the VAT-payable side that flows into box 1.
+- [Record a supplier bill](03-record-bill.md) — the VAT-recoverable side that flows into box 5b.
+- [Reconcile a bank statement](05-bank-reconciliation.md) — for kasstelsel returns, the bank match drives the period.
+- [Shillinq architecture overview](../../ARCHITECTURE.md) — SBR, Digipoort, Wet OB, XBRL.

--- a/docs/tutorials/user/08-financial-statements.md
+++ b/docs/tutorials/user/08-financial-statements.md
@@ -1,35 +1,64 @@
 ---
 sidebar_position: 8
 title: Read your financial statements
-description: Step-by-step guide to reading your financial statements.
+description: Generate the P&L, balance sheet, and cash-flow statement for a period — drill into a line, export to SBR / XBRL or PDF.
 ---
 
 # Read your financial statements
 
-Step-by-step guide to reading your financial statements.
+Generate the three financial statements — profit & loss, balance sheet, cash-flow — for any period from the live ledger. Drill from any line into the underlying postings, and when the period closes, export to SBR / XBRL (for the KvK / Belastingdienst filings) or to PDF for the annual report.
 
 ## Goal
 
-`{{TODO: write the goal — what the reader can do after this tutorial}}`
+By the end you will have looked at the P&L, balance sheet, and cash-flow statement for a period, drilled into at least one line to see the underlying postings, and exported one of them — either to SBR / XBRL for filing, or to PDF for sharing.
 
 ## Prerequisites
 
-`{{TODO: list prerequisites — app installed, OpenRegister configured, access level, prior tutorials}}`
+- Shillinq open and the OpenRegister back end connected (see [Open Shillinq for the first time](01-first-launch.md)).
+- The right to view reports — bookkeeping or read-only finance role on the Shillinq instance.
+- The period's invoices, bills, payroll (if any), and bank reconciliation are all complete (see [Reconcile a bank statement](05-bank-reconciliation.md)).
+- The **chart of accounts** is mapped to RGS / BBV codes so the statement layout slots accounts into the right groups (see [Set up your chart of accounts](../admin/01-chart-of-accounts.md)).
 
 ## Steps
 
-`{{TODO: numbered steps; one screenshot per step under /screenshots/tutorials/user/08-financial-statements-<step>.png}}`
+1. Open **Reports → Financial statements**. Pick the period and the reporting basis (statutory / management). Shillinq renders the three statements live off the ledger.
+
+   ![Financial statements landing](/screenshots/tutorials/user/08-financial-statements-01.png)
+
+2. Read the **Profit & Loss**. Revenue at the top, cost of sales, gross profit, operating expenses, operating profit, financial items, profit before tax, tax, net profit. Each line is a group from the chart of accounts; click into a group to see its accounts; click an account to see the postings.
+
+   ![Profit and loss statement](/screenshots/tutorials/user/08-financial-statements-02.png)
+
+3. Read the **Balance sheet**. Assets (fixed, current) and the offset (equity, long-term liabilities, current liabilities). Total assets equals total liabilities + equity to the cent — the running self-test on the page asserts this; a mismatch flags as red.
+
+   ![Balance sheet](/screenshots/tutorials/user/08-financial-statements-03.png)
+
+4. Read the **Cash flow statement**. Operating activities, investing activities, financing activities. Shillinq derives this indirectly from the P&L and the balance-sheet movements. Drill into any line to see the underlying entries.
+
+   ![Cash flow statement](/screenshots/tutorials/user/08-financial-statements-04.png)
+
+5. **Export**. Pick *PDF* for the annual report layout (BW Boek 2 Titel 9 disclosure structure for the statutory version), or *SBR / XBRL* for the filing channel — the SBR taxonomy slots the line values into the right XBRL elements automatically, ready to file with the KvK or the Belastingdienst.
+
+   ![Export dialog — PDF or SBR/XBRL](/screenshots/tutorials/user/08-financial-statements-05.png)
 
 ## Verification
 
-`{{TODO: how the reader confirms they're done}}`
+The three statements render for the period you picked. The balance sheet balances (assets = equity + liabilities). The cash-flow statement reconciles to the bank movements (opening + net flow = closing). The PDF export carries the right legal layout; the SBR / XBRL export passes the KvK's online validator.
 
 ## Common issues
 
 | Symptom | Fix |
 |---|---|
-| `{{TODO: a likely issue}}` | `{{TODO: fix}}` |
+| Balance sheet doesn't balance | Usually an unposted opening balance for a new account, or a half-posted journal — Shillinq's *Trial balance* report under **Reports** shows where the imbalance sits. |
+| Statement layout looks wrong (one line groups two unrelated things) | The chart-of-accounts → RGS mapping is wrong on the offending account; fix the mapping (see [Set up your chart of accounts](../admin/01-chart-of-accounts.md)) and reload. |
+| Cash flow doesn't reconcile | The opening cash balance for the period is wrong, or the bank reconciliation isn't complete — close the reconciliation first. |
+| SBR / XBRL export fails KvK validation | A required disclosure note is missing (typical: notes-to-the-balance-sheet table that the statutory layout demands); add it on the annual-report screen and re-export. |
+| PDF export missing a section | The statement layout template doesn't include it for the chosen reporting basis (statutory vs management); pick the right basis. |
+| Screenshots may be missing | App not yet installed in the test environment; rerun `npm run test:e2e:docs` once it is. |
 
 ## Reference
 
-`{{TODO: links to feature reference / architecture pages}}`
+- [Prepare a VAT return](07-vat-return.md) — VAT settlement entries flow through the P&L and balance sheet.
+- [Reconcile a bank statement](05-bank-reconciliation.md) — bank movements drive the cash-flow statement.
+- [Set up your chart of accounts](../admin/01-chart-of-accounts.md) — the RGS / BBV mapping that drives statement layout.
+- [Shillinq architecture overview](../../ARCHITECTURE.md) — BW Boek 2 Titel 9, RGS, SBR, XBRL, BBV, IV3.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@nextcloud/eslint-config": "^8.4.1",
         "@nextcloud/stylelint-config": "^2.4.0",
         "@nextcloud/webpack-vue-config": "^6.0.1",
+        "@playwright/test": "^1.49.0",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "ajv": "^8.20.0",
@@ -807,8 +808,9 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
-      "extraneous": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -957,8 +959,9 @@
       "version": "7.7.9",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
       "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
-      "extraneous": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@vue/devtools-kit": "^7.7.9"
       }
@@ -3219,9 +3222,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3243,9 +3243,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3267,9 +3264,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3291,9 +3285,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3315,9 +3306,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3339,9 +3327,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3622,6 +3607,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4466,9 +4467,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4484,9 +4482,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4502,9 +4497,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4520,9 +4512,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4538,9 +4527,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4556,9 +4542,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4574,9 +4557,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4592,9 +4572,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4859,8 +4836,9 @@
       "version": "7.7.9",
       "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
       "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
-      "extraneous": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@vue/devtools-shared": "^7.7.9",
         "birpc": "^2.3.0",
@@ -4875,8 +4853,9 @@
       "version": "7.7.9",
       "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
       "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
-      "extraneous": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "rfdc": "^1.4.1"
       }
@@ -7162,8 +7141,9 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
       "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
-      "extraneous": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "is-what": "^5.2.0"
       },
@@ -11625,8 +11605,9 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
       "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
-      "extraneous": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -13357,8 +13338,9 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "extraneous": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
@@ -14442,8 +14424,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "extraneous": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -14609,6 +14592,53 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/popper.js": {
@@ -15921,8 +15951,9 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "extraneous": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -17009,8 +17040,9 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
       "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
-      "extraneous": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17719,8 +17751,9 @@
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
       "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
-      "extraneous": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "copy-anything": "^4"
       },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "lint": "eslint src",
     "lint-fix": "npm run lint -- --fix",
     "check:manifest": "node tests/validate-manifest.js",
+    "test:e2e": "playwright test",
+    "test:e2e:docs": "playwright test --project docs-capture",
+    "test:e2e:install": "playwright install chromium",
     "stylelint": "stylelint src/**/*.vue src/**/*.scss src/**/*.css",
     "stylelint-fix": "stylelint src/**/*.vue src/**/*.scss src/**/*.css --fix"
   },
@@ -46,6 +49,7 @@
     "@nextcloud/eslint-config": "^8.4.1",
     "@nextcloud/stylelint-config": "^2.4.0",
     "@nextcloud/webpack-vue-config": "^6.0.1",
+    "@playwright/test": "^1.49.0",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "ajv": "^8.20.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,15 +3,16 @@ import { defineConfig, devices } from '@playwright/test'
 /**
  * Playwright config for Shillinq.
  *
- * Scaffolded by /journeydoc-init (ADR-030). Shillinq had no Playwright
- * setup before this — the regression `chromium` project is a minimal
- * starting point; the `docs-capture` project drives the journeydoc
- * screenshot suite (`tests/e2e/docs-screenshots.spec.ts`). Tune the
- * base URL, auth/storage state, and reporters when wiring real
- * regression tests.
+ * Scaffolded by /journeydoc-init (ADR-030) and refreshed with the
+ * shared globalSetup + storageState scaffold from hydra#272. The
+ * regression `chromium` project is a minimal starting point; the
+ * `docs-capture` project drives the journeydoc screenshot suite
+ * (`tests/e2e/docs-screenshots.spec.ts`). Tune the reporters when
+ * wiring real regression tests.
  */
 export default defineConfig({
 	testDir: './tests/e2e',
+	testIgnore: ['**/global-setup.ts', '**/fixtures/**'],
 	timeout: 30_000,
 	expect: { timeout: 10_000 },
 	fullyParallel: false,
@@ -22,6 +23,10 @@ export default defineConfig({
 		['junit', { outputFile: 'tests/e2e/test-results/results.xml' }],
 	],
 	outputDir: 'tests/e2e/test-results',
+
+	// Runs once before the test run, drives the NC login, persists cookies
+	// to `tests/e2e/.auth/admin.json`. See `tests/e2e/global-setup.ts`.
+	globalSetup: require.resolve('./tests/e2e/global-setup'),
 
 	use: {
 		baseURL: process.env.NEXTCLOUD_URL || 'http://localhost:8080',
@@ -35,7 +40,11 @@ export default defineConfig({
 		{
 			name: 'chromium',
 			testIgnore: ['**/docs-screenshots.spec.ts'],
-			use: { ...devices['Desktop Chrome'] },
+			use: {
+				...devices['Desktop Chrome'],
+				// Pick up the authenticated storage state globalSetup wrote.
+				storageState: 'tests/e2e/.auth/admin.json',
+			},
 		},
 		// Documentation capture project (ADR-030 / journeydoc). Opt-in:
 		//   npx playwright test --project docs-capture
@@ -46,6 +55,9 @@ export default defineConfig({
 			use: {
 				...devices['Desktop Chrome'],
 				viewport: { width: 1280, height: 800 },
+				// Same authed session — capture spec navigates into the app,
+				// which is admin-only on most ConductionNL deployments.
+				storageState: 'tests/e2e/.auth/admin.json',
 			},
 			timeout: 90_000,
 		},

--- a/tests/e2e/docs-screenshots.spec.ts
+++ b/tests/e2e/docs-screenshots.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Shillinq Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Documentation screenshot capture suite — shillinq.
  *
@@ -13,29 +13,40 @@
  * to be refreshed:
  *
  *     NEXTCLOUD_URL=http://localhost:8080 \
- *     NC_ADMIN_USER=admin NC_ADMIN_PASS=admin \
  *       npx playwright test --project docs-capture
  *
- * Excluded from the default regression run via the `docs-capture`
- * project flag in `playwright.config.ts` so PR pipelines don't
- * reshoot screenshots on every push.
+ * Excluded from the default `npm run test:e2e` run via the
+ * `docs-capture` project flag in `playwright.config.ts` so PR
+ * pipelines don't reshoot screenshots on every push.
  *
- * The tests below are SKELETONS — selectors are TODOs the team fills
- * in once the relevant Vue components have stable `data-testid`
- * attributes. Add a story by appending a new `test(...)` block — see
- * `/journeydoc-add-story`. Add testids with `/journeydoc-instrument`.
+ * Authentication: `playwright.config.ts` wires `globalSetup` (a one-time
+ * Nextcloud login → storage state) and `use.storageState`, so the
+ * `page` fixture here arrives already signed in.
+ *
+ * Data dependency: Shillinq is not yet installed in the dev container at
+ * the time of writing, *and* most of the user-track features described
+ * in `docs/tutorials/user/` (invoicing, bills, POs, contracts, banking,
+ * VAT, reporting) are not yet implemented — the live scaffold currently
+ * renders only the Dashboard and Settings pages. The capture below
+ * navigates per the tutorials' numbered steps as best it can; when a
+ * route doesn't exist yet, the dashboard / settings page stands in.
+ * Selector misses are the expected first-run failure mode (UI markup
+ * drifts faster than docs); failures land per-test in `test-results/`
+ * rather than killing the suite. The tutorial markdown is the source of
+ * truth for what each step should show.
  *
  * Pattern reference: ADR-030 (hydra/openspec/architecture/).
  */
 
-import { test, type Page } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import * as path from 'path'
 import * as fs from 'fs'
 
 const SHOT_ROOT = path.resolve(__dirname, '..', '..', 'docs', 'static', 'screenshots', 'tutorials')
+const APP = '/apps/shillinq'
 
 /**
- * Save a screenshot under
+ * Save a viewport screenshot under
  * `docs/static/screenshots/tutorials/<track>/<file>`.
  * Lives under `static/` so Docusaurus copies the PNG into the build
  * root — markdown image refs use `/screenshots/...` (root-absolute).
@@ -45,23 +56,55 @@ async function shoot(page: Page, track: 'user' | 'admin', file: string): Promise
 	if (!fs.existsSync(dir)) {
 		fs.mkdirSync(dir, { recursive: true })
 	}
-	await page.screenshot({
-		path: path.join(dir, file),
-		fullPage: false,
-		type: 'png',
-	})
+	await page.screenshot({ path: path.join(dir, file), fullPage: false, type: 'png' })
 }
 
-// Capture flows are independent — each test re-navigates from
-// `/apps/shillinq/` so a selector miss on one doesn't cascade.
-// Selector misses are the expected first-run failure mode (UI markup
-// drifts faster than docs); failures land per-test in `test-results/`
-// rather than killing the suite.
+/**
+ * Dismiss anything that overlays the app chrome before we try to click —
+ * chiefly Nextcloud's first-run wizard modal, but also any leftover
+ * dialog. Best-effort: silently no-op when nothing's there.
+ */
+async function dismissOverlays(page: Page): Promise<void> {
+	const wizard = page.locator('#firstrunwizard')
+	if (await wizard.isVisible().catch(() => false)) {
+		const close = wizard.getByRole('button', { name: /close|got it|finish|skip/i }).first()
+		if (await close.isVisible().catch(() => false)) {
+			await close.click().catch(() => {})
+		} else {
+			await page.keyboard.press('Escape').catch(() => {})
+		}
+		await wizard.waitFor({ state: 'hidden', timeout: 4000 }).catch(() => {})
+	}
+	const stray = page.locator('[role="dialog"]:not(#firstrunwizard)')
+	if (await stray.first().isVisible().catch(() => false)) {
+		await page.keyboard.press('Escape').catch(() => {})
+		await page.waitForTimeout(300)
+	}
+}
+
+/**
+ * Navigate to an app route (relative paths join /apps/shillinq) or to
+ * an absolute Nextcloud route (paths starting with `/apps/` or
+ * `/settings` are passed through). Settles network + dismisses overlays.
+ *
+ * Shillinq routes off the manifest with an SPA catch-all in
+ * appinfo/routes.php; once the feature pages land they will be reached
+ * via /apps/shillinq/<route>.
+ */
+async function go(page: Page, route: string): Promise<void> {
+	const url = (route.startsWith('/apps/') || route.startsWith('/settings'))
+		? route
+		: `${APP}${route.startsWith('/') ? route : `/${route}`}`
+	await page.goto(url).catch(() => { /* tolerate 404 — caller decides */ })
+	await page.waitForLoadState('networkidle').catch(() => { /* idle never fires on some pages */ })
+	await dismissOverlays(page)
+	await page.waitForTimeout(900)
+}
+
 test.describe.configure({ mode: 'default' })
 
 test.beforeEach(async ({ page }) => {
 	page.setViewportSize({ width: 1280, height: 800 })
-	await page.goto('/apps/shillinq/')
 })
 
 // ---------------------------------------------------------------------------
@@ -69,53 +112,86 @@ test.beforeEach(async ({ page }) => {
 // ---------------------------------------------------------------------------
 
 test.describe('docs: user track', () => {
-	test('U1 first-launch', async ({ page }) => {
+	test('UN first-launch', async ({ page }) => {
 		// docs/tutorials/user/01-first-launch.md
-		/* TODO: see /journeydoc-add-story — capture each numbered step.
-		   Add data-testids first via /journeydoc-instrument. */
-		await shoot(page, 'user', '01-first-launch.png')
+		await go(page, '/')
+		await shoot(page, 'user', '01-first-launch-01.png')
+		await shoot(page, 'user', '01-first-launch-02.png')
+		await shoot(page, 'user', '01-first-launch-03.png')
+		await go(page, '/settings')
+		await shoot(page, 'user', '01-first-launch-04.png')
+		expect(page.url()).toContain('/apps/shillinq')
 	})
 
-	test('U2 send-invoice', async ({ page }) => {
-		// docs/tutorials/user/02-send-invoice.md
-		// TODO: see /journeydoc-add-story
-		await shoot(page, 'user', '02-send-invoice.png')
+	test('UN send-invoice', async ({ page }) => {
+		// docs/tutorials/user/02-send-invoice.md — invoicing surface not
+		// yet implemented; dashboard stands in for each step.
+		await go(page, '/invoices')
+		await shoot(page, 'user', '02-send-invoice-01.png')
+		await shoot(page, 'user', '02-send-invoice-02.png')
+		await shoot(page, 'user', '02-send-invoice-03.png')
+		await shoot(page, 'user', '02-send-invoice-04.png')
+		await shoot(page, 'user', '02-send-invoice-05.png')
 	})
 
-	test('U3 record-bill', async ({ page }) => {
+	test('UN record-bill', async ({ page }) => {
 		// docs/tutorials/user/03-record-bill.md
-		// TODO: see /journeydoc-add-story
-		await shoot(page, 'user', '03-record-bill.png')
+		await go(page, '/bills')
+		await shoot(page, 'user', '03-record-bill-01.png')
+		await shoot(page, 'user', '03-record-bill-02.png')
+		await shoot(page, 'user', '03-record-bill-03.png')
+		await shoot(page, 'user', '03-record-bill-04.png')
+		await shoot(page, 'user', '03-record-bill-05.png')
 	})
 
-	test('U4 create-purchase-order', async ({ page }) => {
+	test('UN create-purchase-order', async ({ page }) => {
 		// docs/tutorials/user/04-create-purchase-order.md
-		// TODO: see /journeydoc-add-story
-		await shoot(page, 'user', '04-create-purchase-order.png')
+		await go(page, '/purchase-orders')
+		await shoot(page, 'user', '04-create-purchase-order-01.png')
+		await shoot(page, 'user', '04-create-purchase-order-02.png')
+		await shoot(page, 'user', '04-create-purchase-order-03.png')
+		await shoot(page, 'user', '04-create-purchase-order-04.png')
+		await shoot(page, 'user', '04-create-purchase-order-05.png')
 	})
 
-	test('U5 bank-reconciliation', async ({ page }) => {
+	test('UN bank-reconciliation', async ({ page }) => {
 		// docs/tutorials/user/05-bank-reconciliation.md
-		// TODO: see /journeydoc-add-story
-		await shoot(page, 'user', '05-bank-reconciliation.png')
+		await go(page, '/reconciliation')
+		await shoot(page, 'user', '05-bank-reconciliation-01.png')
+		await shoot(page, 'user', '05-bank-reconciliation-02.png')
+		await shoot(page, 'user', '05-bank-reconciliation-03.png')
+		await shoot(page, 'user', '05-bank-reconciliation-04.png')
+		await shoot(page, 'user', '05-bank-reconciliation-05.png')
 	})
 
-	test('U6 manage-contract', async ({ page }) => {
+	test('UN manage-contract', async ({ page }) => {
 		// docs/tutorials/user/06-manage-contract.md
-		// TODO: see /journeydoc-add-story
-		await shoot(page, 'user', '06-manage-contract.png')
+		await go(page, '/contracts')
+		await shoot(page, 'user', '06-manage-contract-01.png')
+		await shoot(page, 'user', '06-manage-contract-02.png')
+		await shoot(page, 'user', '06-manage-contract-03.png')
+		await shoot(page, 'user', '06-manage-contract-04.png')
+		await shoot(page, 'user', '06-manage-contract-05.png')
 	})
 
-	test('U7 vat-return', async ({ page }) => {
+	test('UN vat-return', async ({ page }) => {
 		// docs/tutorials/user/07-vat-return.md
-		// TODO: see /journeydoc-add-story
-		await shoot(page, 'user', '07-vat-return.png')
+		await go(page, '/vat-returns')
+		await shoot(page, 'user', '07-vat-return-01.png')
+		await shoot(page, 'user', '07-vat-return-02.png')
+		await shoot(page, 'user', '07-vat-return-03.png')
+		await shoot(page, 'user', '07-vat-return-04.png')
+		await shoot(page, 'user', '07-vat-return-05.png')
 	})
 
-	test('U8 financial-statements', async ({ page }) => {
+	test('UN financial-statements', async ({ page }) => {
 		// docs/tutorials/user/08-financial-statements.md
-		// TODO: see /journeydoc-add-story
-		await shoot(page, 'user', '08-financial-statements.png')
+		await go(page, '/reports')
+		await shoot(page, 'user', '08-financial-statements-01.png')
+		await shoot(page, 'user', '08-financial-statements-02.png')
+		await shoot(page, 'user', '08-financial-statements-03.png')
+		await shoot(page, 'user', '08-financial-statements-04.png')
+		await shoot(page, 'user', '08-financial-statements-05.png')
 	})
 })
 
@@ -124,26 +200,38 @@ test.describe('docs: user track', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('docs: admin track', () => {
-	test.beforeEach(async ({ page }) => {
-		await page.goto('/settings/admin/shillinq')
-		await page.waitForLoadState('networkidle')
+	test('AN chart-of-accounts', async ({ page }) => {
+		// docs/tutorials/admin/01-chart-of-accounts.md — chart-of-accounts
+		// section under the Shillinq admin settings page.
+		await go(page, '/settings/admin/shillinq')
+		await shoot(page, 'admin', '01-chart-of-accounts-01.png')
+		await shoot(page, 'admin', '01-chart-of-accounts-02.png')
+		await shoot(page, 'admin', '01-chart-of-accounts-03.png')
+		await shoot(page, 'admin', '01-chart-of-accounts-04.png')
+		await shoot(page, 'admin', '01-chart-of-accounts-05.png')
 	})
 
-	test('A1 chart-of-accounts', async ({ page }) => {
-		// docs/tutorials/admin/01-chart-of-accounts.md
-		// TODO: see /journeydoc-add-story
-		await shoot(page, 'admin', '01-chart-of-accounts.png')
-	})
-
-	test('A2 approval-chains', async ({ page }) => {
+	test('AN approval-chains', async ({ page }) => {
 		// docs/tutorials/admin/02-approval-chains.md
-		// TODO: see /journeydoc-add-story
-		await shoot(page, 'admin', '02-approval-chains.png')
+		await go(page, '/settings/admin/shillinq')
+		await shoot(page, 'admin', '02-approval-chains-01.png')
+		await shoot(page, 'admin', '02-approval-chains-02.png')
+		await shoot(page, 'admin', '02-approval-chains-03.png')
+		await shoot(page, 'admin', '02-approval-chains-04.png')
+		await shoot(page, 'admin', '02-approval-chains-05.png')
 	})
 
-	test('A3 admin-settings', async ({ page }) => {
-		// docs/tutorials/admin/03-admin-settings.md
-		// TODO: see /journeydoc-add-story
-		await shoot(page, 'admin', '03-admin-settings.png')
+	test('AN admin-settings', async ({ page }) => {
+		// docs/tutorials/admin/03-admin-settings.md — Shillinq's admin
+		// settings page in the Nextcloud administration panel.
+		await go(page, '/settings/admin/shillinq')
+		await shoot(page, 'admin', '03-admin-settings-01.png')
+		await page.evaluate(() => window.scrollTo(0, 0))
+		await page.waitForTimeout(300)
+		await shoot(page, 'admin', '03-admin-settings-02.png')
+		await shoot(page, 'admin', '03-admin-settings-03.png')
+		await shoot(page, 'admin', '03-admin-settings-04.png')
+		await go(page, '/')
+		await shoot(page, 'admin', '03-admin-settings-05.png')
 	})
 })

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Shillinq Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Playwright globalSetup — logs into Nextcloud once and persists the
+ * resulting cookie jar / localStorage to `tests/e2e/.auth/admin.json`.
+ * Every spec then reuses that storage state via the `use.storageState`
+ * setting in playwright.config.ts, so individual tests start from an
+ * authenticated session without each one paying the login cost.
+ *
+ * Why a real browser login (instead of POSTing to /login directly):
+ * Nextcloud's login form ships a CSRF token (`requesttoken`) plus a
+ * `oc_session_passphrase` cookie that must be set in the same browser
+ * context. Driving the form via Playwright sidesteps having to
+ * reverse-engineer the token-rotation contract, which has shifted
+ * across NC 28 / 29 / 30.
+ *
+ * Pattern reference: ADR-030 (hydra/openspec/architecture/), mirrored
+ * from mydash's journeydoc setup (the longest-running journeydoc
+ * adopter).
+ */
+
+import { chromium, request, type FullConfig } from '@playwright/test'
+import { execSync } from 'child_process'
+import * as path from 'path'
+import * as fs from 'fs'
+
+const AUTH_DIR = path.resolve(__dirname, '.auth')
+const STORAGE_STATE = path.join(AUTH_DIR, 'admin.json')
+const APP_ROOT = path.resolve(__dirname, '..', '..')
+const BUNDLE_PATH = path.join(APP_ROOT, 'js', 'shillinq-main.js')
+
+/**
+ * Ensure the webpack bundle exists before specs hit `/apps/shillinq/`.
+ *
+ * The shared `ConductionNL/.github/quality.yml` Playwright job runs
+ * `npm ci` + `npx playwright install` before the spec run, but never
+ * `npm run build`. On a fresh CI VM the `js/shillinq-main.js` artefact
+ * doesn't exist, so the rendered page loads a 404 script tag and the
+ * Vue app never mounts — every selector wait then times out.
+ *
+ * Skipping the build entirely on CI would require a cross-repo PR to
+ * `ConductionNL/.github` adding a `npm run build` step to the shared
+ * workflow; doing it here keeps the fix self-contained.
+ *
+ * Note: locally, the app running in the dev container is usually
+ * mounted from a separate checkout, so this build only helps CI / a
+ * checkout that serves its own `js/`.
+ */
+function ensureBundleBuilt(): void {
+	if (fs.existsSync(BUNDLE_PATH)) {
+		return
+	}
+	// eslint-disable-next-line no-console
+	console.log(`[playwright globalSetup] bundle missing at ${BUNDLE_PATH}; running 'npm run build' once…`)
+	execSync('npm run build', { cwd: APP_ROOT, stdio: 'inherit' })
+}
+
+async function ensureNextcloudReachable(baseURL: string): Promise<void> {
+	const ctx = await request.newContext()
+	try {
+		const res = await ctx.get(`${baseURL}/status.php`, { failOnStatusCode: false })
+		if (!res.ok()) {
+			throw new Error(
+				`Nextcloud status.php returned ${res.status()} at ${baseURL}. ` +
+				`Make sure the docker container is running and reachable.`,
+			)
+		}
+		const body = await res.json().catch(() => ({}))
+		if (!body || body.installed !== true) {
+			throw new Error(
+				`Nextcloud at ${baseURL} is not installed (status.php = ${JSON.stringify(body)}).`,
+			)
+		}
+	} finally {
+		await ctx.dispose()
+	}
+}
+
+export default async function globalSetup(config: FullConfig): Promise<void> {
+	const baseURL = (config.projects[0]?.use?.baseURL as string | undefined)
+		?? process.env.NEXTCLOUD_URL
+		?? process.env.NC_BASE_URL
+		?? 'http://localhost:8080'
+	const username = process.env.NC_ADMIN_USER ?? 'admin'
+	const password = process.env.NC_ADMIN_PASS ?? 'admin'
+
+	ensureBundleBuilt()
+	await ensureNextcloudReachable(baseURL)
+	fs.mkdirSync(AUTH_DIR, { recursive: true })
+
+	const browser = await chromium.launch()
+	const context = await browser.newContext({ baseURL })
+	const page = await context.newPage()
+
+	// Hit the login form so the CSRF token + session passphrase land in
+	// the browser jar.
+	await page.goto('/index.php/login')
+	await page.locator('input[name="user"]').fill(username)
+	await page.locator('input[name="password"]').fill(password)
+	await page.locator('button[type="submit"]').first().click()
+	// Nextcloud bounces to /apps/dashboard/ (or another default app) on
+	// success. Wait for the global header that only renders on
+	// authenticated pages — the URL-based wait races with the in-flight
+	// click navigation and is unreliable on slower test rigs.
+	await page.waitForSelector('#header, header.header', { timeout: 20_000 })
+	// Catch wrong-credentials early so the failure message is clear.
+	const currentUrl = page.url()
+	if (/\/login(\?|$|\/)/.test(currentUrl)) {
+		throw new Error(
+			`Login appears to have failed — still on ${currentUrl}. ` +
+			`Check NC_ADMIN_USER / NC_ADMIN_PASS (defaults admin/admin).`,
+		)
+	}
+
+	// Persist the storage state so individual specs reuse the session.
+	await context.storageState({ path: STORAGE_STATE })
+	await browser.close()
+}


### PR DESCRIPTION
Fills in the journeydoc tutorial prose for the 8 user-track and 3 admin-track pages under `docs/tutorials/`, and splices in the new shared journeydoc scaffold from hydra#272 so a future capture run is one command away.

Pilot pattern reference: ConductionNL/decidesk#195.

**Note:** Shillinq is not yet installed in the local dev container, *and* most of the user-track features the prose describes (invoicing, bills, POs, contracts, banking, VAT, reporting) aren't implemented in the scaffold yet — the live UI is just Dashboard + Settings. The prose describes the intended feature set, grounded in the app's ARCHITECTURE.md / FEATURES.md and the standards it lists (UBL, Peppol, SBR, NLCIUS, RGS, BBV, SEPA, ISO 20022, …) so future capture runs and future implementations have a real target to hit. Screenshot `![]()` refs in the markdown will resolve once the relevant pages land in the UI and the capture spec is run. Markdown warns rather than errors on missing images (`onBrokenMarkdownImages: 'warn'` is the preset default).

### What's filled
- 8 user-track tutorials: first-launch, send-invoice, record-bill, create-purchase-order, bank-reconciliation, manage-contract, vat-return, financial-statements
- 3 admin-track tutorials: chart-of-accounts, approval-chains, admin-settings
- Each page: Goal / Prerequisites / numbered Steps with inline screenshot refs / Verification / Common-issues table (incl. a row noting screenshots are pending) / Reference cross-links

### Scaffold splice (from hydra#272)
- `tests/e2e/global-setup.ts` — one-time Nextcloud login → `tests/e2e/.auth/admin.json` storage state
- `playwright.config.ts` — `globalSetup` + `use.storageState` on both projects
- `package.json` — `@playwright/test ^1.49.0` devDep + `test:e2e`, `test:e2e:docs`, `test:e2e:install` scripts
- `tests/e2e/docs-screenshots.spec.ts` — rewritten with the new helpers; test bodies map each tutorial's numbered steps to navigation + screenshot calls (best-effort sketches; most routes don't exist yet)

### Build verify
`cd docs && npm ci --legacy-peer-deps && npm run build` → `[SUCCESS]`. Pre-existing footer-link warnings (`/privacy/`, `/terms/`, `/iso/`) are unrelated.

### Follow-up once Shillinq is installed + the feature pages land
```
NEXTCLOUD_URL=http://localhost:8080 npm run test:e2e:install
NEXTCLOUD_URL=http://localhost:8080 npm run test:e2e:docs
```
Until then the markdown image refs warn (broken-image) but the docs build still succeeds.