### PR TITLE
retrofit: spec-cover preferences API (REQ-PREF-001/002)

### DIFF
--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -60,6 +60,8 @@ class PreferencesController extends Controller
      *
      * @return JSONResponse `{value: string|null}`.
      *
+     * @spec openspec/changes/retrofit-2026-05-26-preferences-api/tasks.md#task-1
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      */
@@ -98,6 +100,8 @@ class PreferencesController extends Controller
      * @param string $value The value to store (empty string clears it).
      *
      * @return JSONResponse `{value: string|null}`.
+     *
+     * @spec openspec/changes/retrofit-2026-05-26-preferences-api/tasks.md#task-2
      *
      * @NoAdminRequired
      * @NoCSRFRequired


### PR DESCRIPTION
## Why

The generic per-user preferences endpoint introduced two uncovered backend methods — `getPreference` / `setPreference` in `lib/Controller/PreferencesController.php` — pushing this repo to 2 uncovered methods on Gate-16 spec coverage. This is a true capability, so it gets a real reverse-spec (not an exclude).

## What

- New reverse-spec change `retrofit-2026-05-26-preferences-api` with capability `preferences-api` (REQ-PREF-001 get / REQ-PREF-002 set).
- `@spec` docblock annotations on both controller methods.
- `openspec validate --strict` green; `python3 /tmp/csc.py . --mode report` → uncovered_count == 0.

Comment-only; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)