### PR TITLE
fix: drop setPreference CSRF bypass, dynamic register slug, and add unit tests

### DIFF
--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -108,7 +108,6 @@ class PreferencesController extends Controller
      * @spec openspec/changes/retrofit-2026-05-26-preferences-api/tasks.md#task-2
      *
      * @NoAdminRequired
-     * @NoCSRFRequired
      */
     public function setPreference(string $key, string $value=''): JSONResponse
     {

--- a/lib/Listener/DeepLinkRegistrationListener.php
+++ b/lib/Listener/DeepLinkRegistrationListener.php
@@ -21,9 +21,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Listener;
 
+use OCA\Shillinq\AppInfo\Application;
 use OCA\OpenRegister\Event\DeepLinkRegistrationEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\IAppConfig;
 
 /**
  * Registers Shillinq's deep link URL patterns with OpenRegister's search provider.
@@ -38,11 +40,27 @@ use OCP\EventDispatcher\IEventListener;
 class DeepLinkRegistrationListener implements IEventListener
 {
     /**
+     * Construct the listener with app config for dynamic register-slug resolution (L3).
+     *
+     * @param IAppConfig $appConfig App config — reads the 'register' key to resolve
+     *                              the actual register slug set by the admin. Falls
+     *                              back to the canonical default 'shillinq'.
+     */
+    public function __construct(
+        private readonly IAppConfig $appConfig,
+    ) {
+    }//end __construct()
+
+    /**
      * Handle the deep link registration event.
      *
      * Registers deep links for real Shillinq schemas. The `account` schema is
      * the only schema present in T1. Additional schemas (invoice, payment, etc.)
      * should be added here once their Vue detail routes are implemented.
+     *
+     * The register slug is read from app config (key: 'register') instead of being
+     * hardcoded, so deep links keep working if the admin binds the app to a
+     * non-default register (L3).
      *
      * @param Event $event The event to handle
      *
@@ -56,10 +74,16 @@ class DeepLinkRegistrationListener implements IEventListener
             return;
         }
 
+        // L3: read the configured register slug; fall back to 'shillinq' if unset.
+        $registerSlug = $this->appConfig->getValueString(Application::APP_ID, 'register', 'shillinq');
+        if ($registerSlug === '') {
+            $registerSlug = 'shillinq';
+        }
+
         // Register deep link for the Account schema (T1 schema).
         $event->register(
             appId: 'shillinq',
-            registerSlug: 'shillinq',
+            registerSlug: $registerSlug,
             schemaSlug: 'account',
             urlTemplate: '/apps/shillinq/#/accounts/{uuid}'
         );

--- a/tests/Unit/Controller/PrefsControllerTest.php
+++ b/tests/Unit/Controller/PrefsControllerTest.php
@@ -1,0 +1,225 @@
+<?php
+
+/**
+ * Unit tests for PreferencesController (prefs API — get/set/clear per-user values).
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/retrofit-2026-05-26-preferences-api/tasks.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\PreferencesController;
+use OCP\AppFramework\Http;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for PreferencesController.
+ *
+ * Verifies the per-user key/value prefs API (get/set/clear) and the
+ * key-sanitization behaviour. setPreference must NOT carry @NoCSRFRequired (H1).
+ */
+class PrefsControllerTest extends TestCase
+{
+
+    /**
+     * Mock IRequest.
+     *
+     * @var IRequest&MockObject
+     */
+    private IRequest&MockObject $request;
+
+    /**
+     * Mock IConfig.
+     *
+     * @var IConfig&MockObject
+     */
+    private IConfig&MockObject $config;
+
+    /**
+     * Mock IUserSession.
+     *
+     * @var IUserSession&MockObject
+     */
+    private IUserSession&MockObject $userSession;
+
+    /**
+     * The controller under test.
+     *
+     * @var PreferencesController
+     */
+    private PreferencesController $controller;
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request     = $this->createMock(IRequest::class);
+        $this->config      = $this->createMock(IConfig::class);
+        $this->userSession = $this->createMock(IUserSession::class);
+
+        $this->controller = new PreferencesController(
+            request: $this->request,
+            config: $this->config,
+            userSession: $this->userSession,
+        );
+
+    }//end setUp()
+
+    /**
+     * setPreference must NOT have @NoCSRFRequired annotation (H1, per user policy).
+     *
+     * @return void
+     */
+    public function testSetPreferenceHasNoCSRFRequiredRemoved(): void
+    {
+        $reflection = new \ReflectionMethod(PreferencesController::class, 'setPreference');
+        $docComment = ($reflection->getDocComment() ?: '');
+
+        self::assertStringNotContainsString(
+            '@NoCSRFRequired',
+            $docComment,
+            'H1: setPreference must not bypass CSRF protection'
+        );
+
+    }//end testSetPreferenceHasNoCSRFRequiredRemoved()
+
+    /**
+     * getPreference returns 401 when the user is not logged in.
+     *
+     * @return void
+     */
+    public function testGetPreferenceReturns401WhenUnauthenticated(): void
+    {
+        $this->userSession->method('getUser')->willReturn(null);
+
+        $response = $this->controller->getPreference(key: 'some-key');
+
+        self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+    }//end testGetPreferenceReturns401WhenUnauthenticated()
+
+    /**
+     * getPreference returns the stored value for a valid key.
+     *
+     * @return void
+     */
+    public function testGetPreferenceReturnsStoredValue(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $this->userSession->method('getUser')->willReturn($user);
+
+        $this->config->method('getUserValue')->willReturn('true');
+
+        $response = $this->controller->getPreference(key: 'support-seen');
+        $data     = $response->getData();
+
+        self::assertSame(Http::STATUS_OK, $response->getStatus());
+        self::assertSame('support-seen', $data['key']);
+        self::assertSame('true', $data['value']);
+
+    }//end testGetPreferenceReturnsStoredValue()
+
+    /**
+     * getPreference returns null value when the key has no stored value.
+     *
+     * @return void
+     */
+    public function testGetPreferenceReturnsNullWhenKeyNotSet(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $this->userSession->method('getUser')->willReturn($user);
+
+        $this->config->method('getUserValue')->willReturn('');
+
+        $response = $this->controller->getPreference(key: 'unset-key');
+        $data     = $response->getData();
+
+        self::assertSame(Http::STATUS_OK, $response->getStatus());
+        self::assertNull($data['value']);
+
+    }//end testGetPreferenceReturnsNullWhenKeyNotSet()
+
+    /**
+     * setPreference stores the value and returns 200 with the key+value.
+     *
+     * @return void
+     */
+    public function testSetPreferenceStoresValue(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $this->userSession->method('getUser')->willReturn($user);
+
+        $this->config->expects($this->once())->method('setUserValue');
+
+        $response = $this->controller->setPreference(key: 'support-seen', value: 'true');
+        $data     = $response->getData();
+
+        self::assertSame(Http::STATUS_OK, $response->getStatus());
+        self::assertSame('true', $data['value']);
+
+    }//end testSetPreferenceStoresValue()
+
+    /**
+     * setPreference with empty value deletes the key and returns null.
+     *
+     * @return void
+     */
+    public function testSetPreferenceDeletesWhenValueIsEmpty(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $this->userSession->method('getUser')->willReturn($user);
+
+        $this->config->expects($this->once())->method('deleteUserValue');
+
+        $response = $this->controller->setPreference(key: 'support-seen', value: '');
+        $data     = $response->getData();
+
+        self::assertSame(Http::STATUS_OK, $response->getStatus());
+        self::assertNull($data['value']);
+
+    }//end testSetPreferenceDeletesWhenValueIsEmpty()
+
+    /**
+     * getPreference returns 400 for an invalid key (non-alphanumeric).
+     *
+     * @return void
+     */
+    public function testGetPreferenceReturns400ForInvalidKey(): void
+    {
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $this->userSession->method('getUser')->willReturn($user);
+
+        // A key that contains only non-alphanumeric chars (e.g. '!!!') is invalid.
+        $response = $this->controller->getPreference(key: '!!!');
+
+        self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+
+    }//end testGetPreferenceReturns400ForInvalidKey()
+
+}//end class

