### PR TITLE
[change request] shillinq notifications (chained on AR/AP/PO schemas)

### DIFF
--- a/openspec/changes/shillinq-notifications/.openspec.yaml
+++ b/openspec/changes/shillinq-notifications/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/shillinq-notifications/proposal.md
+++ b/openspec/changes/shillinq-notifications/proposal.md
@@ -1,0 +1,89 @@
+---
+kind: config
+depends_on: [notification-updated-field-change-condition]
+---
+
+# Shillinq Notifications
+
+## ⚠ BLOCKED ON DATA MODEL — read first
+
+Shillinq's register today declares only an `Account` schema (plus the scaffold
+`example`). The financial schemas this notification change targets —
+**`Invoice`, `PurchaseOrder`, `Contract`, `Payment`** — **do not exist yet**.
+Notification rules are declared as `x-openregister-notifications` annotations
+**on a schema's properties**, so there is nothing to attach these rules to
+until those schemas are modelled. **This change request therefore documents the
+target state; it cannot be applied until the financial data model lands** (see
+the blocking prerequisite task in tasks.md). Related unmerged Shillinq work
+(`bookkeeping-accounts-receivable-core` introducing `ARInvoice`/`CustomerMaster`,
+`bookkeeping-accounts-payable-core`) is the natural home for these schemas; this
+change should be sequenced after whichever change establishes the canonical
+financial schema names and their `status`/`dueDate`/`renewalDate`/owner fields.
+
+## Why
+
+The fleet notification analysis (`hydra/openspec/fleet-notification-plan.md`,
+shillinq row) recommends finance/procurement notifications: **invoice
+overdue/paid, purchase-order approval chain, contract renewal/expiry**. These
+keep finance and procurement users on top of money-movement and contractual
+deadlines without polling. Shillinq owns no notification code of its own — it
+declares rules on its schemas and the OpenRegister notification engine
+(`notificatie-engine`) delivers them, so this is `kind: config` (declarative
+annotations only) once the schemas exist.
+
+## Prerequisite (must land first)
+
+Model the financial schemas with the fields the rules need:
+
+- **`Invoice`** — `status` (e.g. `draft → issued → paid` / `overdue`),
+  `dueDate`, `ownerUid` (issuer/finance owner).
+- **`PurchaseOrder`** — `status` (`draft → submitted → approved → rejected`),
+  `approverId`, `ownerUid`.
+- **`Contract`** — `status`, `renewalDate` / `expiryDate`, `ownerUid`.
+- **`Payment`** — `status`, links to the `Invoice` it settles, `ownerUid`.
+
+(Field names are indicative; align with the canonical financial schemas from
+the bookkeeping changes once chosen.)
+
+## What Changes (target state, after the prerequisite)
+
+Declare `x-openregister-notifications` on the financial schemas. Subjects are
+bilingual nl/en and metadata-only. Builds on
+`notification-updated-field-change-condition` so status-change rules use
+`updated`+`condition`.
+
+- **Invoice overdue** — `scheduled` deadline check against `dueDate`, or
+  `updated`+`condition` `{"field":"status","operator":"equals","value":"overdue"}`
+  → `{"kind":"field","field":"ownerUid"}` + finance group.
+- **Invoice paid** — `updated`+`condition`
+  `{"field":"status","operator":"equals","value":"paid"}` →
+  `{"kind":"field","field":"ownerUid"}`.
+- **PO submitted for approval** — `updated`+`condition`
+  `{"field":"status","operator":"equals","value":"submitted"}` →
+  `{"kind":"field","field":"approverId"}` (the approval chain).
+- **PO approved / rejected** — `updated`+`condition` on `status` equals
+  `approved` / `rejected` → `{"kind":"field","field":"ownerUid"}`.
+- **Contract renewal / expiry approaching** — `scheduled` deadline check
+  against `renewalDate` / `expiryDate` → `{"kind":"field","field":"ownerUid"}`
+  + a contracts/procurement group.
+
+## Capabilities
+
+### Added Capabilities
+
+- `notifications`: Shillinq declares finance/procurement notification rules
+  (`x-openregister-notifications`) on its `Invoice`, `PurchaseOrder`,
+  `Contract`, and `Payment` schemas — invoice overdue/paid, PO approval chain,
+  contract renewal/expiry — consumed by the OpenRegister `notificatie-engine`.
+  **Gated on the financial data model being modelled first.**
+
+## Impact
+
+- **Config (Shillinq):** `x-openregister-notifications` annotations on the
+  financial schemas in `lib/Settings/shillinq_register.json` (no PHP).
+- **Blocked:** cannot apply until `Invoice`/`PurchaseOrder`/`Contract`/`Payment`
+  schemas (with the listed fields) exist in the register.
+- **Engine dependency:** status-change rules require
+  `notification-updated-field-change-condition` (archived in openregister).
+- **No** new external-email channel needed — all recipients are internal uids
+  (owner/approver) or groups.

--- a/openspec/changes/shillinq-notifications/proposal.md
+++ b/openspec/changes/shillinq-notifications/proposal.md
@@ -1,89 +1,136 @@
 ---
 kind: config
-depends_on: [notification-updated-field-change-condition]
+depends_on:
+  - notification-updated-field-change-condition
+  - add-shillinq-accounts-receivable-core
+  - add-shillinq-accounts-payable-core
+  - bookkeeping-purchase-order-3way
 ---
 
 # Shillinq Notifications
 
