### PR TITLE
docs(openspec): add portal-payment-initiation ff change

### DIFF
--- a/openspec/changes/portal-payment-initiation/.openspec.yaml
+++ b/openspec/changes/portal-payment-initiation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/portal-payment-initiation/design.md
+++ b/openspec/changes/portal-payment-initiation/design.md
@@ -1,0 +1,162 @@
+# Design: portal-payment-initiation
+
+## Context
+
+hydra ADR-046 makes **portaliq** the ONE external portal for people without a
+Nextcloud account. Contribution contract v2.2 defines **A6 endpoint
+bearer-forward actions**: an app declares actions `{id, label, endpoint, method,
+minTrust?}` (type `create` | `update` | `endpoint-forward`) on a manifest, and a
+collection may reference an action as a `rowAction`; portaliq exposes
+`POST /portal/api/actions/{appId}/{actionId}`, authorises against the SUBJECT's
+own aggregated manifest, re-checks `minTrust`, then forwards the call
+server-to-server to the declared instance-local endpoint, attaching a
+short-lived HS256 `X-Portal-Subject` assertion and NEVER the client's
+`Authorization` header, and relays the domain app's JSON status + body.
+
+Shillinq's `customer` manifest (`portal-contribution`) already exposes the
+`paymentRequests` collection (schema `PaymentRequest`, reached via a reverse
+`via` join through `ARInvoice.customerId`, scoped by the
+`claims.shillinq.customerMasterId` CustomerMaster object UUID) and a
+`salesInvoices` collection (schema `ARInvoice`, scoped by `customerId`). Both are
+read-only (`actions: []`). This change adds the write leg: an initiation action.
+
+### Verified facts (HEAD, shillinq)
+
+- **The Mollie provider exists and returns a checkout URL.**
+  `MolliePaymentAdapterInterface::createPayment(array $payload): MolliePaymentResult`
+  takes `amount{value,currency}, description, redirectUrl, webhookUrl,
+  method (ideal|creditcard|bancontact|sepadirectdebit), metadata{invoiceId,
+  administrationId, correlationId}` and returns a result carrying the Mollie
+  `paymentId` + `checkoutUrl`. `isDormant()` reports whether it is the log-only
+  `LogMolliePaymentAdapter` stub (activated by binding the openconnector
+  `mollie-payments` source + API key in `Application::register()`).
+- **The webhook exists and settles.** `PaymentRequestWebhookController::handle()`
+  (route `POST /api/v1/payment-requests/webhook/{gateway}`, `#[PublicPage]` +
+  `#[NoCSRFRequired]`) HMAC-verifies the raw body against
+  `deposit_webhook_secret_{gateway}` (fail-closed when unset), decodes the
+  Mollie/Stripe event, and hands off to
+  `PaymentReconciliationService::reconcile()`. A Mollie `paid` maps to
+  `OUTCOME_CAPTURED`; reconciliation is idempotent (`RESULT_NOOP` on replay) and
+  `settleLinkedInvoice()` flips the linked AR invoice.
+- **`PaymentRequest` schema** (`lib/Settings/register.d/ar-invoice-payment-links.json`)
+  properties: `invoiceReference, amount, currency, paymentGateway,
+  paymentIntentId, state, expiresAt, failureReason, settlementReference,
+  gatewayFeeAmount, capturedAt, administrationId, paymentLink`.
+- **`ARInvoice.state`** enum: `draft, issued, partially-paid, paid, overdue,
+  disputed, written-off, voided`. "Open / payable" = `issued`, `partially-paid`,
+  `overdue`. `ARInvoice.customerId` is the CustomerMaster object UUID
+  (`format: uuid`, `$ref: CustomerMaster`).
+- **No portal inbox/message schema** exists in shillinq (grep of `lib/Settings`
+  for a customer-facing message/inbox collection is empty) — hence the
+  confirmation is a summary on the `PaymentRequest`, not an inbox row.
+
+## The initiation chain (server-derived, never client)
+
+```
+portaliq SPA (accountless debtor, trust per AR surface)
+  → clicks "pay" on an open salesInvoices/paymentRequests row
+  → POST /portal/api/actions/shillinq/pay   body: {invoiceId | paymentRequestId}
+  → portaliq authorises against the subject's OWN manifest, re-checks minTrust
+  → forwards to /apps/shillinq/api/portal/payments/initiate
+        header  X-Portal-Subject: <HS256 assertion carrying customerMasterId scope>
+        body    {invoiceId | paymentRequestId}          (client-supplied opaque id)
+  → shillinq receiver:
+        1. PortalAssertionVerifier: HS256 vs shared secret; alg=HS256 only;
+           iss=portaliq; use=assertion; unexpired; frozen claim set → else 401
+        2. audience==customer                                        → else 403
+        3. customerMasterId := verified assertion scope claim (NEVER body) → else 403
+        4. target := body.invoiceId (opaque id; reject URL/path → SSRF)
+        5. invoice := OR find ARInvoice where id==target
+                       AND customerId==customerMasterId
+                       AND state in {issued,partially-paid,overdue} → else uniform 403/404
+        6. paymentRequest := reuse pending PR for invoice OR mint one
+                             (amount, currency read from the SERVER invoice)
+        7. result := PaymentProviderInterface::createPayment(method='ideal', ...)
+        8. persist paymentIntentId on the PR; return {checkoutUrl}; 502 on downstream fail
+```
+
+Steps 1–5 make ownership entirely server-derived. Step 5 is the anti-IDOR
+boundary: knowing another debtor's invoice id buys nothing because the invoice's
+`customerId` must equal the verified `customerMasterId`. Step 6 reads the amount
+from the invoice, never the request body — a client can never dictate what it
+pays (or pay a smaller amount than owed).
+
+## Declarative vs imperative
+
+- **Declarative (pure data):** the `pay` action declaration + the `rowAction`
+  reference on the open-invoice rows. Like the rest of
+  `PortalContributionProvider`, they are constants — no I/O — keeping the
+  provider a plain, duck-typed, dependency-free class (ADR-046 A1).
+- **Imperative (justified external-integration exception, ADR-031):** the
+  `PortalPaymentInitiationController` + `PortalAssertionVerifier` +
+  `PortalPaymentSessionService` verify a cryptographic assertion, query
+  OpenRegister for the owned invoice, and call the PSP. A signed
+  server-to-server assertion and a PSP call cannot be expressed declaratively;
+  this is the A6 consumer half of a cross-app protocol, mirroring the existing
+  webhook's documented single-method exception.
+
+## The provider port
+
+`PaymentProviderInterface` is a thin port —
+`createSession(PaymentSessionRequest): PaymentSessionResult` and
+`isDormant(): bool` — that the session service depends on. Its shipped binding
+delegates to the existing `MolliePaymentAdapterInterface` (Mollie API key +
+test-mode read from app config), so iDEAL is live once the openconnector
+`mollie-payments` binding is configured and DORMANT (deferred outcome, no
+checkout URL, honest 503/`deferred` to the portal) otherwise. The port keeps the
+door open for additional PSPs without touching the receiver, but only the Mollie
+iDEAL binding ships here.
+
+## Confirmation without an inbox
+
+Shillinq's customer portal has no message/inbox schema. On a captured webhook,
+`PaymentReconciliationService` already stamps `PaymentRequest.state`,
+`settlementReference` and `capturedAt`; this change adds a subject-safe
+`confirmationSummary` string (e.g. "Invoice INV-2026-014 paid on 2026-07-23,
+reference tr_xxx") written on settlement and adds it to the existing
+`paymentRequests` collection field whitelist so the debtor sees a plain-language
+receipt through the read-only collection they already have. No new schema, no
+inbox, no register-version churn beyond the one added scalar.
+
+## Security Considerations
+
+- **Fail closed on every path** (ADR-005): `401` (missing/invalid/expired/
+  wrong-`alg`/wrong-`iss`/wrong-`use` assertion, or no shared secret), `403`
+  (wrong audience, not the owner, malformed target), `404`/`403` uniform where an
+  oracle would leak, `502`/`503` (downstream/PSP failure or dormant provider). No
+  path falls open to minting a session without a verified, owning assertion.
+- **Amount integrity:** the amount is ALWAYS the server invoice amount; a
+  body-supplied amount is ignored. The webhook independently never trusts
+  client-supplied amounts (it reconciles the PSP event against the stored PR).
+- **No cross-debtor IDOR:** the invoice's `customerId` must equal the verified
+  `customerMasterId`; a body-supplied customer id is ignored.
+- **Idempotent initiation:** a repeat `pay` on an invoice with a still-pending PR
+  reuses that PR rather than minting duplicate sessions.
+- **SSRF:** the receiver makes no outbound request to a client-controlled URL;
+  the `invoiceId` is used only as an OR object id and is rejected if it looks
+  like a URL/path.
+- **alg-confusion / `none` defeated:** the verifier accepts ONLY `alg == HS256`.
+- **No client secrets or endpoints** are introduced by the manifest — only a
+  relative endpoint path and the action's `method`.
+
+## Seed Data
+
+This change adds NO new OpenRegister schema or register — it reuses `ARInvoice`
+and `PaymentRequest` verified at HEAD, adding one subject-safe
+`confirmationSummary` scalar to `PaymentRequest`. Unit tests construct the
+controller/service directly (no container), build synthetic assertions on the
+nil-UUID pattern so fixtures are self-evidently fake, and mock the
+`PaymentProviderInterface` so no test contacts a real PSP.
+
+## Open questions (apply-time confirmations)
+
+1. **Scope-claim forwarding.** As with the docudesk portal-signing work, the
+   frozen A6 assertion must carry (or the receiver must resolve) the subject's
+   `customerMasterId` scope claim server-side; the receiver fails closed (`403`)
+   when no owner-identifying claim is present, so shipping early is safe.
+2. **Shared-secret sourcing.** Confirm the verifier reads portaliq's instance
+   signing secret the same way the receiver-side apps do — an ops decision at
+   apply.
+3. **redirectUrl.** portaliq owns the return URL the debtor lands on after iDEAL;
+   confirm the return-URL contract at apply (the endpoint accepts it from the
+   forwarded assertion/config, never from the raw client body).

--- a/openspec/changes/portal-payment-initiation/proposal.md
+++ b/openspec/changes/portal-payment-initiation/proposal.md
@@ -1,0 +1,130 @@
+---
+kind: code
+depends_on: [portal-contribution, ar-invoice-payment-links]
+---
+
+# Proposal: portal-payment-initiation
+
+## Why
+
+Shillinq's Wave-2 customer portal (archived `customer-invoice-portal-wave2`,
+canonical `portal-contribution` spec) lets a debtor SEE their own AR invoices
+and a "Pay my invoices" `paymentRequests` collection through **portaliq**, the
+shared external portal for people WITHOUT a Nextcloud account (hydra ADR-046,
+contribution contract v2.2). What it does NOT do is let the debtor actually
+**start a payment**: the `paymentRequests` collection surfaces a
+pre-computed `paymentLink` field, but that link is minted by the internal AR
+collection lifecycle, not by the subject. There is no subject-initiated,
+ownership-scoped endpoint that turns "here is my open invoice" into "here is a
+checkout URL I can pay right now". iDEAL is the must-have rail — 65 tenders in
+the corpus demand iDEAL specifically — and the MKB debtor expects a one-click
+pay-now button, not a link that may be stale or absent.
+
+The payment plumbing already exists and is honest at HEAD, so this change is
+deliberately thin and CONSUMES rather than rebuilds it (hence the `depends_on`):
+
+- `MolliePaymentAdapterInterface::createPayment()`
+  (`lib/Service/External/Mollie/MolliePaymentAdapterInterface.php`, verified at
+  HEAD) already returns a structured `MolliePaymentResult` carrying the
+  Mollie-side `paymentId` + `checkoutUrl`, accepts `method: 'ideal'`, and is
+  dormant-by-default (`LogMolliePaymentAdapter`) until a live binding is wired.
+- `PaymentRequestWebhookController`
+  (`lib/Controller/PaymentRequestWebhookController.php`, route
+  `POST /api/v1/payment-requests/webhook/{gateway}`, `REQ-APL-004`) is a
+  `#[PublicPage]` + `#[NoCSRFRequired]` webhook that HMAC-verifies the PSP
+  signature over the raw body, fail-closes when no secret is configured, is
+  idempotent, and settles the `PaymentRequest` + its linked AR invoice through
+  `PaymentReconciliationService`.
+
+What is missing is the SUBJECT-FACING initiation half and the pay-now action
+wiring. This change adds a bearer-subject-scoped, A6-endpoint-forward-compatible
+initiation endpoint that creates a payment session for a row the subject
+verifiably OWNS and returns its checkout URL; a `pay` endpoint-forward action on
+the customer manifest, surfaced as a `rowAction` on the open-invoice rows; and a
+subject-visible confirmation written on settlement. Without it the portal's
+"Pay my invoices" collection is a read-only teaser — the debtor can look but not
+pay.
+
+## What Changes
+
+- **A `PaymentProviderInterface` seam + iDEAL-first provider.** Formalise the
+  provider port the initiation endpoint consumes. The existing
+  `MolliePaymentAdapterInterface` (Mollie API key + test-mode via app config) IS
+  the shipped iDEAL provider; this change binds the initiation endpoint to it (no
+  fork). iDEAL is the required method for the Dutch MKB rail.
+- **A bearer-subject-scoped initiation endpoint.** A new controller exposes a
+  `#[PublicPage]` + `#[NoCSRFRequired]` receiver at
+  `/api/portal/payments/initiate` that portaliq's A6 endpoint-forward calls
+  server-to-server under the frozen `X-Portal-Subject` assertion. It resolves the
+  subject's verified `customerMasterId` scope claim SERVER-SIDE, verifies the
+  target AR invoice / payment request belongs to that CustomerMaster, mints (or
+  reuses a pending) `PaymentRequest`, drives `createPayment()` with the
+  server-side invoice amount, and returns `{ checkoutUrl }`.
+- **Confirmation on settlement.** `PaymentReconciliationService`, on a captured
+  webhook, writes a subject-safe confirmation summary the debtor sees through the
+  existing read-only `paymentRequests` collection (Shillinq has no portal
+  inbox/message schema — see Out of Scope), in addition to flipping the invoice
+  to `paid`.
+- **Portal contribution gains a `pay` action + rowAction.** Extend
+  `lib/Portal/PortalContributionProvider.php` (still plain, dependency-free) so
+  the `customer` manifest declares a contract-v2 `endpoint-forward` action `pay`
+  and references it as a `rowAction` on the open-invoice rows of the
+  `salesInvoices` / `paymentRequests` collections; `minTrust` tracks the AR
+  surface. The `supplier` / `accountant` manifests stay read-only.
+- **Refund path is a named follow-up, out of scope here** (see Out of Scope).
+
+## Capabilities
+
+### Added Capabilities
+
+- `portal-payment-initiation`: an accountless debtor pays their own open AR
+  invoice from portaliq's SPA — a fail-closed, ownership-scoped initiation
+  endpoint mints an iDEAL payment session through the existing Mollie provider,
+  returns the checkout URL as an A6 endpoint-forward action surfaced as a
+  pay-now rowAction, and the existing signature-verified webhook settles it and
+  writes the debtor a confirmation.
+
+## Affected Projects
+
+- [x] Project: `shillinq` — extend `lib/Portal/PortalContributionProvider.php` (`pay` action + rowAction); new `lib/Controller/PortalPaymentInitiationController.php` + `lib/Portal/PortalAssertionVerifier.php`; a `PaymentProviderInterface` port bound to the existing `MolliePaymentAdapterInterface`; a session-creation service (`PortalPaymentSessionService`); a confirmation write on `PaymentReconciliationService`; route in `appinfo/routes.php`; unit tests under `tests/unit/Portal/`; this OpenSpec change.
+- Consumes (verified at HEAD, not re-implemented): `MolliePaymentAdapterInterface::createPayment()`, `PaymentRequestWebhookController` (`REQ-APL-004`), `PaymentReconciliationService`.
+- Contract: `apps-extra/portaliq` — the A6 "Endpoint bearer-forward actions" + "Frozen assertion wire format" requirements this receiver is templated against; runtime consumer that forwards the action.
+- Reference: `hydra` ADR-046 (portaliq external portal, contribution contract v2.2, A6).
+- Depends on: `portal-contribution` (customer manifest, `customerMasterId` scope), `ar-invoice-payment-links` (Mollie provider + webhook + reconciliation).
+
+## Out of Scope
+
+- Any portal UI, session, auth edge or rendering — portaliq owns the entire
+  external surface (ADR-046); Shillinq ships zero portal frontend, only the
+  receiver + action declaration.
+- Any change to portaliq itself; this receiver is templated against portaliq's
+  FROZEN assertion wire format and its A6 forward.
+- **Refunds / partial reversals.** A `refund` action (portal-initiated or
+  operator-initiated) and its reconciliation are a deliberately deferred
+  follow-up — the settle path here is capture-only.
+- A dedicated portal inbox/message schema. Shillinq's customer portal has no
+  message collection (unlike decidesk/procest); the settlement confirmation is
+  delivered as a subject-safe summary on the existing `paymentRequests` row, not
+  a new inbox surface.
+- SEPA direct-debit / recurring mandates, card-on-file, and non-Mollie PSPs
+  (the port allows them; only the Mollie iDEAL binding ships).
+
+## Success Criteria
+
+- `openspec validate portal-payment-initiation --strict` exits 0.
+- The initiation endpoint returns a checkout URL ONLY for a row whose
+  server-resolved owner matches the verified assertion's `customerMasterId`; a
+  foreign, non-existent, or non-owned target yields the identical fail-closed
+  result (no existence oracle) and never calls the PSP.
+- The payment amount sent to the PSP is read from the server-side invoice /
+  payment-request, never from the client body.
+- The provider is driven with `method: 'ideal'`; a dormant provider returns a
+  deferred outcome without contacting Mollie and the endpoint degrades honestly.
+- The webhook settlement (existing `REQ-APL-004` path) additionally writes a
+  subject-visible confirmation and the debtor reads it through the existing
+  `paymentRequests` collection.
+- The `customer` manifest declares exactly one `pay` `endpoint-forward` action
+  with an instance-local relative endpoint, referenced as a rowAction on open
+  invoices; `supplier` / `accountant` manifests keep empty `actions`.
+- `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) and the unit suite pass
+  on the new files with zero new violations.

--- a/openspec/changes/portal-payment-initiation/specs/portal-payment-initiation/spec.md
+++ b/openspec/changes/portal-payment-initiation/specs/portal-payment-initiation/spec.md
@@ -1,0 +1,164 @@
+# portal-payment-initiation Specification (delta)
+
+---
+status: proposed
+---
+
+## Purpose
+
+Shillinq lets an external, accountless debtor PAY their own open AR invoice from
+**portaliq**, the shared external portal (hydra ADR-046, contribution contract
+v2.2). Today the `customer` manifest surfaces AR invoices and a "Pay my
+invoices" collection READ-ONLY. This change adds the write leg: a
+bearer-subject-scoped, A6-endpoint-forward initiation endpoint that verifies the
+target invoice belongs to the subject, mints an iDEAL payment session through
+the existing Mollie provider and returns its checkout URL; a `pay`
+`endpoint-forward` action surfaced as a `rowAction` on the open-invoice rows;
+and a subject-visible confirmation written by the existing signature-verified
+webhook on settlement. Every path fails closed and the paid amount is always the
+server-side invoice amount, never the client's.
+
+## ADDED Requirements
+
+### Requirement: A payment-provider port drives iDEAL through the existing Mollie adapter (REQ-SPPI-001)
+
+Shillinq MUST expose a `PaymentProviderInterface` port whose shipped binding
+delegates to the existing
+`OCA\Shillinq\Service\External\Mollie\MolliePaymentAdapterInterface`
+(`createPayment()` → `MolliePaymentResult{paymentId, checkoutUrl}`). The port
+MUST request iDEAL (`method: 'ideal'`) as the payment method for the portal
+pay-now flow (iDEAL is the required Dutch MKB rail). The Mollie API key and
+test-mode flag MUST be sourced from app config (never hardcoded). When the bound
+provider is dormant (`isDormant()` true — no live binding configured) the port
+MUST return a deferred outcome carrying NO checkout URL, and the initiation
+endpoint MUST surface that honestly (a `deferred`/`503` result) rather than a
+fabricated URL. The port MUST NOT be a second, forked Mollie client — it wraps
+the one verified adapter.
+
+#### Scenario: The port mints an iDEAL session through the Mollie adapter
+
+- GIVEN a live-bound `PaymentProviderInterface` and a server-resolved invoice amount and currency
+- WHEN the initiation flow requests a payment session
+- THEN the port calls `MolliePaymentAdapterInterface::createPayment()` with `method: 'ideal'`, the server-side amount/currency, and the app-config API key/test-mode
+- AND it returns the Mollie `checkoutUrl` + `paymentId`
+- AND when the bound adapter is dormant it returns a deferred outcome with no checkout URL and the endpoint responds `503`/`deferred` rather than a fabricated URL
+- @e2e exclude e2e added in apply phase - spec-only PR
+
+### Requirement: A bearer-subject-scoped initiation endpoint returns a checkout URL for an owned invoice (REQ-SPPI-002)
+
+Shillinq MUST ship a `#[PublicPage]` + `#[NoCSRFRequired]` receiver at an
+instance-local endpoint under `/apps/shillinq/api/portal/payments/` that
+portaliq forwards the `pay` action to server-to-server. A `PortalAssertionVerifier`
+MUST validate the inbound `X-Portal-Subject` header as portaliq's frozen A6
+assertion BEFORE any other work: verify the HS256 signature against the
+portaliq-managed shared signing secret; reject any token whose header `alg` is
+not exactly `HS256` (defeating `none`/alg-confusion); require `iss = portaliq`,
+`use = assertion`, and a present, unexpired `exp`; and require the frozen claim
+set. A missing, malformed, wrongly-signed, expired or wrong-`use` assertion — or
+an unconfigured shared secret — MUST fail closed with `401` before any
+OpenRegister read or PSP call. On a valid assertion the endpoint MUST require
+`audience = customer` (else `403`), resolve the target invoice / payment-request
+from the client-supplied opaque id, mint or reuse a `PaymentRequest`, drive the
+provider port, and relay `{ checkoutUrl }` as JSON, returning `502` on a
+downstream/OpenRegister failure without leaking internals.
+
+#### Scenario: An invalid assertion is rejected before any work
+
+- GIVEN a POST to the portal payment initiation endpoint
+- WHEN the `X-Portal-Subject` header is absent, has `alg` other than `HS256`, has `iss` other than `portaliq`, has `use` other than `assertion`, is expired, or its signature does not match the shared secret, or no shared secret is configured
+- THEN the receiver responds `401` and performs no OpenRegister read, no PaymentRequest write and no PSP call
+- @e2e exclude e2e added in apply phase - spec-only PR
+
+#### Scenario: A verified owning subject receives a checkout URL
+
+- GIVEN a valid `customer` assertion carrying the subject's `customerMasterId` scope claim, and a body `invoiceId` naming an open AR invoice whose `customerId` equals that `customerMasterId`
+- WHEN the receiver processes the `pay` action
+- THEN it mints (or reuses a pending) `PaymentRequest` for that invoice, drives the provider port with `method: 'ideal'`, persists the `paymentIntentId`, and relays `{ checkoutUrl }`
+- AND a downstream/PSP/OpenRegister failure is relayed as `502` with no raw exception text
+- @e2e exclude e2e added in apply phase - spec-only PR
+
+### Requirement: Ownership is server-derived and a non-owned invoice is unreachable (REQ-SPPI-003)
+
+The receiver MUST derive the owning identity ONLY from the verified assertion's
+`customerMasterId` scope claim, NEVER from the request body, query or
+`Authorization` header. It MUST treat the client-supplied `invoiceId` /
+`paymentRequestId` ONLY as an opaque OpenRegister object id, MUST reject any
+value that is a full URL or contains a path/scheme/host (SSRF hardening), and
+MUST NEVER use it to build an outbound request. Before minting a session the
+receiver MUST resolve, via OpenRegister, the `ARInvoice` whose `id` equals the
+target AND whose `customerId` equals the assertion-derived `customerMasterId`
+AND whose `state` is a payable state (`issued`, `partially-paid` or `overdue`).
+When no such invoice exists (foreign owner, non-payable/settled state, or a
+non-existent id) the receiver MUST fail closed with a single uniform
+not-authorised result, MUST NOT reveal whether the invoice exists (no existence
+oracle), and MUST NOT call the PSP. A body-supplied `customerId` / `amount` /
+`customerMasterId` MUST NEVER influence the resolution or the charged amount.
+
+#### Scenario: A debtor cannot pay an invoice they do not own
+
+- GIVEN a valid `customer` assertion resolving to `customerMasterId` M
+- AND a body `invoiceId` whose AR invoice `customerId` is NOT M, or is in a settled/non-payable state, or does not exist
+- WHEN the receiver processes the `pay` action
+- THEN it fails closed with the identical not-authorised response for a foreign invoice, a non-payable invoice, and a non-existent id (no existence oracle)
+- AND the PSP is never called and no `PaymentRequest` is written
+- AND an `invoiceId` value that is a full URL or contains a path is rejected before any lookup
+- @e2e exclude e2e added in apply phase - spec-only PR
+
+### Requirement: The charged amount is the server-side invoice amount (REQ-SPPI-004)
+
+The amount and currency sent to the PSP MUST be read from the server-resolved
+`ARInvoice` (or its linked `PaymentRequest`) — never from the request body. A
+client that supplies an `amount` in the body MUST be charged the invoice's own
+outstanding amount regardless. The minted `PaymentRequest.amount` MUST equal the
+server-side outstanding amount.
+
+#### Scenario: A client-supplied amount is ignored
+
+- GIVEN a valid owning `customer` assertion for an open invoice with outstanding amount A
+- AND a request body that also carries a smaller `amount`
+- WHEN the receiver mints the payment session
+- THEN the `PaymentRequest.amount` and the PSP payload amount are A (the server invoice amount), and the body `amount` is ignored entirely
+- @e2e exclude e2e added in apply phase - spec-only PR
+
+### Requirement: The signature-verified webhook settles idempotently and writes a subject confirmation (REQ-SPPI-005)
+
+On a captured payment the existing signature-verified, idempotent webhook path (`PaymentRequestWebhookController` and `PaymentReconciliationService`, `REQ-APL-004`) MUST settle the payment and write the subject a confirmation. It MUST transition the `PaymentRequest` to a captured/paid state, settle the linked `ARInvoice` (`state` becomes `paid`), and — added by this change — write a subject-safe
+`confirmationSummary` onto the `PaymentRequest` that the debtor reads through the
+existing read-only `paymentRequests` portal collection. The webhook MUST remain
+idempotent (a replayed event is a no-op) and MUST NOT trust any amount supplied
+by the caller: settlement reconciles the PSP event against the stored
+`PaymentRequest`. The `confirmationSummary` MUST be added to the
+`paymentRequests` collection field whitelist so the subject can see it.
+
+#### Scenario: Settlement pays the invoice and shows the debtor a confirmation
+
+- GIVEN a minted `PaymentRequest` for an owned invoice and a captured PSP webhook event with a valid signature
+- WHEN the webhook reconciles the event
+- THEN the `PaymentRequest` moves to captured/paid, the linked `ARInvoice.state` becomes `paid`, and a subject-safe `confirmationSummary` is written and exposed through the `paymentRequests` collection
+- AND a replayed webhook event is an idempotent no-op that does not double-settle or overwrite the confirmation
+- AND the settlement amount is reconciled from the stored `PaymentRequest`, never from a client-supplied amount
+- @e2e exclude e2e added in apply phase - spec-only PR
+
+### Requirement: The customer manifest declares a pay action as a rowAction on open invoices (REQ-SPPI-006)
+
+`OCA\Shillinq\Portal\PortalContributionProvider`'s `customer` manifest MUST
+declare exactly one contract-v2 `endpoint-forward` action `pay`
+(`{id, label, type: 'endpoint-forward', endpoint, method: 'POST', minTrust}`)
+whose `endpoint` is an instance-local RELATIVE path under
+`/apps/shillinq/api/portal/payments/` (leading slash, no scheme, no host, no
+`..`). The manifest MUST reference `pay` as a `rowAction` on the open-invoice
+rows of the `salesInvoices` and/or `paymentRequests` collections so portaliq
+renders a per-row pay-now control (a settled/non-payable row MUST NOT offer it).
+`minTrust` MUST track the AR surface. The `supplier` and `accountant` manifests'
+`actions` MUST remain empty. The provider MUST stay a plain, dependency-free
+class (no portaliq import, no `implements`, no constructor) — it only adds
+pure-data action + rowAction declarations.
+
+#### Scenario: The customer manifest carries the pay action and rowAction
+
+- GIVEN a constructed `PortalContributionProvider` and a subject with `audience: 'customer'`
+- WHEN `getContribution($subject)` is called
+- THEN the returned manifest's `actions` contains exactly a `pay` action of type `endpoint-forward` with an instance-local relative `endpoint` under `/apps/shillinq/api/portal/payments/`, method `POST`, and a `minTrust` tracking the AR surface
+- AND the `salesInvoices` / `paymentRequests` collections reference `pay` as a `rowAction` gated to open/payable rows
+- AND the `supplier` and `accountant` manifests' `actions` stay empty
+- @e2e exclude e2e added in apply phase - spec-only PR

