### PR TITLE
docs(briefs): preserve Placement & IA annotations from 17 superseded spec PRs

### DIFF
--- a/openspec/changes/bookings-availability-rules/context-brief.md
+++ b/openspec/changes/bookings-availability-rules/context-brief.md
@@ -4,6 +4,17 @@ status: draft
 
 # Booking Availability Rules (hours, breaks, holidays)
 
+## Placement & Information Architecture
+
+**Placement type:** `SETTING` — Setting under the app's Beheer/Admin/Configuration surface. Lives in the existing settings UI; no top-level menu entry.
+
+**Lives at:** Verkoop / Afspraken → Beschikbaarheid settings (inside Afspraken page)
+
+**Rationale:** Hours/breaks/holidays config.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 Per-resource working hours, breaks, holidays, vacation, blackout dates.

--- a/openspec/changes/bookings-create-appointment/context-brief.md
+++ b/openspec/changes/bookings-create-appointment/context-brief.md
@@ -4,6 +4,17 @@ status: draft
 
 # Booking Create Appointment (single source of truth)
 
+## Placement & Information Architecture
+
+**Placement type:** `SUB_PAGE` — Sub-page beneath a top-level menu entry. Renders as a page inside the parent surface (usually reachable via a router child route or a tab on the parent index page).
+
+**Lives at:** Verkoop / Afspraken (Agenda tab)
+
+**Rationale:** The single-source-of-truth booking flow.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 Admin + customer + API booking through one canonical create flow.

--- a/openspec/changes/bookings-deposits/context-brief.md
+++ b/openspec/changes/bookings-deposits/context-brief.md
@@ -4,6 +4,17 @@ status: draft
 
 # Booking Deposits at Booking Time
 
+## Placement & Information Architecture
+
+**Placement type:** `DETAIL_TAB` — Tab on the detail view of an existing object. NOT a standalone page — appears inside the parent record's detail surface (e.g. an extra tab on the existing detail header).
+
+**Lives at:** Verkoop / Afspraken → Aanbetalingen tab
+
+**Rationale:** Deposit-at-booking-time.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 Take partial / full payment at booking time via Mollie/Stripe.

--- a/openspec/changes/bookings-email-templates/context-brief.md
+++ b/openspec/changes/bookings-email-templates/context-brief.md
@@ -4,6 +4,17 @@ status: draft
 
 # Booking Email Templates (branded)
 
+## Placement & Information Architecture
+
+**Placement type:** `SETTING` — Setting under the app's Beheer/Admin/Configuration surface. Lives in the existing settings UI; no top-level menu entry.
+
+**Lives at:** Beheer (under Booking templates)
+
+**Rationale:** Branded email templates.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 Branded confirmation/reminder/cancel templates.

--- a/openspec/changes/bookings-nl-btw-invoice/context-brief.md
+++ b/openspec/changes/bookings-nl-btw-invoice/context-brief.md
@@ -4,6 +4,17 @@ status: draft
 
 # Booking NL BTW + Kassakoppeling-shape Invoice
 
+## Placement & Information Architecture
+
+**Placement type:** `DETAIL_TAB` — Tab on the detail view of an existing object. NOT a standalone page — appears inside the parent record's detail surface (e.g. an extra tab on the existing detail header).
+
+**Lives at:** Verkoop / Facturen → Kassakoppeling tab on bookings-generated invoices
+
+**Rationale:** BTW + kassakoppeling-shape compliance for bookings invoices.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 Service / product VAT on invoice in NL kassakoppeling-friendly shape.

--- a/openspec/changes/bookings-notification-triggers/context-brief.md
+++ b/openspec/changes/bookings-notification-triggers/context-brief.md
@@ -4,6 +4,17 @@ status: draft
 
 # Booking Notification Triggers
 
+## Placement & Information Architecture
+
+**Placement type:** `SETTING` — Setting under the app's Beheer/Admin/Configuration surface. Lives in the existing settings UI; no top-level menu entry.
+
+**Lives at:** Beheer (booking-notifications)
+
+**Rationale:** Trigger config.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 On created/changed/cancelled/reminder — wired to channel via openconnector.

--- a/openspec/changes/bookings-pipelinq-customer-bridge/context-brief.md
+++ b/openspec/changes/bookings-pipelinq-customer-bridge/context-brief.md
@@ -4,6 +4,17 @@ status: draft
 
 # Booking → pipelinq Customer Profile Bridge
 
+## Placement & Information Architecture
+
+**Placement type:** `ACTION` — Action button or menu item on an existing surface. Implemented as a single button / context-menu entry that opens a modal/wizard or runs a backend operation — NOT a page.
+
+**Lives at:** "Bridge naar pipelinq" action on klant
+
+**Rationale:** Cross-app sync action.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 Detail view loads customer profile + history from pipelinq klantbeeld 360.