-## ⚠ BLOCKED ON DATA MODEL — read first
+## ⚠ BLOCKED until the chained schema changes merge — read first
 
-Shillinq's register today declares only an `Account` schema (plus the scaffold
-`example`). The financial schemas this notification change targets —
-**`Invoice`, `PurchaseOrder`, `Contract`, `Payment`** — **do not exist yet**.
-Notification rules are declared as `x-openregister-notifications` annotations
-**on a schema's properties**, so there is nothing to attach these rules to
-until those schemas are modelled. **This change request therefore documents the
-target state; it cannot be applied until the financial data model lands** (see
-the blocking prerequisite task in tasks.md). Related unmerged Shillinq work
-(`bookkeeping-accounts-receivable-core` introducing `ARInvoice`/`CustomerMaster`,
-`bookkeeping-accounts-payable-core`) is the natural home for these schemas; this
-change should be sequenced after whichever change establishes the canonical
-financial schema names and their `status`/`dueDate`/`renewalDate`/owner fields.
+The financial schemas these notification rules attach to are created by
+**other, still-unmerged Shillinq changes**, not by this one. Notification rules
+are declared as `x-openregister-notifications` annotations **on a schema's
+properties**, so there is nothing to attach to until those schemas land. This
+change is therefore `depends_on`-chained to the changes that own the real
+schemas (see frontmatter) and **cannot be applied until they merge**:
+
+- `add-shillinq-accounts-receivable-core` → creates **`CustomerMaster`,
+  `ARInvoice`, `DunningRecord`** (sales / AR invoicing). `ARInvoice` carries a
+  `state` enum (`draft → issued → partially-paid → paid` / `overdue` /
+  `disputed` / `written-off` / `voided`) and a `dueDate` date field.
+- `add-shillinq-accounts-payable-core` → creates **`VendorMaster`, `APInvoice`,
+  `PaymentRun`** (purchase invoices + payment runs). `APInvoice` carries a
+  `state` enum (`draft → pending → approved → posted → paid` / `disputed` /
+  `voided`), a separate `approvalState` enum (`not-required` / `pending` /
+  `approved` / `rejected`) and a `dueDate`. `PaymentRun` carries a `state` enum
+  (`draft → ready → submitted → executed` / `failed`).
+- `bookkeeping-purchase-order-3way` → creates **`PurchaseOrder`** (plus
+  `PurchaseOrderLine`, `GoodsReceiptNote`, `SupplierInvoice`, `ThreeWayMatch`,
+  …). `PurchaseOrder` carries a `status` enum (`draft → approved → sent →
+  partial_received → fully_received → invoiced → closed` / `cancelled`) and a
+  `requester` field (FK to Person — the employee that initiated the PO).
+
+The earlier draft of this change targeted generic `Invoice` / `PurchaseOrder` /
+`Contract` / `Payment` schemas with invented `ownerUid` / `approverId` fields.
+**Those schemas and fields do not exist.** This revision re-targets the rules
+onto the real schema slugs and real field names listed above. See `## Caveats`
+for the dropped contract rule and the purchase-order recipient note.
 
 ## Why
 
 The fleet notification analysis (`hydra/openspec/fleet-notification-plan.md`,
 shillinq row) recommends finance/procurement notifications: **invoice
-overdue/paid, purchase-order approval chain, contract renewal/expiry**. These
-keep finance and procurement users on top of money-movement and contractual
-deadlines without polling. Shillinq owns no notification code of its own — it
-declares rules on its schemas and the OpenRegister notification engine
-(`notificatie-engine`) delivers them, so this is `kind: config` (declarative
-annotations only) once the schemas exist.
+overdue/paid, the AP approval chain, payment-run ready, and purchase-order
+approval**. These keep finance and procurement users on top of money-movement
+and approval deadlines without polling. Shillinq owns no notification code of
+its own — it declares rules on its schemas and the OpenRegister notification
+engine (`notificatie-engine`) delivers them, so this is `kind: config`
+(declarative annotations only) once the chained schemas exist.
 
-## Prerequisite (must land first)
+## What Changes (target state, after the chained changes merge)
 
-Model the financial schemas with the fields the rules need:
+Declare `x-openregister-notifications` on the real financial schemas. Subjects
+are bilingual nl/en and metadata-only (invoice/PO number, due date — never line
+contents). Status-change rules build on
+`notification-updated-field-change-condition` so they use `updated` + a
+field-change `condition` on the real `state` / `approvalState` / `status`
+field. Deadline rules use `scheduled` with a filter on the real date field.
 
-- **`Invoice`** — `status` (e.g. `draft → issued → paid` / `overdue`),
-  `dueDate`, `ownerUid` (issuer/finance owner).
-- **`PurchaseOrder`** — `status` (`draft → submitted → approved → rejected`),
-  `approverId`, `ownerUid`.
-- **`Contract`** — `status`, `renewalDate` / `expiryDate`, `ownerUid`.
-- **`Payment`** — `status`, links to the `Invoice` it settles, `ownerUid`.
+Recipient note: none of the AR/AP schemas declares a per-object owner/assignee
+**uid** field, so the owner recipient is resolved via
+`{"kind":"object-acl","permission":"manage"}` (the actor who can manage the
+object) rather than an invented uid field. The `PurchaseOrder` schema **does**
+declare a real `requester` uid field, so PO rules can use
+`{"kind":"field","field":"requester"}`.
 