--- a/openspec/changes/portal-payment-initiation/tasks.md
+++ b/openspec/changes/portal-payment-initiation/tasks.md
@@ -1,0 +1,41 @@
+# Tasks: portal-payment-initiation
+
+<!-- HYDRA CAP: max 20 unindented `- [ ]` lines. This file uses 12. -->
+
+## Prerequisites (apply-time confirmations)
+
+- [ ] T01 — Confirm the A6 assertion carries (or the receiver resolves) the subject's `customerMasterId` scope claim server-side; the receiver fails closed `403` without an owner-identifying claim, so this gates go-live, not authoring (design.md Open Q1).
+- [ ] T02 — Confirm shared-secret sourcing (verifier reads portaliq's instance signing secret; fail closed `401` when unset) and the portaliq-owned `redirectUrl` return-URL contract (design.md Open Q2/Q3).
+
+## Implementation
+
+- [ ] T03 — Add `PaymentProviderInterface` port + shipped Mollie binding (REQ-SPPI-001). Define `lib/Service/Payment/PaymentProviderInterface.php` (`createSession(...)`, `isDormant()`); ship a binding that delegates to the existing `MolliePaymentAdapterInterface` with `method: 'ideal'`, API key/test-mode from app config; register the DI binding in `Application::register()`. Do NOT fork a second Mollie client. EUPL-1.2/SPDX docblock + `@spec` tags.
+
+- [ ] T04 — Ship `lib/Portal/PortalAssertionVerifier.php` (REQ-SPPI-002). Verify HS256 vs the portaliq-managed shared secret; accept `alg == HS256` ONLY; require `iss=portaliq`, `use=assertion`, unexpired `exp`, frozen claim set; return derived claims or fail closed. No client input, no `Authorization` header.
+
+- [ ] T05 — Ship `lib/Service/Payment/PortalPaymentSessionService.php` (REQ-SPPI-002/003/004). Resolve the owned `ARInvoice` (id + `customerId == customerMasterId` + payable `state`) via OpenRegister; reject URL/path ids (SSRF); mint or reuse a pending `PaymentRequest`; read amount/currency from the SERVER invoice (ignore body amount); drive the provider port; persist `paymentIntentId`; return the checkout URL. Uniform not-authorised (no existence oracle).
+
+- [ ] T06 — Ship `lib/Controller/PortalPaymentInitiationController.php` (REQ-SPPI-002/003). One `#[PublicPage]` + `#[NoCSRFRequired]` route; verify assertion first; require `audience==customer`; delegate to the session service; fail closed 401/403/404/502/503; never echo raw exception text. Register the route in `appinfo/routes.php` (declared before the SPA catch-all).
+
+- [ ] T07 — Extend `PaymentReconciliationService` to write a subject-safe `confirmationSummary` on capture (REQ-SPPI-005). Add the `confirmationSummary` scalar to the `PaymentRequest` schema (`ar-invoice-payment-links.json`, register-version bump); keep settlement idempotent; reconcile amount from the stored PR only.
+
+- [ ] T08 — Extend `lib/Portal/PortalContributionProvider.php` — `pay` action + rowAction (REQ-SPPI-006). Add exactly one `pay` `endpoint-forward` action (instance-local relative endpoint under `/apps/shillinq/api/portal/payments/`, `method: POST`, `minTrust` tracking the AR surface); reference it as a `rowAction` on the open/payable rows of `salesInvoices`/`paymentRequests`; add `confirmationSummary` to the `paymentRequests` whitelist; keep `supplier`/`accountant` `actions` empty; class stays plain/dependency-free.
+
+## Testing & quality
+
+- [ ] T09 — Unit tests `tests/unit/Portal/PortalContributionProviderTest.php` (extend): pin the `pay` action (id, `type: endpoint-forward`, method, `minTrust`, relative endpoint) and the rowAction reference on open invoices; assert `supplier`/`accountant` `actions` stay empty; assert `confirmationSummary` in the `paymentRequests` whitelist.
+
+- [ ] T10 — Unit tests `tests/unit/Portal/PortalAssertionVerifierTest.php` + `PortalPaymentInitiationControllerTest.php` + `PortalPaymentSessionServiceTest.php` with a MOCKED `PaymentProviderInterface`: fail-closed matrix (missing/expired/wrong-`alg`/`iss`/`use`/bad-sig → 401; no secret → 401; wrong audience → 403; non-owned/non-payable/non-existent invoice → identical uniform result, PSP never called; URL `invoiceId` rejected); client-supplied amount ignored (charged = invoice amount); dormant provider → `503`/deferred, no fabricated URL; happy-path returns checkout URL.
+
+- [ ] T11 — Unit tests for the webhook confirmation (REQ-SPPI-005): a captured event writes `confirmationSummary` and settles the invoice to `paid`; a replayed event is an idempotent no-op; settlement amount reconciled from the stored PR, never the caller.
+
+- [ ] T12 — Quality gates: `php -l`, `composer check:strict` (PHPCS, PHPMD, Psalm, PHPStan) and the unit suite pass on the new files with zero new violations; relevant Hydra gates (route-auth, route-reachability, no-admin-idor, security-change-has-tests, spec-coverage) green; `openspec validate portal-payment-initiation --strict` exits 0.
+
+## Quality checklist
+
+- Every MUST in the spec has a unit test; the fail-closed matrix, the no-cross-debtor-IDOR guard, and the amount-integrity invariant are explicitly asserted (PSP never called on a non-authorised path; charged amount = server invoice amount).
+- The PSP is MOCKED in every unit test — no test contacts a real Mollie endpoint.
+- Manifest labels ship in English source (i18n policy); portaliq owns portal-side translation.
+- Refunds/partial reversals are explicitly out of scope (proposal) — no refund action ships.
+- Every referenced property (`ARInvoice.customerId/state`, `PaymentRequest.amount/state/paymentIntentId`) verified against HEAD; the only schema addition is `PaymentRequest.confirmationSummary`.
+- No Shillinq portal UI ships (portaliq owns the SPA) — no Playwright; receiver covered by PHPUnit.


### PR DESCRIPTION
## What

Spec-only OpenSpec `ff` change **`portal-payment-initiation`** (proposal + design + delta spec + tasks) — no code yet; tests + implementation land in the apply phase.

Lets an accountless debtor **pay their own open AR invoice** from the portaliq portal: a bearer-subject-scoped, A6-endpoint-forward initiation endpoint that verifies the invoice belongs to the subject, mints an **iDEAL** session through the existing Mollie provider, and returns the checkout URL — surfaced as a `pay` rowAction on open invoices.

## Evidence

- Builds on verified HEAD infra (consumed, not rebuilt): `MolliePaymentAdapterInterface::createPayment()` returns `{paymentId, checkoutUrl}`; `PaymentRequestWebhookController` (`POST /api/v1/payment-requests/webhook/{gateway}`, HMAC-verified, idempotent, `REQ-APL-004`); `PaymentReconciliationService`.
- Genuine gap closed: no subject-initiated, ownership-scoped session-creation endpoint exists today; the `customer` manifest `paymentRequests` collection is read-only (`actions: []`).
- Fail-closed: session minted only when `ARInvoice.customerId == verified customerMasterId` and `state in {issued, partially-paid, overdue}`; the charged amount is always the server invoice amount; PSP is mocked in tests.
- iDEAL demand: 65 tenders in the corpus require iDEAL specifically.
- `openspec validate portal-payment-initiation --strict` passes.
- Deviation noted in the spec: shillinq has **no** portal inbox/message schema, so the settlement confirmation is a subject-safe summary on the `PaymentRequest` (not an inbox row). Refunds explicitly out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)