### PR TITLE
retrofit: drive shillinq spec-coverage to zero

### DIFF
--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -50,6 +50,9 @@ class DashboardController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+     *
+     * @spec exclude SPA shell — returns the bundled Vue index template with no
+     * app-specific behavior; pure Nextcloud TemplateResponse framework glue.
      */
     public function page(): TemplateResponse
     {
@@ -63,6 +66,9 @@ class DashboardController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+     *
+     * @spec exclude SPA history-mode catch-all — delegates verbatim to page();
+     * pure Vue-router deep-link framework glue with no app-specific behavior.
      */
     public function catchAll(): TemplateResponse
     {

--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -50,6 +50,8 @@ class HealthController extends Controller
      * Return application health status.
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-3
      */
     #[PublicPage]
     #[NoCSRFRequired]

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -49,6 +49,8 @@ class MetricsController extends Controller
      * Return application metrics in Prometheus text format.
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-4
      */
     #[AuthorizedAdminSetting(Application::APP_ID)]
     #[NoCSRFRequired]

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -53,6 +53,8 @@ class SettingsController extends Controller
      * @NoAdminRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-1
      */
     public function index(): JSONResponse
     {
@@ -65,6 +67,8 @@ class SettingsController extends Controller
      * Update settings with provided data.
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-1
      */
     public function create(): JSONResponse
     {
@@ -86,6 +90,8 @@ class SettingsController extends Controller
      * all schema and register IDs from the import result.
      *
      * @return JSONResponse
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-2
      */
     public function load(): JSONResponse
     {

--- a/lib/Listener/DeepLinkRegistrationListener.php
+++ b/lib/Listener/DeepLinkRegistrationListener.php
@@ -41,6 +41,10 @@ class DeepLinkRegistrationListener implements IEventListener
      * @param Event $event The event to handle
      *
      * @return void
+     *
+     * @spec exclude Scaffold stub — registers the placeholder `example` schema
+     * deep link only; OpenRegister search-provider event wiring with no real
+     * shillinq behavior yet. To be reverse-specced when domain pages land.
      */
     public function handle(Event $event): void
     {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -85,6 +85,8 @@ class SettingsService
      * fields (openregisters, isAdmin) consumed by the frontend.
      *
      * @return array<string,mixed>
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-1
      */
     public function getSettings(): array
     {
@@ -111,6 +113,8 @@ class SettingsService
      * @param array<string,mixed> $data The data to update
      *
      * @return array<string,mixed> The updated settings
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-1
      */
     public function updateSettings(array $data): array
     {
@@ -258,6 +262,8 @@ class SettingsService
      * @param bool $force Force re-import even if already configured.
      *
      * @return array<string,mixed> Result with success flag, message, and version.
+     *
+     * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-2
      */
     public function loadConfiguration(bool $force=false): array
     {

--- a/openspec/changes/retrofit-2026-05-25-app-administration/proposal.md
+++ b/openspec/changes/retrofit-2026-05-25-app-administration/proposal.md
@@ -1,0 +1,64 @@
+# Proposal: retrofit-2026-05-25-app-administration
+
+`kind: retrofit` — reverse-engineered spec for already-shipped code.
+
+## Summary
+
+Shillinq ships a small **application-administration** surface that has
+been live since the app scaffold but was never captured in a spec: a
+settings controller/service pair (`GET`/`POST /api/settings`, plus a
+forced `load` re-import), a health endpoint, a metrics endpoint, the
+generic OpenRegister object store the Vue shell uses to read register
+data, and the admin/in-app settings forms that consume them.
+
+This change reverse-specs that observed behavior so every method in the
+cluster carries an `@spec` reference (ADR-003 spec-coverage), without
+altering a single line of runtime code. All tasks are `[x]` — the code
+already exists.
+
+## Motivation
+
+Gate-16 spec-coverage flags every settings/observability/object-store
+method as `missing @spec`. These are real, user-observable behaviors
+(an admin saves a register ID; a monitoring probe hits `/health`), not
+framework glue, so the correct closure is a reverse-spec rather than an
+`@spec exclude`. The SPA template shell (`DashboardController`,
+`App.vue` bootstrap, the deep-link scaffold stub) remains genuine glue
+and is handled with reasoned `@spec exclude` markers, not this change.
+
+## Affected Projects
+
+- [x] Project: shillinq — annotation-only; adds one `app-administration`
+  capability spec and `@spec` docblock/JSDoc references on the covered
+  methods. No behavioral change.
+
+## Scope
+
+### In Scope
+
+- New `app-administration` capability spec with 5 REQs covering settings
+  read/write, configuration re-import, health/metrics observability, and
+  the generic object store.
+- `@spec` annotations on the covered backend and frontend methods.
+
+### Out of Scope
+
+- Any change to runtime behavior, endpoints, or schemas.
+- The SPA template shell and deep-link scaffold stub (excluded as glue).
+
+## Risks
+
+Negligible — annotation-only. Spec text describes observed behavior; if
+the code is later found buggy the spec is the place to tighten it.
+
+## Rollback
+
+Revert the commit; no data or schema migration involved.
+
+## Open Questions
+
+- The metrics endpoint currently returns an empty `metrics: []` array
+  (placeholder). The REQ documents this observed shape; a future change
+  can populate real metrics.
+- The deep-link listener still registers the scaffold's `example` schema;
+  tracked as glue, to be wired to real schemas when domain pages land.

--- a/openspec/changes/retrofit-2026-05-25-app-administration/specs/app-administration/spec.md
+++ b/openspec/changes/retrofit-2026-05-25-app-administration/specs/app-administration/spec.md
@@ -1,0 +1,117 @@
+# Spec: app-administration
+
+**Status:** proposed
+**Scope:** shillinq
+**Tier:** T0 (platform)
+**Depends on:** none
+
+> Reverse-engineered from observed code (ADR-003 retrofit). Describes the
+> application-administration surface as it ships today.
+
+## ADDED Requirements
+
+### Requirement: REQ-Admin-001 The system SHALL expose the app's configuration through a settings endpoint
+
+Shillinq MUST provide an authenticated settings surface backed by
+`SettingsService`. `GET /apps/shillinq/api/settings` returns the
+managed config keys (`register`, `rgs_template`, `administration_id`)
+plus the derived metadata fields `openregisters` (whether OpenRegister
+is installed) and `isAdmin` (whether the current user is a Nextcloud
+admin). `POST /apps/shillinq/api/settings` persists any supplied managed
+key via `IAppConfig` and returns the refreshed settings. Keys not in the
+managed set are ignored.
+
+#### Scenario: Operator reads current settings
+
+- **GIVEN** shillinq is installed
+- **WHEN** an authenticated user calls `GET /apps/shillinq/api/settings`
+- **THEN** the response MUST contain each managed config key (empty
+  string when unset) plus `openregisters` and `isAdmin` flags.
+
+#### Scenario: Operator updates a managed key
+
+- **GIVEN** an authenticated request to `POST /apps/shillinq/api/settings`
+  with `{ "register": "shillinq" }`
+- **WHEN** the request is processed
+- **THEN** the `register` app-config value MUST be stored as a string and
+  the response MUST report `success: true` with the refreshed `config`.
+
+### Requirement: REQ-Admin-002 The system SHALL support forced re-import of the register configuration
+
+Shillinq MUST offer an operator action that re-imports
+`lib/Settings/shillinq_register.json` into OpenRegister via
+`ConfigurationService::importFromApp()` with `force: true`, regardless of
+the currently-installed version. When OpenRegister is unavailable, the
+configuration file is missing, or the import returns an empty result, the
+action MUST fail gracefully with `success: false` and a human-readable
+message rather than throwing.
+
+#### Scenario: Operator forces a configuration re-import
+
+- **GIVEN** OpenRegister is installed and `shillinq_register.json` is present
+- **WHEN** the operator triggers the `load` action
+- **THEN** the configuration MUST be imported with `force: true` and the
+  response MUST report `success: true` with the imported `version`.
+
+#### Scenario: Re-import attempted without OpenRegister
+
+- **GIVEN** OpenRegister is not installed
+- **WHEN** the `load` action runs
+- **THEN** the response MUST report `success: false` with a message
+  stating OpenRegister is not installed, and MUST NOT throw.
+
+### Requirement: REQ-Admin-003 The system SHALL expose a public health endpoint
+
+Shillinq MUST provide an unauthenticated (`PublicPage`, CSRF-exempt)
+health endpoint that returns a JSON body `{ status: "ok", app: "shillinq" }`,
+suitable for liveness probes and uptime monitors.
+
+#### Scenario: Monitor probes health
+
+- **GIVEN** the app is running
+- **WHEN** any client calls the health endpoint
+- **THEN** the response MUST be JSON with `status: "ok"` and
+  `app: "shillinq"`, requiring no authentication.
+
+### Requirement: REQ-Admin-004 The system SHALL expose an admin-only metrics endpoint
+
+Shillinq MUST provide a metrics endpoint guarded by
+`AuthorizedAdminSetting` that returns a JSON body containing the app id and
+a `metrics` collection. The collection MAY be empty (current placeholder
+shape); the endpoint MUST remain reachable only to authorized admins.
+
+#### Scenario: Admin reads metrics
+
+- **GIVEN** an authorized admin
+- **WHEN** the admin calls the metrics endpoint
+- **THEN** the response MUST be JSON containing `app: "shillinq"` and a
+  `metrics` array (currently empty).
+
+### Requirement: REQ-Admin-005 The frontend SHALL read register data through a generic OpenRegister object store
+
+The Vue shell MUST use a generic Pinia object store that is configured
+once with the OpenRegister object and schema base URLs, lets callers
+register named object types (mapping a type to its register + schema),
+and fetches objects for a registered type via the OpenRegister object
+API (carrying the Nextcloud request token). Fetching an unregistered
+type MUST warn and return an empty list rather than erroring. The
+settings store MUST likewise load and persist settings against the
+shillinq settings endpoint, exposing `hasOpenRegisters` / `isAdmin`
+flags derived from the response.
+
+#### Scenario: Shell fetches objects for a registered type
+
+- **GIVEN** the object store is configured and a type is registered with
+  its register + schema
+- **WHEN** the shell calls `fetchObjects(type)`
+- **THEN** the store MUST request the OpenRegister object API with the
+  mapped register/schema and the request token, and store the returned
+  results under that type.
+
+#### Scenario: Shell fetches an unregistered type
+
+- **GIVEN** the object store is configured
+- **WHEN** the shell calls `fetchObjects` with a type that was never
+  registered
+- **THEN** the store MUST emit a warning and return an empty list without
+  performing a request.

--- a/openspec/changes/retrofit-2026-05-25-app-administration/tasks.md
+++ b/openspec/changes/retrofit-2026-05-25-app-administration/tasks.md
@@ -1,0 +1,29 @@
+# Tasks — retrofit-2026-05-25-app-administration
+
+> Reverse-spec: code already exists. Every task is `[x]`; the work is
+> capturing observed behavior and annotating the covered methods with
+> `@spec` references (ADR-003). No runtime code is modified.
+
+## Tasks
+
+- [x] Task 1: Capture settings read/write behavior — annotate
+  `SettingsController::index`, `SettingsController::create`,
+  `SettingsService::getSettings`, `SettingsService::updateSettings`, and
+  the frontend `settings.js::fetchSettings` / `settings.js::saveSettings`
+  and `Settings.vue::save` against REQ-Admin-001.
+- [x] Task 2: Capture forced configuration re-import — annotate
+  `SettingsController::load` and `SettingsService::loadConfiguration`
+  against REQ-Admin-002.
+- [x] Task 3: Capture the public health endpoint — annotate
+  `HealthController::index` against REQ-Admin-003.
+- [x] Task 4: Capture the admin-only metrics endpoint — annotate
+  `MetricsController::index` against REQ-Admin-004.
+- [x] Task 5: Capture the generic OpenRegister object store — annotate
+  `object.js::configure`, `object.js::registerObjectType`,
+  `object.js::fetchObjects`, and `AdminRoot.vue::created` against
+  REQ-Admin-005.
+
+## Verification
+
+`openspec validate` exits clean on the change folder. Gate-16
+spec-coverage reports 0 uncovered methods after annotation.

--- a/src/App.vue
+++ b/src/App.vue
@@ -34,6 +34,12 @@ export default {
 		CnAppRoot,
 	},
 
+	/**
+	 * Provide the shared objectSidebarState to descendant pages.
+	 *
+	 * @spec exclude Shell glue — CnAppRoot provide/inject channel for the
+	 * sidebar; no app-specific behavior.
+	 */
 	provide() {
 		return {
 			// Provide/inject channel for index/detail pages that auto-mount
@@ -99,11 +105,25 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * Current user's Nextcloud permissions, passed through to CnAppRoot.
+		 *
+		 * @return {Array} Permission list (empty when unavailable).
+		 * @spec exclude Shell glue — reads window.OC permissions for CnAppRoot;
+		 * no app-specific behavior.
+		 */
 		permissions() {
 			return window.OC?.currentUser?.permissions ?? []
 		},
 	},
 
+	/**
+	 * Bring up the Pinia stores for the admin-settings store / future custom
+	 * components before CnAppRoot dispatches pages.
+	 *
+	 * @spec exclude Shell glue — bootstraps stores for CnAppRoot; the store
+	 * behaviors are specced in REQ-Admin-001 / REQ-Admin-005.
+	 */
 	async created() {
 		// Pinia stores still need to come up so the admin-settings store
 		// (AdminRoot.vue) and any future custom components keep working.
@@ -119,6 +139,8 @@ export default {
 		 *
 		 * @param {string} key Translation key.
 		 * @return {string} Translated string (or the key on miss).
+		 * @spec exclude Shell glue — closes over @nextcloud/l10n translate so
+		 * CnAppRoot need not know the app id; no app-specific behavior.
 		 */
 		translateForApp(key) {
 			return ncT('shillinq', key)

--- a/src/store/modules/object.js
+++ b/src/store/modules/object.js
@@ -14,11 +14,27 @@ export const useObjectStore = defineStore('object', {
 	}),
 
 	actions: {
+		/**
+		 * Configure the store with the OpenRegister object/schema base URLs.
+		 *
+		 * @param {object} opts Configuration options.
+		 * @param {string} opts.baseUrl OpenRegister object API base URL.
+		 * @param {string} opts.schemaBaseUrl OpenRegister schema API base URL.
+		 * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-5
+		 */
 		configure({ baseUrl, schemaBaseUrl }) {
 			this.baseUrl = baseUrl
 			this.schemaBaseUrl = schemaBaseUrl
 		},
 
+		/**
+		 * Register a named object type mapped to its register + schema.
+		 *
+		 * @param {string} type Logical object type name.
+		 * @param {string} schema OpenRegister schema slug.
+		 * @param {string} register OpenRegister register slug.
+		 * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-5
+		 */
 		registerObjectType(type, schema, register) {
 			this.objectTypes[type] = { schema, register }
 			if (!this.objects[type]) {
@@ -26,6 +42,15 @@ export const useObjectStore = defineStore('object', {
 			}
 		},
 
+		/**
+		 * Fetch objects for a registered type from the OpenRegister object API.
+		 * Warns and returns an empty list for unregistered types.
+		 *
+		 * @param {string} type Registered object type.
+		 * @param {object} params Extra query parameters.
+		 * @return {Promise<Array>} The fetched objects (empty on miss/error).
+		 * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-5
+		 */
 		async fetchObjects(type, params = {}) {
 			if (!this.objectTypes[type]) {
 				console.warn(`Object type "${type}" is not registered`)

--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -15,6 +15,13 @@ export const useSettingsStore = defineStore('settings', {
 	},
 
 	actions: {
+		/**
+		 * Load app settings from the shillinq settings endpoint and derive
+		 * the hasOpenRegisters / isAdmin flags from the response.
+		 *
+		 * @return {Promise<object|null>} The settings payload, or null on error.
+		 * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-1
+		 */
 		async fetchSettings() {
 			this.loading = true
 			try {
@@ -36,6 +43,13 @@ export const useSettingsStore = defineStore('settings', {
 			return null
 		},
 
+		/**
+		 * Persist app settings to the shillinq settings endpoint.
+		 *
+		 * @param {object} settings The settings to save.
+		 * @return {Promise<object|null>} The refreshed settings, or null on error.
+		 * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-1
+		 */
 		async saveSettings(settings) {
 			this.loading = true
 			try {

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -2,6 +2,15 @@ import { generateUrl } from '@nextcloud/router'
 import { useObjectStore } from './modules/object.js'
 import { useSettingsStore } from './modules/settings.js'
 
+/**
+ * Bootstrap the Pinia stores: point the object store at OpenRegister and
+ * eagerly load settings.
+ *
+ * @return {Promise<object>} The instantiated settings + object stores.
+ * @spec exclude Store bootstrap glue — wires base URLs and triggers the
+ * settings load; the observable behaviors live in the store actions
+ * themselves (see REQ-Admin-001 / REQ-Admin-005).
+ */
 export async function initializeStores() {
 	const settingsStore = useSettingsStore()
 	const objectStore = useObjectStore()

--- a/src/views/settings/AdminRoot.vue
+++ b/src/views/settings/AdminRoot.vue
@@ -36,6 +36,12 @@ export default {
 			appVersion: document.getElementById('shillinq-settings')?.dataset?.version || 'Unknown',
 		}
 	},
+	/**
+	 * Bring up the Pinia stores (object + settings) so the embedded Settings
+	 * form can read register data, then reveal it.
+	 *
+	 * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-5
+	 */
 	async created() {
 		await initializeStores()
 		this.storesReady = true

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -46,11 +46,23 @@ export default {
 			successMessage: '',
 		}
 	},
+	/**
+	 * Prefill the register form field from the loaded settings store.
+	 *
+	 * @spec exclude UI glue — one-line form prefill from store state; no
+	 * observable app behavior beyond seeding the input.
+	 */
 	created() {
 		const settingsStore = useSettingsStore()
 		this.form.register = settingsStore.settings?.register || ''
 	},
 	methods: {
+		/**
+		 * Persist the configuration form via the settings store and show a
+		 * success message.
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-1
+		 */
 		async save() {
 			this.saving = true
 			this.successMessage = ''


### PR DESCRIPTION
## Summary

Drives shillinq gate-16 spec-coverage from **24 uncovered methods (11 backend + 13 frontend) to 0**, annotation-only — no runtime behavior changes.

- **Real behavior → reverse-spec.** New `retrofit-2026-05-25-app-administration` change (5 REQs) captures the application-administration surface: settings read/write, forced register re-import, public health endpoint, admin-only metrics endpoint, and the generic OpenRegister object store. Covered methods carry `@spec` references to its `tasks.md`.
- **Genuine framework glue → `@spec exclude` (reason required).** SPA shell (`DashboardController::page/catchAll`), deep-link scaffold stub (`DeepLinkRegistrationListener::handle`), CnAppRoot bootstrap (`App.vue` provide/permissions/created/translateForApp), store bootstrap (`store.js::initializeStores`), and the one-line form prefill (`Settings.vue::created`).

## Tally

| Disposition | Count |
|---|---|
| Reverse-spec (REQ-Admin-001..005) | 14 |
| `@spec exclude` (reasoned glue) | 10 |
| **Total** | **24** |

## Verification

- gate-16 spec-coverage to **0 uncovered**
- `openspec validate retrofit-2026-05-25-app-administration --strict` to valid
- `php -l` clean on all touched PHP files