### PR TITLE
fix(repair): downstream defects in 2 repair steps, found by #382 live e2e

### DIFF
--- a/lib/Repair/RetireCostProjectStep.php
+++ b/lib/Repair/RetireCostProjectStep.php
@@ -320,7 +320,15 @@ class RetireCostProjectStep implements IRepairStep
      */
     private function mintCode(object $objectService, string $registerSlug, string $projectNumber, IOutput $output): ?string
     {
-        $baseCode  = 'CP-'.$projectNumber;
+        // AnalyticalDimension.code must match ^[a-z][a-z0-9-]*$, so the minted code
+        // must be lower-case and hyphen-normalised — a raw "CP-<projectNumber>"
+        // (upper-case prefix / mixed-case number) never validates. The 'cp-' prefix
+        // guarantees a leading letter. (Exposed by #382 live e2e once the step
+        // actually read rows.)
+        $slug      = strtolower($projectNumber);
+        $slug      = preg_replace('/[^a-z0-9-]+/', '-', $slug) ?? '';
+        $slug      = trim($slug, '-');
+        $baseCode  = 'cp-'.$slug;
         $candidate = $baseCode;
 
         for ($attempt = 2; $attempt <= self::MAX_COLLISION_ATTEMPTS + 1; $attempt++) {
@@ -390,6 +398,11 @@ class RetireCostProjectStep implements IRepairStep
             'dimensionType'      => 'project',
             'code'               => $code,
             'name'               => (string) ($source['name'] ?? $code),
+            // AnalyticalDimension requires dataType; a migrated project dimension is
+            // a categorical code, so it is a 'string' dimension. Omitting this made
+            // every migration fail validation once the step actually read rows
+            // (the limit=>0 dead-read had hidden it — #382 live e2e).
+            'dataType'           => 'string',
             'administrationId'   => (string) ($source['administrationId'] ?? ''),
             'lifecycleState'     => $this->mapLifecycleState(costProjectState: (string) ($source['lifecycleState'] ?? 'active')),
             'migratedFrom'       => $costProjectId,

--- a/lib/Repair/RetireCostProjectStep.php
+++ b/lib/Repair/RetireCostProjectStep.php
@@ -323,8 +323,8 @@ class RetireCostProjectStep implements IRepairStep
         // AnalyticalDimension.code must match ^[a-z][a-z0-9-]*$, so the minted code
         // must be lower-case and hyphen-normalised — a raw "CP-<projectNumber>"
         // (upper-case prefix / mixed-case number) never validates. The 'cp-' prefix
-        // guarantees a leading letter. (Exposed by #382 live e2e once the step
-        // actually read rows.)
+        // guarantees a leading letter. Exposed by #382 live e2e once the step
+        // actually read real rows.
         $slug      = strtolower($projectNumber);
         $slug      = preg_replace('/[^a-z0-9-]+/', '-', $slug) ?? '';
         $slug      = trim($slug, '-');

--- a/lib/Repair/UnifyAnalyticalDimensions.php
+++ b/lib/Repair/UnifyAnalyticalDimensions.php
@@ -329,8 +329,13 @@ class UnifyAnalyticalDimensions implements IRepairStep
             ->setSchema('AnalyticalDimension')
             ->findAll(
                     [
-                        'limit'  => 1,
-                        'filter' => [
+                        'limit'   => 1,
+                        // OpenRegister's key is 'filters' (plural); the old 'filter'
+                        // was IGNORED, so this returned unfiltered rows and every
+                        // source was reported "already exists" and skipped — 0 created
+                        // on any instance that had any AnalyticalDimension row
+                        // (#382 live e2e). All three keys are top-level (filterable).
+                        'filters' => [
                             'code'             => $code,
                             'administrationId' => $administrationId,
                             'dimensionType'    => $dimensionType,
@@ -358,6 +363,10 @@ class UnifyAnalyticalDimensions implements IRepairStep
             'dimensionType'    => 'cost-center',
             'code'             => (string) ($source['code'] ?? ''),
             'name'             => (string) ($source['name'] ?? ''),
+            // AnalyticalDimension requires dataType; a folded cost-center is a
+            // categorical code -> 'string'. Omitting it failed every migration
+            // once the step actually read rows (#382 live e2e).
+            'dataType'         => 'string',
             'administrationId' => (string) ($source['administrationId'] ?? ''),
             'lifecycleState'   => (string) ($source['lifecycleState'] ?? 'active'),
         ];
@@ -396,6 +405,8 @@ class UnifyAnalyticalDimensions implements IRepairStep
             'dimensionType'    => 'cost-object',
             'code'             => (string) ($source['code'] ?? ''),
             'name'             => (string) ($source['name'] ?? ''),
+            // AnalyticalDimension requires dataType (see buildCostCenterRecord).
+            'dataType'         => 'string',
             'administrationId' => (string) ($source['administrationId'] ?? ''),
             'lifecycleState'   => (string) ($source['lifecycleState'] ?? 'active'),
         ];

--- a/tests/Unit/Repair/RetireCostProjectStepTest.php
+++ b/tests/Unit/Repair/RetireCostProjectStepTest.php
@@ -5,7 +5,7 @@
  *
  * Verifies the field mapping, lifecycle mapping, costsIncurredToDate drop,
  * code minting + collision disambiguation, idempotent re-run behaviour, and
- * fail-safe skip for unmappable source records (per REQ-RCP-005).
+ * fail-safe skip for unmappable source records (per REQ-Rcp-005).
  *
  * @category Test
  * @package  OCA\Shillinq\Tests\Unit\Repair
@@ -17,7 +17,7 @@
  * @link https://conduction.nl
  *
  * @spec openspec/changes/retire-cost-project/tasks.md#phase-4
- * @spec openspec/changes/retire-cost-project/specs/retire-cost-project/spec.md (REQ-RCP-005)
+ * @spec openspec/changes/retire-cost-project/specs/retire-cost-project/spec.md (REQ-Rcp-005)
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2
@@ -133,9 +133,9 @@ class RetireCostProjectStepTest extends TestCase
     /**
      * A typical CostProject is correctly mapped to an AnalyticalDimension.
      *
-     * Verifies the field mapping table from REQ-RCP-005:
+     * Verifies the field mapping table from REQ-Rcp-005:
      *   - projectNumber → projectNumber
-     *   - minted code = CP-<projectNumber>
+     *   - minted code = cp-<projectNumber>
      *   - name, description, startDate, endDate → same
      *   - totalBudget, totalEstimatedCosts → same
      *   - costCenterCode → parentCode
@@ -175,7 +175,8 @@ class RetireCostProjectStepTest extends TestCase
         $obj = $saved['object'];
 
         self::assertSame('project', $obj['dimensionType']);
-        self::assertSame('CP-2026-001', $obj['code']);
+        self::assertSame('cp-2026-001', $obj['code']);
+        self::assertSame('string', $obj['dataType']);
         self::assertSame('2026-001', $obj['projectNumber']);
         self::assertSame('Test Project', $obj['name']);
         self::assertSame('A test cost project', $obj['description']);
@@ -197,7 +198,7 @@ class RetireCostProjectStepTest extends TestCase
 
 
     /**
-     * Lifecycle state mapping table per REQ-RCP-005.
+     * Lifecycle state mapping table per REQ-Rcp-005.
      *
      * draft, active, on-hold → active
      * closed, archived        → archived
@@ -248,7 +249,7 @@ class RetireCostProjectStepTest extends TestCase
 
     /**
      * costsIncurredToDate is never copied to the migrated AnalyticalDimension
-     * (it is re-derived from GL as spentToDate per REQ-RCP-005).
+     * (it is re-derived from GL as spentToDate per REQ-Rcp-005).
      *
      * @return void
      */
@@ -273,7 +274,7 @@ class RetireCostProjectStepTest extends TestCase
 
 
     /**
-     * The minted code is "CP-<projectNumber>".
+     * The minted code is "cp-<projectNumber>".
      *
      * @return void
      */
@@ -291,13 +292,13 @@ class RetireCostProjectStepTest extends TestCase
         $step->run($this->output);
 
         self::assertCount(1, $this->fakeObjectService->saves);
-        self::assertSame('CP-2026-MINT', $this->fakeObjectService->saves[0]['object']['code']);
+        self::assertSame('cp-2026-mint', $this->fakeObjectService->saves[0]['object']['code']);
 
     }//end testCodeIsMintedWithCpPrefix()
 
 
     /**
-     * When the minted code "CP-<projectNumber>" is already taken, the step
+     * When the minted code "cp-<projectNumber>" is already taken, the step
      * appends "-2", "-3", etc. until a free slot is found. The collision is
      * reported but never silently overwritten.
      *
@@ -313,9 +314,9 @@ class RetireCostProjectStepTest extends TestCase
             'lifecycleState'   => 'active',
         ];
 
-        // Simulate "CP-COLL-001" already existing — step must try "CP-COLL-001-2".
+        // Simulate "cp-coll-001" already existing — step must try "cp-coll-001-2".
         $existingDimensions = [
-            ['code' => 'CP-COLL-001', 'administrationId' => 'adm-1', 'migratedFrom' => null],
+            ['code' => 'cp-coll-001', 'administrationId' => 'adm-1', 'migratedFrom' => null],
         ];
 
         $step = $this->makeStep(costProjects: [$source], existingDimensions: $existingDimensions);
@@ -324,7 +325,7 @@ class RetireCostProjectStepTest extends TestCase
         self::assertCount(1, $this->fakeObjectService->saves);
         $saved = $this->fakeObjectService->saves[0];
         // Original code taken; disambiguated to -2.
-        self::assertSame('CP-COLL-001-2', $saved['object']['code']);
+        self::assertSame('cp-coll-001-2', $saved['object']['code']);
         // migratedFrom marker is preserved.
         self::assertSame('cp-coll', $saved['object']['migratedFrom']);
 
@@ -349,7 +350,7 @@ class RetireCostProjectStepTest extends TestCase
 
         // Existing AnalyticalDimension carrying the migratedFrom marker.
         $existingDimensions = [
-            ['code' => 'CP-IDEM-001', 'administrationId' => 'adm-1', 'migratedFrom' => 'cp-idem'],
+            ['code' => 'cp-idem-001', 'administrationId' => 'adm-1', 'migratedFrom' => 'cp-idem'],
         ];
 
         $step = $this->makeStep(costProjects: [$source], existingDimensions: $existingDimensions);
@@ -389,7 +390,7 @@ class RetireCostProjectStepTest extends TestCase
 
         // Only the normal record is saved; the unmappable one is not.
         self::assertCount(1, $this->fakeObjectService->saves);
-        self::assertSame('CP-NORMAL-001', $this->fakeObjectService->saves[0]['object']['code']);
+        self::assertSame('cp-normal-001', $this->fakeObjectService->saves[0]['object']['code']);
 
         // The fake ObjectService records zero deletes (fail-safe guarantee).
         self::assertSame([], $this->fakeObjectService->deletes);
@@ -419,9 +420,9 @@ class RetireCostProjectStepTest extends TestCase
             static fn (array $s): string => $s['object']['code'],
             $this->fakeObjectService->saves
         );
-        self::assertContains('CP-A-001', $codes);
-        self::assertContains('CP-B-001', $codes);
-        self::assertContains('CP-C-001', $codes);
+        self::assertContains('cp-a-001', $codes);
+        self::assertContains('cp-b-001', $codes);
+        self::assertContains('cp-c-001', $codes);
 
     }//end testMultipleRecordsAreMigrated()
 


### PR DESCRIPTION
Running the (now-un-deadened) repair steps end-to-end on isolated seeded data surfaced real downstream defects the `limit=>0` dead-read had always hidden — the steps had never actually built a record to validate against their target schema.

## RetireCostProjectStep (registered — would fail on any real CostProject row)
1. **Missing required `dataType`** on AnalyticalDimension → every migration failed validation. A migrated project dimension is a categorical code → `dataType: 'string'`.
2. **Invalid `code`** — `mintCode` produced `CP-<projectNumber>`, but `AnalyticalDimension.code` must match `^[a-z][a-z0-9-]*$`. The upper-case prefix never validated. Now slugified to `cp-<slug(projectNumber)>`.

## UnifyAnalyticalDimensions
3. **`analyticalDimensionExists()` used `'filter'` (singular)** — OpenRegister’s key is `'filters'`; the singular one was ignored, so the query returned unfiltered rows and every source was reported "already exists" → **0 created** on any instance with any AnalyticalDimension row.
4. **Missing `dataType`** on both builders (cost-center + cost-object) → would fail validation once the skip bug was fixed.

## Live-verified end-to-end (isolated seeded rows on 8080, deleted after)
| step | result |
|---|---|
| DelegateSigningMigrationRepair | ACMReport signing backfilled (`legacy-local:<fp>` + signed), idempotent — no defects |
| RetireCostProjectStep | CostProject → AnalyticalDimension (code `cp-…`, dataType=string) after fixes |
| UnifyAnalyticalDimensions | CostCenter + KostenDrager → 2 AnalyticalDimensions after fixes |
| StampJournalTypeOnGlTransactions | GLTransaction stamped `journalType=closing`, idempotent — no defects |

Unit tests updated (they had encoded the buggy CP-/no-dataType behaviour). Full suite **3966 green**; phpcs/phpmd clean.

Refs #382