### PR TITLE
fix: replace non-existent OR ObjectService methods with real API

### DIFF
--- a/lib/Guard/AccountBalanceGuard.php
+++ b/lib/Guard/AccountBalanceGuard.php
@@ -64,9 +64,9 @@ class AccountBalanceGuard
      * exists yet (T2 `bookkeeping-general-ledger` introduces it). Returns
      * true unconditionally with a debug log noting the deferral.
      *
-     * **T2+ behaviour:** computes `SUM(GLLine.debit) - SUM(GLLine.credit)`
-     * for `accountNumber + administrationId` via OR's aggregation API.
-     * Returns true iff the sum is zero.
+     * **T2+ behaviour:** retrieves all GLLine records for the account via
+     * OR's real `setRegister()->setSchema()->findAll()` API and sums
+     * debit minus credit in PHP. Returns true iff the sum is zero.
      *
      * @param array<string, mixed> $account Account object array (loaded by OR)
      *
@@ -86,23 +86,33 @@ class AccountBalanceGuard
 
         try {
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-            $sum           = $objectService->aggregate(
-                register: 'shillinq',
-                schema: 'GLLine',
-                aggregate: ['debit_minus_credit' => 'SUM(debit) - SUM(credit)'],
-                filter: [
-                    'accountNumber'    => ($account['accountNumber'] ?? ''),
-                    'administrationId' => ($account['administrationId'] ?? ''),
-                ]
+            $lines         = $objectService
+                ->setRegister('shillinq')
+                ->setSchema('GLLine')
+                ->findAll(
+                        [
+                            'filters' => [
+                                'accountNumber'    => ($account['accountNumber'] ?? ''),
+                                'administrationId' => ($account['administrationId'] ?? ''),
+                            ],
+                        ]
+                        );
+
+            $balance = array_sum(
+                array_map(
+                    static fn($line) => (float) ($line['debit'] ?? 0) - (float) ($line['credit'] ?? 0),
+                    $lines
+                )
             );
-            return ((int) ($sum['debit_minus_credit'] ?? 0)) === 0;
+
+            return $balance === 0.0;
         } catch (\Throwable $e) {
             $this->logger->error(
                 'AccountBalanceGuard: balance computation failed — denying archive (fail-closed)',
                 ['exception' => $e->getMessage()]
             );
             return false;
-        }
+        }//end try
     }//end requireZeroBalance()
 
     /**
@@ -129,33 +139,43 @@ class AccountBalanceGuard
 
         try {
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-            $existing      = $objectService->findObjects(
-                register: 'shillinq',
-                schema: 'Account',
-                params: [
-                    'administrationId' => ($account['administrationId'] ?? ''),
-                    'isClosingAccount' => true,
-                    '_limit'           => 2,
-                ]
-            );
+            $existing      = $objectService
+                ->setRegister('shillinq')
+                ->setSchema('Account')
+                ->findAll(
+                        [
+                            'filters' => [
+                                'administrationId' => ($account['administrationId'] ?? ''),
+                                'isClosingAccount' => true,
+                            ],
+                            'limit'   => 2,
+                        ]
+                        );
 
             // Filter out the current account (by id, if persisted; by accountNumber otherwise).
+            // Defence-in-depth: also verify administrationId matches to prevent cross-tenant leakage.
             $currentId            = ($account['id'] ?? null);
             $currentAccountNumber = ($account['accountNumber'] ?? null);
+            $currentAdminId       = ($account['administrationId'] ?? null);
             $otherClosing         = array_filter(
-                    $existing,
-                    static function ($candidate) use ($currentId, $currentAccountNumber) {
-                        if ($currentId !== null && ($candidate['id'] ?? null) === $currentId) {
-                            return false;
-                        }
-
-                        if ($currentId === null && ($candidate['accountNumber'] ?? null) === $currentAccountNumber) {
-                            return false;
-                        }
-
-                        return true;
+                $existing,
+                static function ($candidate) use ($currentId, $currentAccountNumber, $currentAdminId) {
+                    // Cross-tenant defence: only consider candidates in the same administration.
+                    if ($currentAdminId !== null && ($candidate['administrationId'] ?? null) !== $currentAdminId) {
+                        return false;
                     }
-                    );
+
+                    if ($currentId !== null && ($candidate['id'] ?? null) === $currentId) {
+                        return false;
+                    }
+
+                    if ($currentId === null && ($candidate['accountNumber'] ?? null) === $currentAccountNumber) {
+                        return false;
+                    }
+
+                    return true;
+                }
+            );
 
             return count($otherClosing) === 0;
         } catch (\Throwable $e) {
@@ -168,9 +188,9 @@ class AccountBalanceGuard
     }//end requireSingleClosingAccount()
 
     /**
-     * Probe whether the GLLine register is declared (i.e. T2 has shipped).
-     *
-     * Lazy check via ObjectService → schema lookup; absence treated as T1 state.
+     * Probe whether the GLLine schema is declared in the shillinq register
+     * (i.e. T2 has shipped). Uses OR's real API: attempt to find the schema
+     * via setRegister + setSchema; absence is treated as T1 state.
      *
      * @return bool True when the GLLine schema exists in OR's `shillinq` register.
      */