-(Field names are indicative; align with the canonical financial schemas from
-the bookkeeping changes once chosen.)
+Rules (schema → trigger → recipient field):
 
-## What Changes (target state, after the prerequisite)
-
-Declare `x-openregister-notifications` on the financial schemas. Subjects are
-bilingual nl/en and metadata-only. Builds on
-`notification-updated-field-change-condition` so status-change rules use
-`updated`+`condition`.
-
-- **Invoice overdue** — `scheduled` deadline check against `dueDate`, or
-  `updated`+`condition` `{"field":"status","operator":"equals","value":"overdue"}`
-  → `{"kind":"field","field":"ownerUid"}` + finance group.
-- **Invoice paid** — `updated`+`condition`
-  `{"field":"status","operator":"equals","value":"paid"}` →
-  `{"kind":"field","field":"ownerUid"}`.
-- **PO submitted for approval** — `updated`+`condition`
-  `{"field":"status","operator":"equals","value":"submitted"}` →
-  `{"kind":"field","field":"approverId"}` (the approval chain).
-- **PO approved / rejected** — `updated`+`condition` on `status` equals
-  `approved` / `rejected` → `{"kind":"field","field":"ownerUid"}`.
-- **Contract renewal / expiry approaching** — `scheduled` deadline check
-  against `renewalDate` / `expiryDate` → `{"kind":"field","field":"ownerUid"}`
-  + a contracts/procurement group.
+- **`ARInvoice` overdue** — `scheduled` (intervalSec ≥ 86400) with a filter on
+  `state` ≠ `paid`/`written-off`/`voided` and `dueDate` in the past →
+  `{"kind":"object-acl","permission":"manage"}` + the `shillinq-finance` group.
+- **`ARInvoice` paid** — `updated` + `condition`
+  `{"field":"state","operator":"equals","value":"paid"}` →
+  `{"kind":"object-acl","permission":"manage"}`.
+- **`APInvoice` approval needed** — `updated` + `condition`
+  `{"field":"approvalState","operator":"equals","value":"pending"}` →
+  `{"kind":"object-acl","permission":"manage"}` + the `shillinq-finance` group
+  (the eligible approver comes from OR's approval-workflow config, not a schema
+  field — see Caveats).
+- **`APInvoice` approved** — `updated` + `condition`
+  `{"field":"approvalState","operator":"equals","value":"approved"}` →
+  `{"kind":"object-acl","permission":"manage"}`.
+- **`PaymentRun` ready** — `updated` + `condition`
+  `{"field":"state","operator":"equals","value":"ready"}` →
+  `{"kind":"object-acl","permission":"manage"}` + the `shillinq-finance` group.
+- **`PurchaseOrder` submitted for approval** — `created` →
+  `{"kind":"field","field":"requester"}` + the `shillinq-procurement` group.
+- **`PurchaseOrder` approved** — `updated` + `condition`
+  `{"field":"status","operator":"equals","value":"approved"}` →
+  `{"kind":"field","field":"requester"}`.
 
 ## Capabilities
 
 ### Added Capabilities
 
 - `notifications`: Shillinq declares finance/procurement notification rules
-  (`x-openregister-notifications`) on its `Invoice`, `PurchaseOrder`,
-  `Contract`, and `Payment` schemas — invoice overdue/paid, PO approval chain,
-  contract renewal/expiry — consumed by the OpenRegister `notificatie-engine`.
-  **Gated on the financial data model being modelled first.**
+  (`x-openregister-notifications`) on its **`ARInvoice`, `APInvoice`,
+  `PaymentRun`, and `PurchaseOrder`** schemas — AR invoice overdue/paid, AP
+  approval-needed/approved, payment-run ready, PO submitted/approved — consumed
+  by the OpenRegister `notificatie-engine`. **Chained on the AR/AP/PO schema
+  changes landing first (see frontmatter `depends_on`).**
+
+## Caveats
+
+- **No `Contract` schema exists yet** anywhere in Shillinq. The contract
+  renewal/expiry rule from the earlier draft is **deferred** until a contract
+  is modelled (likely a future `bookkeeping-*` change). It is intentionally NOT
+  included here and is NOT chained, to avoid inventing a schema.
+- **AP/PO approver is not a schema field.** AP approval routing comes from OR's
+  approval-workflow configuration (REQ-AP-005), and `PurchaseOrder.approval_chain`
+  is an *array* of approver roles/users, not a single resolvable uid. So the
+  AP approval-needed rule notifies the finance group (the pool eligible to
+  approve) via a group + `object-acl manage`, and the PO submitted rule notifies
+  the `requester` plus the procurement group — neither invents a single-approver
+  uid field. If the AP/PO changes later add a concrete `approverUid` field, a
+  follow-up can narrow these rules to `{"kind":"field","field":"approverUid"}`.
+- **No per-object owner uid field on AR/AP schemas.** Owner-targeted rules use
+  `{"kind":"object-acl","permission":"manage"}` rather than an invented
+  `ownerUid` field.
 
 ## Impact
 
 - **Config (Shillinq):** `x-openregister-notifications` annotations on the
