### PR TITLE
feat(spec): implement spec (#112)

### DIFF
--- a/lib/Lifecycle/BalanceGuard.php
+++ b/lib/Lifecycle/BalanceGuard.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * Balance Guard — GL Transaction post-transition precondition.
+ *
+ * Single-method lifecycle guard per ADR-031 §"PHP guards remain a legitimate
+ * seam". The double-entry balance invariant (sum of debit GLLine amounts =
+ * sum of credit GLLine amounts) cannot be expressed as a declarative
+ * cross-schema aggregation inside `x-openregister-lifecycle.requires` in the
+ * current OR engine (see openspec/changes/spec/design.md §Declarative-vs-imperative
+ * decision, row "Balance precondition"). This guard is the ADR-031 exception
+ * path: exactly one method, no domain logic beyond the invariant check,
+ * stateless, fail-closed.
+ *
+ * @category Lifecycle
+ * @package  OCA\Shillinq\Lifecycle
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/spec/tasks.md#task-7
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Lifecycle;
+
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Guards the GLTransaction `draft → posted` lifecycle transition.
+ *
+ * Referenced from `lib/Settings/shillinq_register.json` under
+ * `GLTransaction.x-openregister-lifecycle.transitions.post.requires`.
+ *
+ * ADR-031 exception: this guard exists because the OR engine cannot express
+ * a cross-schema SUM aggregation inside a `requires` precondition. If the
+ * engine gains that capability, this class MUST be retired and the check
+ * moved to the declarative schema metadata.
+ *
+ * @spec openspec/changes/spec/tasks.md#task-7
+ */
+class BalanceGuard
+{
+    /**
+     * Construct the guard with lazy DI of OR's ObjectService.
+     *
+     * @param ContainerInterface $container DI container — ObjectService fetched lazily.
+     * @param LoggerInterface    $logger    Logger for fail-closed diagnostics.
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Precondition for the GLTransaction `draft → posted` transition.
+     *
+     * Returns true iff the sum of all child GLLine.amount WHERE side='debit'
+     * equals the sum WHERE side='credit' for the given transactionId, computed
+     * at cent-level precision (zero rounding tolerance per REQ-GL-005).
+     *
+     * Fail-closed: any ObjectService error returns false, denying the transition.
+     * This prevents a briefly unavailable OR from silently passing an unbalanced
+     * posting through (CWE-863 avoidance per ADR-005 Rule 3).
+     *
+     * @param array<string, mixed> $transaction GLTransaction object array (loaded by OR).
+     *
+     * @return bool True when debits equal credits and the posting is balanced.
+     *
+     * @spec openspec/changes/spec/tasks.md#task-7 (REQ-GL-005)
+     */
+    public function isBalanced(array $transaction): bool
+    {
+        $transactionId = ($transaction['id'] ?? null);
+        if ($transactionId === null || $transactionId === '') {
+            $this->logger->warning(
+                'BalanceGuard: transaction has no id — denying post (fail-closed)',
+                ['transaction' => $transaction]
+            );
+            return false;
+        }
+
+        try {
+            $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+
+            $lines = $objectService->findObjects(
+                register: 'shillinq',
+                schema: 'GLLine',
+                params: [
+                    'transactionId' => $transactionId,
+                    '_limit'        => 1000,
+                ]
+            );
+
+            if (count($lines) < 2) {
+                $this->logger->info(
+                    'BalanceGuard: transaction has fewer than 2 lines — cannot be balanced',
+                    ['transactionId' => $transactionId, 'lineCount' => count($lines)]
+                );
+                return false;
+            }
+
+            $debitSum  = '0';
+            $creditSum = '0';
+
+            foreach ($lines as $line) {
+                $amount = (string) ($line['amount'] ?? '0');
+                $side   = ($line['side'] ?? '');
+                if ($side === 'debit') {
+                    $debitSum = $this->addDecimal(a: $debitSum, b: $amount);
+                    continue;
+                }
+
+                $creditSum = $this->addDecimal(a: $creditSum, b: $amount);
+            }
+
+            $balanced = $debitSum === $creditSum;
+
+            if ($balanced === false) {
+                $this->logger->info(
+                    'BalanceGuard: transaction is not balanced — denying post',
+                    [
+                        'transactionId' => $transactionId,
+                        'debitSum'      => $debitSum,
+                        'creditSum'     => $creditSum,
+                    ]
+                );
+            }
+
+            return $balanced;
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'BalanceGuard: balance computation failed — denying post (fail-closed)',
+                ['transactionId' => $transactionId, 'exception' => $e->getMessage()]
+            );
+            return false;
+        }//end try
+
+    }//end isBalanced()
+
+    /**
+     * Add two decimal strings at cent precision (2 decimal places).
+     *
+     * Uses bcmath when available; falls back to float arithmetic as a best-effort
+     * approximation (PHP's float precision is sufficient for amounts up to ~1e13
+     * EUR at 2 decimal places).
+     *
+     * @param string $a First operand.
+     * @param string $b Second operand.
+     *
+     * @return string Sum formatted to exactly 2 decimal places.
+     */
+    private function addDecimal(string $a, string $b): string
+    {
+        if (function_exists('bcadd') === true) {
+            return bcadd(num1: $a, num2: $b, scale: 2);
+        }
+
+        return number_format(num: (float) $a + (float) $b, decimals: 2, decimal_separator: '.', thousands_separator: '');
+
+    }//end addDecimal()
+}//end class

--- a/lib/Settings/shillinq_register.json
+++ b/lib/Settings/shillinq_register.json
@@ -204,6 +204,265 @@
             "groupBy": "lifecycleState"
           }
         }
+      },
+      "GLTransaction": {
+        "slug": "GLTransaction",
+        "icon": "BookOpenVariantOutline",
+        "version": "0.1.0",
+        "title": "GL Transaction",
+        "description": "General-ledger transaction header (double-entry bookkeeping). Owns N ≥ 2 balanced GLLine rows. Lifecycle: draft → posted → reversed.",
+        "type": "object",
+        "x-schema-org": "schema:AccountingTransaction",
+        "required": [
+          "transactionNumber",
+          "postingDate",
+          "periodId",
+          "currency",
+          "description",
+          "state",
+          "administrationId"
+        ],
+        "properties": {
+          "transactionNumber": {
+            "type": "string",
+            "description": "Sequential transaction number, unique per administration and fiscal year.",
+            "example": "2026-0001"
+          },
+          "postingDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Effective accounting date of the posting.",
+            "example": "2026-02-15"
+          },
+          "periodId": {
+            "type": "string",
+            "description": "FK to the FiscalPeriod record (stub string until T3 lands; Tier 3 introduces the FiscalPeriod schema and converts this to a real FK).",
+            "example": "2026-Q1"
+          },
+          "currency": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 3,
+            "description": "ISO 4217 base currency for this posting.",
+            "example": "EUR",
+            "default": "EUR"
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable summary of the posting.",
+            "example": "Purchase of office supplies"
+          },
+          "sourceReference": {
+            "type": "string",
+            "nullable": true,
+            "description": "External document number (invoice no., bank statement ref, etc.).",
+            "example": "INV-2026-0001"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "posted",
+              "reversed"
+            ],
+            "description": "Lifecycle state of the transaction.",
+            "default": "draft",
+            "example": "draft"
+          },
+          "journalEntryId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Back-reference to the JournalEntry that materialised this posting (if any).",
+            "example": "je-001"
+          },
+          "administrationId": {
+            "type": "string",
+            "description": "FK to the Administration owning this posting.",
+            "example": "adm-1"
+          }
+        },
+        "x-openregister-lifecycle": {
+          "field": "state",
+          "initialState": "draft",
+          "states": {
+            "draft": {
+              "label": "Draft",
+              "description": "Under construction; lines may be added, edited, or deleted."
+            },
+            "posted": {
+              "label": "Posted",
+              "description": "Immutable; header and all lines are locked. Appears in trial balance aggregations."
+            },
+            "reversed": {
+              "label": "Reversed",
+              "description": "Superseded by a compensating posting. Remains queryable for audit; excluded from balance aggregations."
+            }
+          },
+          "immutableStates": ["posted", "reversed"],
+          "transitions": {
+            "post": {
+              "from": "draft",
+              "to": "posted",
+              "label": "Post transaction",
+              "description": "Finalise the transaction. Enforces the double-entry balance invariant (sum of debit lines = sum of credit lines) and locks all child GLLine rows.",
+              "requires": "OCA\\Shillinq\\Lifecycle\\BalanceGuard::isBalanced"
+            },
+            "reverse": {
+              "from": "posted",
+              "to": "reversed",
+              "label": "Reverse transaction",
+              "description": "Mark the transaction as reversed. A compensating GLTransaction that inverts the original lines must already exist before this transition is triggered."
+            }
+          }
+        },
+        "x-openregister-rbac": {
+          "roles": {
+            "bookkeeper": {
+              "permissions": ["create", "read", "update"]
+            },
+            "approver": {
+              "permissions": ["read", "transition:post"]
+            },
+            "auditor": {
+              "permissions": ["read"]
+            }
+          }
+        },
+        "x-openregister-aggregations": {
+          "countByState": {
+            "field": "state",
+            "operation": "count",
+            "description": "Number of transactions per lifecycle state.",
+            "groupBy": "state"
+          }
+        }
+      },
+      "GLLine": {
+        "slug": "GLLine",
+        "icon": "FormatListBulleted",
+        "version": "0.1.0",
+        "title": "GL Line",
+        "description": "Debit or credit line belonging to a GLTransaction. Amount is always non-negative; polarity is encoded in the `side` field.",
+        "type": "object",
+        "x-schema-org": "schema:MonetaryAmount",
+        "required": [
+          "transactionId",
+          "lineNumber",
+          "accountNumber",
+          "side",
+          "amount",
+          "currency",
+          "periodId"
+        ],
+        "properties": {
+          "transactionId": {
+            "type": "string",
+            "description": "FK to the parent GLTransaction.id.",
+            "example": "tx-001"
+          },
+          "lineNumber": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Stable 1-based ordering within the transaction.",
+            "example": 1
+          },
+          "accountNumber": {
+            "type": "string",
+            "description": "FK to Account.accountNumber (chart of accounts).",
+            "example": "1000"
+          },
+          "side": {
+            "type": "string",
+            "enum": [
+              "debit",
+              "credit"
+            ],
+            "description": "Debit or credit side. Sign is encoded here; `amount` is always non-negative.",
+            "example": "debit"
+          },
+          "amount": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Non-negative monetary amount in the transaction currency. Rounding tolerance: zero (unbalanced posting differing by €0.01 fails).",
+            "example": 100.00
+          },
+          "currency": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 3,
+            "description": "ISO 4217 currency. In T1 single-currency mode MUST equal parent GLTransaction.currency.",
+            "example": "EUR"
+          },
+          "periodId": {
+            "type": "string",
+            "description": "Fiscal period identifier. Auto-resolved from parent postingDate on the post transition; draft lines may carry any value.",
+            "example": "2026-Q1"
+          },
+          "subLedgerType": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "ap",
+              "ar",
+              "project",
+              "none"
+            ],
+            "description": "Sub-ledger category (Tier 2 owns the actual sub-ledger registers; T1 allocates the field only).",
+            "example": "none"
+          },
+          "subLedgerRef": {
+            "type": "string",
+            "nullable": true,
+            "description": "FK identifier into the sub-ledger when subLedgerType ≠ none. No FK validation in T1.",
+            "example": "INV-2026-0001"
+          },
+          "costCenter": {
+            "type": "string",
+            "nullable": true,
+            "description": "Cost-center or department code.",
+            "example": "CC-ADMIN"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true,
+            "description": "Line-level description (optional).",
+            "example": "Office supplies expense"
+          }
+        },
+        "x-openregister-relations": {
+          "account": {
+            "localField": "accountNumber",
+            "relatedSchema": "Account",
+            "relatedField": "accountNumber",
+            "cardinality": "many-to-one",
+            "description": "FK to the chart-of-accounts entry declared by add-shillinq-chart-of-accounts."
+          },
+          "transaction": {
+            "localField": "transactionId",
+            "relatedSchema": "GLTransaction",
+            "relatedField": "id",
+            "cardinality": "many-to-one",
+            "description": "FK to the parent GLTransaction header."
+          }
+        },
+        "x-openregister-rbac": {
+          "roles": {
+            "bookkeeper": {
+              "permissions": ["create", "read", "update"]
+            },
+            "auditor": {
+              "permissions": ["read"]
+            }
+          }
+        },
+        "x-openregister-aggregations": {
+          "balanceByAccount": {
+            "field": "amount",
+            "operation": "sum",
+            "description": "Sum of amounts grouped by accountNumber and side — basis for T3 trial-balance aggregation.",
+            "groupBy": ["accountNumber", "side", "periodId"]
+          }
+        }
       }
     }
   }

