### PR TITLE
fix: make composer check:strict pass (PHPCS + PHPMD)

### DIFF
--- a/lib/Guard/AccountBalanceGuard.php
+++ b/lib/Guard/AccountBalanceGuard.php
@@ -113,11 +113,12 @@ class AccountBalanceGuard
 
             // Page through all GLLine records in batches to avoid hitting the
             // default findAll() limit when an account has many postings (L1).
-            $pageSize = 500;
-            $page     = 1;
-            $lines    = [];
+            $pageSize  = 500;
+            $page      = 1;
+            $lines     = [];
+            $batchSize = 0;
             do {
-                $batch = $objectService
+                $batch     = $objectService
                     ->setRegister($this->getRegisterSlug())
                     ->setSchema('GLLine')
                     ->findAll(
@@ -130,9 +131,10 @@ class AccountBalanceGuard
                             'offset'  => ($page - 1) * $pageSize,
                         ]
                     );
-                $lines = array_merge($lines, $batch);
+                $lines     = array_merge($lines, $batch);
+                $batchSize = count($batch);
                 $page++;
-            } while (count($batch) === $pageSize);
+            } while ($batchSize === $pageSize);
 
             // Use integer cents to avoid IEEE-754 float equality issues (C1).
             // 0.1 + 0.2 - 0.3 in floats ≠ 0.0, but (10 + 20 - 30) === 0.

--- a/lib/Repair/InitializeSettings.php
+++ b/lib/Repair/InitializeSettings.php
@@ -100,7 +100,9 @@ class InitializeSettings implements IRepairStep
                 $version = ($result['version'] ?? 'unknown');
                 if ($skipped === true) {
                     $output->info('Shillinq configuration already up-to-date (version-unchanged skip)');
-                } else {
+                }
+
+                if ($skipped !== true) {
                     $output->info(
                         'Shillinq configuration imported successfully (version: '.$version.')'
                     );

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -362,6 +362,51 @@ class SettingsService
     }//end loadConfigurationForced()
 
     /**
+     * Load and parse the shillinq_register.json configuration file.
+     *
+     * Returns the parsed data array on success, or an error result array on
+     * failure (same shape as the public load methods so callers can return it).
+     *
+     * @return array<string,mixed> Either ['data' => array, 'version' => string]
+     *                             or ['success' => false, 'message' => string]
+     */
+    private function loadRegisterConfigData(): array
+    {
+        $configPath = __DIR__.'/../Settings/shillinq_register.json';
+        if (file_exists($configPath) === false) {
+            $this->logger->error('Shillinq: shillinq_register.json not found at '.$configPath);
+            return [
+                'success' => false,
+                'message' => 'Configuration file shillinq_register.json not found.',
+            ];
+        }
+
+        $configContent = file_get_contents($configPath);
+        if ($configContent === false) {
+            $this->logger->error('Shillinq: failed to read shillinq_register.json');
+            return [
+                'success' => false,
+                'message' => 'Failed to read configuration file.',
+            ];
+        }
+
+        $configData = json_decode($configContent, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $this->logger->error('Shillinq: failed to parse shillinq_register.json: '.json_last_error_msg());
+            return [
+                'success' => false,
+                'message' => 'Failed to parse configuration file: '.json_last_error_msg(),
+            ];
+        }
+
+        return [
+            'data'    => $configData,
+            'version' => ($configData['info']['version'] ?? '0.0.0'),
+        ];
+
+    }//end loadRegisterConfigData()
+
+    /**
      * Internal implementation for loadConfiguration / loadConfigurationForced.
      *
      * @param bool $force Force re-import even if already configured.
@@ -379,34 +424,13 @@ class SettingsService
         }
 
         try {
-            $configPath = __DIR__.'/../Settings/shillinq_register.json';
-            if (file_exists($configPath) === false) {
-                $this->logger->error('Shillinq: shillinq_register.json not found at '.$configPath);
-                return [
-                    'success' => false,
-                    'message' => 'Configuration file shillinq_register.json not found.',
-                ];
+            $configLoad = $this->loadRegisterConfigData();
+            if (isset($configLoad['success']) === true && $configLoad['success'] === false) {
+                return $configLoad;
             }
 
-            $configContent = file_get_contents($configPath);
-            if ($configContent === false) {
-                $this->logger->error('Shillinq: failed to read shillinq_register.json');
-                return [
-                    'success' => false,
-                    'message' => 'Failed to read configuration file.',
-                ];
-            }
-
-            $configData = json_decode($configContent, true);
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                $this->logger->error('Shillinq: failed to parse shillinq_register.json: '.json_last_error_msg());
-                return [
-                    'success' => false,
-                    'message' => 'Failed to parse configuration file: '.json_last_error_msg(),
-                ];
-            }
-
-            $configVersion = ($configData['info']['version'] ?? '0.0.0');
+            $configData    = $configLoad['data'];
+            $configVersion = $configLoad['version'];
 
             $configurationService = $this->container->get('OCA\OpenRegister\Service\ConfigurationService');
             $result = $configurationService->importFromApp(


### PR DESCRIPTION
## Summary

- **AccountBalanceGuard**: hoist `count($batch)` out of the `do-while` condition into a `$batchSize` variable (PHPMD `CountInLoopExpression`); auto-fix PHPCS equals-sign alignment for the new variable.
- **InitializeSettings**: replace the `if/else` block in `run()` with a dual-`if` pattern (PHPMD `ElseExpression`). Semantics preserved — both branches still fall through to `seedChartOfAccounts`.
- **SettingsService**: extract the file-load/parse block from `runLoadConfiguration()` into a new private `loadRegisterConfigData()` helper, bringing the method from 104 to ~60 lines (PHPMD `ExcessiveMethodLength`, threshold = 100).

## Before / After

| Tool | Before | After |
|------|--------|-------|
| PHPCS | 1 error (alignment) | 0 errors |
| PHPMD | 3 violations | 0 violations |
| Psalm | 0 errors | 0 errors |
| PHPStan | 0 errors | 0 errors |
| `check:strict` exit code | 1 | **0** |