-  financial schemas in `lib/Settings/shillinq_register.json` (no PHP).
-- **Blocked:** cannot apply until `Invoice`/`PurchaseOrder`/`Contract`/`Payment`
-  schemas (with the listed fields) exist in the register.
+  `ARInvoice`, `APInvoice`, `PaymentRun`, and `PurchaseOrder` schemas in
+  `lib/Settings/shillinq_register.json` (no PHP).
+- **Chained:** cannot apply until `add-shillinq-accounts-receivable-core`,
+  `add-shillinq-accounts-payable-core`, and `bookkeeping-purchase-order-3way`
+  land their schemas (frontmatter `depends_on`).
 - **Engine dependency:** status-change rules require
-  `notification-updated-field-change-condition` (archived in openregister).
+  `notification-updated-field-change-condition` (archived in openregister) so
+  `updated` + field-change `condition` dispatches.
 - **No** new external-email channel needed — all recipients are internal uids
-  (owner/approver) or groups.
+  (`requester`), object ACLs (`object-acl manage`), or groups.

--- a/openspec/changes/shillinq-notifications/specs/notifications/spec.md
+++ b/openspec/changes/shillinq-notifications/specs/notifications/spec.md
@@ -1,40 +1,56 @@
 ## ADDED Requirements
 
-### Requirement: Shillinq MUST declare finance and procurement notification rules on its financial schemas
-Shillinq MUST declare `x-openregister-notifications` rules on its `Invoice`, `PurchaseOrder`, `Contract`, and `Payment` schemas, consumed by the OpenRegister `notificatie-engine`. The rules MUST cover invoice overdue and paid, the purchase-order approval chain (submitted / approved / rejected), and contract renewal/expiry. All subjects MUST be provided in both Dutch (`nl`) and English (`en`) and MUST be metadata-only (no financial-document contents in the subject). Status-change rules MUST use the `updated` trigger with a field-change `condition` (per `notification-updated-field-change-condition`); deadline rules MUST use the `scheduled` trigger against the relevant date field.
+### Requirement: Shillinq MUST declare finance and procurement notification rules on its real AR/AP/PO schemas
+Shillinq MUST declare `x-openregister-notifications` rules on its `ARInvoice`, `APInvoice`, `PaymentRun`, and `PurchaseOrder` schemas, consumed by the OpenRegister `notificatie-engine`. The rules MUST cover AR invoice overdue and paid, the AP approval chain (approval-needed and approved), payment-run ready, and the purchase-order approval flow (submitted and approved). All subjects MUST be provided in both Dutch (`nl`) and English (`en`) and MUST be metadata-only (no financial-document line contents in the subject). Status-change rules MUST use the `updated` trigger with a field-change `condition` (per `notification-updated-field-change-condition`) on the real `state` / `approvalState` / `status` field; the AR overdue rule MUST use the `scheduled` trigger with a filter on the real `dueDate` and `state` fields.
 
 These rules are declarative annotations only — Shillinq MUST NOT author app-local notification service code (ADR-031).
 
-This requirement is GATED on the financial data model: the `Invoice`, `PurchaseOrder`, `Contract`, and `Payment` schemas (with `status`, `dueDate`/`renewalDate`/`expiryDate`, and owner/approver fields as applicable) MUST be modelled in the register before these rules can be attached.
+This requirement is CHAINED on the schema-owning changes: the `ARInvoice` / `APInvoice` / `PaymentRun` schemas (`add-shillinq-accounts-receivable-core`, `add-shillinq-accounts-payable-core`) and the `PurchaseOrder` schema (`bookkeeping-purchase-order-3way`) MUST be modelled in the register before these rules can be attached.
 
-#### Scenario: Invoice becomes overdue notifies the owner
-- GIVEN the `Invoice` schema declares an overdue rule (a `scheduled` deadline check against `dueDate`, or an `updated`+`condition` `{"field":"status","operator":"equals","value":"overdue"}`) with recipients `{"kind":"field","field":"ownerUid"}` plus a finance group
-- WHEN an invoice passes its due date without payment (or its `status` becomes `overdue`)
-- THEN the OpenRegister notification engine MUST deliver a notification to the invoice owner and the finance group
+Recipient resolution MUST use only fields that exist on the real schemas: the `PurchaseOrder.requester` uid field for `{"kind":"field"}`, and `{"kind":"object-acl","permission":"manage"}` plus shillinq groups (`shillinq-finance`, `shillinq-procurement`) where no per-object owner/approver uid field exists. No `ownerUid` / `approverId` field MUST be invented.
+
+#### Scenario: AR invoice becomes overdue notifies the manager and finance
+- GIVEN the `ARInvoice` schema declares an overdue rule as a `scheduled` trigger (intervalSec ≥ 86400) filtering on `state` not in `{paid, written-off, voided}` and `dueDate` in the past, with recipients `{"kind":"object-acl","permission":"manage"}` plus the `shillinq-finance` group
+- WHEN an AR invoice passes its `dueDate` without payment
+- THEN the OpenRegister notification engine MUST deliver a notification to the invoice managers and the finance group
 - AND the subject MUST be available in both `nl` and `en` and contain only metadata (e.g. invoice number, due date)
 