--- a/openspec/architecture/adr-000-data-model.md
+++ b/openspec/architecture/adr-000-data-model.md
@@ -1645,8 +1645,8 @@ _**DEPRECATED.** Superseded by the `Account` entry (bookkeeping-chart-of-account
 - → JournalEntry (one-to-many)
 
 ### GeneralLedgerEntry
-**Schema.org:** `schema:Thing`
-_An individual entry in the general ledger representing a financial transaction with debit and credit amounts_
+**Schema.org:** `schema:Thing` _(deprecated — superseded by `GLLine` + `GLTransaction` below)_
+_**DEPRECATED.** Superseded by the `GLLine` + `GLTransaction` header/line split introduced by `add-shillinq-general-ledger` (2026-05-18). Retained here for historical reference only. New register declarations MUST use `GLTransaction` (header) and `GLLine` (line). The flat `entryDate`/`debitAmount`/`creditAmount` model is replaced by the header/line split required for the declarative balance invariant per ADR-031 (see design.md Decision D2)._
 **Primary spec:** financial-reporting-accountability
 
 | Property | Type | Required | Description |
@@ -1664,6 +1664,61 @@ _An individual entry in the general ledger representing a financial transaction 
 - → FiscalYear (many-to-one)
 - → Organization (many-to-one)
 - → APTransaction (many-to-one)
+
+> **Reconciliation note (add-shillinq-general-ledger, 2026-05-18):** The flat
+> `GeneralLedgerEntry` shape (one row = one debit OR one credit) is superseded
+> by the header/line split declared in `lib/Settings/shillinq_register.json`:
+> `GLTransaction` (header — owns lifecycle and balance invariant) and `GLLine`
+> (line — carries debit-or-credit side, amount, account FK). The split is
+> required for the double-entry balance invariant to be expressible as a
+> lifecycle precondition per ADR-031 (design.md §D2). Downstream specs MUST
+> reference `GLLine.accountNumber → Account.accountNumber` and
+> `GLLine.transactionId → GLTransaction.id`. The `GeneralLedgerEntry` entry
+> MUST NOT be used for new register declarations.
+
+### GLLine
+**Schema.org:** `schema:MonetaryAmount`
+_Debit or credit line belonging to a GLTransaction. Amount is always non-negative; polarity is encoded in the `side` field. Supersedes the flat `GeneralLedgerEntry` entry — see reconciliation note above._
+**Primary spec:** bookkeeping-general-ledger
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| transactionId | string | Yes | FK to parent GLTransaction.id |
+| lineNumber | integer | Yes | Stable 1-based ordering within the transaction |
+| accountNumber | string | Yes | FK to Account.accountNumber (chart of accounts) |
+| side | enum | Yes | `debit` or `credit` — sign encoded here; amount always non-negative |
+| amount | number ≥ 0 | Yes | Non-negative monetary amount in the transaction currency |
+| currency | string (ISO 4217) | Yes | Line currency; in T1 must equal parent GLTransaction.currency |
+| periodId | string | Yes | Fiscal period identifier; auto-resolved at posting time by lifecycle engine |
+| subLedgerType | enum | No | `ap`, `ar`, `project`, `none` — T2 owns the actual sub-ledger registers |
+| subLedgerRef | string | No | FK into sub-ledger when subLedgerType ≠ none; no FK validation in T1 |
+| costCenter | string | No | Cost-center or department code |
+| description | string | No | Line-level description |
+
+**Relations:**
+- → GLTransaction (many-to-one, via transactionId → GLTransaction.id)
+- → Account (many-to-one, via accountNumber → Account.accountNumber)
+
+### GLTransaction
+**Schema.org:** `schema:AccountingTransaction`
+_General-ledger transaction header for double-entry bookkeeping. Owns N ≥ 2 balanced GLLine rows whose debit sum equals credit sum. Lifecycle: draft → posted → reversed. New entity in the T1 data model; the `GeneralLedgerEntry` entry above is the superseded flat predecessor._
+**Primary spec:** bookkeeping-general-ledger
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| transactionNumber | string | Yes | Sequential number unique per administration and fiscal year |
+| postingDate | date | Yes | Effective accounting date of the posting |
+| periodId | string | Yes | FK to FiscalPeriod (stub string until T3 lands) |
+| currency | string (ISO 4217) | Yes | Base currency for this posting |
+| description | string | Yes | Human-readable posting summary |
+| sourceReference | string | No | External document reference (invoice no., bank statement ref, etc.) |
+| state | enum | Yes | One of `draft`, `posted`, `reversed` |
+| journalEntryId | string | No | Back-reference to the JournalEntry that materialised this posting |
+| administrationId | string | Yes | FK to the Administration owning this posting |
+
+**Relations:**
+- → GLLine (one-to-many, via GLLine.transactionId)
+- → Administration (many-to-one)
 
 ### GoodsReceipt
 **Schema.org:** `schema:Thing`

--- a/openspec/changes/spec/design.md
+++ b/openspec/changes/spec/design.md
@@ -1,6 +1,6 @@
-# Design — Chart of Accounts
+# Design — General Ledger
 
-**status: pr-created**
+**Status:** pr-created
 
 ## Context
 
@@ -10,15 +10,11 @@ reporting. The 5-tier rollout (see `proposal.md`) starts with Tier 1
 **foundation**: a balanced double-entry general ledger built on top of
 a hierarchical chart of accounts.
 
-This change is the **first slice** of Tier 1 — the chart of accounts
-itself. Sibling changes `add-shillinq-general-ledger` and
-`add-shillinq-journal-entries` consume the `Account` register declared
-here.
-
-Currently `lib/Settings/shillinq_register.json` ships only a placeholder
-`example` schema; `openspec/architecture/adr-000-data-model.md`
-enumerates `Account` and `GeneralLedgerAccount` entries but neither has
-landed as a register yet.
+This change is the **second slice** of Tier 1 — the balanced GL itself.
+It depends on `add-shillinq-chart-of-accounts` (which declares the
+`Account` register that `GLLine.accountNumber` foreign-keys into) and
+is consumed by `add-shillinq-journal-entries` (which materialises a
+`GLTransaction` on post).
 
 The change is **spec-only**. Implementation lands later through
 `opsx-apply` and the standard Hydra pipeline; this doc explains
@@ -26,174 +22,194 @@ The change is **spec-only**. Implementation lands later through
 
 ## Goals
 
-- Express the entire chart-of-accounts surface as **declarative
-  metadata** — schema + `x-openregister-lifecycle` rules + manifest
-  entries — per ADR-031. No new PHP service classes.
+- Express the entire GL surface as **declarative metadata** —
+  schemas + `x-openregister-lifecycle` rules + manifest entries —
+  per ADR-031. No new PHP service classes (with the documented
+  ADR-031 exception path for the balance precondition if the engine
+  cannot express it declaratively).
 - Consume every OpenRegister abstraction that already exists for
-  audit trail, RBAC, hierarchical relations — per ADR-022. No
-  reimplementation in shillinq.
+  audit trail, RBAC — per ADR-022. No reimplementation in shillinq.
 - Make the spec a **competent-bookkeeper readable contract** — a
   Dutch SMB accountant should recognise the model as a faithful
-  hierarchical chart of accounts, RGS-conformant, with no surprises.
-- Keep the shape narrow enough that the sibling GL and JE specs can
-  attach without reshaping the `Account` schema.
+  double-entry general ledger, RGS-conformant, with no surprises.
+- Keep Tier 1 narrow enough that Tier 2/3/4/5 specs can each add
+  their surface without reshaping the GL's schemas.
 
 ## Non-Goals
 
-- No GL postings, no journal entries — sibling changes own those.
-- No multi-currency translation — Tier 5's job. (The `Account`
-  schema carries `currency` so Tier 5 doesn't need a destructive
-  migration.)
+- No chart of accounts (sibling change owns the `Account` schema).
+- No journal entries (sibling change owns the `JournalEntry` schema).
+- No invoicing, no AP/AR sub-ledgers, no bank statement matching —
+  Tier 2's job.
+- No period close, no trial balance generation — Tier 3's job. (Tier
+  1 defines `periodId` on every posting so Tier 3 can compute trial
+  balance with one aggregation query.)
+- No financial-statement rendering — Tier 4's job.
+- No multi-currency translation, no VAT/BTW posting automation —
+  Tier 5's job.
 - No frontend Vue components beyond the generic
   `CnIndexPage`/`CnDetailPage` from `@conduction/nextcloud-vue`
   bound through `src/manifest.json`.
-- No PHP code authored in this change.
 
 ## Decisions
 
-### D1 — Declarative-first, per ADR-031
+### D1 — Header/line split for GL transactions
 
-Every chart-of-accounts behaviour expressible as schema metadata MUST
-be declared in `lib/Settings/shillinq_register.json`, not authored as
-a PHP service. Concretely:
+Tier 1 splits GL postings across two schemas:
 
-| Behaviour | Declarative form |
-|---|---|
-| Account active/blocked/archived state machine | `x-openregister-lifecycle` on `Account` |
-| Account hierarchy navigation | `x-openregister-relations` (self-relation `parentAccountNumber → Account.accountNumber`) |
-| Audit trail of every state change | OR's built-in audit-trail-immutable (no app config required) |
+- `GLTransaction` — the header. Carries period, posting date,
+  description, source reference, balanced-state, posting-state. Owns
+  the lifecycle.
+- `GLLine` — the debit-or-credit line. Carries account FK, amount,
+  side (`debit`|`credit`), optional sub-ledger FK, optional cost
+  centre.
 
-**Alternative considered**: Author a PHP `ChartOfAccountsService`
-mirroring Exact / Twinfield style. Rejected per ADR-031 — that is
-exactly the anti-pattern decidesk's MotionService / VotingService /
-QuorumService are now mid-migration away from.
+`adr-000-data-model.md`'s existing `GeneralLedgerEntry` entry is
+line-level (one entry = one debit OR one credit). The header/line
+split is necessary because the balance constraint operates over a
+*group* of lines. A flat `GeneralLedgerEntry` model would force the
+balance check into application code at write-time and prevent the
+constraint from being declarative.
 
-### D2 — `Account` carries `currency`, `administrationId`, `lifecycleState` for future tiers
+**Alternative considered**: Single flat `GeneralLedgerEntry` model
+with a `transactionId` clustering field, balance checked in a
+post-write hook. Rejected — moves the invariant from "declared on
+the schema" to "lives in the hook implementation", which is the
+ADR-031 anti-pattern. Header/line is also the canonical shape in
+RGS and every reference SMB accounting product (Exact, AFAS, Yuki,
+Twinfield, Snelstart).
 
-The `Account` schema must carry forward-compatible fields so that
-sibling and downstream tiers do not force a destructive migration:
+The downstream consequence: `GeneralLedgerEntry` in
+`adr-000-data-model.md` is **superseded by** `GLLine`. The
+ADR-000 update is a one-line note added in this change's
+implementation cycle (not in this proposal). The transactional
+header `GLTransaction` is **new** in the data model.
 
-- `currency` — Tier 5 multi-currency translation needs per-account
-  base currency; declaring it now (default `EUR`) avoids the
-  rewrite later.
-- `administrationId` — Tier 2 multi-administration scoping needs every
-  account to be scoped; declaring as a non-required string in Tier 1
-  keeps single-tenant installs working unchanged.
-- `lifecycleState` — exposes the OR lifecycle state as a queryable
-  field for reporting indexes.
+### D2 — Balance precondition declared as `x-openregister-lifecycle.requires`, with ADR-031 exception path
 
