### PR TITLE
fix: integer-cent balance check, skip-seed on missing admin-id, and pagination

### DIFF
--- a/lib/Guard/AccountBalanceGuard.php
+++ b/lib/Guard/AccountBalanceGuard.php
@@ -86,26 +86,40 @@ class AccountBalanceGuard
 
         try {
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-            $lines         = $objectService
-                ->setRegister('shillinq')
-                ->setSchema('GLLine')
-                ->findAll(
+
+            // Page through all GLLine records in batches to avoid hitting the
+            // default findAll() limit when an account has many postings (L1).
+            $pageSize = 500;
+            $page     = 1;
+            $lines    = [];
+            do {
+                $batch = $objectService
+                    ->setRegister('shillinq')
+                    ->setSchema('GLLine')
+                    ->findAll(
                         [
                             'filters' => [
                                 'accountNumber'    => ($account['accountNumber'] ?? ''),
                                 'administrationId' => ($account['administrationId'] ?? ''),
                             ],
+                            'limit'  => $pageSize,
+                            'offset' => ($page - 1) * $pageSize,
                         ]
-                        );
+                    );
+                $lines = array_merge($lines, $batch);
+                $page++;
+            } while (count($batch) === $pageSize);
 
-            $balance = array_sum(
+            // Use integer cents to avoid IEEE-754 float equality issues (C1).
+            // 0.1 + 0.2 - 0.3 in floats ≠ 0.0, but (10 + 20 - 30) === 0.
+            $balanceCents = array_sum(
                 array_map(
-                    static fn($line) => (float) ($line['debit'] ?? 0) - (float) ($line['credit'] ?? 0),
+                    static fn($line) => (int) round(((float) ($line['debit'] ?? 0) - (float) ($line['credit'] ?? 0)) * 100),
                     $lines
                 )
             );
 
-            return $balance === 0.0;
+            return $balanceCents === 0;
         } catch (\Throwable $e) {
             $this->logger->error(
                 'AccountBalanceGuard: balance computation failed — denying archive (fail-closed)',
@@ -139,6 +153,8 @@ class AccountBalanceGuard
 
         try {
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+            // No LIMIT: we need ALL closing accounts in the administration so we
+            // can correctly exclude the current record and count the remainder (L2).
             $existing      = $objectService
                 ->setRegister('shillinq')
                 ->setSchema('Account')
@@ -148,7 +164,6 @@ class AccountBalanceGuard
                                 'administrationId' => ($account['administrationId'] ?? ''),
                                 'isClosingAccount' => true,
                             ],
-                            'limit'   => 2,
                         ]
                         );
 

--- a/lib/Repair/InitializeSettings.php
+++ b/lib/Repair/InitializeSettings.php
@@ -66,6 +66,8 @@ class InitializeSettings implements IRepairStep
      * Phase 2: seeds the chart of accounts from the RGS template selected
      * in app config key 'rgs_template' (default: 'mkb'). Idempotent —
      * existing accounts are skipped on re-run, preserving operator edits.
+     * Seeding is skipped entirely when administration_id is not configured
+     * (C2: prevents "default" contamination of real tenant data).
      *
      * @param IOutput $output The output interface for progress reporting
      *
@@ -100,6 +102,10 @@ class InitializeSettings implements IRepairStep
             if ($result['success'] !== true) {
                 $message = ($result['message'] ?? 'unknown error');
                 $output->warning('Shillinq configuration import issue: '.$message);
+                // H2: skip account seed when schema import failed to avoid writing
+                // accounts into an uninitialized register.
+                $output->warning('Shillinq: schema import failed, skipping account seed');
+                return;
             }
 
             $this->seedChartOfAccounts(output: $output);
@@ -115,6 +121,9 @@ class InitializeSettings implements IRepairStep
 
     /**
      * Seed the chart of accounts from the configured RGS template, idempotently.
+     *
+     * Seeding is skipped when administration_id is not configured (C2) to prevent
+     * orphan accounts under a "default" id that contaminates real tenant data later.
      *
      * @param IOutput $output The output interface for progress reporting
      *
@@ -132,15 +141,18 @@ class InitializeSettings implements IRepairStep
         $administrationId = ($settings['administration_id'] ?? '');
 
         if ($administrationId === '') {
-            $administrationId = 'default';
+            // C2: seeding under a hardcoded "default" administrationId contaminates
+            // real tenants when the admin later configures a proper id. Skip the seed
+            // entirely and surface a clear admin notice instead.
             $output->warning(
-                'Shillinq: administration_id not configured — seeding chart of accounts under '
-                .'administrationId="default". Set administration_id in Shillinq admin settings '
-                .'before going to production to avoid cross-tenant contamination.'
+                'Shillinq: administration_id not configured — skipping chart of accounts seed. '
+                .'Go to Shillinq admin settings, set administration_id, then click '
+                .'"Seed Chart of Accounts" to initialise.'
             );
             $this->logger->warning(
-                'Shillinq: administration_id not configured, using "default" for chart of accounts seed'
+                'Shillinq: administration_id not configured, skipping chart of accounts seed'
             );
+            return;
         }
 
         $output->info('Seeding chart of accounts (template: '.$template.')...');

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -245,6 +245,13 @@ class SettingsService
     /**
      * Import a list of account records into OpenRegister, skipping existing ones.
      *
+     * Deduplication key is (accountNumber, administrationId). This means that if
+     * an admin changes the administrationId app config after an initial seed, the
+     * previously seeded accounts (under the old id) will be orphaned — they remain
+     * in OpenRegister but are no longer matched on re-seed. To clean up, an admin
+     * must manually delete accounts with the stale administrationId via the
+     * OpenRegister UI before re-seeding under the new id (M3).
+     *
      * @param object       $objectService    OpenRegister ObjectService.
      * @param array<mixed> $accounts         Account records to import.
      * @param string       $administrationId The administrationId to stamp.

--- a/tests/Unit/Repair/InitializeSettingsTest.php
+++ b/tests/Unit/Repair/InitializeSettingsTest.php
@@ -154,11 +154,52 @@ class InitializeSettingsTest extends TestCase
     }//end testRunCallsLoadConfigurationAndSeedTemplate()
 
     /**
-     * Test that run() reports a warning when loadConfiguration fails.
+     * Test that run() skips seed (not called at all) when administrationId is unset.
+     *
+     * C2: seeding under a hardcoded "default" id contaminates real tenants.
      *
      * @return void
      */
-    public function testRunWarnsWhenLoadConfigurationFails(): void
+    public function testRunSkipsSeedWhenAdministrationIdUnset(): void
+    {
+        $this->settingsService->expects($this->once())
+            ->method('isOpenRegisterAvailable')
+            ->willReturn(true);
+
+        $this->settingsService->expects($this->once())
+            ->method('loadConfiguration')
+            ->willReturn(['success' => true, 'version' => '0.2.0']);
+
+        $this->settingsService->expects($this->atLeastOnce())
+            ->method('getSettings')
+            ->willReturn([
+                'rgs_template'      => 'mkb',
+                'administration_id' => '',
+                'register'          => '',
+                'openregisters'     => true,
+                'isAdmin'           => false,
+            ]);
+
+        // C2: seedRgsTemplate must NOT be called when administrationId is empty.
+        $this->settingsService->expects($this->never())
+            ->method('seedRgsTemplate');
+
+        $this->output->expects($this->atLeastOnce())
+            ->method('warning')
+            ->with($this->stringContains('administration_id'));
+
+        $this->repairStep->run(output: $this->output);
+
+    }//end testRunSkipsSeedWhenAdministrationIdUnset()
+
+    /**
+     * Test that run() reports a warning and skips seeding when loadConfiguration fails.
+     *
+     * H2: the seed must not run against an uninitialised register.
+     *
+     * @return void
+     */
+    public function testRunSkipsSeedWhenLoadConfigurationFails(): void
     {
         $this->settingsService->expects($this->once())
             ->method('isOpenRegisterAvailable')
@@ -168,26 +209,15 @@ class InitializeSettingsTest extends TestCase
             ->method('loadConfiguration')
             ->willReturn(['success' => false, 'message' => 'Config import error']);
 
-        $this->settingsService->expects($this->atLeastOnce())
-            ->method('getSettings')
-            ->willReturn([
-                'rgs_template'     => 'mkb',
-                'administration_id' => 'default',
-                'register'         => '',
-                'openregisters'    => true,
-                'isAdmin'          => false,
-            ]);
-
-        $this->settingsService->expects($this->once())
-            ->method('seedRgsTemplate')
-            ->willReturn(['success' => true, 'seeded' => 40, 'skipped' => 0]);
+        // H2: seedRgsTemplate must NOT be called when schema import failed.
+        $this->settingsService->expects($this->never())
+            ->method('seedRgsTemplate');
 
         $this->output->expects($this->atLeastOnce())
-            ->method('warning')
-            ->with($this->stringContains('Config import error'));
+            ->method('warning');
 
         $this->repairStep->run(output: $this->output);
 
-    }//end testRunWarnsWhenLoadConfigurationFails()
+    }//end testRunSkipsSeedWhenLoadConfigurationFails()
 
 }//end class


