### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to ^1.0.0-beta.221

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl.
     ]]></description>
-    <version>0.9.16</version>
+    <version>0.9.17</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Shillinq</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.1",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@conduction/nextcloud-vue": "^1.0.0-beta.213",
+        "@conduction/nextcloud-vue": "^1.0.0-beta.221",
         "@nextcloud/axios": "~2.5.2",
         "@nextcloud/dialogs": "^6.4.2",
         "@nextcloud/event-bus": "^3.3.3",
@@ -555,9 +555,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "1.0.0-beta.213",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.213.tgz",
-      "integrity": "sha512-L3E7kT3AvVb8HvxRWc2nSA6aYXbuMOj9f7HiGiJQOJ9om6ImCrdreMqACB4pEbHGy49FeRnmX5aHI1qt8o1SaQ==",
+      "version": "1.0.0-beta.221",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.221.tgz",
+      "integrity": "sha512-2sNPtUYlQNrFg3yVqXHvOwOHeXiOHsjmWhHPc3WCsAq8hpJj1v/T+XeGKFBmUEi4mJ/9UtR+NrrT8Zke0FKcug==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "dependencies": {
-    "@conduction/nextcloud-vue": "^1.0.0-beta.213",
+    "@conduction/nextcloud-vue": "^1.0.0-beta.221",
     "@nextcloud/axios": "~2.5.2",
     "@nextcloud/dialogs": "^6.4.2",
     "@nextcloud/event-bus": "^3.3.3",


### PR DESCRIPTION
## Summary
- Bump `@conduction/nextcloud-vue` to `1.0.0-beta.221`, which carries the `cnTranslate` display-layer translation in `CnDataTable`.
- Rebuild the app bundle (`USE_LOCAL_LIB=false npm run build`) so shipped `js/` (built at release time, gitignored) will contain the translation logic once CI builds it.
- Patch-bump `appinfo/info.xml` version so Nextcloud's `?v=` cache-buster serves the new bundle after release.

Schema property titles for this app are already English with EN/NL l10n merged; this activates translation of those labels at display time via nc-vue.

## Test plan
- [x] `npm ci` succeeded
- [x] `npm install @conduction/nextcloud-vue@1.0.0-beta.221 --save` — package-lock pinned to exact `1.0.0-beta.221`
- [x] `USE_LOCAL_LIB=false npm run build` exits 0 (only 2 pre-existing asset-size warnings)
- [x] Verified `cnTranslate` present in built `shillinq-main.js` / `shillinq-settings.js`
- [ ] CI build (this repo gitignores `/js/`; bundle is built at release)