### PR TITLE
chore(docs): sync development -> documentation (3.6.1 lockfile)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2013,9 +2013,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.6.0.tgz",
-      "integrity": "sha512-gjnM6G+Cjx1WKniMhbQDYjgje0J4nqjeArKUHxisEdsY62fp8mfEzP1NXeD/2F2aYa+eHShCHeYGUM9jTl6yKQ==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.6.1.tgz",
+      "integrity": "sha512-LjA2lwaVkjfUH9qJhXvSJBed2qyKMCcxnWymu2PaYMZLQSbW0/JZ2nZsavQgbq5lqvrddD1m0OtBSORxisBdHA==",
       "license": "EUPL-1.2",
       "bin": {
         "validate-ai-baseline": "bin/validate-ai-baseline.mjs"


### PR DESCRIPTION
Brings the 3.6.1 lockfile fix onto documentation so the deploy succeeds.