### PR TITLE
fix(security): clear Bucket-B (auth/routing fixes)

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -24,6 +24,7 @@ namespace OCA\Shillinq\Controller;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -50,12 +51,11 @@ class SettingsController extends Controller
     /**
      * Retrieve all current settings.
      *
-     * @NoAdminRequired
-     *
      * @return JSONResponse
      *
      * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-1
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function index(): JSONResponse
     {
         return new JSONResponse(
@@ -70,6 +70,7 @@ class SettingsController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-1
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function create(): JSONResponse
     {
         $data   = $this->request->getParams();
@@ -93,6 +94,7 @@ class SettingsController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-2
      */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
     public function load(): JSONResponse
     {
         $result = $this->settingsService->loadConfiguration(force: true);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10,3 +10,7 @@ parameters:
 			message: "#^Parameter \\#1 \\$settings of attribute class OCP\\\\AppFramework\\\\Http\\\\Attribute\\\\AuthorizedAdminSetting constructor expects class\\-string\\<OCP\\\\Settings\\\\IDelegatedSettings\\>, string given\\.$#"
 			count: 1
 			path: lib/Controller/MetricsController.php
+		-
+			message: "#^Parameter \\#1 \\$settings of attribute class OCP\\\\AppFramework\\\\Http\\\\Attribute\\\\AuthorizedAdminSetting constructor expects class\\-string\\<OCP\\\\Settings\\\\IDelegatedSettings\\>, string given\\.$#"
+			count: 3
+			path: lib/Controller/SettingsController.php


### PR DESCRIPTION
## Summary

- **Gate-5 route-auth**: `SettingsController::load()` was routed in `appinfo/routes.php` but had no auth attribute (every routed method must declare its posture).
- **Gate-7 no-admin-idor**: `SettingsController::index()` carried `@NoAdminRequired` without a body guard; `SettingsController::create()` had no auth attribute at all.
- **Fix**: All three methods (`index` / `create` / `load`) are admin-only app-config plumbing. Replaced `@NoAdminRequired` + bare bodies with `#[AuthorizedAdminSetting(Application::APP_ID)]` on each — matching the scholiq PR #169 and mydash pattern.
- **phpstan-baseline**: Added 3 entries for the known `AuthorizedAdminSetting` class-string false-positive (same message already present in baseline for `MetricsController`).
- **ADR-023 action-auth kit**: NOT ported — no user-level mutating endpoints exist in shillinq; all settings operations are admin-only. No `requireAction()` calls needed.

## Gate results

| Gate | Before | After |
|------|--------|-------|
| gate-5 route-auth | FAIL (1 finding: `load` missing attribute) | PASS |
| gate-7 no-admin-idor | FAIL (2 findings: `index` no guard, `create` no guard) | PASS |
| All other gates | PASS | PASS |

## Auth posture decisions

| Controller::method | Before | After | Rationale |
|---|---|---|---|
| `SettingsController::index` | `@NoAdminRequired` + no body guard | `#[AuthorizedAdminSetting]` | App config read — admin plumbing |
| `SettingsController::create` | no attribute + no guard | `#[AuthorizedAdminSetting]` | App config write — admin plumbing |
| `SettingsController::load` | no attribute | `#[AuthorizedAdminSetting]` | Re-imports register config via OpenRegister — admin plumbing |

## Routes changed

None — `appinfo/routes.php` URLs, verbs, and slugs are unchanged.

## Verification

- All 18 Hydra gates green (post-fix scan)
- `php -l` clean on all edited PHP files
- `composer install --ignore-platform-reqs` + `vendor/bin/phpstan analyse` → no errors (3 `AuthorizedAdminSetting` false-positives added to baseline)
- No Vue files touched — no frontend build required

Refs #352