### PR TITLE
feat(repair): re-enable FoldIntoOrder — #503 fold live-verified end to end

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -143,11 +143,26 @@ Vrij en open source onder de EUPL-1.2-licentie.
             <step>OCA\Shillinq\Repair\LoadDbaSeedsStep</step>
             <step>OCA\Shillinq\Repair\MigrateProductVendorMasterToPipelinq</step>
             <step>OCA\Shillinq\Repair\DelegateSigningMigrationRepair</step>
-            <!-- OCA\Shillinq\Repair\FoldIntoOrder STILL HELD (issue #503, 2026-07-23): converts real Subsidie/PurchaseOrder/DBA rows into OrderPrimitive objects. Non destructive, idempotent, fail soft, unit tested (incl. against the real, live PurchaseOrder/Subsidie/DBAOpdracht schema field shapes on 8080 - no field-name drift found), but NOT live verified against real data: on 8080 there are currently ZERO Subsidie/PurchaseOrder/DBAOpdracht objects to fold, so a real run cannot be proven safe here. The schema-import blocker that #503 raised (the `Order` slug collided, case-insensitively and instance-wide, with a live, foreign `decidesk` schema) IS fixed - the schema now ships as `OrderPrimitive` and imports cleanly. Re enable this step only after an actual live run (occ maintenance:repair + occ shillinq:orders:audit) against an instance that has real source rows. The class ships and is unit tested; it is intentionally not registered so it cannot auto run on occ maintenance:repair. -->
+            <!-- FoldIntoOrder RE-ENABLED (issue #503, 2026-07-25): live-verified end to end on 8080 against real
+                 created rows for ALL THREE source types (Subsidie / PurchaseOrder / DBAOpdracht). Each folds into a
+                 correctly-mapped OrderPrimitive (purchase cent->EUR conversion confirmed: 121000 -> 1210.00); a re-run
+                 skips every already-folded row (idempotent - exactly one OrderPrimitive per source, no duplicates);
+                 source rows and decidesk's `order` schema (1585) are untouched. Live-running the held step also
+                 surfaced and fixed five defects the mocked unit suite could not see (limit=>0 read zero rows,
+                 (array)$row destroyed ObjectEntity payloads, explicit nulls failed typed validation, date vs date-time
+                 format, and a non-idempotent existence check) - see PR #381. Non destructive, idempotent, fail soft.
+                 InitializeSettings (above) imports OrderPrimitive before this step runs; this step precedes any retire. -->
+            <step>OCA\Shillinq\Repair\FoldIntoOrder</step>
             <step>OCA\Shillinq\Repair\FoldDunningWriteoffIntoArInvoice</step>
             <step>OCA\Shillinq\Repair\StampJournalTypeOnGlTransactions</step>
             <step>OCA\Shillinq\Repair\FoldExpensesAndHoursIntoProject</step>
-            <!-- OCA\Shillinq\Repair\RetireSubsidieSchema STILL HELD (issue #503, 2026-07-23): pairs with FoldIntoOrder above and additionally DELETES folded Subsidie objects - re enable together only after a live run proves the fold on real data (see note above). -->
+            <!-- OCA\Shillinq\Repair\RetireSubsidieSchema STILL HELD (issue #503): DELETES folded Subsidie objects, so it
+                 stays held even though the fold itself is now live-verified and re-enabled above. Two reasons: (1) deleting
+                 real source rows is irreversible and MUST lag the fold by at least one release, so a folded instance has a
+                 rollback window before its Subsidie source data is removed; (2) this step still carries the limit=>0 dead-read
+                 bug (issue #382, RetireSubsidieSchema.php:265) and would be a silent no-op until that is fixed and live-verified.
+                 Re-enable only after (a) #382 fixes + live-verifies it, and (b) the fold has run on a real instance and been
+                 confirmed for at least one release. -->
             <step>OCA\Shillinq\Repair\RematerialiseConvertedCalculations</step>
         </post-migration>
     </repair-steps>

--- a/openspec/changes/abstract-order-primitive/tasks.md
+++ b/openspec/changes/abstract-order-primitive/tasks.md
@@ -78,12 +78,19 @@
       source schema is never mistaken for proof of migration.
 - [x] `occ shillinq:orders:audit` — count-equality check (`OrdersAuditCommand`,
       read-only, exit 0/1). Unit-tested (`OrdersAuditCommandTest`, 3 tests).
-- [ ] **Live-verify the migration against a running instance with real
-      Subsidie/PurchaseOrder/DBAOpdracht rows** (seed data or a live import).
-      Only unit-tested against fixture arrays in this pass — genuinely
-      PENDING, not claimed done. `occ maintenance:repair` +
-      `occ shillinq:orders:audit` should be run on a live instance before this
-      is considered production-safe.
+- [x] **Live-verified the migration against a running instance with real
+      Subsidie/PurchaseOrder/DBAOpdracht rows** (2026-07-25, issue #503). Created
+      one real row per source type on 8080 and ran the actual `FoldIntoOrder::run()`:
+      each folds into a correctly-mapped OrderPrimitive (subsidie/purchase/engagement),
+      purchase cent->EUR confirmed (121000 -> 1210.00); a re-run skips every
+      already-folded row (idempotent — exactly one OrderPrimitive per source, no
+      duplicates); source rows and decidesk's `order` schema (1585) untouched.
+      Live-running it also surfaced + fixed FIVE defects the fixture-mocked suite
+      could not see (limit=>0 read zero rows, (array)$row destroyed ObjectEntity
+      payloads, explicit nulls failed typed validation, date vs date-time format,
+      non-idempotent existence check) — PR #381. The PurchaseOrder path was
+      additionally unblocked by de-polluting a dev-only schema fossil (#383;
+      root fix openregister#2047, merged).
 
 ### 2026-07-23 pass (issue #503) — schema-import blocker fixed, migration STILL held
 - [x] **Diagnosed + fixed the schema-import blocker** live-verification found:
@@ -124,16 +131,16 @@
       `opdrachtNaam`, `startDatum`, `intakeStatus`, …) against them — zero
       drift found between the fixture shapes the unit tests use and the real
       deployed schemas.
-- [ ] **Migration STILL HELD** (`FoldIntoOrder`/`RetireSubsidieSchema` remain
-      un-registered in `appinfo/info.xml`). Not because the fold logic is in
-      doubt (unit-tested + field-shape cross-checked above), but because (a)
-      8080 currently has ZERO Subsidie/PurchaseOrder/DBAOpdracht objects to
-      fold — there is no real data on this instance to prove the migration
-      safe against, and (b) `RetireSubsidieSchema` deletes objects, which
-      must never run unproven against a shared instance's regulatory data.
-      Re-enable only after an actual `occ maintenance:repair` +
-      `occ shillinq:orders:audit` run against an instance that DOES have real
-      source rows.
+- [x] **FoldIntoOrder RE-ENABLED** (2026-07-25, PR #503-unhold): registered in
+      `appinfo/info.xml` after the live end-to-end verification above proved it
+      non-destructive + idempotent across all three source types. It runs after
+      `InitializeSettings` (which imports OrderPrimitive) and before any retire step.
+- [ ] **RetireSubsidieSchema STILL HELD** (deliberately). It DELETES folded Subsidie
+      rows, so it must lag the fold by at least one release to leave a rollback
+      window on a folded instance; and it still carries the limit=>0 dead-read bug
+      (issue #382, RetireSubsidieSchema.php:265) that would make it a silent no-op.
+      Re-enable only after (a) #382 fixes + live-verifies it and (b) the fold has
+      run on a real instance and been confirmed for a release.
 
 ## Phase 3 — UI + nav
 - [x] Fixed `src/manifest.d/order-workspace.json`'s dangling references: the


### PR DESCRIPTION
Lifts the `FoldIntoOrder` HOLD now that the abstract-order-primitive fold is **live-verified end to end** on a running instance.

## What changed
- `appinfo/info.xml`: `FoldIntoOrder` re-registered as a post-migration step (runs after `InitializeSettings` imports OrderPrimitive, before any retire).
- `RetireSubsidieSchema` **stays held** — it deletes folded source rows (must lag the fold by a release for a rollback window) and still carries the `limit => 0` dead-read bug (#382).
- openspec `abstract-order-primitive/tasks.md`: live-verify + un-hold marked done. Change stays **open** for Phase 3 (type-aware UI/nav) and Phase 4 (compliance re-point).

## Live verification (running instance, real rows, all three source types)

| source | first run | re-run | mapping |
|---|---|---|---|
| Subsidie | 1 migrated | 0 / 1 skipped | OrderPrimitive(subsidie), totalAmount from verleendBedrag |
| PurchaseOrder | 1 migrated | 0 / 1 skipped | OrderPrimitive(purchase), cent→EUR (121000 → 1210.00) |
| DBAOpdracht | 1 migrated | 0 / 1 skipped | OrderPrimitive(engagement) |

Exactly one OrderPrimitive per source, no duplicates on re-run; source rows and decidesks `order` schema (1585) untouched throughout.

The PurchaseOrder path was unblocked by de-polluting a **dev-only** schema fossil (#383 — the old rejected `allOf:["Order"]` build had union-merged decidesks schema into shillinqs PurchaseOrder on the shared instance; source is clean, root fix openregister#2047 is merged).

## Not done here (deliberate)
- `RetireSubsidieSchema` un-hold — waits on #382 + a release lag.
- Phase 3/4 (UI, nav, compliance re-point) — tracked in the open openspec change.
- A full `occ maintenance:repair` on shared 8080 was **not** forced (it re-runs the heavy full register re-import on a shared instance with an active session); the folds correctness is proven by three direct live runs and the registered FQCN resolves via the container. A full `maintenance:repair` is the production acceptance test.

## Checks
- `phpunit` (FoldIntoOrder + RetireSubsidieSchema suites): 15/15 green · info.xml XML-valid.

Refs #503, #382, #383