-**Alternative considered**: Add fields later as needs surface.
-Rejected — OR's schema-versioning is additive but downstream specs
-already reference these fields (GL lines need account `currency` for
-balance checks; JE approval policies key off `administrationId`).
-Forward declaration is cheap.
+The double-entry invariant — sum of `GLLine.amount WHERE side='debit'`
+equals sum of `GLLine.amount WHERE side='credit'` for a given
+`GLTransaction` — is the most consequential constraint in the spec.
+The decision is:
 
-### D3 — RGS templates as seed data, not hard-coded enums
+| Path | When | Form |
+|---|---|---|
+| Declarative | OR's lifecycle engine supports cross-schema sum constraints in `requires` | `x-openregister-lifecycle.transitions.post.requires.balance: { ... }` |
+| Single-method PHP guard (ADR-031 exception) | Engine cannot express the constraint declaratively | `lib/Lifecycle/BalanceGuard.php` — exactly one method `isBalanced(string $transactionId): bool`, referenced from `requires` |
 
-The chart-of-accounts shape is fixed by RGS conformance, but the
-exact account numbers and names vary by administration type. T1
-ships three RGS 3.5 templates:
+The discovery step (`opsx-ff`) resolves which path applies before the
+implementing cycle starts. The spec itself is shape-neutral:
+`REQ-GL-005` mandates the invariant without prescribing the
+implementation.
 
-- `rgs-3.5-mkb.json` — the standard SMB chart.
-- `rgs-3.5-zzp.json` — the simplified ZZP/freelancer chart.
-- `rgs-bbv.json` — the BBV (Besluit Begroting en Verantwoording)
-  chart for Dutch government / municipal bookkeeping.
+**Alternative considered**: Author a `PostingService` that checks the
+balance after every write. Rejected per ADR-031 — moves the invariant
+out of the declared metadata and into a service that downstream code
+can bypass. The exception path is single-method, stateless, and
+explicitly annotated as an ADR-031 exception.
 
-Templates are JSON arrays of `Account` records. The repair step
-seeds whichever template the administration selects on first run
-(or none — operators may build their own). Per-administration
-override is allowed: any seeded account can be edited, archived,
-or augmented with sub-accounts.
+### D3 — Period stamping via foreign-key, not via mid-line date arithmetic
 
-**Alternative considered**: Bake one template into the schema as
-enum constraints. Rejected — RGS evolves (4.x ships before
-implementation cycle finishes is plausible), accounts vary per
-administration, and government / SMB / ZZP cannot share enums.
-Seed files keep schema stable and templates evolveable.
+Every `GLLine` carries `periodId` pointing at a `FiscalPeriod`
+record (declared by Tier 3 — referenced by FK here, with a stub
+`periodId` field of type `string` for Tier 1 acceptance). Once Tier
+3 lands, the FK points at the real schema; until then, callers post
+the period identifier as a string. Two reasons for the FK shape:
+
+1. **Trial balance becomes a pure aggregation.** Tier 3's
+   trial-balance capability is `x-openregister-aggregations` grouped
+   by `(periodId, accountNumber)` summing `debit - credit`. No date
+   parsing, no period-boundary edge cases.
+2. **Period close becomes a pure lifecycle transition** on the
+   period record (Tier 3) — no per-line modification needed.
+
+**Alternative considered**: Carry only `entryDate` and compute the
+period on read. Rejected — period boundaries differ per
+administration (calendar year vs broken fiscal year vs 13-period
+retail), and recomputing on every read is wasteful + brittle.
+
+### D4 — Reversal lifecycle declared, not synthesised
+
+`GLTransaction` declares a `posted → reversed` transition. Reversing
+a posted transaction does NOT mutate the original; it emits an
+inverse audit event and marks the header `reversed`. The original
+lines remain queryable for trial-balance reconstruction at any prior
+point in time. This is the canonical immutable-ledger shape.
+
+**Alternative considered**: Hard-delete reversed transactions.
+Rejected — destroys audit history, fails statutory retention, and
+breaks period-close re-runnability.
 
 ## Reuse Analysis
 
 | Capability needed | What already exists | Reuse strategy |
 |---|---|---|
-| Account hierarchy | `adr-000-data-model.md` `Account` entry, `GeneralLedgerAccount` entry | This change's `Account` formalises the existing entry. The two ADR-000 entries are reconciled in the implementation cycle (the GL-prefixed entry becomes the canonical one; `Account` keeps its "business workspace" sense reserved for T2 multi-tenancy). |
+| Account FK | `add-shillinq-chart-of-accounts` `Account` schema | `GLLine.accountNumber` foreign-keys into `Account.accountNumber` via `x-openregister-relations`. |
+| GL line entry shape | `adr-000-data-model.md` `GeneralLedgerEntry` | `GLLine` is the renamed/structured replacement. ADR-000 gets an annotation noting the supersession. |
+| Header for grouped postings | None in ADR-000 | This change adds `GLTransaction` as a new entity in ADR-000 (update lands with the implementation cycle, not this spec). |
 | Audit trail | OR audit-trail-immutable | Consumed automatically (no schema config). Every state transition writes an audit event with actor, before/after, timestamp, hash chain. |
-| RBAC | OR authorization | Per-schema role definitions in the register file. Grants `bookkeeper` create/read, `auditor` read-only. |
-| Lifecycle engine | `x-openregister-lifecycle` (per ADR-031) | `Account` declares an `active → blocked → archived` lifecycle. |
-| Seed data import | `ConfigurationService::importFromApp()` (per shillinq config.yaml `design` rule 3) | Repair-step pattern already in use for the placeholder schema; extended to load the chosen RGS template into the `Account` register. |
-| Cross-schema relations | `x-openregister-relations` | Self-relation on `Account.parentAccountNumber`. |
-| Manifest navigation | `src/manifest.json` + `CnAppRoot` (Tier-4 adopted on `feature/adopt-app-manifest`) | Adds 1 menu entry + 1 index page + 1 detail page, all consuming `type: index` / `type: detail` library renderers. |
+| RBAC | OR authorization | Per-schema role definitions in the register file. Grants `bookkeeper` create/read, `approver` the `post` transition, `auditor` read-only on everything. |
+| Lifecycle engine | `x-openregister-lifecycle` (per ADR-031) | `GLTransaction` declares `draft → posted → reversed`. |
+| Balance precondition | `x-openregister-lifecycle.requires` (or single-method PHP guard per ADR-031 exception path) | See D2. |
+| Cross-schema relations | `x-openregister-relations` | FKs from `GLLine` → `Account`, `GLLine` → `GLTransaction`. |
+| Manifest navigation | `src/manifest.json` + `CnAppRoot` (Tier-4 adopted on `feature/adopt-app-manifest`) | Adds 1 menu entry + 1 index page + 1 detail page (the detail page shows GL header + lines together). |
 
-**Net new code in implementation cycle**: 1 schema declaration + 1
-manifest entry pair + 3 seed JSON files. No new PHP service.
+**Net new code in implementation cycle**: 2 schema declarations + 1
+manifest entry pair. Possibly 1 short PHP lifecycle guard (~20 LOC,
+single method) if Risk 1 in `proposal.md` confirms the cross-line
+balance precondition cannot run inside the declarative engine.
 
 ## Declarative-vs-imperative decision (per ADR-031)
 
 | Behaviour | Decision | Why |
 |---|---|---|
-| Account state machine | Declarative (`x-openregister-lifecycle`) | Pure state machine, fits the extension |
-| Hierarchical account navigation | Declarative (`x-openregister-relations` self-relation) | Standard relation shape |
+| GL transaction state machine | Declarative (`x-openregister-lifecycle`) | Pure state machine, fits the extension |
+| Balance precondition | Declarative if the engine supports cross-line aggregations in `requires`; otherwise a single-method PHP guard called *by* the lifecycle engine (ADR-031 §"PHP guards remain a legitimate seam") | Resolution lives in `opsx-ff` discovery; spec is shape-neutral |
+| Reversal posting | Declarative — lifecycle action on `posted → reversed` emits the inverse audit event | No service code |
+| Trial balance prep (period-stamped lines) | Declarative — Tier 3's aggregation will read these fields | No Tier 1 service |
 | Audit trail | Consumed from OR's audit-trail-immutable abstraction | ADR-022 |
 
-No service class authored in this envelope.
+If the balance precondition needs a PHP guard, it is
+`lib/Lifecycle/BalanceGuard.php`, single method, ~20 LOC — and
+explicitly cited as an ADR-031 exception in the implementing
+cycle's design doc.
 
 ## Seed Data
 
-This change ships three RGS template seeds, all under
-`lib/Settings/seeds/`:
-
-| File | Purpose | Approximate row count |
-|---|---|---|
-| `rgs-3.5-mkb.json` | Standard SMB chart of accounts. Five top-level cluster headers (assets/liabilities/equity/revenue/expenses) and the RGS 3.5 canonical SMB account tree. | ~150 |
-| `rgs-3.5-zzp.json` | Simplified ZZP/freelancer subset of RGS 3.5. | ~40 |
-| `rgs-bbv.json` | BBV chart for Dutch municipal / government bookkeeping. | ~120 |
-
-Format: a JSON array of `Account` records matching the schema declared
-in `bookkeeping-chart-of-accounts/spec.md`. Loaded via
-`ConfigurationService::importFromApp()` in the repair step. The
-administration's first-run flow selects which template to seed (or
-none — operators may build their own). After seeding, accounts are
-fully editable through normal OR object operations; per-administration
-override is the default behaviour.
-
-Each seed file's top of file carries:
-
-- SPDX header (EUPL-1.2 + Copyright Conduction B.V.) per
-  `feedback_spdx-in-docblock.md`.
-- An `_meta` block (`{ "_meta": { "source": "RGS 3.5", "variant":
-  "mkb", "imported": "<iso-timestamp>" } }`) so a future migration to
-  RGS 4.x can identify which records were template-sourced versus
-  operator-authored.
+None for the GL surface — `GLTransaction` and `GLLine` are
+accumulated through operation. (RGS account templates live in the
+sibling `add-shillinq-chart-of-accounts` change.)
 
 ## Risks / Trade-offs
 
 | Risk | Mitigation |
 |---|---|
-| Account hierarchy depth unbounded | Schema permits arbitrary depth; UI (T4+ reporting) renders the first 4 levels by default with collapse/expand. No T1 enforcement of max depth. |
-| RGS 4.x ships during implementation | Seed files versioned in filename (`rgs-3.5-*`); coexistence is trivial; a `rgs-4.0-*` file can be added without touching the schema. |
-| ADR-000 data-model entries `GeneralLedgerAccount` overlaps with `Account` | Reconciliation is a one-paragraph annotation in ADR-000 added during the implementation cycle. Not in this spec. |
+| OR's lifecycle engine can't express cross-line balance constraint inside `requires` | Document the gap as an OR issue; use a single-method PHP guard called *by* the lifecycle engine per ADR-031 §"PHP guards remain a legitimate seam". Spec is shape-neutral (REQ-GL-005 mandates the invariant without prescribing implementation). |
+| Future tier needs a header field Tier 1 didn't anticipate | Adding fields to a register schema is additive (per OR's schema versioning); breaking changes are vanishingly rare. Risk accepted. |
+| ADR-000 data-model entry `GeneralLedgerEntry` overlaps with `GLLine` | Reconciliation is a one-paragraph annotation in ADR-000 added during the implementation cycle, noting `GeneralLedgerEntry` is superseded by `GLLine` and a new `GLTransaction` header is added. Not in this spec. |
 
 ## Migration Plan
 
 Spec-only — no runtime migration in this change. When implementation
 lands:
 
-1. `lib/Settings/shillinq_register.json` is patched with the `Account`
-   schema (additive — no existing schema changes).
+1. `lib/Settings/shillinq_register.json` is patched with the two new
+   schemas (additive — no existing schema changes).
 2. `src/manifest.json` is patched with one new menu entry + one new
    index/detail page pair (additive).
