### PR TITLE
refactor(repair): shared ReadsSourceRowsInBatches trait (#382 foundation)

### DIFF
--- a/lib/Repair/FoldIntoOrder.php
+++ b/lib/Repair/FoldIntoOrder.php
@@ -55,6 +55,7 @@ namespace OCA\Shillinq\Repair;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\IGroupManager;
 use OCP\IUser;
@@ -71,6 +72,8 @@ use Psr\Log\LoggerInterface;
  */
 class FoldIntoOrder implements IRepairStep
 {
+    use ReadsSourceRowsInBatches;
+
     /**
      * The target schema every fold writes to.
      *
@@ -85,14 +88,6 @@ class FoldIntoOrder implements IRepairStep
      * description for the full account.
      */
     public const TARGET = 'OrderPrimitive';
-
-    /**
-     * How many source rows to read per findAll() page.
-     *
-     * Source rows are read in batches so the fold never depends on implicit
-     * "unlimited" semantics and never loads an unbounded result set at once.
-     */
-    public const READ_BATCH_SIZE = 200;
 
     /**
      * Constructor.
@@ -199,11 +194,9 @@ class FoldIntoOrder implements IRepairStep
      * Read all rows of a source schema. Returns [] when the schema is absent
      * or empty (a valid no-op — e.g. a fresh tenant with 0 source rows).
      *
-     * Reads in explicit limit/offset batches. NEVER pass 'limit' => 0 hoping it
-     * means "unlimited": OpenRegister forwards it as a literal SQL LIMIT 0, so
-     * findAll() returns ZERO rows and this migration becomes a silent no-op that
-     * still reports "0 migrated, 0 skipped, 0 failed" — green, and dead.
-     * Live-verified on a real instance: limit=0 => 0 rows, limit=N/omitted => N.
+     * Delegates the batched read to {@see ReadsSourceRowsInBatches::readAllRows()}
+     * (which is why 'limit' => 0 must never be used — see that trait) and keeps
+     * this step's own fail-soft "schema not available" handling.
      *
      * @param object  $objectService The OR ObjectService.
      * @param string  $registerSlug  The shillinq register slug.
@@ -214,44 +207,12 @@ class FoldIntoOrder implements IRepairStep
      */
     private function readRows(object $objectService, string $registerSlug, string $schema, IOutput $output): array
     {
-        $rows   = [];
-        $offset = 0;
-
         try {
-            while (true) {
-                $page = $objectService
-                    ->setRegister($registerSlug)
-                    ->setSchema($schema)
-                    ->findAll(
-                        [
-                            'limit'         => self::READ_BATCH_SIZE,
-                            'offset'        => $offset,
-                            '_rbac'         => false,
-                            '_multitenancy' => false,
-                        ]
-                    );
-
-                if (is_array($page) === false || $page === []) {
-                    break;
-                }
-
-                foreach ($page as $row) {
-                    $rows[] = $row;
-                }
-
-                if (count($page) < self::READ_BATCH_SIZE) {
-                    break;
-                }
-
-                $offset += self::READ_BATCH_SIZE;
-            }//end while
-
-            return $rows;
+            return $this->readAllRows($objectService, $registerSlug, $schema);
         } catch (\Throwable $e) {
             $output->info('Shillinq: FoldIntoOrder — '.$schema.' schema not available ('.$e->getMessage().'); skipping.');
             return [];
-        }//end try
-
+        }
     }//end readRows()
 
     /**

--- a/lib/Repair/Support/ReadsSourceRowsInBatches.php
+++ b/lib/Repair/Support/ReadsSourceRowsInBatches.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Shillinq repair-step trait: batched source-row reads
+ *
+ * Reads every row of an OpenRegister schema in explicit limit/offset batches.
+ *
+ * WHY THIS EXISTS: `ObjectService::findAll(['limit' => 0])` does NOT mean
+ * "unlimited" — OpenRegister forwards it as a literal SQL `LIMIT 0`, returning
+ * ZERO rows. A repair step written that way enumerates nothing, does nothing,
+ * and still reports a clean summary — green, and dead, on every real instance
+ * (issue #382; first found in FoldIntoOrder, #503/#381). Live-verified on 8080:
+ * `findAll(['limit' => 0])` => 0 rows; omitting `limit` => all rows; `offset`
+ * pages correctly. This trait makes the correct batched pattern the single,
+ * reusable default so the class of bug cannot recur one step at a time.
+ *
+ * The read is unscoped (`_rbac` / `_multitenancy` false): a data migration must
+ * see every tenant's rows regardless of the (session-less) repair context.
+ *
+ * @category Repair
+ * @package  OCA\Shillinq\Repair\Support
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Repair\Support;
+
+/**
+ * Provides a batched, unscoped "read every source row" helper for repair steps.
+ */
+trait ReadsSourceRowsInBatches
+{
+    /**
+     * How many source rows to read per findAll() page.
+     *
+     * Bounds memory and keeps the read off implicit "unlimited" semantics.
+     */
+    public const READ_BATCH_SIZE = 200;
+
+    /**
+     * Read every row of a source schema in explicit limit/offset batches.
+     *
+     * NEVER pass `'limit' => 0` hoping for "unlimited" — see the trait docblock.
+     * Exceptions propagate: each caller keeps its own missing-schema handling
+     * (some warn, some info, some skip) rather than have it swallowed here.
+     *
+     * @param object              $objectService The OR ObjectService.
+     * @param string              $registerSlug  The register slug to read from.
+     * @param string              $schema        The schema slug to read.
+     * @param array<string,mixed> $filters       Optional top-level filters (OR does
+     *                                           NOT support dot-path nested filters).
+     *
+     * @return array<int,mixed> Every matching row (may be empty).
+     */
+    protected function readAllRows(object $objectService, string $registerSlug, string $schema, array $filters=[]): array
+    {
+        $rows   = [];
+        $offset = 0;
+
+        while (true) {
+            $config = [
+                'limit'         => self::READ_BATCH_SIZE,
+                'offset'        => $offset,
+                '_rbac'         => false,
+                '_multitenancy' => false,
+            ];
+            if ($filters !== []) {
+                $config['filters'] = $filters;
+            }
+
+            $page = $objectService
+                ->setRegister($registerSlug)
+                ->setSchema($schema)
+                ->findAll($config);
+
+            if (is_array($page) === false || $page === []) {
+                break;
+            }
+
+            foreach ($page as $row) {
+                $rows[] = $row;
+            }
+
+            if (count($page) < self::READ_BATCH_SIZE) {
+                break;
+            }
+
+            $offset += self::READ_BATCH_SIZE;
+        }//end while
+
+        return $rows;
+
+    }//end readAllRows()
+}//end trait


### PR DESCRIPTION
Phase C foundation for #382 (the eleven repair steps + audit command that silently read zero rows via `findAll(['limit' => 0])`).

Factors the correct batched-read pattern — the fix FoldIntoOrder proved live (#381) — into a shared `ReadsSourceRowsInBatches` trait, so each sibling step adopts one audited helper instead of re-implementing pagination (and re-introducing the bug).

- `readAllRows()` reads every row in explicit limit/offset batches, unscoped (`_rbac`/`_multitenancy` false — a migration must see all tenants), exceptions propagate so each step keeps its own missing-schema handling.
- FoldIntoOrder refactored onto it as the first consumer.

**Behaviour-preserving:** full suite **3966/3966** green; FoldIntoOrder's 11 tests (which now faithfully model OR's limit/offset semantics) pass unchanged. phpcs/phpmd clean.

Follow-ups (this PR is just the foundation): adopt the trait in the 11 dead steps (one at a time, each live-verified), then add a hydra gate forbidding `limit => 0` in repair steps.

Refs #382