### PR TITLE
chore(deps): preset lockfile 3.7.0 -> 3.7.1 (relaxed lastmod threshold)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2013,9 +2013,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.7.0.tgz",
-      "integrity": "sha512-AS6YyXf0NxsTNgxX101+ca0WYxCBRXiKiSpeokWYaIHSluDozsVSs3hH0iwjYZlDyA58RuQm7EydrRh+CD9Vlw==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.7.1.tgz",
+      "integrity": "sha512-GdaXFMfD2geJATKpPy/HwAQZXbZiGxUns5B04QnHB+/00xBhVLGXNFVVRsLwlJ5HYUH/HBC3CQakE0CxpXDWOA==",
       "license": "EUPL-1.2",
       "bin": {
         "validate-ai-baseline": "bin/validate-ai-baseline.mjs"


### PR DESCRIPTION
Preset 3.7.1 relaxes the sitemap-lastmod validator threshold from 90% to 50% so Docusaurus auto-routes don't fail the gate. Unblocks deploy on this site.