-#### Scenario: Invoice paid notifies the owner
-- GIVEN the `Invoice` schema declares an `updated`+`condition` `{"field":"status","operator":"equals","value":"paid"}` rule with recipients `{"kind":"field","field":"ownerUid"}`
-- WHEN an invoice's `status` changes to `paid`
-- THEN the engine MUST deliver a notification to the invoice owner
+#### Scenario: AR invoice paid notifies the manager
+- GIVEN the `ARInvoice` schema declares an `updated` rule with `condition` `{"field":"state","operator":"equals","value":"paid"}` and recipients `{"kind":"object-acl","permission":"manage"}`
+- WHEN an AR invoice's `state` changes to `paid`
+- THEN the engine MUST deliver a notification to the invoice managers
 
-#### Scenario: Purchase order submitted notifies the approver
-- GIVEN the `PurchaseOrder` schema declares an `updated`+`condition` `{"field":"status","operator":"equals","value":"submitted"}` rule with recipients `{"kind":"field","field":"approverId"}`
-- WHEN a purchase order's `status` changes to `submitted`
-- THEN the engine MUST deliver an approval-request notification to the approver
+#### Scenario: AP invoice needs approval notifies finance
+- GIVEN the `APInvoice` schema declares an `updated` rule with `condition` `{"field":"approvalState","operator":"equals","value":"pending"}` and recipients `{"kind":"object-acl","permission":"manage"}` plus the `shillinq-finance` group
+- WHEN an AP invoice's `approvalState` changes to `pending`
+- THEN the engine MUST deliver an approval-request notification to the finance group (the pool eligible to approve), because the eligible approver comes from OR's approval-workflow config and is not a schema field
 
-#### Scenario: Purchase order approved or rejected notifies the owner
-- GIVEN the `PurchaseOrder` schema declares `updated`+`condition` rules on `status` equals `approved` and `rejected` with recipients `{"kind":"field","field":"ownerUid"}`
-- WHEN a purchase order's `status` changes to `approved` (or `rejected`)
-- THEN the engine MUST deliver the corresponding outcome notification to the purchase-order owner
+#### Scenario: AP invoice approved notifies the manager
+- GIVEN the `APInvoice` schema declares an `updated` rule with `condition` `{"field":"approvalState","operator":"equals","value":"approved"}` and recipients `{"kind":"object-acl","permission":"manage"}`
+- WHEN an AP invoice's `approvalState` changes to `approved`
+- THEN the engine MUST deliver the approval-outcome notification to the invoice managers
 
-#### Scenario: Contract renewal approaching notifies the owner
-- GIVEN the `Contract` schema declares a `scheduled` deadline rule against `renewalDate` / `expiryDate` with recipients `{"kind":"field","field":"ownerUid"}` plus a contracts/procurement group
-- WHEN a contract's renewal/expiry date is approaching within the configured window
-- THEN the engine MUST deliver a renewal-reminder notification to the contract owner and the contracts group
-- AND the subject MUST be available in both `nl` and `en`
+#### Scenario: Payment run ready notifies finance
+- GIVEN the `PaymentRun` schema declares an `updated` rule with `condition` `{"field":"state","operator":"equals","value":"ready"}` and recipients `{"kind":"object-acl","permission":"manage"}` plus the `shillinq-finance` group
+- WHEN a payment run's `state` changes to `ready`
+- THEN the engine MUST deliver a "payment run ready" notification to the finance group
 
-#### Scenario: Rules are gated on the financial data model existing
-- GIVEN the register declares only the `Account` schema and not `Invoice`/`PurchaseOrder`/`Contract`/`Payment`
-- WHEN the financial schemas have not yet been modelled
-- THEN these notification rules MUST NOT be attached (there is no schema to annotate), and the change MUST remain blocked until the financial data model lands
+#### Scenario: Purchase order submitted notifies the requester and procurement
+- GIVEN the `PurchaseOrder` schema declares a `created` rule with recipients `{"kind":"field","field":"requester"}` plus the `shillinq-procurement` group
+- WHEN a purchase order is created (submitted into the approval flow)
+- THEN the engine MUST deliver a notification to the PO `requester` and the procurement group, because `approval_chain` is an array of roles/users rather than a single resolvable uid
+
+#### Scenario: Purchase order approved notifies the requester
+- GIVEN the `PurchaseOrder` schema declares an `updated` rule with `condition` `{"field":"status","operator":"equals","value":"approved"}` and recipients `{"kind":"field","field":"requester"}`
+- WHEN a purchase order's `status` changes to `approved`
+- THEN the engine MUST deliver the approval-outcome notification to the PO `requester`
+
+#### Scenario: Contract renewal rule is deferred — no Contract schema exists
+- GIVEN no `Contract` schema exists anywhere in Shillinq
+- WHEN the notification rule set is reviewed
+- THEN no contract renewal/expiry rule MUST be declared, and the rule MUST remain deferred (and unchained) until a contract is modelled, rather than targeting an invented schema
+
+#### Scenario: Rules are chained on the schema-owning changes landing first
+- GIVEN the `ARInvoice` / `APInvoice` / `PaymentRun` / `PurchaseOrder` schemas are not yet present in the register (their owning changes are unmerged)
+- WHEN the financial/procurement schemas have not yet been modelled
+- THEN these notification rules MUST NOT be attached (there is no schema to annotate), and this change MUST remain chained behind `add-shillinq-accounts-receivable-core`, `add-shillinq-accounts-payable-core`, and `bookkeeping-purchase-order-3way`

