### PR TITLE
chore(docs): sync development -> documentation (3.7.0)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2013,9 +2013,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.6.2.tgz",
-      "integrity": "sha512-Ee8CKQknUZ0zDzh9NLWL91kCwz3FzwMOcBDvgR0LygmMOGn9z44LHBK6qoncAnqhRTqLLovMUjyw8ku3dtb1PQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.7.0.tgz",
+      "integrity": "sha512-AS6YyXf0NxsTNgxX101+ca0WYxCBRXiKiSpeokWYaIHSluDozsVSs3hH0iwjYZlDyA58RuQm7EydrRh+CD9Vlw==",
       "license": "EUPL-1.2",
       "bin": {
         "validate-ai-baseline": "bin/validate-ai-baseline.mjs"


### PR DESCRIPTION
Brings the 3.7.0 lockfile onto documentation for deploy.