--- a/tests/Unit/Guard/AccountBalanceGuardTest.php
+++ b/tests/Unit/Guard/AccountBalanceGuardTest.php
@@ -1,0 +1,293 @@
+<?php
+
+/**
+ * Unit tests for AccountBalanceGuard.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Guard
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/add-shillinq-chart-of-accounts/specs/bookkeeping-chart-of-accounts/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Guard;
+
+use OCA\Shillinq\Guard\AccountBalanceGuard;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for AccountBalanceGuard.
+ *
+ * Covers:
+ * - Float-to-cents fix: 0.1 + 0.2 - 0.3 is balanced
+ * - GLLine register unavailable → archive permitted (T1 deferral)
+ * - requireZeroBalance returns false when balance is non-zero
+ * - requireSingleClosingAccount invariant
+ * - Fail-closed on exception
+ */
+class AccountBalanceGuardTest extends TestCase
+{
+
+    /**
+     * Mock ContainerInterface.
+     *
+     * @var ContainerInterface&MockObject
+     */
+    private ContainerInterface&MockObject $container;
+
+    /**
+     * Mock LoggerInterface.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface&MockObject $logger;
+
+    /**
+     * The guard under test.
+     *
+     * @var AccountBalanceGuard
+     */
+    private AccountBalanceGuard $guard;
+
+    /**
+     * Set up test fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->logger    = $this->createMock(LoggerInterface::class);
+        $this->guard     = new AccountBalanceGuard(
+            container: $this->container,
+            logger: $this->logger,
+        );
+
+    }//end setUp()
+
+    /**
+     * requireZeroBalance returns true when the GLLine register is unavailable (T1).
+     *
+     * @return void
+     */
+    public function testRequireZeroBalancePermitsArchiveInT1State(): void
+    {
+        // Simulate T1: container throws when trying to get ObjectService.
+        $this->container->method('get')
+            ->willThrowException(new \RuntimeException('ObjectService not found'));
+
+        $result = $this->guard->requireZeroBalance(['accountNumber' => '0001', 'administrationId' => 'adm-1']);
+
+        self::assertTrue($result, 'T1 state: archive should be permitted when GLLine register is absent');
+
+    }//end testRequireZeroBalancePermitsArchiveInT1State()
+
+    /**
+     * requireZeroBalance uses integer-cent arithmetic so 0.1 + 0.2 - 0.3 is treated as balanced (C1).
+     *
+     * IEEE-754: (float)(0.1 + 0.2 - 0.3) !== 0.0, but (int)round(0.1*100) + (int)round(0.2*100) - (int)round(0.3*100) === 0.
+     *
+     * @return void
+     */
+    public function testRequireZeroBalanceTreatsFloatRoundingAsBalanced(): void
+    {
+        $lines = [
+            ['debit' => 0.1, 'credit' => 0.0],
+            ['debit' => 0.2, 'credit' => 0.0],
+            ['debit' => 0.0, 'credit' => 0.3],
+        ];
+
+        // The ObjectService stub: setRegister/setSchema returns itself, findAll returns $lines.
+        $objectService = $this->buildObjectServiceStub(lines: $lines, closingAccounts: []);
+        $this->container->method('get')->willReturn($objectService);
+
+        $result = $this->guard->requireZeroBalance(['accountNumber' => '0001', 'administrationId' => 'adm-1']);
+
+        self::assertTrue($result, 'C1: 0.1+0.2-0.3 must be treated as balanced via integer-cent arithmetic');
+
+    }//end testRequireZeroBalanceTreatsFloatRoundingAsBalanced()
+
+    /**
+     * requireZeroBalance returns false when debit > credit (actual non-zero balance).
+     *
+     * @return void
+     */
+    public function testRequireZeroBalanceReturnsFalseForNonZeroBalance(): void
+    {
+        $lines = [
+            ['debit' => 100.0, 'credit' => 0.0],
+        ];
+
+        $objectService = $this->buildObjectServiceStub(lines: $lines, closingAccounts: []);
+        $this->container->method('get')->willReturn($objectService);
+
+        $result = $this->guard->requireZeroBalance(['accountNumber' => '0001', 'administrationId' => 'adm-1']);
+
+        self::assertFalse($result, 'Non-zero balance must deny archive');
+
+    }//end testRequireZeroBalanceReturnsFalseForNonZeroBalance()
+
+    /**
+     * requireZeroBalance is fail-closed: returns false (denies archive) on exception.
+     *
+     * @return void
+     */
+    public function testRequireZeroBalanceIsFailClosedOnException(): void
+    {
+        $objectService = $this->buildObjectServiceStubThatThrows();
+        $this->container->method('get')->willReturn($objectService);
+
+        $result = $this->guard->requireZeroBalance(['accountNumber' => '0001', 'administrationId' => 'adm-1']);
+
+        self::assertFalse($result, 'Fail-closed: exception must deny archive');
+
+    }//end testRequireZeroBalanceIsFailClosedOnException()
+
+    /**
+     * requireSingleClosingAccount returns true trivially when account is not a closing account.
+     *
+     * @return void
+     */
+    public function testRequireSingleClosingAccountPermitsNonClosingAccount(): void
+    {
+        // Container should not be touched for non-closing accounts.
+        $this->container->expects($this->never())->method('get');
+
+        $result = $this->guard->requireSingleClosingAccount(['isClosingAccount' => false]);
+
+        self::assertTrue($result);
+
+    }//end testRequireSingleClosingAccountPermitsNonClosingAccount()
+
+    /**
+     * requireSingleClosingAccount permits save when no other closing account exists.
+     *
+     * @return void
+     */
+    public function testRequireSingleClosingAccountPermitsFirstClosingAccount(): void
+    {
+        $objectService = $this->buildObjectServiceStub(lines: [], closingAccounts: []);
+        $this->container->method('get')->willReturn($objectService);
+
+        $result = $this->guard->requireSingleClosingAccount([
+            'isClosingAccount' => true,
+            'accountNumber'    => 'CLOSE',
+            'administrationId' => 'adm-1',
+        ]);
+
+        self::assertTrue($result);
+
+    }//end testRequireSingleClosingAccountPermitsFirstClosingAccount()
+
+    /**
+     * requireSingleClosingAccount denies save when another closing account exists.
+     *
+     * @return void
+     */
+    public function testRequireSingleClosingAccountDeniesDuplicateClosingAccount(): void
+    {
+        $existingClosing = [
+            ['id' => 'other-uuid', 'accountNumber' => 'CLOSE-OLD', 'administrationId' => 'adm-1', 'isClosingAccount' => true],
+        ];
+        $objectService   = $this->buildObjectServiceStub(lines: [], closingAccounts: $existingClosing);
+        $this->container->method('get')->willReturn($objectService);
+
+        $result = $this->guard->requireSingleClosingAccount([
+            'isClosingAccount' => true,
+            'id'               => 'new-uuid',
+            'accountNumber'    => 'CLOSE-NEW',
+            'administrationId' => 'adm-1',
+        ]);
+
+        self::assertFalse($result, 'A second closing account must be denied');
+
+    }//end testRequireSingleClosingAccountDeniesDuplicateClosingAccount()
+
+    /**
+     * Build an anonymous ObjectService stub that returns the given lines and closingAccounts
+     * for the respective findAll() calls. Implements the fluent setRegister/setSchema interface.
+     *
+     * @param array<mixed> $lines           GLLine records to return for balance queries.
+     * @param array<mixed> $closingAccounts Account records to return for uniqueness queries.
+     *
+     * @return object
+     */
+    private function buildObjectServiceStub(array $lines, array $closingAccounts): object
+    {
+        return new class($lines, $closingAccounts) {
+            private array $lines;
+            private array $closingAccounts;
+            private string $currentSchema = '';
+
+            public function __construct(array $lines, array $closingAccounts)
+            {
+                $this->lines           = $lines;
+                $this->closingAccounts = $closingAccounts;
+            }
+
+            public function setRegister(string $register): static
+            {
+                return $this;
+            }
+
+            public function setSchema(string $schema): static
+            {
+                $this->currentSchema = $schema;
+                return $this;
+            }
+
+            /**
+             * @param array<string,mixed> $params
+             * @return array<mixed>
+             */
+            public function findAll(array $params=[]): array
+            {
+                if ($this->currentSchema === 'GLLine') {
+                    return $this->lines;
+                }
+                return $this->closingAccounts;
+            }
+        };
+    }//end buildObjectServiceStub()
+
+    /**
+     * Build an ObjectService stub that throws on findAll().
+     *
+     * @return object
+     */
+    private function buildObjectServiceStubThatThrows(): object
+    {
+        return new class {
+            public function setRegister(string $register): static
+            {
+                return $this;
+            }
+
+            public function setSchema(string $schema): static
+            {
+                return $this;
+            }
+
+            /**
+             * @param array<string,mixed> $params
+             * @return array<mixed>
+             */
+            public function findAll(array $params=[]): array
+            {
+                throw new \RuntimeException('DB error');
+            }
+        };
+    }//end buildObjectServiceStubThatThrows()
+}//end class


### PR DESCRIPTION
H1: remove @NoCSRFRequired from setPreference. L3: read register slug from app config in DeepLinkRegistrationListener. M2: add AccountBalanceGuardTest (7) + PrefsControllerTest (7).