### PR TITLE
i18n(labels): author status/type labels in English source + NL l10n

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl.
     ]]></description>
-    <version>0.9.21</version>
+    <version>0.9.22</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Shillinq</namespace>

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -1,5 +1,12 @@
 {
     "translations": {
+        "Matching": "Matching",
+        "Matched": "Matched",
+        "Exception": "Exception",
+        "Damage": "Damage",
+        "Wrong product": "Wrong product",
+        "Not ordered": "Not ordered",
+        "Appointment": "Appointment",
         "GR Participant": "GR Participant",
         "GR Allocation Key": "GR Allocation Key",
         "Retention period": "Retention period",

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -1,5 +1,12 @@
 {
     "translations": {
+        "Matching": "In afstemming",
+        "Matched": "Gematched",
+        "Exception": "Uitzondering",
+        "Damage": "Schade",
+        "Wrong product": "Verkeerd product",
+        "Not ordered": "Niet besteld",
+        "Appointment": "Afspraak",
         "GR Participant": "GR Deelnemer",
         "GR Allocation Key": "GR Verdeelsleutel",
         "Retention period": "Bewaartermijn",

--- a/src/components/goods-receipt-note/GoodsReceiptNoteForm.vue
+++ b/src/components/goods-receipt-note/GoodsReceiptNoteForm.vue
@@ -204,10 +204,10 @@ export default {
 		},
 		rejectionReasonOptions() {
 			return [
-				{ value: 'schade', label: this.t('shillinq', 'Schade (damage)') },
-				{ value: 'verkeerd_product', label: this.t('shillinq', 'Verkeerd product') },
+				{ value: 'schade', label: this.t('shillinq', 'Damage') },
+				{ value: 'verkeerd_product', label: this.t('shillinq', 'Wrong product') },
 				{ value: 'expired', label: this.t('shillinq', 'Expired') },
-				{ value: 'niet_besteld', label: this.t('shillinq', 'Niet besteld') },
+				{ value: 'niet_besteld', label: this.t('shillinq', 'Not ordered') },
 				{ value: 'short_shipped', label: this.t('shillinq', 'Short shipped') },
 				{ value: 'other', label: this.t('shillinq', 'Other') },
 			]

--- a/src/components/supplier-invoice/SupplierInvoiceDetail.vue
+++ b/src/components/supplier-invoice/SupplierInvoiceDetail.vue
@@ -244,13 +244,13 @@ export default {
 		},
 		statusLabel(statusCode) {
 			const labels = {
-				received: this.t('shillinq', 'Ontvangen'),
-				matching: this.t('shillinq', 'In afstemming'),
-				matched: this.t('shillinq', 'Gematched'),
-				exception: this.t('shillinq', 'Uitzondering'),
-				approved: this.t('shillinq', 'Goedgekeurd'),
-				paid: this.t('shillinq', 'Betaald'),
-				rejected: this.t('shillinq', 'Afgewezen'),
+				received: this.t('shillinq', 'Received'),
+				matching: this.t('shillinq', 'Matching'),
+				matched: this.t('shillinq', 'Matched'),
+				exception: this.t('shillinq', 'Exception'),
+				approved: this.t('shillinq', 'Approved'),
+				paid: this.t('shillinq', 'Paid'),
+				rejected: this.t('shillinq', 'Rejected'),
 			}
 			return labels[statusCode] || statusCode || '—'
 		},

--- a/src/views/bookings/AfspraakDetail.vue
+++ b/src/views/bookings/AfspraakDetail.vue
@@ -35,7 +35,7 @@
 				&larr; {{ label('Back to bookings') }}
 			</router-link>
 			<h1 class="afspraak-detail__title">
-				{{ label('Afspraak') }}
+				{{ label('Appointment') }}
 				<span v-if="bookingReference" class="afspraak-detail__reference">
 					{{ bookingReference }}
 				</span>


### PR DESCRIPTION
## What
Converts the remaining Dutch-authored display labels in the shillinq frontend to **English source strings**, with the matching English→Dutch pair added to `l10n/en.json` + `l10n/nl.json`. English-locale users previously saw Dutch labels (e.g. supplier-invoice status `Ontvangen`, GRN rejection reasons `Schade`, the appointment page title `Afspraak`) because these `t('shillinq', …)` calls passed a **Dutch** source string that resolved to itself in `en.json`.

All converted strings were already `t()`-wrapped at the call site (decision-tree case 2a), so only the string VALUE changed — object KEYS / enum values (`received`, `schade`, `niet_besteld`, …) are untouched. No Dutch user regresses to English: every new English key maps back to its Dutch text in `nl.json`.

## Constants / label maps
- `AuditTrailDetail.vue` `EVENT_LABELS` — **SKIPPED**, values already English.
- `WIDGET_STRINGS`, `REASON_MESSAGES`, `CATEGORY_META`, `SEGMENT_AGGREGATION`, `PDF_DEFERRAL_MESSAGE` — **SKIPPED** (already English source / API-value maps / structured en+nl table).
- `SupplierInvoiceDetail.vue` `statusLabel()` map — converted.
- `GoodsReceiptNoteForm.vue` `rejectionReasonOptions()` — converted.
- `AfspraakDetail.vue` page title — converted.

## Dutch → English value mappings
| Dutch source | English source | Dutch (nl.json) |
|---|---|---|
| Ontvangen | Received | Ontvangen |
| In afstemming | Matching | In afstemming |
| Gematched | Matched | Gematched |
| Uitzondering | Exception | Uitzondering |
| Goedgekeurd | Approved | (Geaccepteerd — see flag) |
| Betaald | Paid | Betaald |
| Afgewezen | Rejected | Afgewezen |
| Schade (damage) | Damage | Schade |
| Verkeerd product | Wrong product | Verkeerd product |
| Niet besteld | Not ordered | Niet besteld |
| Afspraak | Appointment | Afspraak |

Call sites: no case-2b wraps were needed — every affected render was already `t()`/`label()`-wrapped, so only the source strings changed.

## Flagged for human review (finance / three-way-match terms)
- **`In afstemming` → `Matching`** — three-way-match status flow is `received → matching → matched → approved/paid`; "in afstemming" literally is "in reconciliation". Chose **Matching** to fit the status progression; **In reconciliation** is the alternative if a more literal term is preferred.
- **`Uitzondering` → `Exception`** — standard three-way-match term (match exception). Confident.
- **`Goedgekeurd` → `Approved`** — an `"Approved"` key already existed in `nl.json` mapping to **`Geaccepteerd`** (not the source `Goedgekeurd`). Kept the existing value to avoid a duplicate JSON key; Dutch users still see Dutch (no regression). Flagging in case `Goedgekeurd` is the preferred label.
- **`Schade (damage)` → `Damage`** — the original Dutch already carried an inline English gloss; dropped the now-redundant gloss and set `nl.json` to the clean **`Schade`**.

Established abbreviations (PO, GRN, UBL, Peppol) left as-is.

## Verify
- `npm run test:l10n` → **OK** (865 distinct literal keys, all present in en.json).
- `l10n/en.json` + `l10n/nl.json` parse as valid JSON.
- Object keys unchanged in every converted map (values only).
- Version bumped `0.9.21 → 0.9.22`.