### PR TITLE
i18n(l10n): author Dutch-source UI literals in English + NL l10n

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl.
     ]]></description>
-    <version>0.9.22</version>
+    <version>0.9.23</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Shillinq</namespace>

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -2510,6 +2510,7 @@
         "Sync failed; retry {sec}s": "Sync failed; retry {sec}s",
         "Sync now": "Sync now",
         "Syncing…": "Syncing…",
+        "Team lead": "Team lead",
         "Teamleider": "Teamleider",
         "Tolerance override": "Tolerance override",
         "Transferred {qty} units {from} → {to} (pending sync)": "Transferred {qty} units {from} → {to} (pending sync)",

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -2512,6 +2512,7 @@
         "Sync failed; retry {sec}s": "Synchronisatie mislukt; opnieuw over {sec}s",
         "Sync now": "Nu synchroniseren",
         "Syncing…": "Synchroniseren…",
+        "Team lead": "Teamleider",
         "Teamleider": "Teamleider",
         "Tolerance override": "Tolerantie-overschrijving",
         "Transferred {qty} units {from} → {to} (pending sync)": "Overgedragen {qty} eenheden {from} → {to} (synchronisatie in behandeling)",

--- a/src/components/purchase-order/PurchaseOrderDetail.vue
+++ b/src/components/purchase-order/PurchaseOrderDetail.vue
@@ -320,7 +320,7 @@ export default {
 		},
 		roleLabel(role) {
 			const labels = {
-				teamleider: this.t('shillinq', 'Teamleider'),
+				teamleider: this.t('shillinq', 'Team lead'),
 				facility_manager: this.t('shillinq', 'Facility Manager'),
 				procurement_manager: this.t('shillinq', 'Procurement Manager'),
 			}

--- a/src/components/purchase-order/PurchaseOrderForm.vue
+++ b/src/components/purchase-order/PurchaseOrderForm.vue
@@ -257,7 +257,7 @@ export default {
 		},
 		roleLabel(role) {
 			const labels = {
-				teamleider: this.t('shillinq', 'Teamleider'),
+				teamleider: this.t('shillinq', 'Team lead'),
 				facility_manager: this.t('shillinq', 'Facility Manager'),
 				procurement_manager: this.t('shillinq', 'Procurement Manager'),
 			}


### PR DESCRIPTION
## What
Re-author the remaining inline **Dutch-source** `t('shillinq', …)` literal to an **English source string** with the Dutch preserved at the l10n layer, so English-locale users see English while Dutch users keep seeing Dutch (fleet convention: source = English, Dutch at display layer).

## Scope of the sweep
Swept all 121 `src/**/*.{vue,js,ts}` files — 865 distinct `t('shillinq', …)` literals, 0 `n(…)` plurals. Cross-checked every literal against `l10n/nl.json` identity mapping. **The status/domain labels flagged in the brief (Received/Matching/Matched/Exception/Approved/Paid/Rejected/Damage/Wrong product/Not ordered/Appointment) were already converted to English source by label PR #402** and remain only as harmless orphan l10n keys.

Only **one** live Dutch-source literal remained in code:

| Dutch source | English source | Files |
|---|---|---|
| `Teamleider` | `Team lead` | `PurchaseOrderForm.vue`, `PurchaseOrderDetail.vue` |

The `teamleider:` object **key** (role identifier) is unchanged — only the display label passed to `t()` was converted, matching its English siblings `Facility Manager` / `Procurement Manager`.

## l10n
- `en.json`: `"Team lead": "Team lead"` (identity)
- `nl.json`: `"Team lead": "Teamleider"`
- Orphaned Dutch keys (`Teamleider`, and PR #402's `Betaald`/`Ontvangen`/`Goedgekeurd`/`Niet besteld`/`Schade (damage)`/`Verkeerd product`/`Uitzondering`) left in place — harmless, not deleted.

## Flagged (uncertain English — role title)
- **`Teamleider` → `Team lead`**: Dutch org role title. `Team lead` chosen to parallel the English sibling labels; `Team leader` is an equally valid rendering.

## Kept Dutch (intentional)
None encountered in code — no legal/statutory terms (Woo/AVG/Archiefwet categories) or Dutch proper nouns were live in `t()` literals in this app's `src`.

## n() plurals
None (0 in codebase).

## Verify
- `npm run test:l10n` → **exit 0** (`OK — every used translation key is present in l10n/en.json`)
- Both l10n JSON parse valid.
- `git diff` confirms every code hunk is a string-literal swap; object keys and logic unchanged.
- Version bumped `0.9.22 → 0.9.23`.