--- a/openspec/changes/bookings-resource-calendar/context-brief.md
+++ b/openspec/changes/bookings-resource-calendar/context-brief.md
@@ -4,6 +4,17 @@ status: draft
 
 # Booking Resource Calendar (per-staff/room/chair)
 
+## Placement & Information Architecture
+
+**Placement type:** `DETAIL_TAB` — Tab on the detail view of an existing object. NOT a standalone page — appears inside the parent record's detail surface (e.g. an extra tab on the existing detail header).
+
+**Lives at:** Verkoop / Afspraken → Resources tab
+
+**Rationale:** Per-staff/room/chair calendar.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 Per-staff / per-room / per-chair calendar with conflict detection. Foundation of booking module.

--- a/openspec/changes/bookings-service-catalog/context-brief.md
+++ b/openspec/changes/bookings-service-catalog/context-brief.md
@@ -4,6 +4,17 @@ status: draft
 
 # Booking Service Catalogue (duration, price, buffers)
 
+## Placement & Information Architecture
+
+**Placement type:** `DETAIL_TAB` — Tab on the detail view of an existing object. NOT a standalone page — appears inside the parent record's detail surface (e.g. an extra tab on the existing detail header).
+
+**Lives at:** Verkoop / Afspraken → Diensten-catalogus tab
+
+**Rationale:** Service catalogue inside bookings.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 Services with duration, price, buffer (pre/post), prep time, category.

--- a/openspec/changes/docs-product-pages-conformance/context-brief.md
+++ b/openspec/changes/docs-product-pages-conformance/context-brief.md
@@ -1,5 +1,16 @@
 # Proposal: docs-product-pages-conformance
 
+## Placement & Information Architecture
+
+**Placement type:** `SETTING` — Setting under the app's Beheer/Admin/Configuration surface. Lives in the existing settings UI; no top-level menu entry.
+
+**Lives at:** (out-of-app)
+
+**Rationale:** Docs-site conformance — not in-app IA.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Summary
 
 An audit on 2026-05-13 found shillinq's `docs/` directory partially conformant to the canonical product-pages spec that recently shipped to the Conduction design system (`preview/product-pages/`). This change brings shillinq's documentation into full Tier-1 (structural) and Tier-2 (configuration) conformance: renaming folders, moving files, fixing em-dash violations, adding stub placeholder pages for Tier-3 content areas, and wiring up the redocusaurus API docs preset and the `nl` locale so the design-system preset's full feature set is active.

--- a/openspec/changes/expense-capture-core/context-brief.md
+++ b/openspec/changes/expense-capture-core/context-brief.md
@@ -4,6 +4,17 @@ status: draft
 
 # Expense Capture (receipt photo, mileage, per-diem)
 
+## Placement & Information Architecture
+
+**Placement type:** `SUB_PAGE` — Sub-page beneath a top-level menu entry. Renders as a page inside the parent surface (usually reachable via a router child route or a tab on the parent index page).
+
+**Lives at:** Inkoop / Onkosten
+
+**Rationale:** Expense page (capture flow).  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 Receipt photo upload, manual entry, multi-currency, mileage, per-diem, project tag.

--- a/openspec/changes/inventory-cogs-posting/context-brief.md
+++ b/openspec/changes/inventory-cogs-posting/context-brief.md
@@ -4,6 +4,20 @@ status: draft
 
 # Inventory Auto-post COGS + Inventory-asset GL Entries
 
+## Placement & Information Architecture
+
+**Placement type:** `ACTION+SETTING` (compound — implement all of the following):
+
+- **`ACTION`** — Action button or menu item on an existing surface. Implemented as a single button / context-menu entry that opens a modal/wizard or runs a backend operation — NOT a page.
+- **`SETTING`** — Setting under the app's Beheer/Admin/Configuration surface. Lives in the existing settings UI; no top-level menu entry.
+
+**Lives at:** "Genereer COGS-boeking" action on periode + Beheer (COGS-rekening mapping)
+
+**Rationale:** Auto-post action + mapping config.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 Auto-post COGS on sale, inventory-asset on receipt, adjustment on count variance. ERPNext 'Perpetual Inventory' pattern.

--- a/openspec/changes/inventory-lot-batch-expiry/context-brief.md
+++ b/openspec/changes/inventory-lot-batch-expiry/context-brief.md
@@ -4,6 +4,20 @@ status: draft
 
 # Inventory Lot/Batch + Expiry with FEFO
 
+## Placement & Information Architecture
+
+**Placement type:** `DETAIL_TAB+SETTING` (compound — implement all of the following):
+
+- **`DETAIL_TAB`** — Tab on the detail view of an existing object. NOT a standalone page — appears inside the parent record's detail surface (e.g. an extra tab on the existing detail header).
+- **`SETTING`** — Setting under the app's Beheer/Admin/Configuration surface. Lives in the existing settings UI; no top-level menu entry.
+
+**Lives at:** Voorraad / Producten → FEFO-instellingen tab + Beheer (default policy)
+
+**Rationale:** Lot/batch per product + global policy.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 Lot/batch tracking with expiry dates and First-Expiry-First-Out picking. **CRITICAL for pet food and perishables.**