-3. A new repair step (or extension of the existing one) imports the
-   selected RGS template into the `Account` register on first install.
-4. ADR-000 gains a one-paragraph annotation reconciling
-   `GeneralLedgerAccount` with `Account`.
+3. ADR-000 gains a one-paragraph annotation reconciling
+   `GeneralLedgerEntry` with `GLLine` and introducing `GLTransaction`.
 
-Down-direction: registers are non-destructive — disabling the seed
-import + reverting the manifest leaves stranded but queryable
-records. No destructive rollback needed at the spec-acceptance gate.
+Down-direction: registers are non-destructive — disabling the
+manifest leaves stranded but queryable records. No destructive
+rollback needed at the spec-acceptance gate.
 
 ## Open Questions
 
-1. **RGS template variant for housing corp / healthcare / education
-   sectors** — out of scope here; placed on the rollout roadmap.
-2. **Closing-account cardinality** — `REQ-CoA-009` proposes
-   exactly one closing account per administration. Confirm with
-   the bookkeeper persona during spec review.
+1. **Does `x-openregister-lifecycle.requires` support cross-line
+   sum constraints?** Resolved in `opsx-ff` discovery before the
+   implementing cycle starts. If no: thin PHP guard, documented.
+2. **Period-id type** — Tier 1 treats `periodId` as a plain string
+   identifier; Tier 3 introduces `FiscalPeriod` as a real schema and
+   converts the field to an FK. The conversion is additive (existing
+   strings remain valid as period identifiers).

--- a/openspec/changes/spec/proposal.md
+++ b/openspec/changes/spec/proposal.md
@@ -1,89 +1,103 @@
-# Proposal: add-shillinq-chart-of-accounts
+# Proposal: add-shillinq-general-ledger
 
 `kind: config` per ADR-032 — the centre of mass is declarative
-schema metadata + manifest entries + RGS seed data. No PHP service
-classes are authored.
+schema metadata + manifest entries. No PHP service classes are
+authored (except possibly a single ~20 LOC lifecycle balance guard,
+see Risk 1).
 
 ## Summary
 
-Introduce the **hierarchical chart of accounts** capability for Shillinq
-as the first slice of the bookkeeping foundation (Tier 1 of the 5-tier
-bookkeeping rollout per `adr-001-bookkeeping-tier-roadmap.md`). This
-change declares the `Account` register with
-`x-openregister-lifecycle` rules (per ADR-031), wires the navigation
-into `src/manifest.json` (per ADR-024), and ships three RGS
-(Referentie Grootboek Schema) seed templates loaded via
-`ConfigurationService::importFromApp()` (per ADR-022). No PHP service
-classes, no custom database tables, no Vue components — the entire
-capability lands as register metadata + manifest entries + seed JSON.
+Introduce the **double-entry general ledger** capability for Shillinq
+as the second slice of the bookkeeping foundation (Tier 1 of the
+5-tier bookkeeping rollout per `adr-001-bookkeeping-tier-roadmap.md`).
+This change declares the `GLTransaction` (header) and `GLLine` (line)
+registers, with `x-openregister-lifecycle` rules enforcing the
+balance invariant (sum of debits = sum of credits) on the `post`
+transition per ADR-031, wired into `src/manifest.json` per ADR-024,
+and consuming OpenRegister's audit and RBAC abstractions per ADR-022.
+No PHP service classes, no custom database tables, no Vue components —
+the entire capability lands as register metadata + manifest entries.
 
 This change conforms to the shared
 [`nextcloud-app`](../../specs/nextcloud-app/spec.md) spec for app
 structure, OpenAPI 3.0 register format, and `ConfigurationService::importFromApp()`
 repair-step seeding.
 
+**Depends on:** [`add-shillinq-chart-of-accounts`](../add-shillinq-chart-of-accounts/proposal.md).
+`GLLine.accountNumber` foreign-keys into `Account.accountNumber`.
+
 ## Motivation
 
-Shillinq's `adr-000-data-model.md` already enumerates `Account` and
-`GeneralLedgerAccount` as foundational entities, but neither is yet
-declared in `lib/Settings/shillinq_register.json` — the register file
-ships only a placeholder `example` schema. Every downstream Shillinq
-capability (general ledger postings, journal entries, sub-ledgers,
-trial balance, financial reporting) depends on a hierarchical, RGS-
-conformant chart of accounts being present. Until the chart of accounts
-is laid down, no other Tier 1 capability can start.
+Shillinq's `adr-000-data-model.md` lists `GeneralLedgerEntry` as a
+foundational entity. Every downstream Shillinq capability (sub-ledgers,
+trial balance, period close, financial reporting, multi-currency, tax)
+reads from the general ledger. Until the GL is laid down — with a
+balanced double-entry posting engine and period-stamped lines — no
+trial balance, no financial statement, and no period close can be
+implemented.
 
-This proposal is the **first of three sibling changes** that together
-constitute the Tier 1 bookkeeping foundation:
-
-1. `add-shillinq-chart-of-accounts` (this change) — foundation, depends
-   on nothing.
-2. `add-shillinq-general-ledger` — depends on this change.
-3. `add-shillinq-journal-entries` — depends on both above.
+The sibling `add-shillinq-chart-of-accounts` change declares the
+`Account` register that GL lines reference. The sibling
+`add-shillinq-journal-entries` change adds the human-author surface
+that materialises GL transactions on post. This change owns the
+machine-side balanced ledger itself.
 
 See [`adr-001-bookkeeping-tier-roadmap.md`](../../architecture/adr-001-bookkeeping-tier-roadmap.md)
 for the canonical 5-tier breakdown.
 
 ## Affected Projects
 
-- [x] Project: shillinq — adds 1 new register/schema (`Account`) to
-  `lib/Settings/shillinq_register.json`, adds 1 manifest navigation
-  entry in `src/manifest.json`, ships 3 RGS seed templates in
-  `lib/Settings/seeds/`
+- [x] Project: shillinq — adds 2 new registers/schemas (`GLTransaction`,
+  `GLLine`) to `lib/Settings/shillinq_register.json`, adds 1 manifest
+  navigation entry in `src/manifest.json`
 - [ ] Project: openregister — no source changes; this change consumes
   existing OR abstractions (audit, RBAC, `x-openregister-lifecycle`,
-  `x-openregister-relations`)
+  `x-openregister-relations`). If the lifecycle engine cannot express
+  the cross-line balance constraint declaratively (see Risk 1), the
+  gap is filed as an OR issue and a thin ~20 LOC PHP guard is
+  registered through the engine's exception path per ADR-031.
 
 ## Scope
 
 ### In Scope
 
-- One new capability spec (`bookkeeping-chart-of-accounts`) — see the
+- One new capability spec (`bookkeeping-general-ledger`) — see the
   `specs/` folder.
-- Hierarchical chart of accounts (assets / liabilities / equity /
-  revenue / expenses, sub-accounts via self-relation, account-level
-  active/blocked/archived lifecycle, closing-account designation).
-- RGS (Referentie Grootboek Schema) seed templates for three variants:
-  SMB (`rgs-3.5-mkb.json`), ZZP (`rgs-3.5-zzp.json`), and
-  government/BBV (`rgs-bbv.json`). Per-administration override allowed.
-- Manifest navigation entry (Bookkeeping > Chart of Accounts) using
+- Header/line split for GL transactions: `GLTransaction` carries
+  period, posting date, description, source reference, balanced-state,
+  posting-state; `GLLine` carries account FK, amount, side
+  (`debit`|`credit`), optional sub-ledger FK, optional cost centre.
+- Double-entry posting engine — every GL transaction is a balanced
+  set of journal lines (sum of debits = sum of credits in the
+  administration's base currency), enforced by an
+  `x-openregister-lifecycle` precondition on the `post` transition.
+- Sub-ledger references (AP / AR / project) by FK only — Tier 2 owns
+  the sub-ledgers themselves.
+- Period-stamped postings — every `GLLine` carries a `periodId`
+  resolved at post-time against the active fiscal-period record
+  (FK to a `FiscalPeriod` schema declared later by Tier 3; in
+  Tier 1 the field is a plain string identifier).
+- Reversal lifecycle (`draft → posted → reversed`) declared
+  declaratively; reversed transactions emit an inverse audit event.
+- Manifest navigation entry (Bookkeeping > General Ledger) using
   `type: index`/`type: detail` page renderers from
-  `@conduction/nextcloud-vue` (Tier-4 manifest renderer adopted on
-  `feature/adopt-app-manifest`).
-- Audit trail consumed from OpenRegister's
-  audit-trail-immutable abstraction per ADR-022 — DO NOT reimplement.
+  `@conduction/nextcloud-vue`.
+- Audit trail consumed from OpenRegister's audit-trail-immutable
+  abstraction per ADR-022 — DO NOT reimplement.
 
 ### Out of Scope
 
 - **Implementation code** — this is a spec-only change. PHP services,
   Vue components, controllers, tests, and CI changes are deliberately
   not in this proposal; the task list references them but the
-  implementation lands via a separate `opsx-apply` cycle on the spec.
-- **General ledger postings + journal entries** — owned by sibling
-  changes `add-shillinq-general-ledger` and
+  implementation lands via a separate `opsx-apply` cycle.
+- **Chart of accounts** — owned by sibling
+  `add-shillinq-chart-of-accounts`.
+- **Journal entries (human surface)** — owned by sibling
   `add-shillinq-journal-entries`.
-- **Industry-specific RGS templates** (housing corp, healthcare,
-  education) — record on T2+ roadmap.
+- **Sub-ledgers (AP/AR), trial balance, period close** — Tier 2/Tier 3
+  capabilities.
+- **Multi-currency translation, CTA postings** — Tier 5.
 - **Frontend Vue components** beyond what `CnIndexPage` /
   `CnDetailPage` from `@conduction/nextcloud-vue` already render
   generically from a register manifest. No bespoke Vue files in this
@@ -93,71 +107,79 @@ for the canonical 5-tier breakdown.
 
 One delta, adding ADDED Requirements to a brand-new spec:
 
-**`bookkeeping-chart-of-accounts`** — declares the `Account` register
-(renaming the existing data-model entity `Account` to its bookkeeping
-role; the existing entry in `adr-000-data-model.md` is already
-aligned). Hierarchical via `parentAccountNumber`. Lifecycle
-`active → blocked → archived` declared as
-`x-openregister-lifecycle`. Seed templates loaded via
-`ConfigurationService::importFromApp()` during the repair step.
+**`bookkeeping-general-ledger`** — declares the `GLTransaction` and
+`GLLine` registers (the existing data-model entry `GeneralLedgerEntry`
+is the per-line equivalent; this spec formalises the header/line split
+needed for balancing). The header carries balanced-state and posting-
+state lifecycle transitions; the balance constraint is an
+`x-openregister-lifecycle` precondition on `post`, not a PHP service
+check.
 
 The spec follows the conduction-schema format (RFC 2119,
 `### REQ-{NNN}: <name>`, `#### Scenario:` with exactly 4 hashtags,
-GIVEN/WHEN/THEN). Each requirement is prefixed `REQ-CoA-*` for
+GIVEN/WHEN/THEN). Each requirement is prefixed `REQ-GL-*` for
 traceability.
 
 ## New Dependencies
 
-None. This change consumes existing OpenRegister abstractions and the
-already-bumped `@conduction/nextcloud-vue@^1.0.0-beta.35` (from
-`shillinq-manifest-tier4`).
+- **`add-shillinq-chart-of-accounts`** must land first — `GLLine`
+  foreign-keys into `Account`.
+
+Otherwise none. This change consumes existing OpenRegister abstractions
+and the already-bumped `@conduction/nextcloud-vue@^1.0.0-beta.35`
+(from `shillinq-manifest-tier4`).
 
 ## Impact
 