@@ -178,8 +198,8 @@ class AccountBalanceGuard
     {
         try {
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-            $schemas       = $objectService->getSchemas(register: 'shillinq');
-            return isset($schemas['GLLine']);
+            $objectService->setRegister('shillinq')->setSchema('GLLine');
+            return true;
         } catch (\Throwable) {
             return false;
         }

--- a/lib/Listener/DeepLinkRegistrationListener.php
+++ b/lib/Listener/DeepLinkRegistrationListener.php
@@ -32,19 +32,23 @@ use OCP\EventDispatcher\IEventListener;
  * will link directly to the relevant detail views in the app.
  *
  * @implements IEventListener<Event>
+ *
+ * @spec openspec/changes/add-shillinq-chart-of-accounts/specs/bookkeeping-chart-of-accounts/spec.md
  */
 class DeepLinkRegistrationListener implements IEventListener
 {
     /**
      * Handle the deep link registration event.
      *
+     * Registers deep links for real Shillinq schemas. The `account` schema is
+     * the only schema present in T1. Additional schemas (invoice, payment, etc.)
+     * should be added here once their Vue detail routes are implemented.
+     *
      * @param Event $event The event to handle
      *
      * @return void
      *
-     * @spec exclude Scaffold stub — registers the placeholder `example` schema
-     * deep link only; OpenRegister search-provider event wiring with no real
-     * shillinq behavior yet. To be reverse-specced when domain pages land.
+     * @spec openspec/changes/add-shillinq-chart-of-accounts/specs/bookkeeping-chart-of-accounts/spec.md
      */
     public function handle(Event $event): void
     {
@@ -52,14 +56,12 @@ class DeepLinkRegistrationListener implements IEventListener
             return;
         }
 
-        // Register example object deep links.
-        // Replace 'shillinq' with your app ID and update the register slug,
-        // schema slug, and URL template to match your app's actual schemas.
+        // Register deep link for the Account schema (T1 schema).
         $event->register(
             appId: 'shillinq',
             registerSlug: 'shillinq',
-            schemaSlug: 'example',
-            urlTemplate: '/apps/shillinq/#/examples/{uuid}'
+            schemaSlug: 'account',
+            urlTemplate: '/apps/shillinq/#/accounts/{uuid}'
         );
 
     }//end handle()

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -259,15 +259,18 @@ class SettingsService
         foreach ($accounts as $account) {
             $account['administrationId'] = $administrationId;
 
-            $existing = $objectService->findObjects(
-                register: 'shillinq',
-                schema: 'Account',
-                params: [
-                    'accountNumber'    => $account['accountNumber'],
-                    'administrationId' => $administrationId,
-                    '_limit'           => 1,
-                ]
-            );
+            $existing = $objectService
+                ->setRegister('shillinq')
+                ->setSchema('Account')
+                ->findAll(
+                        [
+                            'filters' => [
+                                'accountNumber'    => $account['accountNumber'],
+                                'administrationId' => $administrationId,
+                            ],
+                            'limit'   => 1,
+                        ]
+                        );
 
             if (empty($existing) === false) {
                 $skipped++;
@@ -275,9 +278,9 @@ class SettingsService
             }
 
             $objectService->saveObject(
+                object: $account,
                 register: 'shillinq',
                 schema: 'Account',
-                object: $account
             );
             $seeded++;
         }//end foreach
@@ -374,13 +377,38 @@ class SettingsService
             );
 
             if (empty($result) === false) {
+                $errors   = ($result['errors'] ?? []);
+                $warnings = ($result['warnings'] ?? []);
+
+                if (empty($errors) === false) {
+                    $this->logger->error(
+                        'Shillinq: register configuration imported with errors',
+                        ['errors' => $errors]
+                    );
+                    return [
+                        'success'  => false,
+                        'message'  => 'Configuration import completed with errors.',
+                        'errors'   => $errors,
+                        'warnings' => $warnings,
+                        'version'  => ($result['version'] ?? 'unknown'),
+                    ];
+                }
+
+                if (empty($warnings) === false) {
+                    $this->logger->warning(
+                        'Shillinq: register configuration imported with warnings',
+                        ['warnings' => $warnings]
+                    );
+                }
+
                 $this->logger->info('Shillinq: register configuration imported successfully');
                 return [
-                    'success' => true,
-                    'message' => 'Configuration imported successfully.',
-                    'version' => ($result['version'] ?? 'unknown'),
+                    'success'  => true,
+                    'message'  => 'Configuration imported successfully.',
+                    'warnings' => $warnings,
+                    'version'  => ($result['version'] ?? 'unknown'),
                 ];
-            }
+            }//end if
 
             return [
                 'success' => false,

--- a/tests/unit/Controller/SettingsControllerTest.php
+++ b/tests/unit/Controller/SettingsControllerTest.php
@@ -124,7 +124,7 @@ class SettingsControllerTest extends TestCase
     }//end testCreateCallsUpdateSettingsAndReturnsSuccess()
 
     /**
-     * Test that load() returns the result of loadConfiguration.
+     * Test that load() returns the result of loadConfigurationForced.
      *
      * @return void
      */