--- a/openspec/changes/inventory-product-catalog/context-brief.md
+++ b/openspec/changes/inventory-product-catalog/context-brief.md
@@ -4,6 +4,17 @@ status: draft
 
 # Inventory Product Catalog (items, SKUs, attributes, UoM)
 
+## Placement & Information Architecture
+
+**Placement type:** `SUB_PAGE` — Sub-page beneath a top-level menu entry. Renders as a page inside the parent surface (usually reachable via a router child route or a tab on the parent index page).
+
+**Lives at:** Voorraad / Producten
+
+**Rationale:** Product catalog page.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 Universal foundation — items with SKUs, attributes, unit of measure. Every competitor's bedrock.

--- a/openspec/changes/inventory-valuation-fifo-avg/context-brief.md
+++ b/openspec/changes/inventory-valuation-fifo-avg/context-brief.md
@@ -4,6 +4,20 @@ status: draft
 
 # Inventory Valuation (FIFO + moving-average)
 
+## Placement & Information Architecture
+
+**Placement type:** `SETTING+DETAIL_TAB` (compound — implement all of the following):
+
+- **`SETTING`** — Setting under the app's Beheer/Admin/Configuration surface. Lives in the existing settings UI; no top-level menu entry.
+- **`DETAIL_TAB`** — Tab on the detail view of an existing object. NOT a standalone page — appears inside the parent record's detail surface (e.g. an extra tab on the existing detail header).
+
+**Lives at:** Beheer (default valuation method) + Voorraad / Producten → COGS-mapping tab
+
+**Rationale:** Per-category config + per-product override.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 FIFO + moving-average valuation per item per warehouse. Minimal viable pair.

--- a/openspec/changes/rate-card-engine/context-brief.md
+++ b/openspec/changes/rate-card-engine/context-brief.md
@@ -4,6 +4,20 @@ status: draft
 
 # Rate Card Engine (multi-tier, effective-dated)
 
+## Placement & Information Architecture
+
+**Placement type:** `SETTING+DETAIL_TAB` (compound — implement all of the following):
+
+- **`SETTING`** — Setting under the app's Beheer/Admin/Configuration surface. Lives in the existing settings UI; no top-level menu entry.
+- **`DETAIL_TAB`** — Tab on the detail view of an existing object. NOT a standalone page — appears inside the parent record's detail surface (e.g. an extra tab on the existing detail header).
+
+**Lives at:** Beheer / Rate Cards (settings) + Verkoop / Contracten → Rate-card tab
+
+**Rationale:** Multi-tier effective-dated cards.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Purpose
 
 Multi-tier rate hierarchy (user / role / project / client / blended); effective-dated rates.

--- a/openspec/changes/shillinq-manifest-tier4/context-brief.md
+++ b/openspec/changes/shillinq-manifest-tier4/context-brief.md
@@ -1,5 +1,16 @@
 # Shillinq — adopt the Tier-4 app-manifest shell
 
+## Placement & Information Architecture
+
+**Placement type:** `SETTING` — Setting under the app's Beheer/Admin/Configuration surface. Lives in the existing settings UI; no top-level menu entry.
+
+**Lives at:** Beheer / Over
+
+**Rationale:** App-shell scaffolding, not user-facing flow.  
+_Source: /tmp/ia-shillinq.md_
+
+> **Implementation note for builders:** Respect the placement above. Do not promote this spec to a top-level menu item, sub-page, or new route unless the placement type explicitly says so. If the placement is `DETAIL_TAB`, `WIDGET`, `ACTION`, `SETTING`, or `INFRA`, the feature must NOT introduce a new entry in the app sidebar. When in doubt, ask before creating a new top-level surface.
+
 ## Summary
 
 Shillinq currently renders its UI from a hand-written `vue-router` config


### PR DESCRIPTION
## Summary
- The 17 `spec/*` PRs #213-#229 had their underlying openspec changes already merged to `development` (via Specter import). They were left CONFLICTING purely by the `.claude` submodule->directory conversion churn.
- Their only unique, unmerged content was a later `docs(brief): inject Placement & IA section` commit (added 2026-05-22, after the merges) on each `context-brief.md`. `development` lacked these blocks entirely.
- This PR consolidates all 17 Placement & Information Architecture builder-guidance blocks into `development` in one clean, conflict-free commit, so the noisy submodule-conversion PRs can be closed without losing work.

## Files
17 `openspec/changes/*/context-brief.md` (bookings-*, inventory-*, expense-capture-core, rate-card-engine, docs-product-pages-conformance, shillinq-manifest-tier4).

PRs #209-#212 were byte-identical to `development` (no Placement block on either side) and are fully superseded.