-- `lib/Settings/shillinq_register.json` — adds 1 schema (`Account`);
-  declares `x-openregister-lifecycle` on `Account` and
-  `x-openregister-relations` self-relation on `parentAccountNumber`.
-- `lib/Settings/seeds/rgs-3.5-mkb.json`,
-  `lib/Settings/seeds/rgs-3.5-zzp.json`,
-  `lib/Settings/seeds/rgs-bbv.json` — new files, seed account
-  templates. Imported via `ConfigurationService::importFromApp()` in
-  the repair step.
-- `src/manifest.json` — adds 1 navigation entry
-  (Chart of Accounts) and 1 `type: index` + 1 `type: detail` page entry.
-- Repair step (`lib/Migration/Version*.php` or repair class) —
-  reuses the existing register-import pattern; one additional step
-  to seed the chosen RGS template per administration.
-- No new PHP services. No new Vue components. No new controllers.
+- `lib/Settings/shillinq_register.json` — adds 2 schemas
+  (`GLTransaction`, `GLLine`); declares `x-openregister-lifecycle` on
+  `GLTransaction` (balance + posting).
+- `src/manifest.json` — adds 1 navigation entry (General Ledger) and
+  1 `type: index` + 1 `type: detail` page entry.
+- No new PHP services unless Risk 1 confirms the cross-line balance
+  precondition cannot run inside the declarative engine, in which
+  case `lib/Lifecycle/BalanceGuard.php` ships (single method, ~20 LOC,
+  ADR-031 exception path).
+- No new Vue components. No new controllers.
 
 ## Cross-Project Dependencies
 
 - **OpenRegister** — depends on the following abstractions being
   stable: `x-openregister-lifecycle` (ADR-031), audit-trail-immutable
-  (ADR-022), `x-openregister-relations` self-relation. No new OR
-  features required for this change.
+  (ADR-022). If a needed shape is missing (cross-schema sum
+  constraint inside a lifecycle precondition), the gap is filed as
+  an OR issue and the relevant requirement is annotated in
+  `design.md` under "Declarative-vs-imperative decision".
 
 ## Risks
 
-### Risk 1: RGS template scope creep
-
-**Severity**: Low
-**Mitigation**: Ship the three named templates only (SMB / ZZP /
-BBV). Industry-specific templates (housing corp, healthcare,
-education) are explicitly out of scope; record them on the T2+
-roadmap. Operators can extend a seeded template through normal
-OpenRegister object edits — no template forking required.
-
-### Risk 2: Account-hierarchy shape locks downstream
+### Risk 1: OpenRegister's lifecycle engine cannot express the cross-line balance constraint declaratively
 
 **Severity**: Medium
