### PR TITLE
sync: development to documentation (meta descriptions #81)

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 1
+description: Get started with Shillinq, bookkeeping and e-invoicing for Nextcloud. Contracts, procurement, bank reconciliation, VAT and financial statements.
 ---
 
 # Shillinq

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -585,7 +585,7 @@ export default function Home() {
   return (
     <Layout
       title="Shillinq, bookkeeping and e-invoicing on Nextcloud"
-      description="Open-source business administration on Nextcloud,bookkeeping, e-invoicing, procurement, contracts, bank reconciliation, VAT and financial statements."
+      description="Open-source business administration on Nextcloud. Bookkeeping, e-invoicing, procurement, contracts, bank reconciliation, VAT, and statements."
     >
       <main className="marketing-page">
         <DetailHero


### PR DESCRIPTION
Sync development to documentation so the meta-description deploy fires.