### PR TITLE
feat(nav): add Features & roadmap item + page, bump nc-vue beta.101

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl.
     ]]></description>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
     <licence>agpl</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Shillinq</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@conduction/nextcloud-vue": "^1.0.0-beta.97",
+        "@conduction/nextcloud-vue": "^1.0.0-beta.101",
         "@nextcloud/axios": "~2.5.2",
         "@nextcloud/dialogs": "^3.2.0",
         "@nextcloud/initial-state": "^2.2.0",
@@ -521,9 +521,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "1.0.0-beta.97",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.97.tgz",
-      "integrity": "sha512-jlRpA1tjIX3ysP8a42S6lrbrcZfN63yHDzgWMBNaf9Ofs0jvVqqkYawLuEj8vGMU1H4hwvyb0lEOHIsNRmHP6g==",
+      "version": "1.0.0-beta.101",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.101.tgz",
+      "integrity": "sha512-UVxKWUU7pf6oHr7Oly5HWPC1e8OK3z2lmdS5xgs28+sYZPNj53co9+xs3tb0mqCGXZ8Oqit9NMapI8ir0fy2iA==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "dependencies": {
-    "@conduction/nextcloud-vue": "^1.0.0-beta.97",
+    "@conduction/nextcloud-vue": "^1.0.0-beta.101",
     "@nextcloud/axios": "~2.5.2",
     "@nextcloud/dialogs": "^3.2.0",
     "@nextcloud/initial-state": "^2.2.0",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -36,6 +36,14 @@
 			"order": 90
 		},
 		{
+			"id": "FeaturesRoadmapMenu",
+			"label": "Features & roadmap",
+			"icon": "icon-toggle",
+			"route": "FeaturesRoadmap",
+			"section": "footer",
+			"order": 91
+		},
+		{
 			"id": "Settings",
 			"label": "Settings",
 			"icon": "icon-settings",
@@ -45,6 +53,15 @@
 		}
 	],
 	"pages": [
+		{
+			"id": "FeaturesRoadmap",
+			"route": "/features-roadmap",
+			"type": "roadmap",
+			"title": "Features & roadmap",
+			"config": {
+				"documentationUrl": "https://shillinq.conduction.nl"
+			}
+		},
 		{
 			"id": "ChartOfAccounts",
 			"route": "/chart-of-accounts",


### PR DESCRIPTION
## Summary
- Add **Features & roadmap** nav item (section `footer`, order 91) routing to the new `FeaturesRoadmap` page.
- Add the `FeaturesRoadmap` page (`type: roadmap`, `documentationUrl: https://shillinq.conduction.nl`).
- Bump `@conduction/nextcloud-vue` to `1.0.0-beta.101` (package.json + lockfile).
- Bump app version `0.1.1` -> `0.1.2`.

Result: the three nav items (Documentation, Features & roadmap, Settings) all work.

## Test plan
- [ ] Verify nav shows Documentation, Features & roadmap, Settings
- [ ] Features & roadmap opens the roadmap page