@@ -137,8 +137,7 @@ class SettingsControllerTest extends TestCase
         ];
 
         $this->settingsService->expects($this->once())
-            ->method('loadConfiguration')
-            ->with(force: true)
+            ->method('loadConfigurationForced')
             ->willReturn($loadResult);
 
         $result = $this->controller->load();


### PR DESCRIPTION
## Summary

- Replaces three non-existent `ObjectService` method calls (`aggregate`, `findObjects`, `getSchemas`) in `AccountBalanceGuard` with the real OR API (`setRegister()->setSchema()->findAll()`), unblocking archive and closing-account save operations that were silently fail-closing on every call (#356)
- Adds `administrationId` equality check to the closing-account dedup closure as defence-in-depth against cross-tenant data leakage (#360)
- Fixes `SettingsService::importAccounts` to use `setRegister/setSchema/findAll` instead of non-existent `findObjects`, so the chart of accounts seeds correctly on fresh install (#357)
- Inspects `errors`/`warnings` arrays from `importFromApp` result and downgrades to failure response when errors are present (#361)
- Replaces the placeholder `example` schema registration in `DeepLinkRegistrationListener` with the real `account` schema and correct Vue route (#365)
- Fixes `SettingsControllerTest` to match the `loadConfigurationForced()` method the controller actually calls

## Closes
Closes #356, #357, #360, #361, #365

## Test plan
- [ ] PHPCS: `composer check:strict` passes with no errors
- [ ] PHPStan: no errors on changed files
- [ ] PHPMD: no violations on changed files
- [ ] `AccountBalanceGuard::requireZeroBalance` returns `true` in T1 (no GLLine schema) and computes from `findAll` in T2
- [ ] `AccountBalanceGuard::requireSingleClosingAccount` correctly blocks a second closing-account in the same administration
- [ ] `SettingsService::seedRgsTemplate` seeds 143 MKB accounts on fresh install without throwing
- [ ] `loadConfiguration` returns `success: false` with `errors` array when `importFromApp` returns errors
- [ ] Unified search deep link for `account` schema routes to `/apps/shillinq/#/accounts/{uuid}`