### PR TITLE
chore(deps): preset lockfile 3.7.1 -> 3.8.0 (BreadcrumbList + TechArticle + IndexNow)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2013,9 +2013,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.7.1.tgz",
-      "integrity": "sha512-GdaXFMfD2geJATKpPy/HwAQZXbZiGxUns5B04QnHB+/00xBhVLGXNFVVRsLwlJ5HYUH/HBC3CQakE0CxpXDWOA==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.8.0.tgz",
+      "integrity": "sha512-aakDh5eyzA4qMhExiU+gOCVLviB/ol8UMulFHiFKz5lKGEf5AKPR7NDuE6rnBpS5qakGyiCwgLSojP3HnBROCA==",
       "license": "EUPL-1.2",
       "bin": {
         "validate-ai-baseline": "bin/validate-ai-baseline.mjs"


### PR DESCRIPTION
Preset 3.8.0 adds BreadcrumbList on marketing pages (via DetailHero), TechArticle on docs pages (via DocItem swizzle), and IndexNow plugin for Bing recrawl acceleration.