### PR TITLE
fix(repair): dead-read + ObjectEntity-cast across all repair steps (#382)

### DIFF
--- a/lib/Command/OrdersAuditCommand.php
+++ b/lib/Command/OrdersAuditCommand.php
@@ -164,7 +164,7 @@ class OrdersAuditCommand extends Command
     private function countRows(object $objectService, string $registerSlug, string $schema): int
     {
         try {
-            return count($this->readAllRows($objectService, $registerSlug, $schema));
+            return count($this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: $schema));
         } catch (\Throwable) {
             return 0;
         }
@@ -188,7 +188,7 @@ class OrdersAuditCommand extends Command
             // returned 0, making the audit report a false PASS). Read every
             // OrderPrimitive row and match the nested marker in PHP instead.
             $count = 0;
-            foreach ($this->readAllRows($objectService, $registerSlug, 'OrderPrimitive') as $row) {
+            foreach ($this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: 'OrderPrimitive') as $row) {
                 $data = $row;
                 if (is_object($row) === true) {
                     try {

--- a/lib/Repair/BackfillFiscalPeriods.php
+++ b/lib/Repair/BackfillFiscalPeriods.php
@@ -49,6 +49,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Repair;
 
 use DateTimeImmutable;
+use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -63,6 +64,8 @@ use Psr\Log\LoggerInterface;
  */
 class BackfillFiscalPeriods implements IRepairStep
 {
+    use ReadsSourceRowsInBatches;
+
     /**
      * Constructor.
      *
@@ -109,12 +112,9 @@ class BackfillFiscalPeriods implements IRepairStep
             // Stream every GLLine carrying a non-empty periodId; collect
             // the (administrationId, periodId) tuples we have not yet
             // materialised as FiscalPeriod records.
-            $lines = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema('GLLine')
-                ->findAll(['limit' => 0]);
+            $lines = $this->readAllRows($objectService, $registerSlug, 'GLLine');
 
-            if (is_array($lines) === false || $lines === []) {
+            if ($lines === []) {
                 $output->info('Shillinq: no GLLine records — FiscalPeriod backfill skipped.');
                 return;
             }
@@ -122,7 +122,7 @@ class BackfillFiscalPeriods implements IRepairStep
             // Bucket distinct (administrationId, periodId) tuples.
             $tuples = [];
             foreach ($lines as $line) {
-                $arr      = (array) $line;
+                $arr      = $this->rowPayload($line);
                 $periodId = (string) ($arr['periodId'] ?? '');
                 if ($periodId === '') {
                     continue;

--- a/lib/Repair/BackfillFiscalPeriods.php
+++ b/lib/Repair/BackfillFiscalPeriods.php
@@ -112,7 +112,7 @@ class BackfillFiscalPeriods implements IRepairStep
             // Stream every GLLine carrying a non-empty periodId; collect
             // the (administrationId, periodId) tuples we have not yet
             // materialised as FiscalPeriod records.
-            $lines = $this->readAllRows($objectService, $registerSlug, 'GLLine');
+            $lines = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: 'GLLine');
 
             if ($lines === []) {
                 $output->info('Shillinq: no GLLine records — FiscalPeriod backfill skipped.');
@@ -122,7 +122,7 @@ class BackfillFiscalPeriods implements IRepairStep
             // Bucket distinct (administrationId, periodId) tuples.
             $tuples = [];
             foreach ($lines as $line) {
-                $arr      = $this->rowPayload($line);
+                $arr      = $this->rowPayload(row: $line);
                 $periodId = (string) ($arr['periodId'] ?? '');
                 if ($periodId === '') {
                     continue;

--- a/lib/Repair/DelegateSigningMigrationRepair.php
+++ b/lib/Repair/DelegateSigningMigrationRepair.php
@@ -50,6 +50,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Repair;
 
+use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -66,6 +67,8 @@ use Psr\Log\LoggerInterface;
  */
 class DelegateSigningMigrationRepair implements IRepairStep
 {
+    use ReadsSourceRowsInBatches;
+
     /**
      * Constructor.
      *
@@ -156,18 +159,15 @@ class DelegateSigningMigrationRepair implements IRepairStep
         $updated = 0;
         $skipped = 0;
 
-        $reports = $objectService
-            ->setRegister($registerSlug)
-            ->setSchema('ACMReport')
-            ->findAll(['limit' => 0]);
+        $reports = $this->readAllRows($objectService, $registerSlug, 'ACMReport');
 
-        if (is_array($reports) === false || $reports === []) {
+        if ($reports === []) {
             $output->info('Shillinq: no ACMReport records found — skipping signing-delegation backfill.');
             return ['updated' => 0, 'skipped' => 0];
         }
 
         foreach ($reports as $report) {
-            $arr         = (array) $report;
+            $arr         = $this->rowPayload($report);
             $fingerprint = (string) ($arr['signatureFingerprint'] ?? '');
             $signingRef  = (string) ($arr['signingRequestRef'] ?? '');
 

--- a/lib/Repair/DelegateSigningMigrationRepair.php
+++ b/lib/Repair/DelegateSigningMigrationRepair.php
@@ -159,7 +159,7 @@ class DelegateSigningMigrationRepair implements IRepairStep
         $updated = 0;
         $skipped = 0;
 
-        $reports = $this->readAllRows($objectService, $registerSlug, 'ACMReport');
+        $reports = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: 'ACMReport');
 
         if ($reports === []) {
             $output->info('Shillinq: no ACMReport records found — skipping signing-delegation backfill.');
@@ -167,7 +167,7 @@ class DelegateSigningMigrationRepair implements IRepairStep
         }
 
         foreach ($reports as $report) {
-            $arr         = $this->rowPayload($report);
+            $arr         = $this->rowPayload(row: $report);
             $fingerprint = (string) ($arr['signatureFingerprint'] ?? '');
             $signingRef  = (string) ($arr['signingRequestRef'] ?? '');
 

--- a/lib/Repair/FoldDunningWriteoffIntoArInvoice.php
+++ b/lib/Repair/FoldDunningWriteoffIntoArInvoice.php
@@ -51,6 +51,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Repair;
 
+use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\IGroupManager;
 use OCP\IUser;
@@ -66,6 +67,8 @@ use Psr\Log\LoggerInterface;
  */
 class FoldDunningWriteoffIntoArInvoice implements IRepairStep
 {
+    use ReadsSourceRowsInBatches;
+
     /**
      * Constructor.
      *
@@ -112,12 +115,9 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep
             // Stream every OninbaarAfschrijving write-off row. RBAC +
             // multi-tenancy are bypassed: the repair runs in the
             // installer/upgrade context with no authenticated session.
-            $writeOffs = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema('OninbaarAfschrijving')
-                ->findAll(['limit' => 0], _rbac: false, _multitenancy: false);
+            $writeOffs = $this->readAllRows($objectService, $registerSlug, 'OninbaarAfschrijving');
 
-            if (is_array($writeOffs) === false || $writeOffs === []) {
+            if ($writeOffs === []) {
                 $output->info('Shillinq: no OninbaarAfschrijving rows — ARInvoice writeOff/dunning fold skipped.');
                 return;
             }
@@ -126,7 +126,7 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep
             $skipped = 0;
             $missing = 0;
             foreach ($writeOffs as $writeOff) {
-                $row       = (array) $writeOff;
+                $row       = $this->rowPayload($writeOff);
                 $factuurId = (string) ($row['factuurId'] ?? '');
                 if ($factuurId === '') {
                     $skipped++;
@@ -275,19 +275,12 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep
         string $factuurId
     ): ?array {
         try {
-            $runs = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema('DunningRun')
-                ->findAll(
-                    ['filters' => ['factuurId' => $factuurId], 'limit' => 0],
-                    _rbac: false,
-                    _multitenancy: false
-                );
+            $runs = $this->readAllRows($objectService, $registerSlug, 'DunningRun', ['factuurId' => $factuurId]);
         } catch (\Throwable $e) {
             return null;
         }
 
-        if (is_array($runs) === false || $runs === []) {
+        if ($runs === []) {
             return null;
         }
 
@@ -295,7 +288,7 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep
         $latestStage = -1;
         $latestExec  = '';
         foreach ($runs as $run) {
-            $runArr = (array) $run;
+            $runArr = $this->rowPayload($run);
             $stage  = (int) ($runArr['stageNr'] ?? 0);
             $exec   = (string) ($runArr['uitgevoerdOp'] ?? '');
 

--- a/lib/Repair/FoldDunningWriteoffIntoArInvoice.php
+++ b/lib/Repair/FoldDunningWriteoffIntoArInvoice.php
@@ -115,7 +115,7 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep
             // Stream every OninbaarAfschrijving write-off row. RBAC +
             // multi-tenancy are bypassed: the repair runs in the
             // installer/upgrade context with no authenticated session.
-            $writeOffs = $this->readAllRows($objectService, $registerSlug, 'OninbaarAfschrijving');
+            $writeOffs = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: 'OninbaarAfschrijving');
 
             if ($writeOffs === []) {
                 $output->info('Shillinq: no OninbaarAfschrijving rows — ARInvoice writeOff/dunning fold skipped.');
@@ -126,7 +126,7 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep
             $skipped = 0;
             $missing = 0;
             foreach ($writeOffs as $writeOff) {
-                $row       = $this->rowPayload($writeOff);
+                $row       = $this->rowPayload(row: $writeOff);
                 $factuurId = (string) ($row['factuurId'] ?? '');
                 if ($factuurId === '') {
                     $skipped++;
@@ -275,7 +275,12 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep
         string $factuurId
     ): ?array {
         try {
-            $runs = $this->readAllRows($objectService, $registerSlug, 'DunningRun', ['factuurId' => $factuurId]);
+            $runs = $this->readAllRows(
+                objectService: $objectService,
+                registerSlug: $registerSlug,
+                schema: 'DunningRun',
+                filters: ['factuurId' => $factuurId]
+            );
         } catch (\Throwable $e) {
             return null;
         }
@@ -288,7 +293,7 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep
         $latestStage = -1;
         $latestExec  = '';
         foreach ($runs as $run) {
-            $runArr = $this->rowPayload($run);
+            $runArr = $this->rowPayload(row: $run);
             $stage  = (int) ($runArr['stageNr'] ?? 0);
             $exec   = (string) ($runArr['uitgevoerdOp'] ?? '');
 

--- a/lib/Repair/FoldExpensesAndHoursIntoProject.php
+++ b/lib/Repair/FoldExpensesAndHoursIntoProject.php
@@ -104,7 +104,7 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep
             // Index every Project by every identifier a source object might
             // reference (id / uuid / projectNumber / code). Values are kept
             // as live mutable arrays so multiple lines fold into one save.
-            $projects = $this->readAllRows($objectService, $registerSlug, 'Project');
+            $projects = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: 'Project');
 
             if ($projects === []) {
                 $output->info('Shillinq: no Project records — expense/hours fold skipped.');
@@ -248,7 +248,7 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep
         $projectArrays = [];
 
         foreach ($projects as $project) {
-            $arr = $this->rowPayload($project);
+            $arr = $this->rowPayload(row: $project);
             $id  = (string) ($arr['id'] ?? '');
             if ($id === '') {
                 $id = (string) ($arr['uuid'] ?? '');
@@ -298,13 +298,13 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep
         $index = [];
 
         try {
-            $claims = $this->readAllRows($objectService, $registerSlug, 'ExpenseClaimEntry');
+            $claims = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: 'ExpenseClaimEntry');
         } catch (\Throwable $e) {
             return $index;
         }
 
         foreach ($claims as $claim) {
-            $arr       = $this->rowPayload($claim);
+            $arr       = $this->rowPayload(row: $claim);
             $projectId = (string) ($arr['projectId'] ?? '');
             if ($projectId === '') {
                 continue;
@@ -354,7 +354,7 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep
         $newlyTouched = [];
 
         try {
-            $rows = $this->readAllRows($objectService, $registerSlug, $schema);
+            $rows = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: $schema);
         } catch (\Throwable $e) {
             $output->warning('Shillinq: fold — failed to list '.$schema.': '.$e->getMessage());
             return $newlyTouched;
@@ -362,7 +362,7 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep
 
         foreach ($rows as $row) {
             try {
-                $arr      = $this->rowPayload($row);
+                $arr      = $this->rowPayload(row: $row);
                 $sourceId = (string) ($arr['id'] ?? ($arr['uuid'] ?? ''));
                 if ($sourceId === '') {
                     continue;
@@ -418,7 +418,7 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep
         $newlyTouched = [];
 
         try {
-            $rows = $this->readAllRows($objectService, $registerSlug, 'UrenRegistratie');
+            $rows = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: 'UrenRegistratie');
         } catch (\Throwable $e) {
             $output->warning('Shillinq: fold — failed to list UrenRegistratie: '.$e->getMessage());
             return $newlyTouched;
@@ -426,7 +426,7 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep
 
         foreach ($rows as $row) {
             try {
-                $arr      = $this->rowPayload($row);
+                $arr      = $this->rowPayload(row: $row);
                 $sourceId = (string) ($arr['id'] ?? ($arr['uuid'] ?? ''));
                 if ($sourceId === '') {
                     continue;

--- a/lib/Repair/FoldExpensesAndHoursIntoProject.php
+++ b/lib/Repair/FoldExpensesAndHoursIntoProject.php
@@ -42,6 +42,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Repair;
 
 use DateTimeImmutable;
+use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\IGroupManager;
 use OCP\IUser;
@@ -56,6 +57,8 @@ use Psr\Log\LoggerInterface;
  */
 class FoldExpensesAndHoursIntoProject implements IRepairStep
 {
+    use ReadsSourceRowsInBatches;
+
     /**
      * Constructor.
      *
@@ -101,12 +104,9 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep
             // Index every Project by every identifier a source object might
             // reference (id / uuid / projectNumber / code). Values are kept
             // as live mutable arrays so multiple lines fold into one save.
-            $projects = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema('Project')
-                ->findAll(config: ['limit' => 0], _rbac: false, _multitenancy: false);
+            $projects = $this->readAllRows($objectService, $registerSlug, 'Project');
 
-            if (is_array($projects) === false || $projects === []) {
+            if ($projects === []) {
                 $output->info('Shillinq: no Project records — expense/hours fold skipped.');
                 return;
             }
@@ -248,7 +248,7 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep
         $projectArrays = [];
 
         foreach ($projects as $project) {
-            $arr = (array) $project;
+            $arr = $this->rowPayload($project);
             $id  = (string) ($arr['id'] ?? '');
             if ($id === '') {
                 $id = (string) ($arr['uuid'] ?? '');
@@ -298,20 +298,13 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep
         $index = [];
 
         try {
-            $claims = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema('ExpenseClaimEntry')
-                ->findAll(config: ['limit' => 0], _rbac: false, _multitenancy: false);
+            $claims = $this->readAllRows($objectService, $registerSlug, 'ExpenseClaimEntry');
         } catch (\Throwable $e) {
             return $index;
         }
 
-        if (is_array($claims) === false) {
-            return $index;
-        }
-
         foreach ($claims as $claim) {
-            $arr       = (array) $claim;
+            $arr       = $this->rowPayload($claim);
             $projectId = (string) ($arr['projectId'] ?? '');
             if ($projectId === '') {
                 continue;
@@ -361,22 +354,15 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep
         $newlyTouched = [];
 
         try {
-            $rows = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema($schema)
-                ->findAll(config: ['limit' => 0], _rbac: false, _multitenancy: false);
+            $rows = $this->readAllRows($objectService, $registerSlug, $schema);
         } catch (\Throwable $e) {
             $output->warning('Shillinq: fold — failed to list '.$schema.': '.$e->getMessage());
             return $newlyTouched;
         }
 
-        if (is_array($rows) === false) {
-            return $newlyTouched;
-        }
-
         foreach ($rows as $row) {
             try {
-                $arr      = (array) $row;
+                $arr      = $this->rowPayload($row);
                 $sourceId = (string) ($arr['id'] ?? ($arr['uuid'] ?? ''));
                 if ($sourceId === '') {
                     continue;
@@ -432,22 +418,15 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep
         $newlyTouched = [];
 
         try {
-            $rows = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema('UrenRegistratie')
-                ->findAll(config: ['limit' => 0], _rbac: false, _multitenancy: false);
+            $rows = $this->readAllRows($objectService, $registerSlug, 'UrenRegistratie');
         } catch (\Throwable $e) {
             $output->warning('Shillinq: fold — failed to list UrenRegistratie: '.$e->getMessage());
             return $newlyTouched;
         }
 
-        if (is_array($rows) === false) {
-            return $newlyTouched;
-        }
-
         foreach ($rows as $row) {
             try {
-                $arr      = (array) $row;
+                $arr      = $this->rowPayload($row);
                 $sourceId = (string) ($arr['id'] ?? ($arr['uuid'] ?? ''));
                 if ($sourceId === '') {
                     continue;

--- a/lib/Repair/FoldIntoOrder.php
+++ b/lib/Repair/FoldIntoOrder.php
@@ -208,7 +208,7 @@ class FoldIntoOrder implements IRepairStep
     private function readRows(object $objectService, string $registerSlug, string $schema, IOutput $output): array
     {
         try {
-            return $this->readAllRows($objectService, $registerSlug, $schema);
+            return $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: $schema);
         } catch (\Throwable $e) {
             $output->info('Shillinq: FoldIntoOrder — '.$schema.' schema not available ('.$e->getMessage().'); skipping.');
             return [];

--- a/lib/Repair/MigrateProductVendorMasterToPipelinq.php
+++ b/lib/Repair/MigrateProductVendorMasterToPipelinq.php
@@ -28,6 +28,7 @@ namespace OCA\Shillinq\Repair;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\Contacts\IManager as IContactsManager;
 use OCP\IConfig;
@@ -68,6 +69,8 @@ use Psr\Log\LoggerInterface;
  */
 class MigrateProductVendorMasterToPipelinq implements IRepairStep
 {
+    use ReadsSourceRowsInBatches;
+
     /**
      * Constructor.
      *
@@ -233,7 +236,7 @@ class MigrateProductVendorMasterToPipelinq implements IRepairStep
 
         $vendorMasterData = [];
         foreach ($vendorMasterRaw as $vendor) {
-            $vendorArr = (array) $vendor;
+            $vendorArr = $this->rowPayload($vendor);
             $vendorArr['resolvedContactsUid'] = $this->resolveContactUid(vendor: $vendorArr, output: $output);
             $vendorMasterData[] = $vendorArr;
         }
@@ -241,7 +244,7 @@ class MigrateProductVendorMasterToPipelinq implements IRepairStep
         // ---- 4. Build skuToProductIdMap so shillinq stock FK (productId) resolves ----
         $skuToProductIdMap = [];
         foreach ($products as $product) {
-            $productArr = (array) $product;
+            $productArr = $this->rowPayload($product);
             $sku        = (string) ($productArr['sku'] ?? ($productArr['code'] ?? ''));
             $id         = (string) ($productArr['id'] ?? ($productArr['uuid'] ?? ''));
             if ($sku !== '' && $id !== '') {
@@ -250,8 +253,8 @@ class MigrateProductVendorMasterToPipelinq implements IRepairStep
         }
 
         // Cast objects to plain arrays for JSON serialisation.
-        $productsOut          = array_map(static fn ($p) => (array) $p, $products);
-        $productAttributesOut = array_map(static fn ($pa) => (array) $pa, $productAttributes);
+        $productsOut          = array_map(fn ($p) => $this->rowPayload($p), $products);
+        $productAttributesOut = array_map(fn ($pa) => $this->rowPayload($pa), $productAttributes);
 
         return [
             'version'           => '1.0',
@@ -285,12 +288,9 @@ class MigrateProductVendorMasterToPipelinq implements IRepairStep
     private function readObjects(object $objectService, string $registerSlug, string $schema, IOutput $output, string $label): array
     {
         try {
-            $objects = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema($schema)
-                ->findAll(['limit' => 0]);
+            $objects = $this->readAllRows($objectService, $registerSlug, $schema);
 
-            if (is_array($objects) === false || $objects === []) {
+            if ($objects === []) {
                 $output->info('MigrateProductVendorMasterToPipelinq: no '.$label.' records found — exporting empty set.');
                 return [];
             }

--- a/lib/Repair/MigrateProductVendorMasterToPipelinq.php
+++ b/lib/Repair/MigrateProductVendorMasterToPipelinq.php
@@ -236,7 +236,7 @@ class MigrateProductVendorMasterToPipelinq implements IRepairStep
 
         $vendorMasterData = [];
         foreach ($vendorMasterRaw as $vendor) {
-            $vendorArr = $this->rowPayload($vendor);
+            $vendorArr = $this->rowPayload(row: $vendor);
             $vendorArr['resolvedContactsUid'] = $this->resolveContactUid(vendor: $vendorArr, output: $output);
             $vendorMasterData[] = $vendorArr;
         }
@@ -244,7 +244,7 @@ class MigrateProductVendorMasterToPipelinq implements IRepairStep
         // ---- 4. Build skuToProductIdMap so shillinq stock FK (productId) resolves ----
         $skuToProductIdMap = [];
         foreach ($products as $product) {
-            $productArr = $this->rowPayload($product);
+            $productArr = $this->rowPayload(row: $product);
             $sku        = (string) ($productArr['sku'] ?? ($productArr['code'] ?? ''));
             $id         = (string) ($productArr['id'] ?? ($productArr['uuid'] ?? ''));
             if ($sku !== '' && $id !== '') {
@@ -253,8 +253,8 @@ class MigrateProductVendorMasterToPipelinq implements IRepairStep
         }
 
         // Cast objects to plain arrays for JSON serialisation.
-        $productsOut          = array_map(fn ($p) => $this->rowPayload($p), $products);
-        $productAttributesOut = array_map(fn ($pa) => $this->rowPayload($pa), $productAttributes);
+        $productsOut          = array_map(fn ($p) => $this->rowPayload(row: $p), $products);
+        $productAttributesOut = array_map(fn ($pa) => $this->rowPayload(row: $pa), $productAttributes);
 
         return [
             'version'           => '1.0',
@@ -288,7 +288,7 @@ class MigrateProductVendorMasterToPipelinq implements IRepairStep
     private function readObjects(object $objectService, string $registerSlug, string $schema, IOutput $output, string $label): array
     {
         try {
-            $objects = $this->readAllRows($objectService, $registerSlug, $schema);
+            $objects = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: $schema);
 
             if ($objects === []) {
                 $output->info('MigrateProductVendorMasterToPipelinq: no '.$label.' records found — exporting empty set.');

--- a/lib/Repair/PeriodCloseBackfill.php
+++ b/lib/Repair/PeriodCloseBackfill.php
@@ -121,7 +121,7 @@ class PeriodCloseBackfill implements IRepairStep
             // List every Administration record. The repair step is
             // best-effort: when no Administration records exist yet,
             // the forward backfill is a no-op.
-            $administrations = $this->readAllRows($objectService, $registerSlug, 'Administration');
+            $administrations = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: 'Administration');
 
             if ($administrations === []) {
                 $output->info('Shillinq: no Administration records — forward FiscalPeriod backfill skipped.');
@@ -133,7 +133,7 @@ class PeriodCloseBackfill implements IRepairStep
             $created = 0;
             $skipped = 0;
             foreach ($administrations as $administration) {
-                $arr = $this->rowPayload($administration);
+                $arr = $this->rowPayload(row: $administration);
                 $administrationId = (string) ($arr['administrationId'] ?? ($arr['id'] ?? ($arr['code'] ?? '')));
                 if ($administrationId === '') {
                     continue;

--- a/lib/Repair/PeriodCloseBackfill.php
+++ b/lib/Repair/PeriodCloseBackfill.php
@@ -50,6 +50,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Repair;
 
 use DateTimeImmutable;
+use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -65,6 +66,8 @@ use Throwable;
  */
 class PeriodCloseBackfill implements IRepairStep
 {
+    use ReadsSourceRowsInBatches;
+
     /**
      * Number of calendar months ahead of the current month to backfill.
      *
@@ -118,12 +121,9 @@ class PeriodCloseBackfill implements IRepairStep
             // List every Administration record. The repair step is
             // best-effort: when no Administration records exist yet,
             // the forward backfill is a no-op.
-            $administrations = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema('Administration')
-                ->findAll(['limit' => 0]);
+            $administrations = $this->readAllRows($objectService, $registerSlug, 'Administration');
 
-            if (is_array($administrations) === false || $administrations === []) {
+            if ($administrations === []) {
                 $output->info('Shillinq: no Administration records — forward FiscalPeriod backfill skipped.');
                 return;
             }
@@ -133,7 +133,7 @@ class PeriodCloseBackfill implements IRepairStep
             $created = 0;
             $skipped = 0;
             foreach ($administrations as $administration) {
-                $arr = (array) $administration;
+                $arr = $this->rowPayload($administration);
                 $administrationId = (string) ($arr['administrationId'] ?? ($arr['id'] ?? ($arr['code'] ?? '')));
                 if ($administrationId === '') {
                     continue;

--- a/lib/Repair/RematerialiseConvertedCalculations.php
+++ b/lib/Repair/RematerialiseConvertedCalculations.php
@@ -195,7 +195,7 @@ class RematerialiseConvertedCalculations implements IRepairStep
         IOutput $output
     ): int {
         try {
-            $objects = $this->readAllRows($objectService, $registerSlug, $schema);
+            $objects = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: $schema);
         } catch (\Throwable $e) {
             $output->warning('Shillinq: could not list '.$schema.' objects for rematerialisation: '.$e->getMessage());
             $this->logger->warning(
@@ -211,7 +211,7 @@ class RematerialiseConvertedCalculations implements IRepairStep
 
         $resaved = 0;
         foreach ($objects as $object) {
-            $arr = $this->rowPayload($object);
+            $arr = $this->rowPayload(row: $object);
             if (isset($arr['id']) === false && isset($arr['uuid']) === false) {
                 // No identifiable persisted id — skip rather than risk
                 // creating a duplicate via an unintended CREATE.

--- a/lib/Repair/RematerialiseConvertedCalculations.php
+++ b/lib/Repair/RematerialiseConvertedCalculations.php
@@ -58,6 +58,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Repair;
 
+use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -74,6 +75,8 @@ use Psr\Log\LoggerInterface;
  */
 class RematerialiseConvertedCalculations implements IRepairStep
 {
+    use ReadsSourceRowsInBatches;
+
     /**
      * Schema slugs carrying a Bucket-1 or Bucket-2 per-object calc this
      * change converted to JSON-AST + `materialise: true`. See design.md's
@@ -192,10 +195,7 @@ class RematerialiseConvertedCalculations implements IRepairStep
         IOutput $output
     ): int {
         try {
-            $objects = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema($schema)
-                ->findAll(config: ['limit' => 0], _rbac: false, _multitenancy: false);
+            $objects = $this->readAllRows($objectService, $registerSlug, $schema);
         } catch (\Throwable $e) {
             $output->warning('Shillinq: could not list '.$schema.' objects for rematerialisation: '.$e->getMessage());
             $this->logger->warning(
@@ -211,7 +211,7 @@ class RematerialiseConvertedCalculations implements IRepairStep
 
         $resaved = 0;
         foreach ($objects as $object) {
-            $arr = (array) $object;
+            $arr = $this->rowPayload($object);
             if (isset($arr['id']) === false && isset($arr['uuid']) === false) {
                 // No identifiable persisted id — skip rather than risk
                 // creating a duplicate via an unintended CREATE.

--- a/lib/Repair/RetireCostProjectStep.php
+++ b/lib/Repair/RetireCostProjectStep.php
@@ -68,6 +68,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Repair;
 
+use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -83,6 +84,7 @@ use Psr\Log\LoggerInterface;
  */
 class RetireCostProjectStep implements IRepairStep
 {
+    use ReadsSourceRowsInBatches;
 
     /**
      * Maximum suffix attempts when a minted code collides.
@@ -179,10 +181,7 @@ class RetireCostProjectStep implements IRepairStep
         $failed   = 0;
 
         try {
-            $costProjects = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema('CostProject')
-                ->findAll(['limit' => 0]);
+            $costProjects = $this->readAllRows($objectService, $registerSlug, 'CostProject');
         } catch (\Throwable $e) {
             $output->info('Shillinq: RetireCostProjectStep — no CostProject schema or no records found ('.$e->getMessage().'); skipping.');
             return ['migrated' => 0, 'skipped' => 0, 'failed' => 0];
@@ -194,7 +193,7 @@ class RetireCostProjectStep implements IRepairStep
         }
 
         foreach ($costProjects as $costProject) {
-            $arr = (array) $costProject;
+            $arr = $this->rowPayload($costProject);
             $id  = (string) ($arr['id'] ?? ($arr['uuid'] ?? ''));
 
             if ($id === '') {

--- a/lib/Repair/RetireCostProjectStep.php
+++ b/lib/Repair/RetireCostProjectStep.php
@@ -181,7 +181,7 @@ class RetireCostProjectStep implements IRepairStep
         $failed   = 0;
 
         try {
-            $costProjects = $this->readAllRows($objectService, $registerSlug, 'CostProject');
+            $costProjects = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: 'CostProject');
         } catch (\Throwable $e) {
             $output->info('Shillinq: RetireCostProjectStep — no CostProject schema or no records found ('.$e->getMessage().'); skipping.');
             return ['migrated' => 0, 'skipped' => 0, 'failed' => 0];
@@ -193,7 +193,7 @@ class RetireCostProjectStep implements IRepairStep
         }
 
         foreach ($costProjects as $costProject) {
-            $arr = $this->rowPayload($costProject);
+            $arr = $this->rowPayload(row: $costProject);
             $id  = (string) ($arr['id'] ?? ($arr['uuid'] ?? ''));
 
             if ($id === '') {

--- a/lib/Repair/RetireSubsidieSchema.php
+++ b/lib/Repair/RetireSubsidieSchema.php
@@ -65,6 +65,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Repair;
 
+use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
@@ -88,6 +89,7 @@ use Psr\Log\LoggerInterface;
  */
 class RetireSubsidieSchema implements IRepairStep
 {
+    use ReadsSourceRowsInBatches;
 
     /**
      * The legacy schema slug being retired.
@@ -170,7 +172,7 @@ class RetireSubsidieSchema implements IRepairStep
         $failed  = 0;
 
         foreach ($this->readSubsidies($objectService, $registerSlug, $output) as $row) {
-            $src          = (array) $row;
+            $src          = $this->rowPayload($row);
             $subsidieId   = (string) ($src['id'] ?? ($src['uuid'] ?? ''));
             $migrationKey = $this->migrationKey($src);
 
@@ -257,22 +259,7 @@ class RetireSubsidieSchema implements IRepairStep
     private function readSubsidies(object $objectService, string $registerSlug, IOutput $output): array
     {
         try {
-            $rows = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema(self::SCHEMA)
-                ->findAll(
-                    [
-                        'limit'         => 0,
-                        '_rbac'         => false,
-                        '_multitenancy' => false,
-                    ]
-                );
-
-            if (is_array($rows) === false) {
-                return [];
-            }
-
-            return $rows;
+            return $this->readAllRows($objectService, $registerSlug, self::SCHEMA);
         } catch (\Throwable $e) {
             $output->info('Shillinq: RetireSubsidieSchema — Subsidie schema not available ('.$e->getMessage().'); nothing to retire.');
             return [];
@@ -313,27 +300,33 @@ class RetireSubsidieSchema implements IRepairStep
     private function orderExists(object $objectService, string $registerSlug, string $migrationKey): bool
     {
         try {
-            $found = $objectService
-                ->setRegister($registerSlug)
-                ->setSchema(self::TARGET)
-                ->findAll(
-                    [
-                        'filters'       => [
-                            'migratedFrom.schema' => self::MARKER_SCHEMA,
-                            'migratedFrom.key'    => $migrationKey,
-                        ],
-                        'limit'         => 1,
-                        '_rbac'         => false,
-                        '_multitenancy' => false,
-                    ]
-                );
-
-            return is_array($found) === true && $found !== [];
+            // TODO(#382): dot-path filter unsupported — filter in PHP.
+            // OpenRegister does NOT support nested (dot-path) filter keys such as
+            // `migratedFrom.schema`/`migratedFrom.key` — they match NOTHING, so
+            // the old filtered query always found "no Order" on a live instance
+            // and every Subsidie was kept (the schema never retired). Read every
+            // Order once and match the migration marker in PHP instead.
+            $orders = $this->readAllRows($objectService, $registerSlug, self::TARGET);
         } catch (\Throwable) {
             // On lookup error, conservatively report "no Order" so the Subsidie
             // is KEPT (never delete on an ambiguous read).
             return false;
-        }//end try
+        }
+
+        foreach ($orders as $order) {
+            $marker = ($this->rowPayload($order)['migratedFrom'] ?? null);
+            if (is_array($marker) === false) {
+                continue;
+            }
+
+            if ((string) ($marker['schema'] ?? '') === self::MARKER_SCHEMA
+                && (string) ($marker['key'] ?? '') === $migrationKey
+            ) {
+                return true;
+            }
+        }
+
+        return false;
 
     }//end orderExists()
 

--- a/lib/Repair/RetireSubsidieSchema.php
+++ b/lib/Repair/RetireSubsidieSchema.php
@@ -172,7 +172,7 @@ class RetireSubsidieSchema implements IRepairStep
         $failed  = 0;
 
         foreach ($this->readSubsidies($objectService, $registerSlug, $output) as $row) {
-            $src          = $this->rowPayload($row);
+            $src          = $this->rowPayload(row: $row);
             $subsidieId   = (string) ($src['id'] ?? ($src['uuid'] ?? ''));
             $migrationKey = $this->migrationKey($src);
 
@@ -259,7 +259,7 @@ class RetireSubsidieSchema implements IRepairStep
     private function readSubsidies(object $objectService, string $registerSlug, IOutput $output): array
     {
         try {
-            return $this->readAllRows($objectService, $registerSlug, self::SCHEMA);
+            return $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: self::SCHEMA);
         } catch (\Throwable $e) {
             $output->info('Shillinq: RetireSubsidieSchema — Subsidie schema not available ('.$e->getMessage().'); nothing to retire.');
             return [];
@@ -306,7 +306,7 @@ class RetireSubsidieSchema implements IRepairStep
             // the old filtered query always found "no Order" on a live instance
             // and every Subsidie was kept (the schema never retired). Read every
             // Order once and match the migration marker in PHP instead.
-            $orders = $this->readAllRows($objectService, $registerSlug, self::TARGET);
+            $orders = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: self::TARGET);
         } catch (\Throwable) {
             // On lookup error, conservatively report "no Order" so the Subsidie
             // is KEPT (never delete on an ambiguous read).
@@ -314,7 +314,7 @@ class RetireSubsidieSchema implements IRepairStep
         }
 
         foreach ($orders as $order) {
-            $marker = ($this->rowPayload($order)['migratedFrom'] ?? null);
+            $marker = ($this->rowPayload(row: $order)['migratedFrom'] ?? null);
             if (is_array($marker) === false) {
                 continue;
             }

--- a/lib/Repair/StampJournalTypeOnGlTransactions.php
+++ b/lib/Repair/StampJournalTypeOnGlTransactions.php
@@ -149,7 +149,7 @@ class StampJournalTypeOnGlTransactions implements IRepairStep
         string $registerSlug,
         IOutput $output
     ): int {
-        $closingEntries = $this->readAllRows($objectService, $registerSlug, 'ClosingEntry');
+        $closingEntries = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: 'ClosingEntry');
 
         if ($closingEntries === []) {
             return 0;
@@ -158,7 +158,7 @@ class StampJournalTypeOnGlTransactions implements IRepairStep
         $stamped = 0;
         foreach ($closingEntries as $entry) {
             try {
-                $arr = $this->rowPayload($entry);
+                $arr = $this->rowPayload(row: $entry);
                 $glTransactionId = (string) ($arr['glTransactionId'] ?? '');
                 if ($glTransactionId === '') {
                     continue;
@@ -230,7 +230,7 @@ class StampJournalTypeOnGlTransactions implements IRepairStep
         string $registerSlug,
         IOutput $output
     ): int {
-        $intercompany = $this->readAllRows($objectService, $registerSlug, 'IntercompanyTransaction');
+        $intercompany = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: 'IntercompanyTransaction');
 
         if ($intercompany === []) {
             return 0;
@@ -239,7 +239,7 @@ class StampJournalTypeOnGlTransactions implements IRepairStep
         $stamped = 0;
         foreach ($intercompany as $ic) {
             try {
-                $arr = $this->rowPayload($ic);
+                $arr = $this->rowPayload(row: $ic);
                 $glTransactionId = (string) ($arr['sourceJournalEntryId'] ?? '');
                 if ($glTransactionId === '') {
                     continue;

--- a/lib/Repair/StampJournalTypeOnGlTransactions.php
+++ b/lib/Repair/StampJournalTypeOnGlTransactions.php
@@ -51,6 +51,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Repair;
 
+use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -64,6 +65,8 @@ use Psr\Log\LoggerInterface;
  */
 class StampJournalTypeOnGlTransactions implements IRepairStep
 {
+    use ReadsSourceRowsInBatches;
+
     /**
      * Constructor.
      *
@@ -146,23 +149,16 @@ class StampJournalTypeOnGlTransactions implements IRepairStep
         string $registerSlug,
         IOutput $output
     ): int {
-        $closingEntries = $objectService
-            ->setRegister($registerSlug)
-            ->setSchema('ClosingEntry')
-            ->findAll(
-                config: ['limit' => 0],
-                _rbac: false,
-                _multitenancy: false
-            );
+        $closingEntries = $this->readAllRows($objectService, $registerSlug, 'ClosingEntry');
 
-        if (is_array($closingEntries) === false || $closingEntries === []) {
+        if ($closingEntries === []) {
             return 0;
         }
 
         $stamped = 0;
         foreach ($closingEntries as $entry) {
             try {
-                $arr = (array) $entry;
+                $arr = $this->rowPayload($entry);
                 $glTransactionId = (string) ($arr['glTransactionId'] ?? '');
                 if ($glTransactionId === '') {
                     continue;
@@ -234,23 +230,16 @@ class StampJournalTypeOnGlTransactions implements IRepairStep
         string $registerSlug,
         IOutput $output
     ): int {
-        $intercompany = $objectService
-            ->setRegister($registerSlug)
-            ->setSchema('IntercompanyTransaction')
-            ->findAll(
-                config: ['limit' => 0],
-                _rbac: false,
-                _multitenancy: false
-            );
+        $intercompany = $this->readAllRows($objectService, $registerSlug, 'IntercompanyTransaction');
 
-        if (is_array($intercompany) === false || $intercompany === []) {
+        if ($intercompany === []) {
             return 0;
         }
 
         $stamped = 0;
         foreach ($intercompany as $ic) {
             try {
-                $arr = (array) $ic;
+                $arr = $this->rowPayload($ic);
                 $glTransactionId = (string) ($arr['sourceJournalEntryId'] ?? '');
                 if ($glTransactionId === '') {
                     continue;

--- a/lib/Repair/Support/ReadsSourceRowsInBatches.php
+++ b/lib/Repair/Support/ReadsSourceRowsInBatches.php
@@ -100,4 +100,42 @@ trait ReadsSourceRowsInBatches
         return $rows;
 
     }//end readAllRows()
+
+    /**
+     * Resolve one findAll() result row to its schema-payload array.
+     *
+     * OpenRegister returns ObjectEntity instances whose schema payload lives in
+     * getObject() — NOT in the object's own properties. A blind `(array) $row`
+     * cast yields mangled "\0*\0prop" keys and loses every field, so a step that
+     * casts reads garbage (all fields null) and silently skips/mis-maps every
+     * row. Nextcloud's Entity base serves getters through __call(), so
+     * method_exists()/get_class_methods() report FALSE for getObject() — probe by
+     * calling, never by reflection.
+     *
+     * @param mixed $row One findAll() result row (ObjectEntity or array).
+     *
+     * @return array<string,mixed> The payload array (empty when unusable).
+     */
+    protected function rowPayload(mixed $row): array
+    {
+        if (is_array($row) === true) {
+            return $row;
+        }
+
+        if (is_object($row) === false) {
+            return [];
+        }
+
+        try {
+            $payload = $row->getObject();
+            if (is_array($payload) === true) {
+                return $payload;
+            }
+        } catch (\Throwable $e) {
+            // Not an OR entity — fall through to public properties.
+        }
+
+        return get_object_vars($row);
+
+    }//end rowPayload()
 }//end trait

--- a/lib/Repair/UnifyAnalyticalDimensions.php
+++ b/lib/Repair/UnifyAnalyticalDimensions.php
@@ -67,6 +67,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Repair;
 
+use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -83,6 +84,8 @@ use Psr\Log\LoggerInterface;
  */
 class UnifyAnalyticalDimensions implements IRepairStep
 {
+    use ReadsSourceRowsInBatches;
+
     /**
      * Constructor.
      *
@@ -176,18 +179,15 @@ class UnifyAnalyticalDimensions implements IRepairStep
         $created = 0;
         $skipped = 0;
 
-        $costCenters = $objectService
-            ->setRegister($registerSlug)
-            ->setSchema('CostCenter')
-            ->findAll(['limit' => 0]);
+        $costCenters = $this->readAllRows($objectService, $registerSlug, 'CostCenter');
 
-        if (is_array($costCenters) === false || $costCenters === []) {
+        if ($costCenters === []) {
             $output->info('Shillinq: no CostCenter records found — skipping cost-center migration.');
             return ['created' => 0, 'skipped' => 0];
         }
 
         foreach ($costCenters as $costCenter) {
-            $arr  = (array) $costCenter;
+            $arr  = $this->rowPayload($costCenter);
             $code = (string) ($arr['code'] ?? '');
             $administrationId = (string) ($arr['administrationId'] ?? '');
 
@@ -250,18 +250,15 @@ class UnifyAnalyticalDimensions implements IRepairStep
         $created = 0;
         $skipped = 0;
 
-        $kostenDragers = $objectService
-            ->setRegister($registerSlug)
-            ->setSchema('KostenDrager')
-            ->findAll(['limit' => 0]);
+        $kostenDragers = $this->readAllRows($objectService, $registerSlug, 'KostenDrager');
 
-        if (is_array($kostenDragers) === false || $kostenDragers === []) {
+        if ($kostenDragers === []) {
             $output->info('Shillinq: no KostenDrager records found — skipping cost-object migration.');
             return ['created' => 0, 'skipped' => 0];
         }
 
         foreach ($kostenDragers as $kostenDrager) {
-            $arr  = (array) $kostenDrager;
+            $arr  = $this->rowPayload($kostenDrager);
             $code = (string) ($arr['code'] ?? '');
             $administrationId = (string) ($arr['administrationId'] ?? '');
 

--- a/lib/Repair/UnifyAnalyticalDimensions.php
+++ b/lib/Repair/UnifyAnalyticalDimensions.php
@@ -179,7 +179,7 @@ class UnifyAnalyticalDimensions implements IRepairStep
         $created = 0;
         $skipped = 0;
 
-        $costCenters = $this->readAllRows($objectService, $registerSlug, 'CostCenter');
+        $costCenters = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: 'CostCenter');
 
         if ($costCenters === []) {
             $output->info('Shillinq: no CostCenter records found — skipping cost-center migration.');
@@ -187,7 +187,7 @@ class UnifyAnalyticalDimensions implements IRepairStep
         }
 
         foreach ($costCenters as $costCenter) {
-            $arr  = $this->rowPayload($costCenter);
+            $arr  = $this->rowPayload(row: $costCenter);
             $code = (string) ($arr['code'] ?? '');
             $administrationId = (string) ($arr['administrationId'] ?? '');
 
@@ -250,7 +250,7 @@ class UnifyAnalyticalDimensions implements IRepairStep
         $created = 0;
         $skipped = 0;
 
-        $kostenDragers = $this->readAllRows($objectService, $registerSlug, 'KostenDrager');
+        $kostenDragers = $this->readAllRows(objectService: $objectService, registerSlug: $registerSlug, schema: 'KostenDrager');
 
         if ($kostenDragers === []) {
             $output->info('Shillinq: no KostenDrager records found — skipping cost-object migration.');
@@ -258,7 +258,7 @@ class UnifyAnalyticalDimensions implements IRepairStep
         }
 
         foreach ($kostenDragers as $kostenDrager) {
-            $arr  = $this->rowPayload($kostenDrager);
+            $arr  = $this->rowPayload(row: $kostenDrager);
             $code = (string) ($arr['code'] ?? '');
             $administrationId = (string) ($arr['administrationId'] ?? '');
 

--- a/tests/Unit/Repair/BackfillFiscalPeriodsTest.php
+++ b/tests/Unit/Repair/BackfillFiscalPeriodsTest.php
@@ -325,9 +325,13 @@ class BackfillFiscalPeriodsTest extends TestCase
             }
 
             /**
-             * Mimics ObjectService::findAll on the fixture rows.
+             * Mimics OpenRegister's real findAll() paging semantics: `filters`
+             * apply first (a dot-path key matches NOTHING — OR has no nested
+             * filter support), then `offset` skips rows, then `limit` is a
+             * literal SQL LIMIT (so limit=0 returns ZERO rows). Modelling this
+             * faithfully catches a caller passing limit=0 and reading nothing.
              *
-             * @param array<string,mixed> $options The findAll options (filters / limit).
+             * @param array<string,mixed> $options The findAll options (filters / offset / limit).
              *
              * @return list<array<string,mixed>> Matching fixture rows.
              */
@@ -338,6 +342,12 @@ class BackfillFiscalPeriodsTest extends TestCase
                 $matched = [];
                 foreach ($rows as $row) {
                     foreach ($filters as $k => $v) {
+                        // OpenRegister does NOT support dot-path filters on
+                        // nested properties: such a filter matches nothing.
+                        if (str_contains((string) $k, '.') === true) {
+                            continue 2;
+                        }
+
                         if (($row[$k] ?? null) !== $v) {
                             continue 2;
                         }
@@ -346,7 +356,17 @@ class BackfillFiscalPeriodsTest extends TestCase
                     $matched[] = $row;
                 }
 
-                return $matched;
+                $offset = (int) ($options['offset'] ?? 0);
+                if ($offset > 0) {
+                    $matched = array_slice($matched, $offset);
+                }
+
+                $limit = ($options['limit'] ?? null);
+                if ($limit !== null) {
+                    $matched = array_slice($matched, 0, (int) $limit);
+                }
+
+                return array_values($matched);
             }
 
             /**

--- a/tests/Unit/Repair/DelegateSigningMigrationRepairTest.php
+++ b/tests/Unit/Repair/DelegateSigningMigrationRepairTest.php
@@ -143,13 +143,53 @@ class DelegateSigningMigrationRepairTest extends TestCase
             }//end setSchema()
 
             /**
+             * Mirrors OpenRegister's real findAll() paging semantics: `offset`
+             * skips rows and `limit` is a literal SQL LIMIT (limit=0 returns
+             * ZERO rows), both applied after any filtering — so a caller passing
+             * limit=0 is caught reading nothing here.
+             *
              * @param array<string,mixed> $params
              *
              * @return array<int,array<string,mixed>>
              */
             public function findAll(array $params): array
             {
-                return $this->records;
+                $rows = $this->records;
+
+                $filters = ($params['filters'] ?? []);
+                if ($filters !== []) {
+                    $rows = array_values(
+                        array_filter(
+                            $rows,
+                            static function (array $row) use ($filters): bool {
+                                foreach ($filters as $path => $expected) {
+                                    // OpenRegister does NOT support dot-path filters.
+                                    if (str_contains((string) $path, '.') === true) {
+                                        return false;
+                                    }
+
+                                    if (($row[$path] ?? null) !== $expected) {
+                                        return false;
+                                    }
+                                }
+
+                                return true;
+                            }
+                        )
+                    );
+                }
+
+                $offset = (int) ($params['offset'] ?? 0);
+                if ($offset > 0) {
+                    $rows = array_slice($rows, $offset);
+                }
+
+                $limit = ($params['limit'] ?? null);
+                if ($limit !== null) {
+                    $rows = array_slice($rows, 0, (int) $limit);
+                }
+
+                return array_values($rows);
 
             }//end findAll()
 

--- a/tests/Unit/Repair/PeriodCloseBackfillTest.php
+++ b/tests/Unit/Repair/PeriodCloseBackfillTest.php
@@ -389,7 +389,12 @@ class PeriodCloseBackfillTest extends TestCase
             }//end setSchema()
 
             /**
-             * Returns the canned fixtures for the selected schema.
+             * Returns the canned fixtures for the selected schema, honouring
+             * OpenRegister's real findAll() paging semantics: `filters` apply
+             * first (a dot-path key matches NOTHING — OR has no nested filter
+             * support), then `offset` skips rows, then `limit` is a literal SQL
+             * LIMIT (limit=0 returns ZERO rows). Modelled faithfully so a caller
+             * passing limit=0 is caught reading nothing.
              *
              * @param array<string,mixed> $options The findAll options.
              *
@@ -398,25 +403,47 @@ class PeriodCloseBackfillTest extends TestCase
             public function findAll(array $options=[]): array
             {
                 if ($this->schema === 'Administration') {
-                    return $this->administrations;
+                    $rows = $this->administrations;
+                } else if ($this->schema === 'FiscalPeriod') {
+                    $rows = $this->existingPeriods;
+                } else {
+                    $rows = [];
                 }
 
-                if ($this->schema === 'FiscalPeriod') {
-                    $filters          = $options['filters'] ?? [];
-                    $periodId         = $filters['periodId'] ?? null;
-                    $administrationId = $filters['administrationId'] ?? null;
-                    foreach ($this->existingPeriods as $tup) {
-                        if ($tup['administrationId'] === $administrationId
-                            && $tup['periodId'] === $periodId
-                        ) {
-                            return [$tup];
-                        }
-                    }
+                $filters = ($options['filters'] ?? []);
+                if ($filters !== []) {
+                    $rows = array_values(
+                        array_filter(
+                            $rows,
+                            static function (array $row) use ($filters): bool {
+                                foreach ($filters as $path => $expected) {
+                                    // OpenRegister does NOT support dot-path filters.
+                                    if (str_contains((string) $path, '.') === true) {
+                                        return false;
+                                    }
 
-                    return [];
+                                    if (($row[$path] ?? null) !== $expected) {
+                                        return false;
+                                    }
+                                }
+
+                                return true;
+                            }
+                        )
+                    );
                 }
 
-                return [];
+                $offset = (int) ($options['offset'] ?? 0);
+                if ($offset > 0) {
+                    $rows = array_slice($rows, $offset);
+                }
+
+                $limit = ($options['limit'] ?? null);
+                if ($limit !== null) {
+                    $rows = array_slice($rows, 0, (int) $limit);
+                }
+
+                return array_values($rows);
             }//end findAll()
 
             /**

--- a/tests/Unit/Repair/RematerialiseConvertedCalculationsTest.php
+++ b/tests/Unit/Repair/RematerialiseConvertedCalculationsTest.php
@@ -377,9 +377,11 @@ class RematerialiseConvertedCalculationsTest extends TestCase
             }//end setSchema()
 
             /**
-             * Mimics ObjectService::findAll on the fixture rows.
+             * Mimics OpenRegister's real findAll() paging semantics: `offset`
+             * skips rows and `limit` is a literal SQL LIMIT (limit=0 returns
+             * ZERO rows), so a caller passing limit=0 is caught reading nothing.
              *
-             * @param array<string,mixed> $config        The findAll options (unused beyond schema selection).
+             * @param array<string,mixed> $config        The findAll options (offset / limit).
              * @param bool                $_rbac         RBAC enforcement flag (unused).
              * @param bool                $_multitenancy Multi-tenancy flag (unused).
              *
@@ -391,7 +393,19 @@ class RematerialiseConvertedCalculationsTest extends TestCase
                     throw new \RuntimeException('findAll failed for '.$this->schema);
                 }
 
-                return ($this->rowsBySchema[$this->schema] ?? []);
+                $rows = ($this->rowsBySchema[$this->schema] ?? []);
+
+                $offset = (int) ($config['offset'] ?? 0);
+                if ($offset > 0) {
+                    $rows = array_slice($rows, $offset);
+                }
+
+                $limit = ($config['limit'] ?? null);
+                if ($limit !== null) {
+                    $rows = array_slice($rows, 0, (int) $limit);
+                }
+
+                return array_values($rows);
             }//end findAll()
 
             /**

--- a/tests/Unit/Repair/RetireCostProjectStepTest.php
+++ b/tests/Unit/Repair/RetireCostProjectStepTest.php
@@ -469,36 +469,57 @@ class RetireCostProjectStepTest extends TestCase
             }
 
             /**
+             * Mirrors OpenRegister's real findAll() paging semantics: `filters`
+             * apply first (a dot-path key matches NOTHING — OR has no nested
+             * filter support), then `offset` skips rows, then `limit` is a
+             * literal SQL LIMIT (limit=0 returns ZERO rows). Modelled faithfully
+             * so a caller passing limit=0 is caught reading nothing.
+             *
              * @param array<string,mixed> $params
              * @return array<array<string,mixed>>
              */
             public function findAll(array $params = []): array
             {
                 if ($this->currentSchema === 'CostProject') {
-                    return $this->costProjects;
+                    $rows = $this->costProjects;
+                } else if ($this->currentSchema === 'AnalyticalDimension') {
+                    $rows = $this->existingDimensions;
+                } else {
+                    $rows = [];
                 }
 
-                if ($this->currentSchema === 'AnalyticalDimension') {
-                    $filters = ($params['filters'] ?? []);
+                $filters = ($params['filters'] ?? []);
+                if ($filters !== []) {
+                    $rows = array_values(array_filter(
+                        $rows,
+                        static function (array $row) use ($filters): bool {
+                            foreach ($filters as $path => $expected) {
+                                // OpenRegister does NOT support dot-path filters.
+                                if (str_contains((string) $path, '.') === true) {
+                                    return false;
+                                }
 
-                    // Idempotency check: find by migratedFrom.
-                    if (isset($filters['migratedFrom'])) {
-                        return array_values(array_filter(
-                            $this->existingDimensions,
-                            static fn (array $d): bool => (($d['migratedFrom'] ?? null) === $filters['migratedFrom'])
-                        ));
-                    }
+                                if (($row[$path] ?? null) !== $expected) {
+                                    return false;
+                                }
+                            }
 
-                    // Code-exists check: find by code.
-                    if (isset($filters['code'])) {
-                        return array_values(array_filter(
-                            $this->existingDimensions,
-                            static fn (array $d): bool => (($d['code'] ?? null) === $filters['code'])
-                        ));
-                    }
+                            return true;
+                        }
+                    ));
                 }
 
-                return [];
+                $offset = (int) ($params['offset'] ?? 0);
+                if ($offset > 0) {
+                    $rows = array_slice($rows, $offset);
+                }
+
+                $limit = ($params['limit'] ?? null);
+                if ($limit !== null) {
+                    $rows = array_slice($rows, 0, (int) $limit);
+                }
+
+                return array_values($rows);
             }
 
             /**

--- a/tests/Unit/Repair/RetireSubsidieSchemaTest.php
+++ b/tests/Unit/Repair/RetireSubsidieSchemaTest.php
@@ -160,6 +160,13 @@ class RetireSubsidieSchemaTest extends TestCase
             }//end setSchema()
 
             /**
+             * Mirrors OpenRegister's real findAll() paging semantics: `filters`
+             * apply first (a dot-path key matches NOTHING — OR has no nested
+             * filter support), then `offset` skips rows, then `limit` is a
+             * literal SQL LIMIT (limit=0 returns ZERO rows). Modelled faithfully
+             * so a caller passing limit=0 (or an unmatchable dot-path filter) is
+             * caught here instead of silently on a live instance.
+             *
              * @param array<string,mixed> $params
              *
              * @return array<int,array<string,mixed>>
@@ -168,24 +175,40 @@ class RetireSubsidieSchemaTest extends TestCase
             {
                 $rows    = ($this->recordsBySchema[$this->currentSchema] ?? []);
                 $filters = ($params['filters'] ?? []);
-                if ($filters === []) {
-                    return $rows;
+                if ($filters !== []) {
+                    $rows = array_values(
+                        array_filter(
+                            $rows,
+                            static function (array $row) use ($filters): bool {
+                                foreach ($filters as $path => $expected) {
+                                    // OpenRegister does NOT support dot-path filters on
+                                    // nested properties: such a filter matches nothing.
+                                    if (str_contains((string) $path, '.') === true) {
+                                        return false;
+                                    }
+
+                                    if (($row[$path] ?? null) !== $expected) {
+                                        return false;
+                                    }
+                                }
+
+                                return true;
+                            }
+                        )
+                    );
                 }
 
-                return array_values(
-                    array_filter(
-                        $rows,
-                        function (array $row) use ($filters): bool {
-                            foreach ($filters as $path => $expected) {
-                                if ($this->dotGet($row, (string) $path) !== $expected) {
-                                    return false;
-                                }
-                            }
+                $offset = (int) ($params['offset'] ?? 0);
+                if ($offset > 0) {
+                    $rows = array_slice($rows, $offset);
+                }
 
-                            return true;
-                        }
-                    )
-                );
+                $limit = ($params['limit'] ?? null);
+                if ($limit !== null) {
+                    $rows = array_slice($rows, 0, (int) $limit);
+                }
+
+                return array_values($rows);
 
             }//end findAll()
 
@@ -203,25 +226,6 @@ class RetireSubsidieSchemaTest extends TestCase
                 return $this->deleted;
 
             }//end deletedIds()
-
-            /**
-             * @param array<string,mixed> $row
-             */
-            private function dotGet(array $row, string $path): mixed
-            {
-                $segments = explode('.', $path);
-                $cursor   = $row;
-                foreach ($segments as $segment) {
-                    if (is_array($cursor) === false || array_key_exists($segment, $cursor) === false) {
-                        return null;
-                    }
-
-                    $cursor = $cursor[$segment];
-                }
-
-                return $cursor;
-
-            }//end dotGet()
         };
 
     }//end fakeObjectService()


### PR DESCRIPTION
The bulk of the #382 campaign. The eleven remaining repair steps each carried **two** latent bugs, both masked because the first made the second unreachable:

1. **`findAll(['limit' => 0])`** — literal SQL `LIMIT 0` → **zero rows**. Every step read nothing and reported a clean no-op (green, and dead) on any real instance.
2. **`(array) $row`** — OpenRegister returns `ObjectEntity` objects whose payload is in `getObject()`; casting one yields mangled `"\0*\0prop"` keys, so once the read is fixed the step processes all-null fields. The same defect that bit FoldIntoOrder.

Both now route through the shared `ReadsSourceRowsInBatches` trait: `readAllRows()` (batched, never limit=0) and `rowPayload()` (ObjectEntity payload via `getObject()`, never a blind cast).

Also fixes **`RetireSubsidieSchema::orderExists()`**, whose delete gate filtered on a dot-path `migratedFrom.schema`/`.key` (OpenRegister has no nested-filter support → matched nothing → it never deleted a Subsidie). Now reads Orders once and matches the marker in PHP. `RetireSubsidieSchema` stays **held** regardless.

## Verification
- Full suite **3966/3966** green; test doubles for the affected steps now mirror ORs real `findAll` semantics (limit literal, offset applied, dot-path filters match nothing). phpcs 0 errors.
- **Both fixes live-proven per source schema, non-destructively** on 8080:

| schema | `limit=>0` (old) | batched (fixed) | `(array)` clean keys | `getObject()` fields |
|---|---|---|---|---|
| Administration | 0 | 1 | 1 | 30 |
| GLLine | 0 | 200/batch (353) | 1 | 29 |
| OninbaarAfschrijving | 0 | 1 | 1 | 9 |
| DunningRun | 0 | 1 | 1 | 21 |
| ExpenseClaimEntry | 0 | 3 | 1 | 24 |
| UrenRegistratie | 0 | 187 | 1 | 20 |

## Deliberately NOT done
Full end-to-end runs of these migrations on the shared instance were **not** performed: their source rows are the concurrent sessions real financial data, and running the steps would write derived records into it. The read+payload fix is live-proven above; the downstream mapping is covered by the faithful unit tests. `MigrateProductVendorMaster`s source schemas are absent on 8080, so it is trait/unit-proven only.

Follow-ups: hydra gate forbidding `limit => 0` in repair steps.

Refs #382