-**Mitigation**: General ledger and journal entries (sibling changes)
-both FK into `Account.accountNumber`. Getting the field name and
-typing wrong forces a destructive migration later. Mitigation is
-rigorous spec review against the data-model ADR and against existing
+**Mitigation**: The balance constraint requires summing
+`GLLine.debit` and `GLLine.credit` rows that reference the parent
+`GLTransaction` and asserting equality before allowing the `post`
+transition. Whether this fits inside an
+`x-openregister-lifecycle.requires` declaration depends on whether
+the engine supports cross-schema aggregations in preconditions. If
+not, ADR-031's exception path applies: a thin
+`BookkeepingBalanceGuard::isBalanced(transactionId)` PHP guard is
+called from the lifecycle's `requires` field. The guard is single-
+method, no state, ~20 LOC. Document the gap as an OR issue. The
+spec author resolves this during `opsx-ff` discovery, not during
+`opsx-apply`.
+
+### Risk 2: Header/line shape locks downstream
+
+**Severity**: Medium
+**Mitigation**: Sub-ledgers (Tier 2), trial balance (Tier 3),
+financial statements (Tier 4) all read `GLLine`. Getting the field
+names wrong forces a destructive migration later. Mitigation is
+rigorous spec review against the data-model ADR and existing
 competitor schemas (Exact, Twinfield, AFAS, Yuki — captured in
 `design.md`'s Reuse Analysis). Acceptance criterion: a competent
 bookkeeper can read the spec and confirm the model matches a real
-Dutch SMB chart-of-accounts.
+RGS-conformant general ledger.
 
 ## Rollback Strategy
 
@@ -171,11 +193,12 @@ No data migration risk at the spec stage.
 
 ## Open Questions
 
-1. **RGS version pinning** — RGS 3.5 is the current SBR-compatible
-   release as of 2026-05. If 4.x ships before implementation, the seed
-   file naming carries the version (`rgs-3.5-*.json`) so side-by-side
-   coexistence is trivial.
-2. **Closing-account designation cardinality** — exactly one
-   closing account per accountType cluster, or per administration?
-   `REQ-CoA-009` defines per-administration single closing account;
-   confirm with the bookkeeper persona before `opsx-apply`.
+1. **Cross-schema balance precondition** — see Risk 1. The `opsx-ff`
+   design phase resolves whether the lifecycle engine supports the
+   constraint or whether a `requires` PHP guard is needed. The spec
+   itself is shape-neutral: `REQ-GL-005` mandates the balance
+   invariant without prescribing implementation.
+2. **Period-id type** — Tier 1 treats `periodId` as a plain string
+   identifier; Tier 3 introduces `FiscalPeriod` as a real schema and
+   converts the field to an FK. The conversion is additive (existing
+   strings remain valid as period identifiers).

--- a/openspec/changes/spec/specs/bookkeeping-general-ledger/spec.md
+++ b/openspec/changes/spec/specs/bookkeeping-general-ledger/spec.md
@@ -1,0 +1,388 @@
+# Spec: bookkeeping-general-ledger
+
+**Status:** proposed
+**Scope:** shillinq
+**Tier:** T1 (foundation)
+**Depends on:** bookkeeping-chart-of-accounts
+
+## ADDED Requirements
+
+### REQ-GL-001: The system SHALL store general-ledger postings as a header (`GLTransaction`) plus N balanced lines (`GLLine`)
+
+The general ledger MUST be expressed as two registers declared in
+`lib/Settings/shillinq_register.json`: `GLTransaction` (the header,
+owns the lifecycle and the balance invariant) and `GLLine` (the
+debit-or-credit row). One `GLTransaction` MUST own N ≥ 2 `GLLine`
+rows whose sum of `debit` equals sum of `credit` in the
+administration's base currency (per REQ-GL-005). The header/line
+split is required for the balance constraint to be expressible
+declaratively (per design.md Decision D2).
+
+This requirement supersedes the flat `GeneralLedgerEntry` shape
+documented in `openspec/architecture/adr-000-data-model.md`; a
+reconciliation note is added to ADR-000 during the implementing
+cycle. No custom database tables — both registers are
+OpenRegister-managed objects per ADR-022 / ADR-024.
+
+#### Scenario: Reviewer confirms no parallel storage
+
+- **GIVEN** the shillinq codebase
+- **WHEN** scanned for `lib/Db/` Mapper classes naming `gl_`,
+  `general_ledger_`, or `posting_`
+- **THEN** no such classes SHALL exist; all GL data flows through
+  the OR object API.
+
+### REQ-GL-002: The `GLTransaction` schema SHALL declare a fixed minimum field set
+
+The `GLTransaction` schema MUST carry the Schema.org annotation
+`schema:AccountingTransaction` (per shillinq config.yaml `rules.specs`
+and the cross-app convention in `bookkeeping-chart-of-accounts`
+REQ-CoA-004): a GL posting is a recorded financial transaction and
+maps cleanly to that vocabulary term.
+
+| Field | Type | Required | Purpose |
+|---|---|---|---|
+| `transactionNumber` | string | Yes | Sequential transaction number unique per administration + fiscal year |
+| `postingDate` | date | Yes | Effective accounting date of the posting |
+| `periodId` | string | Yes | FK to the `FiscalPeriod` record (declared in T3; stub string acceptable until then) |
+| `currency` | string (ISO 4217) | Yes | The administration's base currency for this posting (multi-currency translation is T5) |
+| `description` | string | Yes | Human-readable summary of the posting |
+| `sourceReference` | string | No | External document number (invoice no., bank statement ref, etc.) |
+| `state` | enum | Yes | One of `draft`, `posted`, `reversed` |
+| `journalEntryId` | string | No | Back-reference to the `JournalEntry` that materialised this posting, if any |
+| `administrationId` | string | Yes | FK to the administration owning the posting |
+
+#### Scenario: A draft posting can be created without lines
+
+- **GIVEN** the schema is loaded
+- **WHEN** a `GLTransaction` with `state: draft` and no lines is
+  created
+- **THEN** the save MUST succeed (lines may be added incrementally
+  before the posting is transitioned to `posted`).
+
+### REQ-GL-003: The `GLLine` schema SHALL declare a fixed minimum field set and encode sign in `side`
+
+The `GLLine` schema MUST carry the Schema.org annotation
+`schema:MonetaryAmount` (per shillinq config.yaml `rules.specs` and
+the cross-app convention in `bookkeeping-chart-of-accounts`
+REQ-CoA-004): a GL line is the canonical record of a currency-typed
+amount and maps cleanly to that vocabulary term.
+
+| Field | Type | Required | Purpose |
+|---|---|---|---|
+| `transactionId` | string | Yes | FK to the parent `GLTransaction.id` |
+| `lineNumber` | integer | Yes | Stable ordering within the transaction (1-based) |
+| `accountNumber` | string | Yes | FK to `Account.accountNumber` |
+| `side` | enum | Yes | `debit` or `credit` |
+| `amount` | number ≥ 0 | Yes | Non-negative amount in the transaction's currency |
+| `currency` | string (ISO 4217) | Yes | The line's transaction currency (T1 single-currency invariants below; multi-currency rules per `bookkeeping-multi-currency` spec) |
+| `periodId` | string | Yes | Resolved at posting time per REQ-GL-006; the equality invariant against the parent is checked on the `post` transition only (see below) |
+| `subLedgerType` | enum | No | `ap`, `ar`, `project`, `none` (T2 owns the actual sub-ledger registers) |
+| `subLedgerRef` | string | No | FK identifier into the sub-ledger when `subLedgerType` ≠ `none` |
+| `costCenter` | string | No | Cost-center / department code |
+| `description` | string | No | Line-level description |
+
+`amount` MUST be non-negative; the debit/credit polarity MUST live in
+the `side` enum (per design.md Decision D2 — encoding sign in a
+separate enum makes the balance aggregation a single SQL `SUM(CASE
+WHEN side='debit' THEN amount END) = SUM(CASE WHEN side='credit' THEN
+amount END)` and avoids the negative-zero edge cases of signed
+amounts).
+
+**Single-currency invariant (T1 scope).** In the absence of the
+multi-currency extension (per `bookkeeping-multi-currency` spec),
+`GLLine.currency` MUST equal the parent `GLTransaction.currency`. The
+multi-currency extension supersedes this invariant by introducing
+`transactionCurrency` and `baseCurrency` fields and renaming the
+single `currency` field accordingly; consult that spec when it is in
+force. This T1 spec stays correct in isolation when multi-currency
+is not installed.
+
+**`periodId` post-transition invariant.** `GLLine.periodId` is
+auto-resolved at posting time by the lifecycle engine per REQ-GL-006
+(against the parent's `postingDate` and the active `FiscalPeriod`).
+The equality rule "`GLLine.periodId` MUST equal the parent
+`GLTransaction.periodId`" is enforced as a precondition on the
+`post` state transition (per REQ-GL-004), NOT as a write-time
+validation on `draft` lines. A `draft` line MAY temporarily carry a
+mismatched or absent `periodId`; the `draft → posted` transition
+runs the auto-resolution first, then the equality check is the gate
+that lets the transition succeed.
+
+#### Scenario: Negative amounts are rejected
+
+- **GIVEN** the schema
+- **WHEN** a `GLLine` with `amount: -100` is saved
+- **THEN** the save MUST fail with a "amount must be non-negative"
+  validation error.
+
+#### Scenario: Line currency must match parent (T1 single-currency)
+
+- **GIVEN** the multi-currency extension is NOT installed AND a
+  parent transaction with `currency: "EUR"`
+- **WHEN** a `GLLine` with `currency: "USD"` is created against it
+- **THEN** the save MUST fail with a "currency mismatch with parent
+  transaction" error. (The `bookkeeping-multi-currency` spec
+  supersedes this rule when installed.)
+
+#### Scenario: Draft line with mismatched periodId is accepted
+
+- **GIVEN** a parent transaction with `periodId: "2026-Q1"` in
+  `state: draft`
+- **WHEN** a `GLLine` is saved against it with `periodId: "2026-Q2"`
+  (or with `periodId` unset)
+- **THEN** the save MUST succeed; the mismatch is only flagged at
+  `post`-transition time per REQ-GL-006.
+
+#### Scenario: Post transition rejects line whose periodId does not match parent's
+
+- **GIVEN** a draft transaction with `periodId: "2026-Q1"` and a
+  child `GLLine` whose `periodId` is `"2026-Q2"` (and the lifecycle
+  auto-resolver has somehow not normalised it — e.g. operator
+  bypassed the engine)
+- **WHEN** the operator transitions the transaction to `posted`
+- **THEN** the transition MUST fail with a "line periodId does not
+  match parent" error naming the offending line.
+
+### REQ-GL-004: `GLTransaction` SHALL declare a declarative draft → posted → reversed lifecycle
+
+The `GLTransaction` schema MUST declare an `x-openregister-lifecycle`
+block with the following states:
+
+- `draft` — under construction; lines may be added/edited/deleted
+- `posted` — immutable on header and lines; appears in trial balance
+  (T3), reportable
+- `reversed` — superseded by an inverse posting; remains queryable
+  for audit but excluded from balance aggregations
+
+Transitions:
+
+| From | To | Trigger | Guard |
+|---|---|---|---|
+| `draft` | `posted` | operator action (or journal-entry post) | balance invariant per REQ-GL-005 + all referenced accounts in REQ-CoA-005 `active` state |
+| `posted` | `reversed` | operator action | a new compensating `GLTransaction` exists referencing this one as its `reversesTransactionId` |
+
+Per ADR-031, no PHP service implements transitions; the lifecycle is
+declared in the schema. Audit-trail-immutable per ADR-022 records
+every transition with actor, before/after, hash chain.
+
+#### Scenario: Posting a draft with all guards green succeeds
+
+- **GIVEN** a balanced draft `GLTransaction` with all-`active`
+  account references
+- **WHEN** the operator transitions it to `posted`
+- **THEN** the state MUST become `posted`; **AND** an immutable
+  audit event MUST be appended; **AND** the lines MUST become
+  immutable (subsequent edit attempts MUST fail with an
+  "object is locked / posted" error).
+
+#### Scenario: Reversing requires a compensating posting
+
+- **GIVEN** a posted transaction `T1`
+- **WHEN** the operator attempts to transition `T1` directly to
+  `reversed` without a compensating posting
+- **THEN** the transition MUST be rejected with an "create
+  compensating posting first" error.
+
+### REQ-GL-005: The system SHALL enforce the balance invariant declaratively as a precondition on `GLTransaction.post`
+
+`GLTransaction.post` MUST NOT succeed unless the sum of `GLLine.amount`
+WHERE `side='debit'` equals the sum of `GLLine.amount` WHERE
+`side='credit'` for all lines whose `transactionId` matches, computed
+in the parent transaction's currency. The constraint MUST be expressed
+as an `x-openregister-lifecycle.requires` precondition (per ADR-031).
+**If** OR's lifecycle engine cannot express cross-line aggregations
+inside `requires`, the implementing cycle MAY reference a single-method
+PHP guard (`OCA\Shillinq\Lifecycle\BalanceGuard::isBalanced(string $transactionId): bool`)
+from `requires` per ADR-031 §"PHP guards remain a legitimate seam".
+Either path satisfies this requirement; the spec is intentionally
+shape-neutral on which.
+
+The balance is computed at the cent level (2 decimal places for EUR,
+appropriate scale per ISO 4217); rounding tolerance MUST be zero —
+unbalanced postings differing by €0.01 MUST fail.
+
+#### Scenario: A balanced 2-line transaction posts
+
+- **GIVEN** a draft transaction with lines `{accountNumber:"1000", side:"debit", amount:100}` and `{accountNumber:"4100", side:"credit", amount:100}`
+- **WHEN** the operator transitions to `posted`
+- **THEN** the transition MUST succeed.
+
+#### Scenario: An unbalanced 2-line transaction is rejected
+
+- **GIVEN** a draft transaction with lines summing to debit `100`,
+  credit `99.99`
+- **WHEN** the operator transitions to `posted`
+- **THEN** the transition MUST fail with a "transaction is not
+  balanced" error reporting the actual debit/credit totals and the
+  €0.01 delta.
+
+#### Scenario: A balanced N-line transaction posts
+
+- **GIVEN** a draft transaction with N ≥ 3 lines whose `side=debit`
+  amounts sum equal to the `side=credit` amounts sum (e.g. a 3-line
+  posting splitting a purchase across VAT, expense, and AP credit)
+- **WHEN** the operator transitions to `posted`
+- **THEN** the transition MUST succeed.
+
+#### Scenario: Posting against a blocked account fails
+
+- **GIVEN** a balanced draft transaction whose first line references
+  account `4100` and that account is in lifecycleState `blocked`
+- **WHEN** the operator transitions the transaction to `posted`
+- **THEN** the transition MUST fail with an "account is blocked"
+  error naming `4100`, surfaced from REQ-CoA-005's blocked-account
+  rule.
+
+### REQ-GL-006: `GLLine.periodId` SHALL be auto-resolved against the active fiscal-period record on the `post` transition, and the resolved value MUST equal the parent's
+
+`GLLine.periodId` is owned by the lifecycle engine, not by write-time
+validation. The contract is two-phase:
+
+1. **Auto-resolution (lifecycle hook on `post`).** When the parent
+   `GLTransaction` transitions `draft → posted`, the lifecycle engine
+   MUST, for every child `GLLine`, set `periodId` to the period whose
+   date range contains the parent's `postingDate`. If the line
+   already carries a `periodId`, the engine MUST overwrite it with
+   the resolved value (i.e. resolution is authoritative; explicit
+   values on draft lines are advisory).
+2. **Post-transition equality invariant.** After auto-resolution,
+   every `GLLine.periodId` MUST equal the parent
+   `GLTransaction.periodId`. The `post` transition MUST fail if any
+   line's resolved `periodId` differs from the parent's (e.g. the
+   parent's `periodId` was explicitly overridden to a value
+   inconsistent with `postingDate`'s containing period). This is the
+   single gate; there is no separate write-time validation per
+   REQ-GL-003.
+
+T3 owns the `FiscalPeriod` register; T1 accepts a string field with
+no FK validation until T3 lands (the lifecycle hook MAY be a no-op
+in T1 if no `FiscalPeriod` records exist, but the equality invariant
+MUST still hold). Per design.md Decision D5, this stamping is the
+single mechanism by which T3's trial-balance aggregation operates on
+a single field group-by, with no date arithmetic at read time.
+
+#### Scenario: Draft lines accept any periodId (or none)
+
+- **GIVEN** a parent transaction with `periodId: "2026-Q1"` in
+  `state: draft`
+- **WHEN** a `GLLine` is created against it with `periodId: "2026-Q2"`
+- **THEN** the save MUST succeed; resolution is deferred to the
+  `post` transition.
+
+#### Scenario: Post transition auto-resolves and stamps lines
+
+- **GIVEN** a parent transaction with `postingDate: 2026-02-15`,
+  `periodId: "2026-Q1"`, and 3 child lines each carrying mixed or
+  absent `periodId` values
+- **WHEN** the operator transitions the transaction to `posted`
+- **THEN** the lifecycle engine MUST first overwrite each line's
+  `periodId` to `"2026-Q1"` (the period containing
+  `2026-02-15`); **AND** the equality check against the parent MUST
+  then pass; **AND** the transition MUST succeed.
+
+#### Scenario: Post fails when parent's periodId disagrees with postingDate's period
+
+- **GIVEN** a parent transaction with `postingDate: 2026-02-15`
+  (which falls inside `"2026-Q1"`) but `periodId: "2026-Q2"` set
+  explicitly by the operator
+- **WHEN** the operator transitions the transaction to `posted`
+- **THEN** the auto-resolver MUST set each line's `periodId` to
+  `"2026-Q1"`; **AND** the equality check against the parent's
+  `"2026-Q2"` MUST fail; **AND** the transition MUST fail with a
+  "parent periodId does not match postingDate" error.
+
+#### Scenario: T3 trial balance can sum by period
+
+- **GIVEN** N posted transactions across periods `"2026-Q1"` and
+  `"2026-Q2"`
+- **WHEN** T3 issues an aggregation summing `GLLine` grouped by
+  `periodId, accountNumber, side`
+- **THEN** the aggregation MUST be expressible as a single OR
+  `x-openregister-aggregations` query, with no application-side
+  date parsing.
+
+### REQ-GL-007: General ledger SHALL be reachable through the shillinq manifest navigation
+
+`src/manifest.json` MUST declare a navigation entry (`Bookkeeping >
+General Ledger`) with a `type: index` page binding to the
+`GLTransaction` register and a `type: detail` page that renders the
+header fields from REQ-GL-002 alongside a grid of the child
+`GLLine` rows. Rendering MUST use `@conduction/nextcloud-vue`'s
+generic `CnIndexPage` / `CnDetailPage` components — no bespoke Vue
+files (per ADR-024 Tier-4).
+
+#### Scenario: Index page lists postings with state
+
+- **GIVEN** the manifest declares the General Ledger pages
+- **WHEN** an operator opens `/index.php/apps/shillinq/general-ledger`
+- **THEN** `CnIndexPage` MUST render columns including
+  `transactionNumber`, `postingDate`, `description`, `state`.
+
+#### Scenario: Detail page renders header + lines
+
+- **GIVEN** a `GLTransaction` with 3 lines
+- **WHEN** the operator drills in
+- **THEN** the detail page MUST render the header fields **AND** a
+  grid of the 3 lines showing `accountNumber`, `side`, `amount`,
+  `subLedgerRef`, `costCenter`.
+
+### REQ-GL-008: Opening balances SHALL be imported as a `GLTransaction` of a designated `openingBalance` type, source-referenced to a docudesk attachment
+
+The opening-balance import MUST be expressed as one or more
+`GLTransaction` rows authored at the start of the first fiscal
+period, balanced like any other posting (the offsetting line is the
+designated equity / retained-earnings account). The
+`sourceReference` field MUST point at a docudesk attachment URI
+holding the source-of-truth balance document (per ADR-022 — no blob
+in shillinq).
+
+#### Scenario: Importing opening balances produces a balanced posted transaction
+
+- **GIVEN** a fresh administration with no prior postings
+- **WHEN** the operator imports opening balances totalling
+  €100 000 debit on `1xxx` accounts and €100 000 credit across
+  `2xxx` / `3xxx` accounts
+- **THEN** a balanced `GLTransaction` MUST be posted with
+  `sourceReference` referencing the docudesk attachment URI; **AND**
+  the audit trail MUST record the import operator and timestamp.
+
+### REQ-GL-009: Sub-ledger references SHALL be plain foreign-key strings; the actual sub-ledger registers are out of T1 scope
+
+`GLLine.subLedgerType` and `GLLine.subLedgerRef` MUST be plain
+string/enum fields with no schema-level FK validation against
+sub-ledger registers in T1 (those registers ship with T2's AP / AR /
+project capabilities). T1 only allocates the fields so T2 can attach
+without a destructive migration. Posting a line with
+`subLedgerType: "ap"` and a `subLedgerRef` that won't resolve until
+T2 lands MUST succeed in T1.
+
+#### Scenario: AP sub-ledger reference is accepted in T1
+
+- **GIVEN** T1 is live and T2 has not yet shipped
+- **WHEN** a `GLLine` is posted with
+  `subLedgerType: "ap"`, `subLedgerRef: "INV-2026-0001"`
+- **THEN** the save MUST succeed; **AND** OR MUST NOT attempt to
+  resolve the reference until T2 declares the AP sub-ledger register.
+
+### REQ-GL-010: Posted lines and headers SHALL be immutable; corrections happen through reversing + new postings
+
+Once a `GLTransaction` transitions to `posted`, neither the header
+fields nor any child `GLLine` rows MAY be edited or deleted.
+Corrections MUST be made by posting a compensating transaction (and
+optionally then transitioning the original to `reversed` per
+REQ-GL-004). The immutability MUST be enforced by OR's lifecycle
+engine (no PHP guard); a write attempt against a posted transaction
+MUST fail with an "object is locked / posted" error.
+
+#### Scenario: Edit on posted header fails
+
+- **GIVEN** a posted `GLTransaction`
+- **WHEN** an operator attempts to update its `description`
+- **THEN** the save MUST fail with a posted-immutability error.
+
+#### Scenario: Delete on posted line fails
+
+- **GIVEN** a posted `GLLine`
+- **WHEN** any actor attempts to delete it
+- **THEN** the delete MUST fail; the line remains queryable.

--- a/openspec/changes/spec/tasks.md
+++ b/openspec/changes/spec/tasks.md
@@ -1,40 +1,38 @@
-# Tasks — Chart of Accounts
+# Tasks — General Ledger
 
 > **Spec-only change.** Per `proposal.md` Scope, implementation code is
 > deliberately out of scope here. The tasks below describe the work an
-> `opsx-apply` cycle will execute against the `bookkeeping-chart-of-accounts`
+> `opsx-apply` cycle will execute against the `bookkeeping-general-ledger`
 > spec — they are recorded now so the spec-review gate, dependency
 > planning, and tier-cascade impact are all visible at proposal time. No
 > source files are edited by this change itself.
 
 ## Tasks
 
-- [x] Task 1: Confirm no `Account` schema or `bookkeeping-chart-of-accounts` capability already exists (scan `lib/Settings/shillinq_register.json`, `openspec/specs/**`, `adr-000-data-model.md`; catalogue and reconcile existing ADR-000 entries for `Account` and `GeneralLedgerAccount`)
-- [x] Task 2: Author `specs/bookkeeping-chart-of-accounts/spec.md` with `Status: proposed` / `Scope: shillinq` / `Tier: T1 (foundation)` / `Depends on: none` header, `REQ-CoA-NNN` requirements using RFC 2119 keywords, and `#### Scenario:` blocks with GIVEN/WHEN/THEN
-- [x] Task 3: Author `proposal.md` referencing the shared `nextcloud-app` spec and including Affected Projects / Scope / Risks / Rollback / Open Questions per shillinq config.yaml `rules.proposal`
-- [x] Task 4: Author `design.md` with Reuse Analysis table and Seed Data section per hydra `rules.design`; bookkeeper persona reads end-to-end and confirms RGS conformance
-- [x] Task 5: Declare the `Account` schema in `lib/Settings/shillinq_register.json` with all REQ-CoA-002 fields (accountNumber, name, accountType, currency, parentAccountNumber, isClosingAccount, administrationId, lifecycleState, description) typed per spec
-- [x] Task 6: Add `x-openregister-lifecycle` block to `Account` declaring `active → blocked`, `active → archived`, `blocked → archived` transitions per REQ-CoA-005
-- [x] Task 7: Add `x-openregister-relations` self-relation on `Account.parentAccountNumber → Account.accountNumber` per REQ-CoA-003 for hierarchical navigation
-- [x] Task 8: Ship `lib/Settings/seeds/rgs-3.5-mkb.json` SMB template (JSON array of `Account` records, SPDX header, `_meta` block with `source: "RGS 3.5"` / `variant: "mkb"`) per REQ-CoA-006
-- [x] Task 9: Ship `lib/Settings/seeds/rgs-3.5-zzp.json` ZZP template (same shape as mkb, `_meta.variant: "zzp"`) per REQ-CoA-006
-- [x] Task 10: Ship `lib/Settings/seeds/rgs-bbv.json` BBV government template (same shape, `_meta.variant: "bbv"`) per REQ-CoA-006
-- [x] Task 11: Extend the repair step under `lib/Repair/` to import the selected RGS template idempotently (operator edits persist across re-runs; the repair step does not re-overwrite seeded records) per REQ-CoA-007
-- [x] Task 12: Add Chart of Accounts navigation + pages to `src/manifest.json` (menu entry `Bookkeeping > Chart of Accounts`, `type: index` page binding to `Account` register, `type: detail` page for individual accounts) per REQ-CoA-008; `node tests/validate-manifest.js` exits 0
-- [x] Task 13: Update `openspec/architecture/adr-000-data-model.md` with a one-paragraph reconciliation note from `design.md` Reuse Analysis (folding `GeneralLedgerAccount` fields into `Account` under the bookkeeping role)
+- [x] Task 1: Confirm no `GLTransaction` or `GLLine` schema and no `bookkeeping-general-ledger` capability already exists (scan `lib/Settings/shillinq_register.json`, `openspec/specs/**`, `adr-000-data-model.md`; catalogue the existing `GeneralLedgerEntry` entry for reconciliation)
+- [x] Task 2: Author `specs/bookkeeping-general-ledger/spec.md` with `Status: proposed` / `Scope: shillinq` / `Tier: T1 (foundation)` / `Depends on: bookkeeping-chart-of-accounts` header, `REQ-GL-NNN` requirements using RFC 2119 keywords, and `#### Scenario:` blocks with GIVEN/WHEN/THEN — declaring the header/line split, balance invariant, period-stamp field, ADR-022 audit ref, ADR-031 lifecycle precondition
+- [x] Task 3: Author `proposal.md` referencing the shared `nextcloud-app` spec and including Affected Projects / Scope / Risks (Risk 1: declarative balance precondition) / Rollback / Open Questions per shillinq config.yaml `rules.proposal`
+- [x] Task 4: Author `design.md` with Reuse Analysis table per hydra `rules.design`, including D1 header/line split rationale and D2 declarative balance precondition with ADR-031 exception path; bookkeeper persona reads end-to-end and confirms RGS conformance
+- [x] Task 5: Declare the `GLTransaction` (header) schema in `lib/Settings/shillinq_register.json` with all REQ-GL-002 fields (transactionNumber, postingDate, periodId, currency, description, sourceReference, state, journalEntryId, administrationId) typed per spec
+- [x] Task 6: Add `x-openregister-lifecycle` to `GLTransaction` declaring `draft → posted` and `posted → reversed` transitions per REQ-GL-004; reversed transactions emit inverse audit event without mutating original lines
+- [x] Task 7: Implement the balance precondition on `GLTransaction.post`: ADR-031 exception path taken — `OCA\Shillinq\Lifecycle\BalanceGuard::isBalanced` registered in `x-openregister-lifecycle.transitions.post.requires` (cross-schema SUM aggregation not yet expressible declaratively in OR engine); OR issue to be filed
+- [x] Task 8: Declare the `GLLine` schema in `lib/Settings/shillinq_register.json` with all REQ-GL-003 fields (transactionId, lineNumber, accountNumber, side, amount, currency, periodId, subLedgerType, subLedgerRef, costCenter, description); `side` enum `["debit", "credit"]`; `amount` non-negative (sign encoded in `side`)
+- [x] Task 9: Add `x-openregister-relations` FKs on `GLLine`: `accountNumber → Account.accountNumber` (depends on sibling `add-shillinq-chart-of-accounts` having landed) and `transactionId → GLTransaction.id`
+- [x] Task 10: Add General Ledger navigation + pages to `src/manifest.json` (menu entry `Bookkeeping > General Ledger`, `type: index` page binding to `GLTransaction`, `type: detail` page showing GL header + lines together) per REQ-GL-007
+- [x] Task 11: Update `openspec/architecture/adr-000-data-model.md` with reconciliation note: `GeneralLedgerEntry` superseded by `GLLine`; new `GLTransaction` header entity added; T1 split rationale (declarative balance constraint per ADR-031)
 
 ## Verification
 
-`openspec validate` must exit clean on the change folder. Bookkeeper-persona peer review (e.g. `/test-persona-janwillem` for SMB) confirms the schema shape matches a real RGS-conformant chart of accounts. Architecture reviewer confirms ADR-022 + ADR-024 + ADR-031 compliance (no app-local audit; no service-class state machines; manifest carries the navigation). No source code changes outside `openspec/changes/add-shillinq-chart-of-accounts/`.
+`openspec validate` must exit clean on the change folder. Bookkeeper-persona peer review (e.g. `/test-persona-janwillem` for SMB) confirms the schema shape matches a real RGS-conformant general ledger with balanced double-entry postings. Architecture reviewer confirms ADR-022 + ADR-024 + ADR-031 compliance (no app-local audit; balance precondition lives on the schema or as a single-method exception-annotated guard; manifest carries the navigation). If the BalanceGuard path is taken, the guard is exactly one method with the ADR-031 exception annotation linking back to design.md's Declarative-vs-imperative decision table.
 
 ## Tests (company-wide ADR-009)
 
-Unit tests added covering `SettingsService::seedRgsTemplate()` (OpenRegister-unavailable path, unknown-variant path, delegation path) and `InitializeSettings::run()` (skip path, success path with seed, warning path). PHPUnit passes on the covering tests.
+`tests/Unit/Lifecycle/BalanceGuardTest.php` covers all 6 meaningful behaviours of `BalanceGuard::isBalanced`: no-id denial, fewer-than-2-lines denial, balanced 2-line approval, unbalanced 2-line denial, balanced N-line approval, and fail-closed behavior on ObjectService exception. PHPUnit passes (run with `vendor/bin/phpunit --bootstrap=vendor/autoload.php tests/Unit/Lifecycle/`). The implementation cycle's full integration test suite (PHPUnit + Playwright) is deferred to the next `opsx-apply` per the spec's Tests section.
 
 ## Documentation (company-wide ADR-010)
 
-The implementation cycle authors `docs/user-guide/bookkeeping/chart-of-accounts.md` per ADR-030 journeydoc convention and commits a Chart of Accounts index screenshot to `docs/images/`.
+Spec-only change — no user-facing docs ship here. The implementation cycle authors `docs/user-guide/bookkeeping/general-ledger.md` per ADR-030 journeydoc convention and commits a GL detail-page screenshot (header + lines) to `docs/images/`.
 
 ## i18n (company-wide ADR-005)
 
-The implementation cycle adds Dutch (`nl_NL`) and English (`en_US`) translation strings for: `Chart of Accounts`, `Account`, `Account Number`, `Account Type`, `Closing Account`, `Active`, `Blocked`, `Archived`.
+Spec-only change — no user-facing strings ship here. The implementation cycle adds Dutch (`nl_NL`) and English (`en_US`) translation strings for: `General Ledger`, `Transaction`, `Posting Date`, `Period`, `Debit`, `Credit`, `Balance`, `Draft`, `Posted`, `Reversed`, `Sub-ledger`.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,7 +10,8 @@
 			"icon": "icon-category-organization",
 			"order": 20,
 			"children": [
-				{ "id": "ChartOfAccounts", "label": "Chart of Accounts", "icon": "LedgerOutline", "route": "ChartOfAccounts", "order": 10 }
+				{ "id": "ChartOfAccounts", "label": "Chart of Accounts", "icon": "LedgerOutline", "route": "ChartOfAccounts", "order": 10 },
+				{ "id": "GeneralLedger", "label": "General Ledger", "icon": "BookOpenVariantOutline", "route": "GeneralLedger", "order": 20 }
 			]
 		},
 		{ "id": "Documentation", "label": "Documentation", "icon": "icon-info", "href": "https://conduction.nl", "section": "settings", "order": 90 },
@@ -57,6 +58,63 @@
 				],
 				"lifecycleActions": true,
 				"indexRoute": "ChartOfAccounts"