--- a/openspec/changes/shillinq-notifications/specs/notifications/spec.md
+++ b/openspec/changes/shillinq-notifications/specs/notifications/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Shillinq MUST declare finance and procurement notification rules on its financial schemas
+Shillinq MUST declare `x-openregister-notifications` rules on its `Invoice`, `PurchaseOrder`, `Contract`, and `Payment` schemas, consumed by the OpenRegister `notificatie-engine`. The rules MUST cover invoice overdue and paid, the purchase-order approval chain (submitted / approved / rejected), and contract renewal/expiry. All subjects MUST be provided in both Dutch (`nl`) and English (`en`) and MUST be metadata-only (no financial-document contents in the subject). Status-change rules MUST use the `updated` trigger with a field-change `condition` (per `notification-updated-field-change-condition`); deadline rules MUST use the `scheduled` trigger against the relevant date field.
+
+These rules are declarative annotations only — Shillinq MUST NOT author app-local notification service code (ADR-031).
+
+This requirement is GATED on the financial data model: the `Invoice`, `PurchaseOrder`, `Contract`, and `Payment` schemas (with `status`, `dueDate`/`renewalDate`/`expiryDate`, and owner/approver fields as applicable) MUST be modelled in the register before these rules can be attached.
+
+#### Scenario: Invoice becomes overdue notifies the owner
+- GIVEN the `Invoice` schema declares an overdue rule (a `scheduled` deadline check against `dueDate`, or an `updated`+`condition` `{"field":"status","operator":"equals","value":"overdue"}`) with recipients `{"kind":"field","field":"ownerUid"}` plus a finance group
+- WHEN an invoice passes its due date without payment (or its `status` becomes `overdue`)
+- THEN the OpenRegister notification engine MUST deliver a notification to the invoice owner and the finance group
+- AND the subject MUST be available in both `nl` and `en` and contain only metadata (e.g. invoice number, due date)
+
+#### Scenario: Invoice paid notifies the owner
+- GIVEN the `Invoice` schema declares an `updated`+`condition` `{"field":"status","operator":"equals","value":"paid"}` rule with recipients `{"kind":"field","field":"ownerUid"}`
+- WHEN an invoice's `status` changes to `paid`
+- THEN the engine MUST deliver a notification to the invoice owner
+
+#### Scenario: Purchase order submitted notifies the approver
+- GIVEN the `PurchaseOrder` schema declares an `updated`+`condition` `{"field":"status","operator":"equals","value":"submitted"}` rule with recipients `{"kind":"field","field":"approverId"}`
+- WHEN a purchase order's `status` changes to `submitted`
+- THEN the engine MUST deliver an approval-request notification to the approver
+
+#### Scenario: Purchase order approved or rejected notifies the owner
+- GIVEN the `PurchaseOrder` schema declares `updated`+`condition` rules on `status` equals `approved` and `rejected` with recipients `{"kind":"field","field":"ownerUid"}`
+- WHEN a purchase order's `status` changes to `approved` (or `rejected`)
+- THEN the engine MUST deliver the corresponding outcome notification to the purchase-order owner
+
+#### Scenario: Contract renewal approaching notifies the owner
+- GIVEN the `Contract` schema declares a `scheduled` deadline rule against `renewalDate` / `expiryDate` with recipients `{"kind":"field","field":"ownerUid"}` plus a contracts/procurement group
+- WHEN a contract's renewal/expiry date is approaching within the configured window
+- THEN the engine MUST deliver a renewal-reminder notification to the contract owner and the contracts group
+- AND the subject MUST be available in both `nl` and `en`
+
+#### Scenario: Rules are gated on the financial data model existing
+- GIVEN the register declares only the `Account` schema and not `Invoice`/`PurchaseOrder`/`Contract`/`Payment`
+- WHEN the financial schemas have not yet been modelled
+- THEN these notification rules MUST NOT be attached (there is no schema to annotate), and the change MUST remain blocked until the financial data model lands

--- a/openspec/changes/shillinq-notifications/tasks.md
+++ b/openspec/changes/shillinq-notifications/tasks.md
@@ -1,28 +1,30 @@
-## 1. PREREQUISITE — model the financial schemas (BLOCKING)
+## 1. Prerequisite (chained via depends_on)
 
-- [ ] 1.1 Model the `Invoice` schema (`status` with `draft → issued → paid` / `overdue`, `dueDate`, `ownerUid`) in `lib/Settings/shillinq_register.json`. Align names with the canonical bookkeeping financial schemas (`bookkeeping-accounts-receivable-core`) if those land first.
-- [ ] 1.2 Model the `PurchaseOrder` schema (`status` with `draft → submitted → approved → rejected`, `approverId`, `ownerUid`).
-- [ ] 1.3 Model the `Contract` schema (`status`, `renewalDate`/`expiryDate`, `ownerUid`).
-- [ ] 1.4 Model the `Payment` schema (`status`, link to settled `Invoice`, `ownerUid`).
-- [ ] 1.5 Confirm `notification-updated-field-change-condition` is available in the deployed OpenRegister (it is archived) so `updated`+`condition` rules dispatch.
+- [ ] 1.1 The AR/AP/PO schema changes land their schemas first — `add-shillinq-accounts-receivable-core` (`ARInvoice`), `add-shillinq-accounts-payable-core` (`APInvoice`, `PaymentRun`), `bookkeeping-purchase-order-3way` (`PurchaseOrder`). Tracked via frontmatter `depends_on`; this change cannot be applied until they merge.
+- [ ] 1.2 Confirm `notification-updated-field-change-condition` is available in the deployed OpenRegister (it is archived) so `updated` + field-change `condition` rules dispatch.
 
