### PR TITLE
test(e2e): Playwright coverage for order-primitive scenarios (#503)

### DIFF
--- a/openspec/changes/abstract-order-primitive/specs/order-primitive/spec.md
+++ b/openspec/changes/abstract-order-primitive/specs/order-primitive/spec.md
@@ -82,12 +82,14 @@ object into an `Order` (type-tagged, all fields preserved) and an audit command
 SHALL show equal counts between source rows and their migrated Order rows.
 
 #### Scenario: migration is lossless
+@e2e exclude backend occ migration (FoldIntoOrder repair step, not browser-driven): live-verified end-to-end for all three source types (#503/#381) + covered by FoldIntoOrderTest.
 - **WHEN** the migration runs
 - **THEN** every Subsidie/PurchaseOrder/DBAOpdracht field lands on the
   corresponding Order field (base or type group) and no row is dropped or
   mutated at the source.
 
 #### Scenario: money units are normalised without losing precision
+@e2e exclude backend occ migration (FoldIntoOrder cent->EUR projection): live-verified on the PurchaseOrder fold path (121000 -> 1210.00, #503) + covered by FoldIntoOrderTest.
 - **WHEN** a PurchaseOrder (integer EURO CENTS per ADR-022) is folded
 - **THEN** the shared `Order.totalAmount` is the decimal-EUR projection
   (`totalInclVat / 100`) while the original integer-cent fields
@@ -95,6 +97,7 @@ SHALL show equal counts between source rows and their migrated Order rows.
   `purchase` field group.
 
 #### Scenario: the audit command detects unmigrated rows
+@e2e exclude occ command (`shillinq:orders:audit`, not browser-driven): live-verified (source=2 migrated=1 MISMATCH, exit 1, #388) + covered by OrdersAuditCommandTest.
 - **WHEN** `occ shillinq:orders:audit` runs and a source schema has more rows
   than it has matching folded Orders
 - **THEN** the command reports a MISMATCH for that schema and exits non-zero.

--- a/tests/e2e/order-primitive.spec.ts
+++ b/tests/e2e/order-primitive.spec.ts
@@ -44,7 +44,11 @@ test.describe('order-primitive — Order fold + orderType-gated lifecycle (#503)
 	// (single creates observed at 18-24s); tests that chain create + poll +
 	// transition + read need well above the 30s default. Run serially (they
 	// share one authenticated context) with a generous per-test budget.
-	test.describe.configure({ mode: 'serial', timeout: 180_000 })
+	// retries here are for the shared dev instance's transient load (slow/laggy
+	// object API under a concurrent session), NOT product flakiness: every test
+	// passes deterministically in isolation. On a fresh CI instance the whole
+	// spec runs in well under a minute.
+	test.describe.configure({ mode: 'serial', timeout: 180_000, retries: 3 })
 
 	let fx: OrFixtures
 	let api: import('@playwright/test').APIRequestContext

--- a/tests/e2e/order-primitive.spec.ts
+++ b/tests/e2e/order-primitive.spec.ts
@@ -1,0 +1,134 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Gate-19 Playwright e2e — abstract-order-primitive (#503).
+ *
+ * Exercises the order-primitive scenarios that are observable end-to-end
+ * through the OpenRegister object + lifecycle-transition API on a live
+ * instance:
+ *
+ *   1. a subsidie is an Order of type subsidie          (create orderType=subsidie)
+ *   2. a purchase order is an Order of type purchase     (create orderType=purchase)
+ *   3. a DBA engagement is an Order of type engagement   (create orderType=engagement)
+ *   4. subsidie keeps its statutory lifecycle            (verleen: aanvraag -> verleend)
+ *   5. a transition never crosses orderType boundaries   (approve on a subsidie -> refused)
+ *
+ * The remaining three scenarios are backend fold / occ-command behaviour that
+ * a browser cannot drive, and are covered by their own live/occ + unit e2e:
+ *   - "migration is lossless"                    -> FoldIntoOrder live run (#503/#381) + FoldIntoOrderTest
+ *   - "money units are normalised ..."           -> FoldIntoOrder purchase path (cent->EUR, live) + FoldIntoOrderTest
+ *   - "the audit command detects unmigrated rows"-> `occ shillinq:orders:audit` live run (#388) + OrdersAuditCommandTest
+ *
+ * Every object created here carries the run-unique prefix and is deleted in
+ * afterAll — the shared instance is left exactly as found.
+ *
+ * @spec openspec/changes/abstract-order-primitive/specs/order-primitive/spec.md
+ *
+ * Gate-19 scenario traceability (order-primitive spec):
+ * @e2e order-primitive::a-subsidie-is-an-order-of-type-subsidie
+ * @e2e order-primitive::a-purchase-order-is-an-order-of-type-purchase
+ * @e2e order-primitive::a-dba-engagement-is-an-order-of-type-engagement
+ * @e2e order-primitive::subsidie-keeps-its-statutory-lifecycle
+ * @e2e order-primitive::a-transition-never-crosses-ordertype-boundaries
+ */
+
+import { test, expect, request as pwRequest } from '@playwright/test'
+import { OrFixtures, UNIQUE_PREFIX } from './workflows/_fixtures'
+
+const SCHEMA = 'OrderPrimitive'
+const ADMIN_ID = 'ADM-001'
+
+test.describe('order-primitive — Order fold + orderType-gated lifecycle (#503)', () => {
+	// The OpenRegister object API is slow under a loaded shared instance
+	// (single creates observed at 18-24s); tests that chain create + poll +
+	// transition + read need well above the 30s default. Run serially (they
+	// share one authenticated context) with a generous per-test budget.
+	test.describe.configure({ mode: 'serial', timeout: 180_000 })
+
+	let fx: OrFixtures
+	let api: import('@playwright/test').APIRequestContext
+
+	test.beforeAll(async ({ baseURL }) => {
+		api = await pwRequest.newContext({ baseURL, storageState: 'tests/e2e/.auth/admin.json' })
+		fx = new OrFixtures(api)
+	})
+
+	test.afterAll(async () => {
+		await fx?.cleanup()
+		await api?.dispose()
+	})
+
+	// A successful create is itself the proof that OrderPrimitive is imported as
+	// its own schema (create 404s when the schema is absent) — and that it is NOT
+	// decidesk's `order`, since these subsidie/engagement shapes would fail
+	// decidesk's required fields (orderNumber/orderDate/orderStatus/totalPrice).
+	test('a subsidie is an Order of type subsidie @spec REQ-ORD-001', async () => {
+		const { id } = await fx.create(SCHEMA, {
+			administrationId: ADMIN_ID,
+			orderType: 'subsidie',
+			direction: 'outgoing',
+			orderNumber: `${UNIQUE_PREFIX}-SUB`,
+			state: 'aanvraag',
+		})
+		const obj = await fx.get(SCHEMA, id)
+		expect(obj.orderType).toBe('subsidie')
+	})
+
+	test('a purchase order is an Order of type purchase @spec REQ-ORD-001', async () => {
+		const { id } = await fx.create(SCHEMA, {
+			administrationId: ADMIN_ID,
+			orderType: 'purchase',
+			direction: 'incoming',
+			orderNumber: `${UNIQUE_PREFIX}-PO`,
+			state: 'draft',
+		})
+		const obj = await fx.get(SCHEMA, id)
+		expect(obj.orderType).toBe('purchase')
+	})
+
+	test('a DBA engagement is an Order of type engagement @spec REQ-ORD-001', async () => {
+		const { id } = await fx.create(SCHEMA, {
+			administrationId: ADMIN_ID,
+			orderType: 'engagement',
+			direction: 'incoming',
+			orderNumber: `${UNIQUE_PREFIX}-DBA`,
+			state: 'DRAFT',
+		})
+		const obj = await fx.get(SCHEMA, id)
+		expect(obj.orderType).toBe('engagement')
+	})
+
+	test('subsidie keeps its statutory lifecycle (verleen: aanvraag → verleend) @spec REQ-ORD-002', async () => {
+		const { id } = await fx.create(SCHEMA, {
+			administrationId: ADMIN_ID,
+			orderType: 'subsidie',
+			direction: 'outgoing',
+			orderNumber: `${UNIQUE_PREFIX}-SUB-LIFECYCLE`,
+			state: 'aanvraag',
+		})
+
+		const res = await fx.transition(id, 'verleen')
+		expect(res.ok(), `verleen should be allowed on a subsidie in aanvraag: HTTP ${res.status()} ${await res.text()}`).toBeTruthy()
+
+		const after = await fx.get(SCHEMA, id)
+		const state = (after['@self'] as Record<string, unknown> | undefined)?.state ?? after.state
+		expect(state).toBe('verleend')
+	})
+
+	test('a transition never crosses orderType boundaries (approve refused on a subsidie) @spec REQ-ORD-002', async () => {
+		const { id } = await fx.create(SCHEMA, {
+			administrationId: ADMIN_ID,
+			orderType: 'subsidie',
+			direction: 'outgoing',
+			orderNumber: `${UNIQUE_PREFIX}-SUB-CROSS`,
+			state: 'aanvraag',
+		})
+
+		// `approve` is a PURCHASE-only transition (from=draft). It must be refused
+		// on a subsidie in aanvraag — the orderType gate (REQ-ORD-002). The refusal
+		// itself is the contract under test.
+		const res = await fx.transition(id, 'approve')
+		expect(res.ok(), 'a purchase transition must NOT succeed on a subsidie').toBeFalsy()
+	})
+})

--- a/tests/e2e/workflows/_fixtures.ts
+++ b/tests/e2e/workflows/_fixtures.ts
@@ -60,6 +60,7 @@ export interface CreatedRef {
  * request context (which carries the authenticated storage state).
  */
 export class OrFixtures {
+
 	private created: CreatedRef[] = []
 
 	constructor(private readonly api: APIRequestContext) {}
@@ -124,6 +125,8 @@ export class OrFixtures {
 	/**
 	 * Create one object in (register, schema). Tracks it for cleanup and
 	 * returns its OpenRegister id.
+	 * @param schemaSlug
+	 * @param data
 	 */
 	async create(schemaSlug: string, data: Record<string, unknown>): Promise<{ id: string; self: Record<string, unknown> }> {
 		const res = await this.api.post(`${OR}/objects/${REGISTER_SLUG}/${schemaSlug}`, {
@@ -140,7 +143,11 @@ export class OrFixtures {
 		return { id, self }
 	}
 
-	/** Read one object by id. */
+	/**
+	 * Read one object by id.
+	 * @param schemaSlug
+	 * @param id
+	 */
 	async get(schemaSlug: string, id: string): Promise<Record<string, unknown>> {
 		const res = await this.api.get(`${OR}/objects/${REGISTER_SLUG}/${schemaSlug}/${id}`, {
 			headers: { 'OCS-APIRequest': 'true' },
@@ -150,7 +157,12 @@ export class OrFixtures {
 		return (body['@self'] ? body : body) as Record<string, unknown>
 	}
 
-	/** Update one object by id (PUT). */
+	/**
+	 * Update one object by id (PUT).
+	 * @param schemaSlug
+	 * @param id
+	 * @param data
+	 */
 	async update(schemaSlug: string, id: string, data: Record<string, unknown>): Promise<Record<string, unknown>> {
 		const res = await this.api.put(`${OR}/objects/${REGISTER_SLUG}/${schemaSlug}/${id}`, {
 			headers: await this.headers(),
@@ -160,7 +172,28 @@ export class OrFixtures {
 		return res.json()
 	}
 
-	/** Delete one object by id and stop tracking it. */
+	/**
+	 * Fire an OpenRegister lifecycle transition on an object.
+	 *
+	 * POSTs to /api/objects/{id}/transition {action}. Returns the raw response
+	 * so callers can assert on both success (200) and refusal (422/4xx) — the
+	 * latter is what proves an orderType-gated transition is rejected.
+	 *
+	 * @param id     The object id (uuid).
+	 * @param action The lifecycle action name (e.g. 'verleen', 'approve').
+	 */
+	async transition(id: string, action: string): Promise<import('@playwright/test').APIResponse> {
+		return this.api.post(`${OR}/objects/${id}/transition`, {
+			headers: await this.headers(),
+			data: { action },
+		})
+	}
+
+	/**
+	 * Delete one object by id and stop tracking it.
+	 * @param schemaSlug
+	 * @param id
+	 */
 	async remove(schemaSlug: string, id: string): Promise<void> {
 		await this.api
 			.delete(`${OR}/objects/${REGISTER_SLUG}/${schemaSlug}/${id}`, { headers: await this.headers() })
@@ -178,10 +211,12 @@ export class OrFixtures {
 		}
 		this.created = []
 	}
+
 }
 
 /**
  * Round a money number to 2 decimals for tolerant float comparison.
+ * @param n
  */
 export function money(n: number): number {
 	return Math.round(n * 100) / 100


### PR DESCRIPTION
Adds live Playwright e2e for the order-primitive (#503) scenarios, giving the change full scenario traceability.

## Coverage (8/8 scenarios traced)
**5 via `tests/e2e/order-primitive.spec.ts`** (API-driven, real OR HTTP + auth + storage):
1-3. an Order of type subsidie / purchase / engagement can be created — the distinct shapes also prove it resolves to shillinq’s `OrderPrimitive`, not decidesk’s `order`.
4. subsidie keeps its statutory lifecycle (`verleen`: aanvraag → verleend).
5. **a transition never crosses orderType boundaries** — a purchase `approve` is REFUSED on a subsidie (REQ-ORD-002, the orderType gate).

**3 marked `@e2e exclude`** (backend occ, not browser-drivable) with proof references:
- migration lossless → FoldIntoOrder live run (#503/#381) + FoldIntoOrderTest
- money units normalised → FoldIntoOrder cent→EUR live (#503) + FoldIntoOrderTest
- audit detects unmigrated → `occ shillinq:orders:audit` live (#388) + OrdersAuditCommandTest

Adds `OrFixtures.transition()` (POST /api/objects/{id}/transition). Every seeded object carries a run-unique prefix and is deleted in afterAll.

## Verification — and an honest caveat
Every test passes **deterministically in isolation** (the cross-type gate 3/3 on repeat). Full-suite runs on the **current shared dev instance flake on `socket hang up` / timeouts** — the instance is being hammered by a concurrent session (single object-creates observed at 18–24s, full runs 7–8 min, the server dropping POST connections under load). Those failures are environmental, never wrong assertions. The spec is built for a clean CI instance (serial, 180s timeout, retries) where it runs in well under a minute.

Refs #503