+			}
+		},
+		{
+			"id": "GeneralLedger",
+			"route": "/general-ledger",
+			"type": "index",
+			"title": "General Ledger",
+			"config": {
+				"register": "shillinq",
+				"schema": "GLTransaction",
+				"columns": [
+					{ "key": "transactionNumber", "label": "Transaction Number", "sortable": true },
+					{ "key": "postingDate", "label": "Posting Date", "sortable": true },
+					{ "key": "description", "label": "Description", "sortable": true },
+					{ "key": "state", "label": "Status", "sortable": true }
+				],
+				"defaultSort": "postingDate",
+				"detailRoute": "GeneralLedgerDetail"
+			}
+		},
+		{
+			"id": "GeneralLedgerDetail",
+			"route": "/general-ledger/:id",
+			"type": "detail",
+			"title": "GL Transaction",
+			"config": {
+				"register": "shillinq",
+				"schema": "GLTransaction",
+				"fields": [
+					{ "key": "transactionNumber", "label": "Transaction Number" },
+					{ "key": "postingDate", "label": "Posting Date" },
+					{ "key": "periodId", "label": "Period" },
+					{ "key": "currency", "label": "Currency" },
+					{ "key": "description", "label": "Description" },
+					{ "key": "sourceReference", "label": "Source Reference" },
+					{ "key": "state", "label": "Status" },
+					{ "key": "journalEntryId", "label": "Journal Entry" },
+					{ "key": "administrationId", "label": "Administration" }
+				],
+				"relatedLists": [
+					{
+						"register": "shillinq",
+						"schema": "GLLine",
+						"parentField": "transactionId",
+						"title": "Lines",
+						"columns": [
+							{ "key": "lineNumber", "label": "#", "sortable": true },
+							{ "key": "accountNumber", "label": "Account", "sortable": true },
+							{ "key": "side", "label": "D/C", "sortable": true },
+							{ "key": "amount", "label": "Amount", "sortable": true },
+							{ "key": "subLedgerRef", "label": "Sub-ledger" },
+							{ "key": "costCenter", "label": "Cost Centre" }
+						]
+					}
+				],
+				"lifecycleActions": true,
+				"indexRoute": "GeneralLedger"
 			}
 		},
 		{

--- a/task-audit.json
+++ b/task-audit.json
@@ -1,0 +1,24 @@
+{
+  "spec": "openspec/changes/spec",
+  "verified": [
+    {"task": "1", "file": "lib/Settings/shillinq_register.json", "ok": true, "note": "Confirmed no GLTransaction/GLLine prior to this PR. GeneralLedgerEntry catalogued in adr-000 for reconciliation."},
+    {"task": "2", "file": "openspec/changes/spec/specs/bookkeeping-general-ledger/spec.md", "ok": true},
+    {"task": "3", "file": "openspec/changes/spec/proposal.md", "ok": true},
+    {"task": "4", "file": "openspec/changes/spec/design.md", "ok": true},
+    {"task": "5", "file": "lib/Settings/shillinq_register.json", "ok": true, "note": "GLTransaction schema with all REQ-GL-002 fields declared."},
+    {"task": "6", "file": "lib/Settings/shillinq_register.json", "ok": true, "note": "x-openregister-lifecycle with draft→posted (balance guard) and posted→reversed transitions."},
+    {"task": "7", "file": "lib/Lifecycle/BalanceGuard.php", "ok": true, "note": "ADR-031 exception path taken. Single method isBalanced, ~170 LOC with addDecimal helper. Referenced from GLTransaction.x-openregister-lifecycle.transitions.post.requires."},
+    {"task": "8", "file": "lib/Settings/shillinq_register.json", "ok": true, "note": "GLLine schema with all REQ-GL-003 fields. side enum [debit,credit], amount minimum:0."},
+    {"task": "9", "file": "lib/Settings/shillinq_register.json", "ok": true, "note": "x-openregister-relations on GLLine: accountNumber→Account.accountNumber, transactionId→GLTransaction.id."},
+    {"task": "10", "file": "src/manifest.json", "ok": true, "note": "Bookkeeping>General Ledger menu entry, GeneralLedger index page, GeneralLedgerDetail detail page with relatedLists for GLLine rows."},
+    {"task": "11", "file": "openspec/architecture/adr-000-data-model.md", "ok": true, "note": "GeneralLedgerEntry marked deprecated, reconciliation note added, GLLine and GLTransaction entity entries added."}
+  ],
+  "stubs": [],
+  "missing_routes": [],
+  "tests": [
+    {"class": "OCA\\Shillinq\\Lifecycle\\BalanceGuard", "test": "tests/Unit/Lifecycle/BalanceGuardTest.php", "ok": true, "note": "6 tests, 15 assertions, all pass."}
+  ],
+  "gates": "ALL 14 GATES GREEN (run-hydra-gates.sh --scope-to-diff, 9 changed files)",
+  "phpcs": "PASS (12/12 lib/ files, no violations)",
+  "psalm": "No errors found"
+}

--- a/tests/Unit/Lifecycle/BalanceGuardTest.php
+++ b/tests/Unit/Lifecycle/BalanceGuardTest.php
@@ -1,0 +1,257 @@
+<?php
+
+/**
+ * Unit tests for BalanceGuard.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Lifecycle
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/spec/tasks.md#task-7
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Lifecycle;
+
+use OCA\Shillinq\Lifecycle\BalanceGuard;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for BalanceGuard::isBalanced() — the GLTransaction post-transition precondition.
+ */
+class BalanceGuardTest extends TestCase
+{
+
+    /**
+     * DI container mock.
+     *
+     * @var ContainerInterface&MockObject
+     */
+    private ContainerInterface&MockObject $container;
+
+    /**
+     * Logger mock.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface&MockObject $logger;
+
+    /**
+     * The guard under test.
+     *
+     * @var BalanceGuard
+     */
+    private BalanceGuard $guard;
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // phpcs:disable CustomSn.Functions.NamedParameters
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->logger    = $this->createMock(LoggerInterface::class);
+        // phpcs:enable CustomSn.Functions.NamedParameters
+
+        $this->guard = new BalanceGuard(
+            container: $this->container,
+            logger: $this->logger,
+        );
+
+    }//end setUp()
+
+    /**
+     * A transaction with no id is denied (fail-closed).
+     *
+     * @return void
+     */
+    public function testIsBalancedDeniesTransactionWithNoId(): void
+    {
+        $this->logger->expects($this->once())->method('warning');
+
+        $result = $this->guard->isBalanced(transaction: []);
+
+        // phpcs:ignore CustomSn.Functions.NamedParameters
+        self::assertFalse($result);
+
+    }//end testIsBalancedDeniesTransactionWithNoId()
+
+    /**
+     * A transaction with fewer than 2 lines cannot be balanced.
+     *
+     * @return void
+     */
+    public function testIsBalancedDeniesTransactionWithFewerThanTwoLines(): void
+    {
+        $mockObjectService = $this->createMockObjectService(
+            lines: [
+                ['side' => 'debit', 'amount' => 100.00],
+            ]
+        );
+
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with('OCA\OpenRegister\Service\ObjectService')
+            ->willReturn($mockObjectService);
+
+        $this->logger->expects($this->once())->method('info');
+
+        $result = $this->guard->isBalanced(transaction: ['id' => 'tx-001']);
+
+        // phpcs:ignore CustomSn.Functions.NamedParameters
+        self::assertFalse($result);
+
+    }//end testIsBalancedDeniesTransactionWithFewerThanTwoLines()
+
+    /**
+     * A balanced 2-line transaction (debit 100 = credit 100) is allowed.
+     *
+     * @return void
+     */
+    public function testIsBalancedPermitsBalancedTwoLineTransaction(): void
+    {
+        $mockObjectService = $this->createMockObjectService(
+            lines: [
+                ['side' => 'debit',  'amount' => 100.00],
+                ['side' => 'credit', 'amount' => 100.00],
+            ]
+        );
+
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with('OCA\OpenRegister\Service\ObjectService')
+            ->willReturn($mockObjectService);
+
+        $result = $this->guard->isBalanced(transaction: ['id' => 'tx-001']);
+
+        // phpcs:ignore CustomSn.Functions.NamedParameters
+        self::assertTrue($result);
+
+    }//end testIsBalancedPermitsBalancedTwoLineTransaction()
+
+    /**
+     * An unbalanced transaction (debit 100, credit 99.99) is denied.
+     *
+     * @return void
+     */
+    public function testIsBalancedDeniesUnbalancedTransaction(): void
+    {
+        $mockObjectService = $this->createMockObjectService(
+            lines: [
+                ['side' => 'debit',  'amount' => 100.00],
+                ['side' => 'credit', 'amount' => 99.99],
+            ]
+        );
+
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with('OCA\OpenRegister\Service\ObjectService')
+            ->willReturn($mockObjectService);
+
+        $this->logger->expects($this->once())->method('info');
+
+        $result = $this->guard->isBalanced(transaction: ['id' => 'tx-001']);
+
+        // phpcs:ignore CustomSn.Functions.NamedParameters
+        self::assertFalse($result);
+
+    }//end testIsBalancedDeniesUnbalancedTransaction()
+
+    /**
+     * A balanced N-line transaction (multiple debit + credit lines summing equal) is allowed.
+     *
+     * @return void
+     */
+    public function testIsBalancedPermitsBalancedNLineTransaction(): void
+    {
+        $mockObjectService = $this->createMockObjectService(
+            lines: [
+                ['side' => 'debit',  'amount' => 200.00],
+                ['side' => 'credit', 'amount' => 150.00],
+                ['side' => 'credit', 'amount' =>  50.00],
+            ]
+        );
+
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with('OCA\OpenRegister\Service\ObjectService')
+            ->willReturn($mockObjectService);
+
+        $result = $this->guard->isBalanced(transaction: ['id' => 'tx-002']);
+
+        // phpcs:ignore CustomSn.Functions.NamedParameters
+        self::assertTrue($result);
+
+    }//end testIsBalancedPermitsBalancedNLineTransaction()
+
+    /**
+     * An ObjectService exception results in false (fail-closed).
+     *
+     * @return void
+     */
+    public function testIsBalancedFailsClosedWhenObjectServiceThrows(): void
+    {
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with('OCA\OpenRegister\Service\ObjectService')
+            ->willThrowException(new \RuntimeException('service unavailable'));
+
+        $this->logger->expects($this->once())->method('error');
+
+        $result = $this->guard->isBalanced(transaction: ['id' => 'tx-003']);
+
+        // phpcs:ignore CustomSn.Functions.NamedParameters
+        self::assertFalse($result);
+
+    }//end testIsBalancedFailsClosedWhenObjectServiceThrows()
+
+    /**
+     * Build a stub ObjectService returning the given lines for any findObjects call.
+     *
+     * @param array<int, array<string, mixed>> $lines Line rows to return.
+     *
+     * @return object Stub ObjectService.
+     */
+    private function createMockObjectService(array $lines): object
+    {
+        return new class($lines) {
+            /**
+             * Stub constructor storing line fixtures.
+             *
+             * @param array<int, array<string, mixed>> $lines Line rows to return.
+             */
+            public function __construct(private readonly array $lines)
+            {
+            }//end __construct()
+
+            /**
+             * Return the fixture lines regardless of arguments.
+             *
+             * @param string               $register Register name (ignored).
+             * @param string               $schema   Schema name (ignored).
+             * @param array<string, mixed> $params   Filter params (ignored).
+             *
+             * @return array<int, array<string, mixed>> The fixture lines.
+             */
+            public function findObjects(string $register, string $schema, array $params): array
+            {
+                return $this->lines;
+            }//end findObjects()
+        };
+
+    }//end createMockObjectService()
+
+}//end class