-## 2. Declare notification rules (after the prerequisite)
+## 2. Declare notification rules on the real schemas
 
-- [ ] 2.1 `Invoice` overdue rule — `scheduled` against `dueDate` (or `updated`+`condition` equals `overdue`) → `{"kind":"field","field":"ownerUid"}` + finance group; bilingual metadata-only subject.
-- [ ] 2.2 `Invoice` paid rule — `updated`+`condition` equals `paid` → `{"kind":"field","field":"ownerUid"}`.
-- [ ] 2.3 `PurchaseOrder` submitted rule — `updated`+`condition` equals `submitted` → `{"kind":"field","field":"approverId"}`.
-- [ ] 2.4 `PurchaseOrder` approved/rejected rules — `updated`+`condition` equals `approved` / `rejected` → `{"kind":"field","field":"ownerUid"}`.
-- [ ] 2.5 `Contract` renewal/expiry rule — `scheduled` against `renewalDate`/`expiryDate` → `{"kind":"field","field":"ownerUid"}` + contracts/procurement group.
+- [ ] 2.1 `ARInvoice` overdue — `scheduled` (intervalSec ≥ 86400) filtering `state` not in `{paid, written-off, voided}` and `dueDate` in the past → `{"kind":"object-acl","permission":"manage"}` + `shillinq-finance` group; bilingual metadata-only subject.
+- [ ] 2.2 `ARInvoice` paid — `updated` + `condition` `{"field":"state","operator":"equals","value":"paid"}` → `{"kind":"object-acl","permission":"manage"}`.
+- [ ] 2.3 `APInvoice` approval-needed — `updated` + `condition` `{"field":"approvalState","operator":"equals","value":"pending"}` → `{"kind":"object-acl","permission":"manage"}` + `shillinq-finance` group.
+- [ ] 2.4 `APInvoice` approved — `updated` + `condition` `{"field":"approvalState","operator":"equals","value":"approved"}` → `{"kind":"object-acl","permission":"manage"}`.
+- [ ] 2.5 `PaymentRun` ready — `updated` + `condition` `{"field":"state","operator":"equals","value":"ready"}` → `{"kind":"object-acl","permission":"manage"}` + `shillinq-finance` group.
+- [ ] 2.6 `PurchaseOrder` submitted — `created` → `{"kind":"field","field":"requester"}` + `shillinq-procurement` group.
+- [ ] 2.7 `PurchaseOrder` approved — `updated` + `condition` `{"field":"status","operator":"equals","value":"approved"}` → `{"kind":"field","field":"requester"}`.
+- [ ] 2.8 Do NOT declare a contract renewal/expiry rule — no `Contract` schema exists; the rule stays deferred (see proposal `## Caveats`).
 
 ## 3. Validate
 
-- [ ] 3.1 Run OpenRegister's `NotificationAnnotationValidator` shape over the declared rules (valid trigger/recipient/subject shapes).
-- [ ] 3.2 Verify all subjects carry both `nl` and `en` keys.
-- [ ] 3.3 Browser-verify a representative rule dispatches end-to-end (status change → in-app notification) once schemas + engine are deployed.
+- [ ] 3.1 Run OpenRegister's notification-annotation validation over the declared rules (valid `trigger` / `recipients` / `subject` shapes per the `x-openregister-notifications` dialect).
+- [ ] 3.2 Verify all subjects carry both `nl` and `en` keys and are metadata-only.
+- [ ] 3.3 Browser-verify a representative rule dispatches end-to-end (state change → in-app notification) once the chained schemas + engine are deployed.
 
 ## Acceptance criteria
 
-- The financial schemas (`Invoice`, `PurchaseOrder`, `Contract`, `Payment`) exist with the fields the rules reference.
-- `x-openregister-notifications` rules cover invoice overdue/paid, PO approval chain, contract renewal/expiry.
+- The `ARInvoice`, `APInvoice`, `PaymentRun`, and `PurchaseOrder` schemas exist (via the chained changes) with the `state` / `approvalState` / `status`, `dueDate`, and `requester` fields the rules reference.
+- `x-openregister-notifications` rules cover AR overdue/paid, AP approval-needed/approved, payment-run ready, and PO submitted/approved.
+- Recipients use only real fields (`PurchaseOrder.requester`) or `object-acl` / group kinds — no invented `ownerUid` / `approverId` field.
+- No contract rule is declared (no `Contract` schema yet); it is deferred.
 - All subjects are bilingual (nl/en) and metadata-only.
 - No app-local notification service code is authored (ADR-031); rules are declarative annotations only.