### PR DESCRIPTION
## Summary

- **C1**: Replace float equality `balance === 0.0` with integer-cent arithmetic `array_sum(array_map(fn => (int)round(... * 100), ...)) === 0` in `AccountBalanceGuard::requireZeroBalance()`. Avoids IEEE-754 precision issues where `0.1 + 0.2 - 0.3 !== 0.0` in floats.
- **C2**: Skip chart-of-accounts seeding entirely when `administration_id` app config key is empty, instead of seeding under the hardcoded `'default'` id. Surfaces a clear admin notice: "Go to Shillinq admin settings, set administration_id, then click Seed Chart of Accounts". Prevents cross-tenant contamination when the admin later configures a real id.
- **H2**: Short-circuit `seedChartOfAccounts()` when `loadConfiguration()` returns `success=false`, so accounts are never written into an uninitialised register.
- **L1**: Page through GLLine records in 500-record batches (offset+limit loop) so accounts with more than 1k postings are fully counted in `requireZeroBalance()`.
- **L2**: Remove the `limit:2` cap on `requireSingleClosingAccount()` so all closing accounts in an administration are loaded before the uniqueness check.
- **M3**: Document the admin cleanup flow for orphan accounts in `importAccounts()` docblock.

## Test plan

- [ ] PHPStan reports no errors
- [ ] `InitializeSettingsTest::testRunSkipsSeedWhenAdministrationIdUnset` — seeding NOT called when `administration_id` is empty (C2)
- [ ] `InitializeSettingsTest::testRunSkipsSeedWhenLoadConfigurationFails` — seeding NOT called when schema import fails (H2)
- [ ] `InitializeSettingsTest::testRunCallsLoadConfigurationAndSeedTemplate` — seeding IS called with a configured `administration_id`
- [ ] Unit test for 0.1+0.2-0.3 balance: cents calculation gives 0, float calculation would not