### PR TITLE
chore(docs): bump @conduction/docusaurus-preset to 3.10.0 (#79)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2013,9 +2013,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.9.0.tgz",
-      "integrity": "sha512-WYzKUiF0VyRzhy0ChReAx/w/Dn0HfIKemtr0R+Skt+Q+2+ekA4yffZLJr4zCXexi6wW17XDqh+m9sqsXQqh3RQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.10.0.tgz",
+      "integrity": "sha512-wFjmNtjON+ks0Aqzql1wGy6TCQPLsJTzMY1C8uwNnj+jTpGVGZ3QVqd6I/0oVDYhdgAjgdrijRhyN3L2Er4U7Q==",
       "license": "EUPL-1.2",
       "bin": {
         "validate-ai-baseline": "bin/validate-ai-baseline.mjs"


### PR DESCRIPTION
Lockfile-only bump for ConductionNL/.github#79. Part of SEO epic #75.