### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to ^1.0.0-beta.66

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@conduction/nextcloud-vue": "^1.0.0-beta.58",
+        "@conduction/nextcloud-vue": "^1.0.0-beta.66",
         "@nextcloud/axios": "~2.5.2",
         "@nextcloud/dialogs": "^3.2.0",
         "@nextcloud/initial-state": "^2.2.0",
@@ -520,9 +520,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "1.0.0-beta.58",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.58.tgz",
-      "integrity": "sha512-tFoV9jCNv+62c/MKbMgxwbOKH0pUTxnYGYW6pfjdhTLiSJts+BzGffZnK6khs6KDVbEssmAA3ntcpPp0hZqS/Q==",
+      "version": "1.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.67.tgz",
+      "integrity": "sha512-748mIzQGhCSFIg0r1wb260CdczsbH51s7KdOXb5uYzTrqKWe2+uFDOtWTUe3ZV9B+2YY0t0jKSC1MCjzZwst2A==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "dependencies": {
-    "@conduction/nextcloud-vue": "^1.0.0-beta.58",
+    "@conduction/nextcloud-vue": "^1.0.0-beta.66",
     "@nextcloud/axios": "~2.5.2",
     "@nextcloud/dialogs": "^3.2.0",
     "@nextcloud/initial-state": "^2.2.0",


### PR DESCRIPTION
Picks up schema 2.7.0 + CnPageRenderer top-level field forwarding + CnDetailPage `_lockState` rename + `config.schema → objectType` bridging from nextcloud-vue#317/#319/#320. Mechanical dependency bump.