--- a/openspec/changes/shillinq-notifications/tasks.md
+++ b/openspec/changes/shillinq-notifications/tasks.md
@@ -1,0 +1,28 @@
+## 1. PREREQUISITE — model the financial schemas (BLOCKING)
+
+- [ ] 1.1 Model the `Invoice` schema (`status` with `draft → issued → paid` / `overdue`, `dueDate`, `ownerUid`) in `lib/Settings/shillinq_register.json`. Align names with the canonical bookkeeping financial schemas (`bookkeeping-accounts-receivable-core`) if those land first.
+- [ ] 1.2 Model the `PurchaseOrder` schema (`status` with `draft → submitted → approved → rejected`, `approverId`, `ownerUid`).
+- [ ] 1.3 Model the `Contract` schema (`status`, `renewalDate`/`expiryDate`, `ownerUid`).
+- [ ] 1.4 Model the `Payment` schema (`status`, link to settled `Invoice`, `ownerUid`).
+- [ ] 1.5 Confirm `notification-updated-field-change-condition` is available in the deployed OpenRegister (it is archived) so `updated`+`condition` rules dispatch.
+
+## 2. Declare notification rules (after the prerequisite)
+
+- [ ] 2.1 `Invoice` overdue rule — `scheduled` against `dueDate` (or `updated`+`condition` equals `overdue`) → `{"kind":"field","field":"ownerUid"}` + finance group; bilingual metadata-only subject.
+- [ ] 2.2 `Invoice` paid rule — `updated`+`condition` equals `paid` → `{"kind":"field","field":"ownerUid"}`.
+- [ ] 2.3 `PurchaseOrder` submitted rule — `updated`+`condition` equals `submitted` → `{"kind":"field","field":"approverId"}`.
+- [ ] 2.4 `PurchaseOrder` approved/rejected rules — `updated`+`condition` equals `approved` / `rejected` → `{"kind":"field","field":"ownerUid"}`.
+- [ ] 2.5 `Contract` renewal/expiry rule — `scheduled` against `renewalDate`/`expiryDate` → `{"kind":"field","field":"ownerUid"}` + contracts/procurement group.
+
+## 3. Validate
+
+- [ ] 3.1 Run OpenRegister's `NotificationAnnotationValidator` shape over the declared rules (valid trigger/recipient/subject shapes).
+- [ ] 3.2 Verify all subjects carry both `nl` and `en` keys.
+- [ ] 3.3 Browser-verify a representative rule dispatches end-to-end (status change → in-app notification) once schemas + engine are deployed.
+
+## Acceptance criteria
+
+- The financial schemas (`Invoice`, `PurchaseOrder`, `Contract`, `Payment`) exist with the fields the rules reference.
+- `x-openregister-notifications` rules cover invoice overdue/paid, PO approval chain, contract renewal/expiry.
+- All subjects are bilingual (nl/en) and metadata-only.
+- No app-local notification service code is authored (ADR-031); rules are declarative annotations only.


### PR DESCRIPTION
## shillinq notifications — re-targeted onto the real AR/AP/PO schemas

This change request declares `x-openregister-notifications` rules on Shillinq's
**real** financial/procurement schemas. The earlier draft targeted generic
`Invoice`/`PurchaseOrder`/`Contract`/`Payment` schemas with invented
`ownerUid`/`approverId` fields that **do not exist**. This revision re-targets
onto the actual schema slugs + field names and chains the change correctly.

### Real schemas this targets (owned by other, still-unmerged changes)
- `add-shillinq-accounts-receivable-core` → `ARInvoice` (`state`, `dueDate`)
- `add-shillinq-accounts-payable-core` → `APInvoice` (`state`, `approvalState`, `dueDate`), `PaymentRun` (`state`)
- `bookkeeping-purchase-order-3way` → `PurchaseOrder` (`status`, `requester`)

### Rule set (schema → trigger → recipient)
- `ARInvoice` overdue — `scheduled` (filter `state`≠paid/written-off/voided, `dueDate` past) → object-acl manage + `shillinq-finance`
- `ARInvoice` paid — `updated`+`{state==paid}` → object-acl manage
- `APInvoice` approval-needed — `updated`+`{approvalState==pending}` → object-acl manage + `shillinq-finance`
- `APInvoice` approved — `updated`+`{approvalState==approved}` → object-acl manage
- `PaymentRun` ready — `updated`+`{state==ready}` → object-acl manage + `shillinq-finance`
- `PurchaseOrder` submitted — `created` → `field:requester` + `shillinq-procurement`
- `PurchaseOrder` approved — `updated`+`{status==approved}` → `field:requester`

### Deferred / not invented
- **No `Contract` schema exists** → the contract renewal/expiry rule is **dropped/deferred** (documented under `## Caveats`), not invented.
- No per-object owner uid on AR/AP → owner resolved via `object-acl manage`, not a fabricated `ownerUid`.
- AP/PO approver is not a single schema field (OR approval-workflow / `approval_chain` array) → notifies finance/procurement group + requester, no fabricated `approverId`.

### Chain (`depends_on`)
`notification-updated-field-change-condition`, `add-shillinq-accounts-receivable-core`, `add-shillinq-accounts-payable-core`, `bookkeeping-purchase-order-3way`.

### Status
**DRAFT — do not merge.** The schemas these rules attach to do not exist until
the three chained changes land. `openspec validate shillinq-notifications --strict` passes.