### PR TITLE
fix(repair): FoldDunning null-vs-typed writeOff defect (#382 e2e, batch 2)

### DIFF
--- a/lib/Repair/FoldDunningWriteoffIntoArInvoice.php
+++ b/lib/Repair/FoldDunningWriteoffIntoArInvoice.php
@@ -170,8 +170,14 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep
                 }
 
                 // Map the FULL OninbaarAfschrijving field set onto writeOff.
-                $declaration            = (string) ($row['art29OBVerklaring'] ?? '');
-                $invoiceArr['writeOff'] = [
+                // Optional source fields are absent on many real rows (only
+                // factuurId/hoofdsomAfgeschreven/art29OBVerklaring/administrationId
+                // are required on OninbaarAfschrijving), so a null must NOT be
+                // written for a typed target field (e.g. writeOff.btwBedrag is a
+                // number) — an absent optional property is valid, a null is not.
+                // Prune null-valued keys before saving (#382 live e2e).
+                $declaration = (string) ($row['art29OBVerklaring'] ?? '');
+                $writeOff    = [
                     'isWrittenOff'              => true,
                     'writtenOffReason'          => $this->deriveWriteOffReason(declaration: $declaration),
                     'art29OBVerklaring'         => $declaration,
@@ -182,6 +188,7 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep
                     'btwTeruggaafPeriode'       => $this->strOrNull($row['btwAangiftePeriode'] ?? null),
                     'administrationId'          => $this->strOrNull($row['administrationId'] ?? null),
                 ];
+                $invoiceArr['writeOff'] = array_filter($writeOff, static fn ($v) => $v !== null);
 
                 // Mirror the lifecycle onto the discriminator-adjacent flag
                 // only when the invoice has no explicit invoiceType yet:


### PR DESCRIPTION
Second batch of #382 live-e2e downstream fixes.

**FoldDunningWriteoffIntoArInvoice** — the `writeOff` group emitted `null` for optional fields (`btwBedrag`, `evidenceRef`, `btwTeruggaafPeriode`, `writtenOffGLTransactionId`) when the source omitted them, but those target properties are typed (e.g. `writeOff.btwBedrag` is a `number`) — a present `null` fails validation. Only 4 fields are required on `OninbaarAfschrijving`, so a real writeoff lacking the optional ones would fail the fold. Now prunes null-valued keys before saving (absent optional = valid; null = not).

Live-verified (isolated seeded ARInvoice + linked OninbaarAfschrijving): the invoice now folds (writeOff group present, hoofdsomAfgeschreven mapped); a dangling real writeoff (invoice absent) is skipped — no collateral.

Also live-verified clean in this pass (no code change needed): BackfillFiscalPeriods, PeriodCloseBackfill, FoldExpensesAndHoursIntoProject (hours path). Full suite 3966 green.

Refs #382