### PR TITLE
fix(repair): FoldIntoOrder was a silent no-op, then non-idempotent — 5 live-only defects

### DIFF
--- a/lib/Repair/FoldIntoOrder.php
+++ b/lib/Repair/FoldIntoOrder.php
@@ -148,10 +148,17 @@ class FoldIntoOrder implements IRepairStep
             return;
         }
 
+        // Read every already-folded marker ONCE, up front. This is the idempotency
+        // index for the whole run: it needs no nested-property filtering (which
+        // OpenRegister does not support) and no assumption that the target's
+        // orderNumber equals the source migration key (it does not for
+        // DBAOpdracht, whose orderNumber is prefixed "DBA-").
+        $seen = $this->loadFoldedMarkers($objectService, $registerSlug, $output);
+
         $summary = [];
-        $summary['Subsidie']      = $this->foldRows($objectService, $registerSlug, $admin, $output, 'Subsidie', $this->buildSubsidieOrder(...));
-        $summary['PurchaseOrder'] = $this->foldRows($objectService, $registerSlug, $admin, $output, 'PurchaseOrder', $this->buildPurchaseOrder(...));
-        $summary['DBAOpdracht']   = $this->foldRows($objectService, $registerSlug, $admin, $output, 'DBAOpdracht', $this->buildEngagementOrder(...));
+        $summary['Subsidie']      = $this->foldRows($objectService, $registerSlug, $admin, $output, 'Subsidie', $this->buildSubsidieOrder(...), $seen);
+        $summary['PurchaseOrder'] = $this->foldRows($objectService, $registerSlug, $admin, $output, 'PurchaseOrder', $this->buildPurchaseOrder(...), $seen);
+        $summary['DBAOpdracht']   = $this->foldRows($objectService, $registerSlug, $admin, $output, 'DBAOpdracht', $this->buildEngagementOrder(...), $seen);
 
         foreach ($summary as $schema => $counts) {
             $output->info(
@@ -258,17 +265,18 @@ class FoldIntoOrder implements IRepairStep
      * @param IOutput  $output        The repair output.
      * @param string   $sourceSchema  The source schema slug to read.
      * @param callable $builder       fn(array $src, string $migrationKey): array|null — builds the Order record, or null to skip an unresolvable row.
+     * @param array    $seen          Set of already-folded markers, updated in place so a run never folds the same source twice.
      *
      * @return array{migrated:int,skipped:int,failed:int} Per-schema counts.
      */
-    private function foldRows(object $objectService, string $registerSlug, IUser $admin, IOutput $output, string $sourceSchema, callable $builder): array
+    private function foldRows(object $objectService, string $registerSlug, IUser $admin, IOutput $output, string $sourceSchema, callable $builder, array &$seen): array
     {
         $migrated = 0;
         $skipped  = 0;
         $failed   = 0;
 
         foreach ($this->readRows($objectService, $registerSlug, $sourceSchema, $output) as $row) {
-            $src          = (array) $row;
+            $src          = $this->normaliseRow($row);
             $migrationKey = $this->migrationKey($src, $sourceSchema);
 
             if ($migrationKey === '') {
@@ -278,7 +286,7 @@ class FoldIntoOrder implements IRepairStep
             }
 
             try {
-                if ($this->orderExists($objectService, $registerSlug, $sourceSchema, $migrationKey) === true) {
+                if (isset($seen[$this->markerKey($sourceSchema, $migrationKey)]) === true) {
                     $skipped++;
                     continue;
                 }
@@ -291,7 +299,7 @@ class FoldIntoOrder implements IRepairStep
                 }
 
                 $objectService->saveObject(
-                    object: $order,
+                    object: $this->pruneNulls($order),
                     register: $registerSlug,
                     schema: self::TARGET,
                     _rbac: false,
@@ -299,6 +307,7 @@ class FoldIntoOrder implements IRepairStep
                     currentUser: $admin,
                 );
 
+                $seen[$this->markerKey($sourceSchema, $migrationKey)] = true;
                 $migrated++;
             } catch (\Throwable $e) {
                 $output->warning('Shillinq: FoldIntoOrder — '.$sourceSchema.' "'.$migrationKey.'" fold failed: '.$e->getMessage());
@@ -313,6 +322,106 @@ class FoldIntoOrder implements IRepairStep
         return ['migrated' => $migrated, 'skipped' => $skipped, 'failed' => $failed];
 
     }//end foldRows()
+
+    /**
+     * Recursively drop null-valued keys from a built Order record.
+     *
+     * The builders emit an explicit null for every optional source field that is
+     * absent, but OpenRegister validates a present null against the property's
+     * declared type and rejects it ("Property 'subsidie.regelingArtikel' should be
+     * type 'string' but is 'null'"), failing the whole row. An ABSENT optional
+     * property is valid, so pruning is lossless — null carries no data.
+     * Live-verified: without this, every real Subsidie row failed to save.
+     *
+     * @param array<string,mixed> $record The built Order record.
+     *
+     * @return array<string,mixed> The record without null-valued keys.
+     */
+    private function pruneNulls(array $record): array
+    {
+        $clean = [];
+
+        foreach ($record as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            if (is_array($value) === true) {
+                $nested = $this->pruneNulls($value);
+                if ($nested === []) {
+                    continue;
+                }
+
+                $clean[$key] = $nested;
+                continue;
+            }
+
+            $clean[$key] = $value;
+        }
+
+        return $clean;
+
+    }//end pruneNulls()
+
+    /**
+     * Normalise one findAll() result row into its payload array.
+     *
+     * OpenRegister returns ObjectEntity instances, whose schema payload lives in
+     * getObject() — NOT in the object's own properties. A blind `(array) $row`
+     * cast therefore yields mangled "\0*\0prop" keys and loses every payload
+     * field, so the row reads as "no stable id" and gets skipped. Live-verified:
+     * every source row was skipped that way while the step still reported a
+     * clean summary.
+     *
+     * Nextcloud's Entity base implements its getters through __call(), so
+     * method_exists()/get_class_methods() report FALSE for getObject()/getUuid().
+     * Probe by calling, never by reflection.
+     *
+     * @param mixed $row One findAll() result row.
+     *
+     * @return array<string,mixed> The payload array (may be empty when unusable).
+     */
+    private function normaliseRow(mixed $row): array
+    {
+        if (is_array($row) === true) {
+            return $row;
+        }
+
+        if (is_object($row) === false) {
+            return [];
+        }
+
+        $data = [];
+
+        try {
+            $payload = $row->getObject();
+            if (is_array($payload) === true) {
+                $data = $payload;
+            }
+        } catch (\Throwable $e) {
+            $data = [];
+        }
+
+        if ($data === []) {
+            // Not an OR entity — public properties only; never a blind cast.
+            $data = get_object_vars($row);
+        }
+
+        // Guarantee a stable identifier even when the payload omits one.
+        if ((string) ($data['id'] ?? '') === '' && (string) ($data['uuid'] ?? '') === '') {
+            try {
+                $uuid = (string) $row->getUuid();
+                if ($uuid !== '') {
+                    $data['uuid'] = $uuid;
+                }
+            } catch (\Throwable $e) {
+                // No stable id available; the caller reports and skips the row.
+            }
+        }
+
+        return $data;
+
+    }//end normaliseRow()
 
     /**
      * Derive the stable migration key for a source row.
@@ -339,40 +448,63 @@ class FoldIntoOrder implements IRepairStep
     }//end migrationKey()
 
     /**
-     * Whether an Order already exists carrying the given source marker
-     * (idempotency for every fold).
+     * Build the set of already-folded source markers, read once per run.
      *
-     * @param object $objectService The OR ObjectService.
-     * @param string $registerSlug  The shillinq register slug.
-     * @param string $sourceSchema  The source schema slug.
-     * @param string $migrationKey  The stable source marker.
+     * Idempotency cannot be delegated to a query here: OpenRegister's findAll()
+     * does NOT support dot-path filters on nested properties, so the original
+     * `['migratedFrom.key' => ...]` filter matched nothing and the step always
+     * concluded "no existing Order" — re-folding every source row on every run,
+     * so each `occ upgrade` added a duplicate set of financial records
+     * (live-verified: a second run produced 2 Orders for one source key).
+     * Filtering on the top-level `orderNumber` instead is also wrong, because it
+     * only equals the migration key for Subsidie/PurchaseOrder — DBAOpdracht
+     * prefixes it "DBA-" (live-verified: engagement rows duplicated that way).
      *
-     * @return bool True when a matching Order exists.
+     * Reading the markers once is exact, needs no filter support, and costs one
+     * batched scan instead of a query per source row.
+     *
+     * @param object  $objectService The OR ObjectService.
+     * @param string  $registerSlug  The shillinq register slug.
+     * @param IOutput $output        The repair output.
+     *
+     * @return array<string,true> Set keyed by markerKey(schema, key).
      */
-    private function orderExists(object $objectService, string $registerSlug, string $sourceSchema, string $migrationKey): bool
+    private function loadFoldedMarkers(object $objectService, string $registerSlug, IOutput $output): array
     {
-        try {
-            $found = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema(self::TARGET)
-                ->findAll(
-                    [
-                        'filters'       => [
-                            'migratedFrom.schema' => $sourceSchema,
-                            'migratedFrom.key'    => $migrationKey,
-                        ],
-                        'limit'         => 1,
-                        '_rbac'         => false,
-                        '_multitenancy' => false,
-                    ]
-                );
+        $seen = [];
 
-            return is_array($found) === true && $found !== [];
-        } catch (\Throwable) {
-            return false;
+        foreach ($this->readRows($objectService, $registerSlug, self::TARGET, $output) as $row) {
+            $marker = ($this->normaliseRow($row)['migratedFrom'] ?? null);
+            if (is_array($marker) === false) {
+                continue;
+            }
+
+            $schema = (string) ($marker['schema'] ?? '');
+            $key    = (string) ($marker['key'] ?? '');
+            if ($schema === '' || $key === '') {
+                continue;
+            }
+
+            $seen[$this->markerKey($schema, $key)] = true;
         }
 
-    }//end orderExists()
+        return $seen;
+
+    }//end loadFoldedMarkers()
+
+    /**
+     * The set key identifying one folded source row.
+     *
+     * @param string $sourceSchema The source schema slug.
+     * @param string $migrationKey The stable source marker.
+     *
+     * @return string The composite set key.
+     */
+    private function markerKey(string $sourceSchema, string $migrationKey): string
+    {
+        return $sourceSchema."\0".$migrationKey;
+
+    }//end markerKey()
 
     /**
      * Build an Order record (orderType=subsidie) from a legacy Subsidie row.
@@ -404,11 +536,11 @@ class FoldIntoOrder implements IRepairStep
                 'regelingNaam'            => $this->firstNonEmpty([($src['regelingNaam'] ?? null), ($src['grantProgram'] ?? null), ($src['subsidieName'] ?? null)]),
                 'regelingArtikel'         => $this->firstNonEmpty([($src['regelingArtikel'] ?? null), ($src['grantProgram'] ?? null)]),
                 'subsidieRegeling'        => $this->stringOrNull($src['subsidieRegeling'] ?? null),
-                'aanvraagDate'            => $this->toDateTime($src['aanvraagDate'] ?? null),
-                'beschikkingDate'         => $this->toDateTime($src['beschikkingDate'] ?? ($src['awardDate'] ?? null)),
-                'vaststellingDate'        => $this->toDateTime($src['vaststellingDate'] ?? ($src['settlementDate'] ?? null)),
-                'settlementDate'          => $this->toDateTime($src['settlementDate'] ?? null),
-                'disbursementDate'        => $this->toDateTime($src['disbursementDate'] ?? null),
+                'aanvraagDate'            => $this->toDate($src['aanvraagDate'] ?? null),
+                'beschikkingDate'         => $this->toDate($src['beschikkingDate'] ?? ($src['awardDate'] ?? null)),
+                'vaststellingDate'        => $this->toDate($src['vaststellingDate'] ?? ($src['settlementDate'] ?? null)),
+                'settlementDate'          => $this->toDate($src['settlementDate'] ?? null),
+                'disbursementDate'        => $this->toDate($src['disbursementDate'] ?? null),
                 'aangevraagdBedrag'       => $this->floatOrNull($src['aangevraagdBedrag'] ?? null),
                 'verleendBedrag'          => $this->floatOrNull($src['verleendBedrag'] ?? ($src['awardAmount'] ?? null)),
                 'vastgesteldBedrag'       => $this->floatOrNull($src['vastgesteldBedrag'] ?? null),
@@ -471,7 +603,7 @@ class FoldIntoOrder implements IRepairStep
                 'requester'            => $this->stringOrNull($src['requester'] ?? null),
                 'requisitionId'        => $this->stringOrNull($src['requisitionId'] ?? null),
                 'deliveryAddress'      => $this->stringOrNull($src['deliveryAddress'] ?? null),
-                'expectedDeliveryDate' => $this->toDateTime($src['expectedDeliveryDate'] ?? null),
+                'expectedDeliveryDate' => $this->toDate($src['expectedDeliveryDate'] ?? null),
                 'totalExclVat'         => $this->intOrNull($src['totalExclVat'] ?? null),
                 'totalVat'             => $this->intOrNull($src['totalVat'] ?? null),
                 'totalInclVat'         => $totalInclVat,
@@ -518,22 +650,22 @@ class FoldIntoOrder implements IRepairStep
                 'ondernemingId'           => $this->stringOrNull($src['ondernemingId'] ?? null),
                 'klantId'                 => $this->stringOrNull($src['klantId'] ?? null),
                 'opdrachtNaam'            => $this->stringOrNull($src['opdrachtNaam'] ?? null),
-                'verwachteEindDatum'      => $this->toDateTime($src['verwachteEindDatum'] ?? null),
-                'feitelijkeEindDatum'     => $this->toDateTime($src['feitelijkeEindDatum'] ?? null),
+                'verwachteEindDatum'      => $this->toDate($src['verwachteEindDatum'] ?? null),
+                'feitelijkeEindDatum'     => $this->toDate($src['feitelijkeEindDatum'] ?? null),
                 'verwachteOmzet'          => $verwachteOmzet,
                 'gerealiseerdeOmzet'      => $this->intOrNull($src['gerealiseerdeOmzet'] ?? null),
                 'eenmaligLageDrempel'     => $this->boolOrNull($src['eenmaligLageDrempel'] ?? null),
                 'modelOvereenkomstId'     => $this->stringOrNull($src['modelOvereenkomstId'] ?? null),
-                'intakeDatum'             => $this->toDateTime($src['intakeDatum'] ?? null),
+                'intakeDatum'             => $this->toDate($src['intakeDatum'] ?? null),
                 'actueleRisicoscore'      => $this->intOrNull($src['actueleRisicoscore'] ?? null),
                 'risicoNiveau'            => $this->stringOrNull($src['risicoNiveau'] ?? null),
                 'openFlags'               => $this->intOrNull($src['openFlags'] ?? null),
                 'evidenceDossierId'       => $this->stringOrNull($src['evidenceDossierId'] ?? null),
                 'wbaBeoordelingResultaat' => $this->stringOrNull($src['wbaBeoordelingResultaat'] ?? null),
-                'wbaGeldigTot'            => $this->toDateTime($src['wbaGeldigTot'] ?? null),
+                'wbaGeldigTot'            => $this->toDate($src['wbaGeldigTot'] ?? null),
                 'intermediairMode'        => $this->boolOrNull($src['intermediairMode'] ?? null),
                 'perspectief'             => $this->stringOrNull($src['perspectief'] ?? null),
-                'retentieDeadline'        => $this->toDateTime($src['retentieDeadline'] ?? null),
+                'retentieDeadline'        => $this->toDate($src['retentieDeadline'] ?? null),
             ],
             'migratedFrom'     => [
                 'schema' => 'DBAOpdracht',
@@ -646,6 +778,37 @@ class FoldIntoOrder implements IRepairStep
      *
      * @return string|null The ISO date-time, or null.
      */
+    /**
+     * Normalise a source value to a bare calendar date (YYYY-MM-DD).
+     *
+     * Target properties declared `format: date` reject a full ISO-8601 timestamp
+     * ("should match format 'date' but '2026-01-15T00:00:00+00:00' does not"), so
+     * date-typed fields must NOT go through toDateTime(). Live-verified: emitting
+     * ATOM into a date field failed every real Subsidie row.
+     *
+     * @param mixed $value The raw source value.
+     *
+     * @return string|null The YYYY-MM-DD date, or null when unusable.
+     */
+    private function toDate(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $str = trim((string) $value);
+        if ($str === '') {
+            return null;
+        }
+
+        try {
+            return (new DateTimeImmutable($str))->format('Y-m-d');
+        } catch (\Throwable) {
+            return null;
+        }
+
+    }//end toDate()
+
     private function toDateTime(mixed $value): ?string
     {
         if ($value === null) {

--- a/lib/Repair/FoldIntoOrder.php
+++ b/lib/Repair/FoldIntoOrder.php
@@ -87,6 +87,14 @@ class FoldIntoOrder implements IRepairStep
     public const TARGET = 'OrderPrimitive';
 
     /**
+     * How many source rows to read per findAll() page.
+     *
+     * Source rows are read in batches so the fold never depends on implicit
+     * "unlimited" semantics and never loads an unbounded result set at once.
+     */
+    public const READ_BATCH_SIZE = 200;
+
+    /**
      * Constructor.
      *
      * @param SettingsService    $settingsService Provides the shillinq register slug.
@@ -184,6 +192,12 @@ class FoldIntoOrder implements IRepairStep
      * Read all rows of a source schema. Returns [] when the schema is absent
      * or empty (a valid no-op — e.g. a fresh tenant with 0 source rows).
      *
+     * Reads in explicit limit/offset batches. NEVER pass 'limit' => 0 hoping it
+     * means "unlimited": OpenRegister forwards it as a literal SQL LIMIT 0, so
+     * findAll() returns ZERO rows and this migration becomes a silent no-op that
+     * still reports "0 migrated, 0 skipped, 0 failed" — green, and dead.
+     * Live-verified on a real instance: limit=0 => 0 rows, limit=N/omitted => N.
+     *
      * @param object  $objectService The OR ObjectService.
      * @param string  $registerSlug  The shillinq register slug.
      * @param string  $schema        The source schema slug to read.
@@ -193,21 +207,37 @@ class FoldIntoOrder implements IRepairStep
      */
     private function readRows(object $objectService, string $registerSlug, string $schema, IOutput $output): array
     {
-        try {
-            $rows = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema($schema)
-                ->findAll(
-                    [
-                        'limit'         => 0,
-                        '_rbac'         => false,
-                        '_multitenancy' => false,
-                    ]
-                );
+        $rows   = [];
+        $offset = 0;
 
-            if (is_array($rows) === false) {
-                return [];
-            }
+        try {
+            while (true) {
+                $page = $objectService
+                    ->setRegister($registerSlug)
+                    ->setSchema($schema)
+                    ->findAll(
+                        [
+                            'limit'         => self::READ_BATCH_SIZE,
+                            'offset'        => $offset,
+                            '_rbac'         => false,
+                            '_multitenancy' => false,
+                        ]
+                    );
+
+                if (is_array($page) === false || $page === []) {
+                    break;
+                }
+
+                foreach ($page as $row) {
+                    $rows[] = $row;
+                }
+
+                if (count($page) < self::READ_BATCH_SIZE) {
+                    break;
+                }
+
+                $offset += self::READ_BATCH_SIZE;
+            }//end while
 
             return $rows;
         } catch (\Throwable $e) {

--- a/lib/Repair/FoldIntoOrder.php
+++ b/lib/Repair/FoldIntoOrder.php
@@ -769,16 +769,6 @@ class FoldIntoOrder implements IRepairStep
     }//end boolOrNull()
 
     /**
-     * Normalise a date / date-time source value to an ISO date-time string
-     * ('2026-03-01T00:00:00+00:00'), because OR validates the date-time format.
-     * A bare date ('2026-03-01') is widened to midnight UTC. Returns null when
-     * the source is empty or unparseable.
-     *
-     * @param mixed $value The raw date value.
-     *
-     * @return string|null The ISO date-time, or null.
-     */
-    /**
      * Normalise a source value to a bare calendar date (YYYY-MM-DD).
      *
      * Target properties declared `format: date` reject a full ISO-8601 timestamp
@@ -809,6 +799,19 @@ class FoldIntoOrder implements IRepairStep
 
     }//end toDate()
 
+    /**
+     * Normalise a date / date-time source value to an ISO date-time string
+     * ('2026-03-01T00:00:00+00:00'), because OR validates the date-time format.
+     * A bare date ('2026-03-01') is widened to midnight UTC. Returns null when
+     * the source is empty or unparseable.
+     *
+     * Use this ONLY for properties declared `format: date-time`; properties
+     * declared `format: date` must go through toDate().
+     *
+     * @param mixed $value The raw date value.
+     *
+     * @return string|null The ISO date-time, or null.
+     */
     private function toDateTime(mixed $value): ?string
     {
         if ($value === null) {

--- a/tests/Unit/Repair/FoldIntoOrderTest.php
+++ b/tests/Unit/Repair/FoldIntoOrderTest.php
@@ -150,6 +150,12 @@ class FoldIntoOrderTest extends TestCase
             }//end setSchema()
 
             /**
+             * Mirrors OpenRegister's real findAll() paging semantics: `limit` is a
+             * literal SQL LIMIT (so limit=0 returns ZERO rows, NOT "unlimited"),
+             * `offset` skips rows, and both apply AFTER filtering. Modelling this
+             * faithfully is what catches a caller passing limit=0 and silently
+             * reading nothing.
+             *
              * @param array<string,mixed> $params
              *
              * @return array<int,array<string,mixed>>
@@ -159,24 +165,34 @@ class FoldIntoOrderTest extends TestCase
                 $rows = ($this->recordsBySchema[$this->currentSchema] ?? []);
 
                 $filters = ($params['filters'] ?? []);
-                if ($filters === []) {
-                    return $rows;
+                if ($filters !== []) {
+                    $rows = array_values(
+                        array_filter(
+                            $rows,
+                            function (array $row) use ($filters): bool {
+                                foreach ($filters as $path => $expected) {
+                                    if ($this->dotGet($row, (string) $path) !== $expected) {
+                                        return false;
+                                    }
+                                }
+
+                                return true;
+                            }
+                        )
+                    );
                 }
 
-                return array_values(
-                    array_filter(
-                        $rows,
-                        function (array $row) use ($filters): bool {
-                            foreach ($filters as $path => $expected) {
-                                if ($this->dotGet($row, (string) $path) !== $expected) {
-                                    return false;
-                                }
-                            }
+                $offset = (int) ($params['offset'] ?? 0);
+                if ($offset > 0) {
+                    $rows = array_slice($rows, $offset);
+                }
 
-                            return true;
-                        }
-                    )
-                );
+                $limit = ($params['limit'] ?? null);
+                if ($limit !== null) {
+                    $rows = array_slice($rows, 0, (int) $limit);
+                }
+
+                return array_values($rows);
 
             }//end findAll()
 
@@ -461,6 +477,54 @@ class FoldIntoOrderTest extends TestCase
         self::assertCount(0, $fakeOs->saved('OrderPrimitive'));
 
     }//end testSkipsRowWithoutId()
+
+    /**
+     * Every source row is folded, including rows beyond the first read batch.
+     *
+     * Regression guard for the live-verified defect where readRows() passed
+     * `'limit' => 0` meaning "unlimited": OpenRegister forwards it as a literal
+     * SQL LIMIT 0, so the fold read ZERO rows and still reported
+     * "0 migrated, 0 skipped, 0 failed" — a silent, green no-op on every real
+     * instance. Seeding more rows than one batch also proves the offset paging
+     * actually advances instead of re-reading page one forever.
+     */
+    public function testFoldsEverySourceRowAcrossReadBatches(): void
+    {
+        $total     = (FoldIntoOrder::READ_BATCH_SIZE + 5);
+        $subsidies = [];
+        for ($i = 0; $i < $total; $i++) {
+            $subsidies[] = [
+                'id'                => 'sub-'.$i,
+                'administrationId'  => 'adm-1',
+                'direction'         => 'outgoing',
+                'subsidieNumber'    => sprintf('SUB-2026-%04d', $i),
+                'counterpartyName'  => 'Stichting '.$i,
+                'aangevraagdBedrag' => 1000.0,
+                'verleendBedrag'    => 900.0,
+                'state'             => 'verleend',
+                'currency'          => 'EUR',
+            ];
+        }
+
+        $fakeOs = $this->fakeObjectService(['Subsidie' => $subsidies]);
+        $this->container->method('get')->willReturn($fakeOs);
+
+        $step = new FoldIntoOrder(
+            settingsService: $this->settingsService,
+            logger: $this->logger,
+            groupManager: $this->groupManager,
+            container: $this->container,
+        );
+        $step->run($this->output);
+
+        $saved = $fakeOs->saved('OrderPrimitive');
+        self::assertCount($total, $saved, 'every source row must be folded, not just the first batch');
+
+        // The last row must be present — proves paging reached the final page.
+        $numbers = array_column($saved, 'orderNumber');
+        self::assertContains(sprintf('SUB-2026-%04d', ($total - 1)), $numbers);
+
+    }//end testFoldsEverySourceRowAcrossReadBatches()
 
     /**
      * Empty source schemas are handled gracefully (fresh-tenant no-op).

--- a/tests/Unit/Repair/FoldIntoOrderTest.php
+++ b/tests/Unit/Repair/FoldIntoOrderTest.php
@@ -169,8 +169,20 @@ class FoldIntoOrderTest extends TestCase
                     $rows = array_values(
                         array_filter(
                             $rows,
-                            function (array $row) use ($filters): bool {
+                            function (mixed $row) use ($filters): bool {
+                                if (is_array($row) === false) {
+                                    return false;
+                                }
+
                                 foreach ($filters as $path => $expected) {
+                                    // OpenRegister does NOT support dot-path filters on
+                                    // nested properties: such a filter matches nothing.
+                                    // Modelled faithfully so a caller relying on one is
+                                    // caught here instead of silently on a live instance.
+                                    if (str_contains((string) $path, '.') === true) {
+                                        return false;
+                                    }
+
                                     if ($this->dotGet($row, (string) $path) !== $expected) {
                                         return false;
                                     }
@@ -525,6 +537,152 @@ class FoldIntoOrderTest extends TestCase
         self::assertContains(sprintf('SUB-2026-%04d', ($total - 1)), $numbers);
 
     }//end testFoldsEverySourceRowAcrossReadBatches()
+
+    /**
+     * Rows arriving as OpenRegister ObjectEntity instances are folded.
+     *
+     * Regression guard for the live-verified defect where foldRows() did
+     * `(array) $row`. OpenRegister's findAll() returns ObjectEntity objects whose
+     * payload lives in getObject(); casting one to array yields mangled
+     * "\0*\0prop" keys, so every field — including the id — vanished and every
+     * row was rejected as "row without a stable id" while the step still printed
+     * a clean summary.
+     *
+     * The double below mirrors Nextcloud's Entity base by exposing getObject()
+     * and getUuid() through __call(), which is what makes method_exists() return
+     * FALSE for them on the real class.
+     */
+    public function testFoldsRowsDeliveredAsObjectEntities(): void
+    {
+        $payload = [
+            'id'                => 'sub-obj-1',
+            'administrationId'  => 'adm-1',
+            'direction'         => 'outgoing',
+            'subsidieNumber'    => 'SUB-2026-777',
+            'counterpartyName'  => 'Stichting Entity',
+            'aangevraagdBedrag' => 5000.0,
+            'verleendBedrag'    => 4500.0,
+            'state'             => 'verleend',
+            'currency'          => 'EUR',
+        ];
+
+        $entity = new class($payload) {
+
+            /**
+             * @var array<string,mixed>
+             */
+            private array $payload;
+
+            /**
+             * @param array<string,mixed> $payload
+             */
+            public function __construct(array $payload)
+            {
+                $this->payload = $payload;
+
+            }//end __construct()
+
+            /**
+             * Mirrors OCP\AppFramework\Db\Entity: getters resolve via __call, so
+             * method_exists() reports false for them.
+             *
+             * @param array<int,mixed> $arguments
+             */
+            public function __call(string $name, array $arguments): mixed
+            {
+                if ($name === 'getObject') {
+                    return $this->payload;
+                }
+
+                if ($name === 'getUuid') {
+                    return 'uuid-obj-1';
+                }
+
+                throw new \BadMethodCallException($name);
+
+            }//end __call()
+        };
+
+        $fakeOs = $this->fakeObjectService(['Subsidie' => [$entity]]);
+        $this->container->method('get')->willReturn($fakeOs);
+
+        $step = new FoldIntoOrder(
+            settingsService: $this->settingsService,
+            logger: $this->logger,
+            groupManager: $this->groupManager,
+            container: $this->container,
+        );
+        $step->run($this->output);
+
+        $saved = $fakeOs->saved('OrderPrimitive');
+        self::assertCount(1, $saved, 'an ObjectEntity row must fold, not be skipped as id-less');
+        self::assertSame('SUB-2026-777', $saved[0]['orderNumber']);
+        self::assertSame('subsidie', $saved[0]['orderType']);
+        self::assertSame('Stichting Entity', $saved[0]['counterpartyName']);
+
+    }//end testFoldsRowsDeliveredAsObjectEntities()
+
+    /**
+     * Re-running the step folds nothing again — for EVERY source type.
+     *
+     * Regression guard for the live-verified idempotency defect. The original
+     * check filtered on `migratedFrom.key`, which OpenRegister cannot match
+     * (no dot-path filter support), so every run re-folded every row and each
+     * `occ upgrade` added a duplicate set of financial records. Filtering on the
+     * top-level `orderNumber` instead still duplicated DBAOpdracht, whose
+     * orderNumber is prefixed "DBA-" and therefore never equals its migration
+     * key — which is why the marker set is read up front instead.
+     */
+    public function testSecondRunIsIdempotentForEverySourceType(): void
+    {
+        $records = [
+            'Subsidie'    => [
+                [
+                    'id'               => 'sub-idem-1',
+                    'administrationId' => 'adm-1',
+                    'direction'        => 'outgoing',
+                    'subsidieNumber'   => 'SUB-IDEM-1',
+                    'counterpartyName' => 'Stichting Idem',
+                    'verleendBedrag'   => 100.0,
+                    'state'            => 'verleend',
+                    'currency'         => 'EUR',
+                ],
+            ],
+            'DBAOpdracht' => [
+                [
+                    'id'            => 'dba-idem-1',
+                    'ondernemingId' => 'onp-1',
+                    'klantId'       => 'kl-1',
+                    'opdrachtNaam'  => 'Opdracht Idem',
+                    'startDatum'    => '2026-02-01',
+                    'intakeStatus'  => 'ACTIEF',
+                    'risicoNiveau'  => 'LAAG',
+                ],
+            ],
+        ];
+
+        $fakeOs = $this->fakeObjectService($records);
+        $this->container->method('get')->willReturn($fakeOs);
+
+        $step = new FoldIntoOrder(
+            settingsService: $this->settingsService,
+            logger: $this->logger,
+            groupManager: $this->groupManager,
+            container: $this->container,
+        );
+
+        $step->run($this->output);
+        $afterFirst = count($fakeOs->saved('OrderPrimitive'));
+        self::assertSame(2, $afterFirst, 'first run folds one Order per source row');
+
+        $step->run($this->output);
+        self::assertCount(
+            $afterFirst,
+            $fakeOs->saved('OrderPrimitive'),
+            'a second run must fold nothing again — no duplicate financial records'
+        );
+
+    }//end testSecondRunIsIdempotentForEverySourceType()
 
     /**
      * Empty source schemas are handled gracefully (fresh-tenant no-op).


### PR DESCRIPTION
Live-running the held `FoldIntoOrder` migration on a real instance (the precondition for un-holding it, per #503) surfaced **five defects**, none visible to the unit suite. Each is fixed and guarded by a test that fails without the fix.

## The defects

1. **`limit => 0` read ZERO rows.** `readRows()` passed it meaning "unlimited"; OpenRegister forwards it as a literal SQL `LIMIT 0`. The migration was a silent no-op that still reported `0 migrated, 0 skipped, 0 failed` — green, and dead, on every real instance. Now reads in explicit limit/offset batches.

   Live-verified (schema `Account`, 155 rows): `limit=0` → **0 rows**; omitted/`N` → **155**; `offset` pages disjoint.

2. **ObjectEntity rows were unreadable.** `foldRows()` did `(array) $row`, but `findAll()` returns `ObjectEntity` objects whose payload lives in `getObject()`. The cast yields mangled `"\0*\0prop"` keys, so every field — including the id — vanished and every row was rejected as *"row without a stable id"*. Note NC's `Entity` base serves getters via `__call()`, so `method_exists()` reports FALSE for `getObject()`/`getUuid()` — the fix probes by calling, never by reflection.

3. **Explicit nulls failed validation.** Builders emit `null` for absent optional fields; OR validates a present null against the declared type (`Property 'subsidie.regelingArtikel' should be type 'string' but is 'null'`) and fails the whole row. `pruneNulls()` drops them — lossless, since an absent optional property is valid.

4. **Date-typed fields got timestamps.** 11 target properties declare `format: date` and reject `2026-01-15T00:00:00+00:00`. Adds `toDate()` and routes exactly those 11 through it; `orderDate`/`endDate`/`peppolSentAt` stay `date-time` as declared.

5. **Not idempotent — the dangerous one.** `orderExists()` filtered on `migratedFrom.key`; OR does **not** support dot-path filters on nested properties, so it always answered "no existing Order". Every run re-folded every source row, so **each `occ upgrade` would add a duplicate set of financial records**. Filtering on top-level `orderNumber` instead still duplicated `DBAOpdracht` (its orderNumber is prefixed `DBA-`, so it never equals the migration key). Markers are now read once per run into a set, updated after each save.

## Why the tests missed all of this

The test double was **more permissive than the real service**: its `findAll()` ignored `limit`/`offset` entirely, accepted dot-path filters, and returned plain arrays. It now mirrors OpenRegister's real semantics, which is what turns these into genuine guards — reintroducing `limit => 0` fails 5 tests instead of 0.

## Live verification (running instance, real rows)

| source | first run | re-run | result |
|---|---|---|---|
| Subsidie | 1 migrated | 0 migrated / 1 skipped | exactly 1 Order, correctly mapped |
| DBAOpdracht | 1 migrated | 0 migrated / 1 skipped | exactly 1 Order, correctly mapped |
| PurchaseOrder | — | — | **unproven, see below** |

Source rows untouched; decidesk's `order` schema (1585) untouched throughout.

## Still held

The migration stays **HELD** (unregistered in `info.xml`). The `PurchaseOrder` path cannot be exercised at all: schema 1115 carries `all_of: ["1585"]` — it composes **decidesk's** Order schema and so demands decidesk's required properties, meaning no PurchaseOrder row can be created on a live instance. That is a separate data-level defect, filed separately, and it blocks un-holding.

## Checks

- `phpunit`: **3966/3966** green
- `phpcs`: 0 errors · `phpmd`: 0 violations

Refs #503