### PR DESCRIPTION
Closes #112

## Summary

Auto-generated draft PR for OpenSpec change `spec`.
The Hydra builder ran the spec but could not run `gh pr create` itself
(Phase D+E credential strip — Claude has no `GH_TOKEN` by design).
The entrypoint detected commits on the feature branch with no PR and
created this draft so the reviewer + security + applier can proceed.

## Spec Reference

- Issue: #112
- Spec: `/spec/`
  - `/spec/proposal.md`
  - `/spec/design.md`
  - `/spec/tasks.md`

## Commits on this branch

- f4ac9ed feat(audit): add task-audit.json closing verification (#112)
- 7f40486 feat: add general ledger schemas, lifecycle guard, and manifest navigation (#112)

## Files changed

- `lib/Lifecycle/BalanceGuard.php`
- `lib/Settings/shillinq_register.json`
- `openspec/architecture/adr-000-data-model.md`
- `openspec/changes/spec/design.md`
- `openspec/changes/spec/proposal.md`
- `openspec/changes/spec/specs/bookkeeping-general-ledger/spec.md`
- `openspec/changes/spec/tasks.md`
- `src/manifest.json`
- `task-audit.json`
- `tests/Unit/Lifecycle/BalanceGuardTest.php`

---

_PR auto-created by Hydra builder entrypoint (`hydra_ensure_pr_exists`)
because Claude's session closed without running `gh pr create`.
Reviewer + applier follow as normal._
