### PR TITLE
fix: ConfigurationService::importFromApp 4-arg signature (closes #82)

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -139,8 +139,42 @@ class SettingsService
         }
 
         try {
+            $configPath = __DIR__.'/../Settings/shillinq_register.json';
+            if (file_exists($configPath) === false) {
+                $this->logger->error('Shillinq: shillinq_register.json not found at '.$configPath);
+                return [
+                    'success' => false,
+                    'message' => 'Configuration file shillinq_register.json not found.',
+                ];
+            }
+
+            $configContent = file_get_contents($configPath);
+            if ($configContent === false) {
+                $this->logger->error('Shillinq: failed to read shillinq_register.json');
+                return [
+                    'success' => false,
+                    'message' => 'Failed to read configuration file.',
+                ];
+            }
+
+            $configData = json_decode($configContent, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                $this->logger->error('Shillinq: failed to parse shillinq_register.json: '.json_last_error_msg());
+                return [
+                    'success' => false,
+                    'message' => 'Failed to parse configuration file: '.json_last_error_msg(),
+                ];
+            }
+
+            $configVersion = ($configData['info']['version'] ?? '0.0.0');
+
             $configurationService = $this->container->get('OCA\OpenRegister\Service\ConfigurationService');
-            $result = $configurationService->importFromApp(appId: Application::APP_ID, force: $force);
+            $result = $configurationService->importFromApp(
+                appId: Application::APP_ID,
+                data: $configData,
+                version: $configVersion,
+                force: $force
+            );
 
             if (empty($result) === false) {
                 $this->logger->info('Shillinq: register configuration imported successfully');


### PR DESCRIPTION
The OpenRegister `ConfigurationService::importFromApp` signature changed from `($appId, $force)` to `($appId, array $data, string $version, bool $force)`. The old 2-arg call was throwing `ArgumentCountError` at install/upgrade time, leaving 0 schemas configured and Add-Item forms empty.

This loads `shillinq_register.json` from `lib/Settings/` in the app itself, extracts the version from `info.version`, and passes both to the 4-arg method.

Mirrors the canonical fix in decidesk#199 (also applied previously in planix, scholiq, opencatalogi).

Fixes #82