### PR TITLE
fix(command): orders:audit reported a false PASS — limit=>0 + dot-path filter (#382)

### DIFF
--- a/lib/Command/OrdersAuditCommand.php
+++ b/lib/Command/OrdersAuditCommand.php
@@ -32,6 +32,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Command;
 
+use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -50,6 +51,8 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class OrdersAuditCommand extends Command
 {
+    use ReadsSourceRowsInBatches;
+
     /**
      * Source schema slug => discriminator orderType it folds onto.
      *
@@ -161,22 +164,7 @@ class OrdersAuditCommand extends Command
     private function countRows(object $objectService, string $registerSlug, string $schema): int
     {
         try {
-            $rows = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema($schema)
-                ->findAll(
-                    [
-                        'limit'         => 0,
-                        '_rbac'         => false,
-                        '_multitenancy' => false,
-                    ]
-                );
-
-            if (is_array($rows) === false) {
-                return 0;
-            }
-
-            return count($rows);
+            return count($this->readAllRows($objectService, $registerSlug, $schema));
         } catch (\Throwable) {
             return 0;
         }
@@ -195,23 +183,29 @@ class OrdersAuditCommand extends Command
     private function countMigrated(object $objectService, string $registerSlug, string $sourceSchema): int
     {
         try {
-            $rows = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema('OrderPrimitive')
-                ->findAll(
-                    [
-                        'filters'       => ['migratedFrom.schema' => $sourceSchema],
-                        'limit'         => 0,
-                        '_rbac'         => false,
-                        '_multitenancy' => false,
-                    ]
-                );
+            // OpenRegister does NOT support dot-path filters on nested properties,
+            // so `['migratedFrom.schema' => ...]` matches nothing (it silently
+            // returned 0, making the audit report a false PASS). Read every
+            // OrderPrimitive row and match the nested marker in PHP instead.
+            $count = 0;
+            foreach ($this->readAllRows($objectService, $registerSlug, 'OrderPrimitive') as $row) {
+                $data = $row;
+                if (is_object($row) === true) {
+                    try {
+                        $data = $row->getObject();
+                    } catch (\Throwable) {
+                        $data = [];
+                    }
+                }
 
-            if (is_array($rows) === false) {
-                return 0;
+                if (is_array($data) === true
+                    && (string) (($data['migratedFrom']['schema'] ?? '')) === $sourceSchema
+                ) {
+                    $count++;
+                }
             }
 
-            return count($rows);
+            return $count;
         } catch (\Throwable) {
             return 0;
         }//end try

--- a/tests/Unit/Command/OrdersAuditCommandTest.php
+++ b/tests/Unit/Command/OrdersAuditCommandTest.php
@@ -108,6 +108,12 @@ class OrdersAuditCommandTest extends TestCase
             }//end setSchema()
 
             /**
+             * Mirrors OpenRegister's real findAll() semantics: `limit` is a literal
+             * SQL LIMIT (limit=0 => ZERO rows), `offset` skips, and dot-path filters
+             * on nested properties match NOTHING. Modelling this faithfully is what
+             * catches limit=>0 reads and nested-filter idempotency checks — the two
+             * bugs that made this audit report a false PASS.
+             *
              * @param array<string,mixed> $params
              *
              * @return array<int,array<string,mixed>>
@@ -116,24 +122,39 @@ class OrdersAuditCommandTest extends TestCase
             {
                 $rows    = ($this->recordsBySchema[$this->currentSchema] ?? []);
                 $filters = ($params['filters'] ?? []);
-                if ($filters === []) {
-                    return $rows;
+                if ($filters !== []) {
+                    $rows = array_values(
+                        array_filter(
+                            $rows,
+                            static function (array $row) use ($filters): bool {
+                                foreach ($filters as $path => $expected) {
+                                    // OR does not support dot-path filters on nested props.
+                                    if (str_contains((string) $path, '.') === true) {
+                                        return false;
+                                    }
+
+                                    if (($row[$path] ?? null) !== $expected) {
+                                        return false;
+                                    }
+                                }
+
+                                return true;
+                            }
+                        )
+                    );
                 }
 
-                return array_values(
-                    array_filter(
-                        $rows,
-                        static function (array $row) use ($filters): bool {
-                            foreach ($filters as $path => $expected) {
-                                if (($row['migratedFrom']['schema'] ?? null) !== $expected) {
-                                    return false;
-                                }
-                            }
+                $offset = (int) ($params['offset'] ?? 0);
+                if ($offset > 0) {
+                    $rows = array_slice($rows, $offset);
+                }
 
-                            return true;
-                        }
-                    )
-                );
+                $limit = ($params['limit'] ?? null);
+                if ($limit !== null) {
+                    $rows = array_slice($rows, 0, (int) $limit);
+                }
+
+                return array_values($rows);
 
             }//end findAll()
         };


### PR DESCRIPTION
First step of the #382 campaign. `shillinq:orders:audit` — the tool the FoldIntoOrder hold notes cite to validate the fold — was **green-but-dead**.

## Bug
- `countRows()` used `findAll(['limit' => 0])` → literal SQL LIMIT 0 → **0 rows**.
- `countMigrated()` used **both** `limit => 0` and a `['migratedFrom.schema' => ...]` dot-path filter (OpenRegister does not support nested filters → matches nothing).

Every schema reported `source=0 migrated=0`, so `migrated >= source` was `0>=0` → **OK/PASS for everything, always** — even with nothing folded.

## Fix
Adopt `ReadsSourceRowsInBatches` for the counts; match the nested `migratedFrom` marker in PHP (reading the ObjectEntity payload via `getObject()`) instead of an unsupported dot-path filter.

The test double was unfaithful in the two masking ways (ignored `limit`, supported dot-path filters), so it passed with broken code. Now mirrors ORs real semantics.

## Live-verified on 8080
| state | audit output | exit |
|---|---|---|
| 0 source rows | `source=0 migrated=0 OK` · PASS | 0 |
| 1 folded Subsidie | `source=1 migrated=1 OK` · PASS | 0 |
| +1 unfolded Subsidie | `source=2 migrated=1 MISMATCH` · FAIL | **1** |

Real counts and real mismatch detection — the false PASS is gone. Test rows cleaned up.

## Checks
`phpunit` (OrdersAuditCommand): 3/3 green · phpcs/phpmd clean.

Refs #382