### PR TITLE
feat(icons): adopt the ADR-077 semantic icon vocabulary

### DIFF
--- a/lib/Settings/register.d/10-bookings-email-templates.json
+++ b/lib/Settings/register.d/10-bookings-email-templates.json
@@ -220,7 +220,7 @@
       },
       "BookingReminderTemplate": {
         "slug": "BookingReminderTemplate",
-        "icon": "EmailClockOutline",
+        "icon": "EmailOutline",
         "version": "0.1.0",
         "title": "Booking Reminder Template",
         "description": "Branded reminder email dispatched N hours before a booking starts. The hoursBeforeBooking field configures the reminder timing; the booking system queues dispatch at that offset (REQ-BET-005). Subject/body support {{variable}} placeholders including {{hoursUntilBooking}}. Lifecycle draft -> published -> archived controls the active version.",

--- a/lib/Settings/register.d/20-bookkeeping-tenderned-integratie.json
+++ b/lib/Settings/register.d/20-bookkeeping-tenderned-integratie.json
@@ -3,7 +3,7 @@
     "schemas": {
       "TenderNedAanbesteding": {
         "slug": "TenderNedAanbesteding",
-        "icon": "GavelOutline",
+        "icon": "Gavel",
         "version": "0.1.0",
         "title": "TenderNed Aanbesteding",
         "description": "A procurement tender imported from TenderNed (Logius central procurement platform). Wraps the public dossier metadata (REQ-001) and links to the materialised Shillinq Verplichting. Both the aanbestedende dienst (public buyer) and the inschrijvende leverancier (winning vendor) consume this schema, with role-based visibility filtering (design D6).",
@@ -230,7 +230,7 @@
       },
       "Verplichting": {
         "slug": "Verplichting",
-        "icon": "FileSignOutline",
+        "icon": "FileSign",
         "version": "0.1.0",
         "title": "Verplichting",
         "description": "A financial obligation (commitment) that reserves budget. The obligation may originate manually, from an inkooporder, or from a won TenderNed tender (bron field, REQ-001). A concept obligation must be enriched (kostenplaats, grootboekrekening) and activated by a contractmanager before it locks budget (design D2).",

--- a/lib/Settings/register.d/20-inventory-barcode-sku.json
+++ b/lib/Settings/register.d/20-inventory-barcode-sku.json
@@ -6,7 +6,7 @@
     "schemas": {
       "Barcode": {
         "slug": "Barcode",
-        "icon": "BarcodeOutline",
+        "icon": "Barcode",
         "version": "0.1.0",
         "title": "Barcode",
         "description": "A scannable code (EAN, GTIN, UPC, SSCC, or internal) bound to a Product at a specific unit-of-measure. A single Product carries 1..N barcodes — one per UoM or channel (e.g. EAN-13 per unit, GTIN-14 per carton, SSCC per pallet). Declared as a separate register (not an inline array on Product) so barcodes are individually queryable, auditable, and have an independent lifecycle (deactivate without delete). Consumed by the shillinq barcode lookup endpoint and the pipelinq pos-barcode-scan module. Spec: inventory-barcode-sku. Depends on inventory-product-catalog (Product schema). The 'InventoryItem' wording in the spec refers to the shillinq Product schema.",

--- a/lib/Settings/register.d/50-bookings-deposits.json
+++ b/lib/Settings/register.d/50-bookings-deposits.json
@@ -3,7 +3,7 @@
     "schemas": {
       "DepositPayment": {
         "slug": "DepositPayment",
-        "icon": "CashClockOutline",
+        "icon": "CashClock",
         "version": "0.1.0",
         "title": "Deposit Payment",
         "description": "A deposit (partial or full prepayment) collected at booking time via Mollie or Stripe, routed through OpenConnector. On authorization a Shillinq AR invoice is materialised; on void an AR credit note reverses it. Payment routing, tokenization and gateway selection are OpenConnector's responsibility — this register never stores card data (REQ-DP-001).",

--- a/lib/Settings/register.d/add-shillinq-bookkeeping-compliance.json
+++ b/lib/Settings/register.d/add-shillinq-bookkeeping-compliance.json
@@ -956,7 +956,7 @@
       },
       "BankStatementLine": {
         "slug": "BankStatementLine",
-        "icon": "BankTransferOutline",
+        "icon": "BankTransfer",
         "version": "0.1.0",
         "title": "Bank Statement Line",
         "description": "A single transaction line within a BankStatement per REQ-BR-003. Parsed from CAMT.053, MT940, or manual CSV import. Matched against AR/AP via MatchingRule predicates (REQ-BR-004/REQ-BR-005/REQ-BR-006); unmatched lines route to a suspense account (REQ-BR-007).",

--- a/lib/Settings/register.d/add-shillinq-detachering-payroll-administratie.json
+++ b/lib/Settings/register.d/add-shillinq-detachering-payroll-administratie.json
@@ -250,7 +250,7 @@
       },
       "OpdrachtgeversVerklaring": {
         "slug": "OpdrachtgeversVerklaring",
-        "icon": "FileSignOutline",
+        "icon": "FileSign",
         "version": "0.1.0",
         "title": "Opdrachtgevers Verklaring",
         "description": "Wet DBA (Deregulering Beoordeling Arbeidsrelaties) position record per ZZP assignment. Declares the opdrachtgever-opdrachtnemer relationship and risicobeoordeling per REQ-DPA-003. No PHP DBA service — lifecycle and document rendering are declarative per ADR-031.",

--- a/lib/Settings/register.d/add-shillinq-sbr-xbrl-reporting.json
+++ b/lib/Settings/register.d/add-shillinq-sbr-xbrl-reporting.json
@@ -12,7 +12,7 @@
     "schemas": {
       "XbrlInstance": {
         "slug": "XbrlInstance",
-        "icon": "FileXmlBoxOutline",
+        "icon": "FileXmlBox",
         "version": "0.1.0",
         "title": "XBRL Instance",
         "description": "An NL-taxonomie XBRL instance document derived from a posted T3 FinancialStatement (REQ-SBR-001/002). One record per filing event per administration + reporting period + entry point. Carries the canonicalised XML payload, its SHA-256 tamper-evidence hash, the resolved Mapping FK (REQ-SBR-006), the Digipoort acknowledgement receipt id when submitted (REQ-SBR-004), and the declarative draft → validated → submitted → accepted/rejected lifecycle (REQ-SBR-003 / ADR-031). No re-aggregation of ledger lines; the instance is a pure transformation on top of FinancialStatement (D1 in design.md).",

--- a/lib/Settings/register.d/administration-import-migration.json
+++ b/lib/Settings/register.d/administration-import-migration.json
@@ -508,7 +508,7 @@
       },
       "ImportMapping": {
         "slug": "ImportMapping",
-        "icon": "SwapHorizontalBoldOutline",
+        "icon": "SwapHorizontalBold",
         "version": "0.1.0",
         "title": "Import Mapping",
         "description": "One source-account → Shillinq-account mapping row per REQ-AIM-004. Separate rows (not embedded on the batch) because a real chart has hundreds of accounts and the mapping needs its own review grid, per-row status, and reuse as a saved profile across an accountant's client migrations. Resolution order: source RGS code → target with same RGS (rgs-auto, pre-confirmed); saved profile hit (profile-default); code/name similarity (manual review); else unmapped. Unmapped or unconfirmed rows referenced by staged data block the mapping→validated transition (fail-closed).",

--- a/lib/Settings/register.d/bookings-deposit-to-invoice.json
+++ b/lib/Settings/register.d/bookings-deposit-to-invoice.json
@@ -336,7 +336,7 @@
       },
       "DepositPayment": {
         "slug": "DepositPayment",
-        "icon": "CashLockOutline",
+        "icon": "CashLock",
         "version": "0.1.0",
         "title": "Deposit Payment",
         "description": "An authorised booking deposit (owned by bookings-deposits T1). Declared here as a dimension so deposit-to-invoice can resolve the authorised amount for the credit line (REQ-DI-003) and so cancellation can transition it to refunded (REQ-DI-006). The full collection/state machine lives in bookings-deposits.",

--- a/lib/Settings/register.d/bookings-email-templates.json
+++ b/lib/Settings/register.d/bookings-email-templates.json
@@ -245,7 +245,7 @@
       },
       "BookingReminderTemplate": {
         "slug": "BookingReminderTemplate",
-        "icon": "EmailClockOutline",
+        "icon": "EmailOutline",
         "version": "0.1.0",
         "title": "Boekingsherinneringssjabloon",
         "description": "Branded email template dispatched a configurable number of hours before booking start (REQ-BET-005/010). Carries hoursBeforeBooking timing, subject/body with {{variables}}, plain-text fallback, branding, and the same draft → published → archived lifecycle as the confirmation template. Multiple reminder templates can coexist (e.g. 24h and 2h) — the notification engine schedules one dispatch per published reminder per booking.",

--- a/lib/Settings/register.d/bookkeeping-aansluitingen.json
+++ b/lib/Settings/register.d/bookkeeping-aansluitingen.json
@@ -136,7 +136,7 @@
       },
       "AansluitingResult": {
         "slug": "AansluitingResult",
-        "icon": "FileCompareOutline",
+        "icon": "FileCompare",
         "version": "0.1.0",
         "title": "Aansluiting Resultaat",
         "description": "One per-period computed instance of an Aansluiting (REQ-AANS-004): the resolved source A / source B totals, the difference, whether it is within tolerance, a bucket-level drill-down (lineDeltas), and the open -> explained -> resolved lifecycle with an audit-trailed explanation (who explained what, REQ-AANS-006). Computed by AansluitingService::compute(); one result per (aansluitingId, periodId) — recomputing replaces the totals/lineDeltas of an `open` result in place but never a result already `explained` or `resolved` (must reopen first).",

--- a/lib/Settings/register.d/bookkeeping-accounts-payable-core.json
+++ b/lib/Settings/register.d/bookkeeping-accounts-payable-core.json
@@ -1016,7 +1016,7 @@
       },
       "PaymentRun": {
         "slug": "PaymentRun",
-        "icon": "BankTransferOutline",
+        "icon": "BankTransfer",
         "version": "0.3.0",
         "title": "Payment Run",
         "description": "A batch of approved Payee payments per REQ-AP-013 (consolidate-accounts-payable). Groups open AP invoices into a single outgoing payment instruction with a declarative lifecycle draft → approved → exported → reconciled. Approval (RBAC controller) is a hard gate before export — there is NO direct draft → exported transition. The actual SEPA pain.001 / CSV bank-file GENERATION is the separate payment-run-sepa-export change (writes exportedFileRef); this schema models only the batch + its lifecycle. Each paymentLines[] entry references one Payee + one APTransaction. bankAccount.iban / bankAccount.bic on the referenced Payee are the SEPA creditor source of truth.",

--- a/lib/Settings/register.d/bookkeeping-bank-reconciliation.json
+++ b/lib/Settings/register.d/bookkeeping-bank-reconciliation.json
@@ -242,7 +242,7 @@
       },
       "BankReconciliationMatch": {
         "slug": "BankReconciliationMatch",
-        "icon": "BankTransferOutline",
+        "icon": "BankTransfer",
         "version": "0.1.0",
         "title": "Bank Reconciliation Match",
         "description": "One paired transaction: a bank-statement line matched to a journal entry (APTransaction, GLLine, or Payment). Auto-matching is deterministic by amount + date ± reference; ambiguous and orphaned items are flagged pending-review for operator resolution. Every decision is timestamped and attributed (REQ-BBR-002/003/004/008). The bank transaction is NOT embedded as a full object — only a reference key + cached amount are stored (design D3).",

--- a/lib/Settings/register.d/bookkeeping-emu-reporting.json
+++ b/lib/Settings/register.d/bookkeeping-emu-reporting.json
@@ -524,7 +524,7 @@
       },
       "DebtPosition": {
         "slug": "DebtPosition",
-        "icon": "BankMinusOutline",
+        "icon": "BankMinus",
         "version": "0.1.0",
         "title": "Schuldpositie",
         "description": "Uitstaande schuld per instrument per peildatum (kwartaal- of jaar-ultimo) per REQ-EMU-004. Bruto nominaal bedrag classified per Eurostat ESA2010 (AF.2/AF.3/AF.4 tellen mee; AF.7 derivaten niet). Can be sourced from the schatkistbankieren daily sync (REQ-EMU-011) or entered manually.",

--- a/lib/Settings/register.d/bookkeeping-ensia-zelfevaluatie.json
+++ b/lib/Settings/register.d/bookkeeping-ensia-zelfevaluatie.json
@@ -321,7 +321,7 @@
       },
       "Evaluatievraag": {
         "slug": "Evaluatievraag",
-        "icon": "ClipboardQuestionOutline",
+        "icon": "ClipboardTextOutline",
         "version": "0.1.0",
         "title": "ENSIA Evaluatievraag",
         "description": "Single evaluation question within an ENSIAJaarcyclus (REQ-ENSIA-001 + REQ-ENSIA-002 + REQ-ENSIA-003). One record per (cyclusId, vraagCode). Carries antwoordType (ja-nee-nvt / volwassenheidsniveau-1-5 / vrije-tekst); antwoord; volwassenheidsScore; toelichting; bewijsstukken; beantwoorder; peerReviewer; peerReviewStatus state machine. Maturity ≥ 3 requires bewijsstukken non-empty AND toelichting ≥ 50 chars per REQ-ENSIA-003 — enforced declaratively at persist preconditions plus the ENSIAValidationGuard fallback. Post-peer-review edits require a `reden` field per REQ-ENSIA-008 (enforced by ENSIAValidationGuard).",

--- a/lib/Settings/register.d/bookkeeping-ifrs-rj-dual-gaap.json
+++ b/lib/Settings/register.d/bookkeeping-ifrs-rj-dual-gaap.json
@@ -674,7 +674,7 @@
       },
       "FrameworkElection": {
         "slug": "FrameworkElection",
-        "icon": "GavelOutline",
+        "icon": "Gavel",
         "version": "0.1.0",
         "title": "Framework Election",
         "description": "Records a legal entity's primary-framework election with comply-or-explain motivation, RJ variant, measured size criteria and AVA-besluit reference (REQ-DGAAP-007, REQ-DGAAP-010). Lifecycle: draft → active → superseded. Activation requires a motivation, an AVA-besluit reference and a variant consistent with the measured size criteria; the system warns when criteria breach the threshold for two consecutive years.",

--- a/lib/Settings/register.d/bookkeeping-investeringsaftrek.json
+++ b/lib/Settings/register.d/bookkeeping-investeringsaftrek.json
@@ -289,7 +289,7 @@
       },
       "MilieulijstCode": {
         "slug": "MilieulijstCode",
-        "icon": "LeafOutline",
+        "icon": "Leaf",
         "version": "0.1.0",
         "title": "MilieulijstCode",
         "description": "Reference data: a single RvO Milieulijst code (MIA/Vamil) for a given jaartal. Carries the MIA percentage (27/36/45) and the vamilToegestaan flag. Versioned per year. Seeded from lib/Settings/seeds/investeringsaftrek-milieulijst-2026.json.",

--- a/lib/Settings/register.d/bookkeeping-market-government-separation.json
+++ b/lib/Settings/register.d/bookkeeping-market-government-separation.json
@@ -904,7 +904,7 @@
       },
       "AlgemeenBelangBesluit": {
         "slug": "AlgemeenBelangBesluit",
-        "icon": "GavelOutline",
+        "icon": "Gavel",
         "version": "0.1.0",
         "title": "Public Interest Decision",
         "description": "AlgemeenBelangBesluit (ABB) lifecycle record (REQ-WMO-005). Workflow: concept → raadsvoorstel → raadsbesluit → publicatie → acm-notified → bezwaar → geldig → evaluatie-due → herziening/intrekking. State transitions enforce preconditions (raadsbesluit requires kenmerk; geldig requires publicatieDatum + ACM-kenmerk). Automatic tasks are generated on raadsbesluit (publish gemeenteblad +14d), publicatie (notify ACM +7d), acm-notified (review bezwaarschriften +42d), and when volgendeEvaluatie is reached.",

--- a/lib/Settings/register.d/bookkeeping-pension-ias19.json
+++ b/lib/Settings/register.d/bookkeeping-pension-ias19.json
@@ -611,7 +611,7 @@
       },
       "PensionMovement": {
         "slug": "PensionMovement",
-        "icon": "SwapVerticalBoldOutline",
+        "icon": "SwapVerticalBold",
         "version": "0.1.0",
         "title": "Pension Movement",
         "description": "Per-period roll-forward of DBO and plan assets, split into the three IAS 19R buckets: service + past service + settlement (P&L), net interest (P&L) and actuarial gain/loss (OCI, non-recycling per IAS 19 §122) (REQ-PEN-003, REQ-PEN-004, REQ-PEN-009). dboClosing, planAssetsClosing, netPensionMovementPL and netPensionMovementOCI are computed roll-forward fields. Past service cost from a plan amendment is posted directly to P&L on the amendment date (REQ-PEN-009).",

--- a/lib/Settings/register.d/bookkeeping-reconciliation-reports.json
+++ b/lib/Settings/register.d/bookkeeping-reconciliation-reports.json
@@ -11,7 +11,7 @@
     "schemas": {
       "BankReconciliation": {
         "slug": "BankReconciliation",
-        "icon": "BankCheckOutline",
+        "icon": "BankCheck",
         "version": "0.1.0",
         "title": "Bank Reconciliation",
         "description": "A bounded reconciliation session for one bank account + one statement period per REQ-REC-001. Captures opening/closing balances, expected GL balance, computed variance, lifecycle status (draft → in-progress → verified → closed), preparer/verifier signatures, and the closedAt timestamp. NOT a live dashboard — an immutable audit artifact once closed. Per ADR-022/ADR-031 declarative-first: matching is delegated to the T2 bookkeeping-bank-reconciliation engine; T4 records outcomes and closes the audit loop.",

--- a/lib/Settings/register.d/bookkeeping-sepa-direct-debit.json
+++ b/lib/Settings/register.d/bookkeeping-sepa-direct-debit.json
@@ -3,7 +3,7 @@
     "schemas": {
       "SepaMandate": {
         "slug": "SepaMandate",
-        "icon": "FileSignOutline",
+        "icon": "FileSign",
         "version": "0.1.0",
         "title": "SEPA Mandate",
         "description": "A SEPA Direct Debit mandate (incassomachtiging) authorising the creditor to collect from a debtor account under the SDD CORE or B2B rulebook (REQ-SDD-001). Source of truth for incasso eligibility; collections may only be scheduled against an `active` mandate (design D1).",
@@ -270,7 +270,7 @@
       },
       "DirectDebitCollection": {
         "slug": "DirectDebitCollection",
-        "icon": "BankTransferInOutline",
+        "icon": "BankTransferIn",
         "version": "0.1.0",
         "title": "Direct Debit Collection",
         "description": "A single SEPA Direct Debit collection against a mandate (REQ-SDD-002). sequenceType is derived from mandate history, never operator-supplied (design D2).",
@@ -693,7 +693,7 @@
       },
       "RTransaction": {
         "slug": "RTransaction",
-        "icon": "BankTransferOutOutline",
+        "icon": "BankTransferOut",
         "version": "0.1.0",
         "title": "R-Transaction",
         "description": "A bank-side R-transaction (reject/return/refund/reversal/revocation) parsed from pain.002 or camt.054 (REQ-SDD-007). Captured separately for audit and reposting decisions (design D7). Non-deletable (REQ-SDD-010).",

--- a/lib/Settings/register.d/bookkeeping-soft-close-flux.json
+++ b/lib/Settings/register.d/bookkeeping-soft-close-flux.json
@@ -622,7 +622,7 @@
       },
       "CloseChecklistInstance": {
         "slug": "CloseChecklistInstance",
-        "icon": "FormatListChecksSolid",
+        "icon": "FormatListChecks",
         "version": "0.1.0",
         "title": "Close Checklist Instance",
         "description": "Per-period instantiation of a CloseChecklistTemplate (REQ-CLS-004). Carries per-task status (pending | in-progress | completed | overdue), owner override, completedAt, evidence attachment, and slaBreach flag. Lifecycle: pending → in-progress → completed with SLA escalation on overdue.",

--- a/lib/Settings/register.d/bookkeeping-voorzieningen-claims.json
+++ b/lib/Settings/register.d/bookkeeping-voorzieningen-claims.json
@@ -1041,7 +1041,7 @@
       },
       "ClaimsVoorzieningDetail": {
         "slug": "ClaimsVoorzieningDetail",
-        "icon": "GavelOutline",
+        "icon": "Gavel",
         "version": "0.1.0",
         "title": "Claims Voorziening Detail",
         "description": "Type-specific detail register for claims- en geschillen-voorzieningen (IAS 37 §37, REQ-PROV-006). FK back to a Provision with provisionType=claims. legalAdviceMemo is mandatory and stored under restricted access (CFO / audit committee / accountant only) to preserve legal privilege. The activation guard blocks status=active when the memo FK is missing.",

--- a/lib/Settings/register.d/bookkeeping-vpb-mkb.json
+++ b/lib/Settings/register.d/bookkeeping-vpb-mkb.json
@@ -1648,7 +1648,7 @@
       },
       "BezwaarBeroep": {
         "slug": "BezwaarBeroep",
-        "icon": "GavelOutline",
+        "icon": "Gavel",
         "version": "0.1.0",
         "title": "Bezwaar / Beroep",
         "description": "Geschilprocedure tegen een aanslag (REQ-VPB-010): bezwaar -> uitspraak inspecteur -> beroep -> hoger beroep -> cassatie, met wettelijke termijnen per Awb (6 weken bezwaar; 6 weken uitspraak inspecteur, verlengbaar tot 12; 6 weken beroep). termijnEinde wordt per type berekend; termijnVerstreken markeert overschrijding. Escalatie-alerts op T-7d/T-3d/op-de-dag worden door de termijn-bewaking gegenereerd.",

--- a/lib/Settings/register.d/contract-lifecycle-management.json
+++ b/lib/Settings/register.d/contract-lifecycle-management.json
@@ -10,7 +10,7 @@
     "schemas": {
       "Contract": {
         "slug": "Contract",
-        "icon": "FileSignOutline",
+        "icon": "FileSign",
         "version": "0.1.0",
         "title": "Contract",
         "description": "Generic contract master record covering every contract type (purchase, sales, service, subscription, lease, employment, other) per REQ-CLM-001. CRUD goes through OpenRegister's generic object surface (ADR-022) — no custom PHP model, no parallel table. The counterparty is referenced as a Nextcloud addressbook contact (counterpartyReference); no Party/Customer/Supplier schema is invented. Renewal terms are an embedded object (D3); renewalDecisionDate is a declared calculation. Documents are NC Files references (link, don't store; REQ-CLM-005). Lease contracts become a specialization by link via specializationReference → LeaseContract (REQ-CLM-007); generic records never duplicate lease accounting fields. Lifecycle and notifications are declarative (REQ-CLM-002 / REQ-CLM-004).",

--- a/lib/Settings/register.d/dba-compliance-marker.json
+++ b/lib/Settings/register.d/dba-compliance-marker.json
@@ -888,7 +888,7 @@
       },
       "DBARisicoflag": {
         "slug": "DBARisicoflag",
-        "icon": "FlagAlertOutline",
+        "icon": "FlagVariantOutline",
         "version": "0.1.0",
         "title": "DBA risico-flag",
         "description": "Per-opdracht append-only flag, automatisch gegenereerd door de dagelijkse monitoring-engine (REQ-DBA-004/005/006/014/015/016). Bevat type, ernst, detectiemoment, fiscale grondslag en actie-suggestie. Immutabel (audit-trail).",

--- a/lib/Settings/register.d/inventory-cogs-posting.json
+++ b/lib/Settings/register.d/inventory-cogs-posting.json
@@ -6,7 +6,7 @@
     "schemas": {
       "InventoryGLConfig": {
         "slug": "InventoryGLConfig",
-        "icon": "BankTransferOutline",
+        "icon": "BankTransfer",
         "version": "0.1.0",
         "title": "Inventory GL Posting Configuration",
         "titleNl": "Voorraad GL Boekingsconfiguratie",

--- a/lib/Settings/register.d/inventory-lot-batch-expiry.json
+++ b/lib/Settings/register.d/inventory-lot-batch-expiry.json
@@ -39,7 +39,7 @@
       },
       "InventoryLot": {
         "slug": "InventoryLot",
-        "icon": "BarcodeOutline",
+        "icon": "Barcode",
         "version": "0.1.0",
         "title": "Inventory Lot",
         "description": "Lot/batch identifier for a homogeneous quantity of a Product received together (one supplier, one date, one expiry). Sits below InventoryStock — InventoryStock is the aggregate position per (sku, locationId); InventoryLot adds the per-lot granularity required for FEFO (First-Expiry-First-Out) picking, expiry tracking, quality quarantine, and recall traceability per REQ-LOT-001..009. Lifecycle: active → quarantined (release back) | expired (terminal) | exhausted (terminal, qty == 0). FEFO order is declared via x-openregister-sort on expiryDate ASC NULLS LAST so all consumers (pick list, expiry dashboard, batch reports) inherit FEFO ordering. ADR-031 exception path: if the declarative sort directive is advisory rather than enforced at the OR API layer, the single-method FefoSort::sortLots PHP guard in lib/Sort/ applies the order before the response leaves the controller. No bespoke PHP CRUD — spec REQ-LOT-001 prohibits parallel storage. Spec: inventory-lot-batch-expiry. The 'InventoryItem' wording in the spec refers to the shillinq Product schema.",

--- a/lib/Settings/register.d/inventory-stock-movement-ledger.json
+++ b/lib/Settings/register.d/inventory-stock-movement-ledger.json
@@ -6,7 +6,7 @@
     "schemas": {
       "StockMove": {
         "slug": "StockMove",
-        "icon": "SwapHorizontalBoldOutline",
+        "icon": "SwapHorizontalBold",
         "version": "0.1.0",
         "title": "Stock Move",
         "description": "Immutable double-entry stock-movement ledger entry (Odoo / Tryton Stock Move pattern). One StockMove atomically debits source location and credits destination location for a single (item + quantity + unit cost) tuple. Movement type taxonomy: receipt (null source = goods inbound), transfer (both locations populated = lateral move), issue (null destination = goods outbound), manufacture (assembly), repack (consolidation). Lifecycle draft → posted → cancelled; posting flips `locked = true` and triggers GL materialisation (asset / COGS) via x-openregister-lifecycle-action. Cancellation creates an offsetting StockMove (not patch) so the original posted row remains immutable per IAS 2 + Dutch CTR. No PHP StockMoveService — the lifecycle, GL materialisation and audit trail are declarative per ADR-031 (ADR-031 exception path: StockReservationGuard + StockMoveImmutabilityGuard + StockMoveOffsetCreator for the optimistic-lock CAS, the locked-after-post guard, and the offset-row materialisation that the declarative DSL cannot yet express). Reserved quantity is held against InventoryStock.reservedQuantity on draft and released on post or cancel.",

--- a/lib/Settings/register.d/inventory-stock-tracking.json
+++ b/lib/Settings/register.d/inventory-stock-tracking.json
@@ -6,7 +6,7 @@
     "schemas": {
       "InventoryStock": {
         "slug": "InventoryStock",
-        "icon": "WarehouseOutline",
+        "icon": "Warehouse",
         "version": "0.1.0",
         "title": "Inventory Stock",
         "titleNl": "Voorraad",

--- a/lib/Settings/register.d/procurement-governance.json
+++ b/lib/Settings/register.d/procurement-governance.json
@@ -160,7 +160,7 @@
       },
       "FrameworkAgreement": {
         "slug": "FrameworkAgreement",
-        "icon": "FileSignOutline",
+        "icon": "FileSign",
         "version": "0.1.0",
         "title": "Framework Agreement",
         "description": "Generic framework agreement (raamovereenkomst abstracted): a supplier contract with a spend ceiling that PurchaseOrder call-offs draw down against. A call-off exceeding the remaining ceiling is blocked by FrameworkAgreementDrawdownGuard (REQ-PG-004). Distinct from the generic Contract (contract-lifecycle-management), which has no ceiling/drawdown accounting. Money is integer euro cents (ADR-022).",

--- a/lib/Settings/shillinq_register.json
+++ b/lib/Settings/shillinq_register.json
@@ -416,7 +416,7 @@
       },
       "GLTransaction": {
         "slug": "GLTransaction",
-        "icon": "LedgerOutline",
+        "icon": "NotebookOutline",
         "version": "0.1.0",
         "title": "GL Transaction",
         "description": "A double-entry general-ledger posting header. Owns the lifecycle and the balance invariant; child GLLine rows carry the debit/credit amounts per REQ-GL-001.",
@@ -782,7 +782,7 @@
       },
       "GLLine": {
         "slug": "GLLine",
-        "icon": "TableRowOutline",
+        "icon": "TableRow",
         "version": "0.1.0",
         "title": "GL Line",
         "description": "A debit-or-credit line within a GLTransaction, encoding the polarity in the side enum per REQ-GL-003. Extended with eliminationFlag to support GR consolidation per REQ-GRC-003.",
@@ -1290,7 +1290,7 @@
       },
       "GRVerdeelsleutel": {
         "slug": "GRVerdeelsleutel",
-        "icon": "ScaleBalanceOutline",
+        "icon": "ScaleBalance",
         "version": "0.1.0",
         "title": "GR Allocation Key",
         "description": "An apportionment rule linking a cost-cluster (set of accountNumbers) to a per-deelnemer split method. Multiple verdeelsleutels MAY apply to the same cost cluster, sequenced by lineNumber per REQ-GRC-002.",
@@ -1373,7 +1373,7 @@
       },
       "Account": {
         "slug": "Account",
-        "icon": "LedgerOutline",
+        "icon": "NotebookOutline",
         "version": "0.1.0",
         "title": "Account",
         "description": "A hierarchical chart-of-accounts entry conforming to the RGS (Referentie Grootboek Schema) standard for Dutch bookkeeping.",
@@ -1934,7 +1934,7 @@
       },
       "BalanceSheet": {
         "slug": "BalanceSheet",
-        "icon": "TableAccountOutline",
+        "icon": "TableAccount",
         "version": "0.1.0",
         "title": "Balance Sheet",
         "description": "Financial statement showing assets, liabilities, and equity at a fiscal-period snapshot. Status lifecycle: draft → final → published. Totals are computed via x-openregister-aggregations from GL entries grouped by Account.accountType per REQ-FS-004.",
@@ -2152,7 +2152,7 @@
       },
       "TrialBalance": {
         "slug": "TrialBalance",
-        "icon": "ScaleBalanceOutline",
+        "icon": "ScaleBalance",
         "version": "0.1.0",
         "title": "Trial Balance",
         "description": "Listing of all GL accounts with debit/credit balances for period verification. isBalanced flag (totalDebits = totalCredits) computed via aggregation per REQ-FS-005. No TrialBalanceService.",
@@ -2993,7 +2993,7 @@
       },
       "kernGegevensConfig": {
         "slug": "kernGegevensConfig",
-        "icon": "ChartBarOutline",
+        "icon": "ChartBar",
         "version": "0.1.0",
         "title": "Core Data Configuration",
         "description": "Administration-level configuration record holding the denominators required for the CBS Kerngegevens jaarstaten computation per REQ-CBSE-003. Operators set these values yearly; the aggregation surfaces a 'denominator last updated' warning when any value is >12 months old.",
@@ -5049,7 +5049,7 @@
       },
       "TaxEstimate": {
         "slug": "TaxEstimate",
-        "icon": "CalculatorOutline",
+        "icon": "Calculator",
         "version": "0.1.0",
         "title": "Tax Estimate",
         "description": "Real-time annual income tax (IB) liability projection for Dutch ZZP freelancers. Materialized view consuming GL year-to-date snapshot and TaxRegimeConfiguration per REQ-TAX-004 and ADR-031 D3. Computed on read or scheduled refresh; records calculation inputs for audit trail per D5.",
@@ -6811,7 +6811,7 @@
       },
       "RateSchedule": {
         "slug": "RateSchedule",
-        "icon": "TableRowOutline",
+        "icon": "TableRow",
         "version": "0.1.0",
         "title": "Rate Schedule",
         "description": "Tier-specific rate entry for a RateCardVersion. Defines a fixed or volume-bracketed rate for a single tier (user / role / project / client / blended) within an effective-date window. Non-overlapping effective windows per (tier, entityId) are enforced (REQ-RATE-006). REQ-RATE-004.",
@@ -7179,7 +7179,7 @@
       },
       "RateRecord": {
         "slug": "RateRecord",
-        "icon": "HistoryOutline",
+        "icon": "History",
         "version": "0.1.0",
         "title": "Rate Record",
         "description": "Immutable materialized audit-trail entry created for each rate lookup. Stores the resolved tier, rate, effective window, and lookup context so historical rates remain queryable and disputable (REQ-RATE-007, REQ-RATE-010, D4). No updates after creation.",
@@ -10286,7 +10286,7 @@
       },
       "MileageRate": {
         "slug": "MileageRate",
-        "icon": "RoadVariantOutline",
+        "icon": "RoadVariant",
         "version": "0.1.0",
         "title": "Mileage Rate",
         "description": "Master data table of reimbursement rates per kilometre by fiscal year, vehicle type, and tax jurisdiction. Seeded with NL and FI 2026 rates per design.md Seed Data. Operators maintain rates per fiscal year; MileageEntry.ratePerKm is looked up from this table at capture time and locked at claim submission per REQ-EC-003 and Task 16.",
@@ -10367,7 +10367,7 @@
       },
       "PerDiemRate": {
         "slug": "PerDiemRate",
-        "icon": "CurrencyEurOutline",
+        "icon": "CurrencyEur",
         "version": "0.1.0",
         "title": "Per Diem Rate",
         "description": "Master data table of official daily travel allowance rates per country and calendar year. Seeded with NL and FI 2026 rates per design.md Seed Data. Operators maintain rates per calendar year; PerDiem.dailyRate is looked up from this table at capture time and locked at claim submission per REQ-EC-004 and Task 16.",
@@ -10521,7 +10521,7 @@
       },
       "InventoryReorderRule": {
         "slug": "InventoryReorderRule",
-        "icon": "CartArrowDownOutline",
+        "icon": "CartArrowDown",
         "version": "0.1.0",
         "title": "Inventory Reorder Rule",
         "description": "Per-item, per-location reorder policy declaring min/max stock levels, lead-time-aware reorder-point thresholds, low-stock alert policy, and optional auto-purchase-order generation. Reorder decision logic is fully declarative via x-openregister-lifecycle, x-openregister-aggregations, and x-openregister-notifications per ADR-031 and ADR-022. No PHP InventoryReorderService — all reorder triggers and alert dispatch are schema-driven.",
@@ -11628,7 +11628,7 @@
       },
       "CashflowARProjection": {
         "slug": "CashflowARProjection",
-        "icon": "CashFastOutline",
+        "icon": "CashFast",
         "version": "0.1.0",
         "title": "Cashflow AR Projection",
         "description": "Projected expected-receipt date per open AR invoice, derived from customer-specific betalingsgedrag (12-month moving average + confidence). REQ-CF-003, REQ-CF-004.",
@@ -12766,7 +12766,7 @@
       },
       "AuditDocument": {
         "slug": "AuditDocument",
-        "icon": "FileSignOutline",
+        "icon": "FileSign",
         "version": "0.1.0",
         "title": "Audit Document",
         "description": "A financial document participating in SiSa audit (invoice, purchase order, journal entry, payment). Every state transition triggers an immutable audit-trail event via OR's audit service per REQ-SISA-001 and REQ-SISA-003.",
@@ -14867,7 +14867,7 @@
       },
       "XBRLMapping": {
         "slug": "XBRLMapping",
-        "icon": "SwapHorizontalOutline",
+        "icon": "SwapHorizontal",
         "version": "0.1.0",
         "title": "XBRL Mapping",
         "description": "Transformation rule mapping a Shillinq Account (chart-of-accounts entry) to an XBRL GL concept URI. Mappings are taxonomy-version-specific; multiple versions coexist per REQ-SBR-004.",
@@ -16285,7 +16285,7 @@
       },
       "MatchingRule": {
         "slug": "MatchingRule",
-        "icon": "RuleOutline",
+        "icon": "ClipboardCheckOutline",
         "version": "0.1.0",
         "title": "Matching Rule",
         "description": "Operator-authored rule declaring predicates for auto-matching bank statement lines against AP/AR invoices or GL transactions. Predicates are consumed by an x-openregister-aggregations query (REQ-BR-004). No MatchingService.php. x-openregister-audit: true per REQ-BR-001.",
@@ -16860,7 +16860,7 @@
       },
       "IPAssetValuation": {
         "slug": "IPAssetValuation",
-        "icon": "BulbOutline",
+        "icon": "LightbulbOutline",
         "version": "0.1.0",
         "title": "IP Asset Valuation",
         "description": "Immaterieel activum (IP asset) qualifying for the innovatiebox under the afpelmethode (Wet Vpb art. 12b). Applied to afpelmethode elections only — no per-asset entries are required for the forfaitair route. Per REQ-IBA-001. No PHP IP-service per ADR-031.",
@@ -17338,7 +17338,7 @@
       },
       "WinstToerekening": {
         "slug": "WinstToerekening",
-        "icon": "ChartBarOutline",
+        "icon": "ChartBar",
         "version": "0.1.0",
         "title": "Profit Allocation",
         "description": "Per-period profit attribution from operating profit to one or more IP assets via a configurable verdeelsleutel. Used by the afpelmethode route of the innovatiebox aggregation per REQ-IBA-004. MUST NOT be populated when InnovatieboxElection.route is forfaitair. No PHP winsttoerekening service per ADR-031.",
@@ -17530,7 +17530,7 @@
       },
       "IcpStatement": {
         "slug": "IcpStatement",
-        "icon": "EarthOutline",
+        "icon": "Earth",
         "version": "0.1.0",
         "title": "ICP Statement",
         "description": "Quarterly ICP-opgaaf (intracommunautaire prestaties) per Wet OB 1968 art. 37a. Lists intra-EU supply totals per customer for filing with Belastingdienst.",
@@ -18470,7 +18470,7 @@
       },
       "CurrencyBalance": {
         "slug": "CurrencyBalance",
-        "icon": "CurrencyEurOutline",
+        "icon": "CurrencyEur",
         "version": "0.1.0",
         "title": "Currency Balance",
         "description": "Point-in-time balance snapshot for one (account, currency) pair. Enables per-currency cash-position tracking for Dutch SMBs with foreign operations. Snapshot-based; not a transactional ledger. Per REQ-MC-003 (bookkeeping-multi-currency).",
@@ -21359,7 +21359,7 @@
     },
     "AuditDocument": {
       "slug": "AuditDocument",
-      "icon": "FileSignOutline",
+      "icon": "FileSign",
       "version": "0.1.0",
       "title": "Audit Document",
       "description": "A financial document participating in SiSa audit (invoice, purchase order, journal entry, payment). Every state transition triggers an immutable audit-trail event via OR's audit service per REQ-SISA-001 and REQ-SISA-003.",
@@ -23697,7 +23697,7 @@
     },
     "VATGLAccounts": {
       "slug": "VATGLAccounts",
-      "icon": "BankCheckOutline",
+      "icon": "BankCheck",
       "version": "0.1.0",
       "title": "VAT GL Accounts",
       "description": "Per-administration mapping from VAT rate to the GL liability (VATPayable*) account credited by the ARInvoice.issue lifecycle action per REQ-VAT-006. One record per administrationId. Defaults from the RGS (Referentie Grootboekschema) chart (vat21=2020, vat9=2021, vat6=2022, vat0=2023) and seeded on installer first-run.",
@@ -24065,7 +24065,7 @@
     },
     "Location": {
       "slug": "Location",
-      "icon": "WarehouseOutline",
+      "icon": "Warehouse",
       "version": "0.1.0",
       "title": "Location",
       "description": "Physical or virtual storage location in the warehouse hierarchy (warehouse → zone → bin → in-transit). Hierarchical parent-child FK (parentLocationId) enables rollup stock visibility and inter-location transfers per REQ-LOC-001 through REQ-LOC-009 and design.md D1-D6. No parallel warehouse table in PHP per ADR-031 — location hierarchy is pure declarative metadata.",
@@ -24547,7 +24547,7 @@
     },
     "InventoryStock": {
       "slug": "InventoryStock",
-      "icon": "PackageVariantClosedOutline",
+      "icon": "PackageVariantClosed",
       "version": "0.1.0",
       "title": "Inventory Stock",
       "description": "Stock level per SKU at a specific bin Location per REQ-LOC-009 and inventory-stock-tracking spec. Always recorded at bin level (most-granular); warehouse/zone aggregation via Location.stockRollup. locationId FK references bin-type Location only.",
@@ -25361,7 +25361,7 @@
     },
     "VpbBalansLink": {
       "slug": "VpbBalansLink",
-      "icon": "ScaleBalanceOutline",
+      "icon": "ScaleBalance",
       "version": "0.1.0",
       "title": "Vpb-balans Link",
       "description": "Overlay register tying an ondernemingsactiviteit cost-center to its cluster of Vpb-pligtige accounts. Declared per REQ-VPB-002 from bookkeeping-vpb-corporate-tax. No PHP service — pure schema overlay per ADR-031.",

--- a/src/icons.js
+++ b/src/icons.js
@@ -1,65 +1,108 @@
 // SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
+//
+// Icon registry for shillinq (ADR-077 semantic icon vocabulary).
+//
+// CnAppNav, CnIcon, CnIndexPage / CnDetailPage headers and empty states resolve
+// an `icon` by PascalCase name through the registry that `registerIcons()`
+// populates. A name that is not registered renders NO icon in the navigation —
+// not a fallback glyph — so this file must cover every `icon` the manifests and
+// register files name. Keep it in sync when you add a menu entry.
+//
+// Generated from the app's own manifests; every name is verified to exist in
+// vue-material-design-icons.
 
-// Central MDI icon registry for the manifest-driven navigation and pages.
-// CnAppNav resolves a menu item's `icon` string through the lib's
-// `registerIcons()` registry (ICON_MAP); any name missing from the registry
-// silently renders NO icon. Every MDI name referenced by src/manifest.json
-// or a src/manifest.d/*.json fragment therefore MUST be registered here.
-// Names ending in the ALIASES block do not exist in vue-material-design-icons
-// — they are mapped to the closest real icon so fragments keep working.
-
+import AccountArrowRightOutline from 'vue-material-design-icons/AccountArrowRightOutline.vue'
+import AccountCancelOutline from 'vue-material-design-icons/AccountCancelOutline.vue'
 import AccountCashOutline from 'vue-material-design-icons/AccountCashOutline.vue'
+import AccountCheckOutline from 'vue-material-design-icons/AccountCheckOutline.vue'
 import AccountGroup from 'vue-material-design-icons/AccountGroup.vue'
 import AccountGroupOutline from 'vue-material-design-icons/AccountGroupOutline.vue'
 import AccountHardHatOutline from 'vue-material-design-icons/AccountHardHatOutline.vue'
 import AccountKey from 'vue-material-design-icons/AccountKey.vue'
+import AccountKeyOutline from 'vue-material-design-icons/AccountKeyOutline.vue'
+import AccountLockOutline from 'vue-material-design-icons/AccountLockOutline.vue'
 import AccountMultipleOutline from 'vue-material-design-icons/AccountMultipleOutline.vue'
+import AccountStarOutline from 'vue-material-design-icons/AccountStarOutline.vue'
 import AccountSwitch from 'vue-material-design-icons/AccountSwitch.vue'
 import AccountSwitchOutline from 'vue-material-design-icons/AccountSwitchOutline.vue'
 import AccountTie from 'vue-material-design-icons/AccountTie.vue'
 import AccountTieOutline from 'vue-material-design-icons/AccountTieOutline.vue'
 import AlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline.vue'
 import AlertOctagonOutline from 'vue-material-design-icons/AlertOctagonOutline.vue'
+import AlertOutline from 'vue-material-design-icons/AlertOutline.vue'
+import ArchiveArrowDownOutline from 'vue-material-design-icons/ArchiveArrowDownOutline.vue'
+import ArchiveArrowUpOutline from 'vue-material-design-icons/ArchiveArrowUpOutline.vue'
 import ArrowDecisionOutline from 'vue-material-design-icons/ArrowDecisionOutline.vue'
 import ArrowDownBoldOutline from 'vue-material-design-icons/ArrowDownBoldOutline.vue'
 import ArrowRightBoldOutline from 'vue-material-design-icons/ArrowRightBoldOutline.vue'
 import ArrowUpDown from 'vue-material-design-icons/ArrowUpDown.vue'
+import AutoFix from 'vue-material-design-icons/AutoFix.vue'
 import Bank from 'vue-material-design-icons/Bank.vue'
 import BankCheck from 'vue-material-design-icons/BankCheck.vue'
+import BankCircle from 'vue-material-design-icons/BankCircle.vue'
+import BankMinus from 'vue-material-design-icons/BankMinus.vue'
 import BankOutline from 'vue-material-design-icons/BankOutline.vue'
 import BankTransfer from 'vue-material-design-icons/BankTransfer.vue'
+import BankTransferIn from 'vue-material-design-icons/BankTransferIn.vue'
+import BankTransferOut from 'vue-material-design-icons/BankTransferOut.vue'
 import Barcode from 'vue-material-design-icons/Barcode.vue'
 import BarcodeScan from 'vue-material-design-icons/BarcodeScan.vue'
+import Bell from 'vue-material-design-icons/Bell.vue'
+import BellOffOutline from 'vue-material-design-icons/BellOffOutline.vue'
+import BellOutline from 'vue-material-design-icons/BellOutline.vue'
 import BellRingOutline from 'vue-material-design-icons/BellRingOutline.vue'
 import BookEditOutline from 'vue-material-design-icons/BookEditOutline.vue'
+import BookMinusOutline from 'vue-material-design-icons/BookMinusOutline.vue'
 import BookOpenPageVariantOutline from 'vue-material-design-icons/BookOpenPageVariantOutline.vue'
 import BookOpenVariant from 'vue-material-design-icons/BookOpenVariant.vue'
 import BookOpenVariantOutline from 'vue-material-design-icons/BookOpenVariantOutline.vue'
 import BookOutline from 'vue-material-design-icons/BookOutline.vue'
+import BookRemoveOutline from 'vue-material-design-icons/BookRemoveOutline.vue'
 import BookmarkCheckOutline from 'vue-material-design-icons/BookmarkCheckOutline.vue'
 import BookmarkOutline from 'vue-material-design-icons/BookmarkOutline.vue'
+import Briefcase from 'vue-material-design-icons/Briefcase.vue'
 import BriefcaseAccountOutline from 'vue-material-design-icons/BriefcaseAccountOutline.vue'
 import BriefcaseCheckOutline from 'vue-material-design-icons/BriefcaseCheckOutline.vue'
 import BriefcaseClockOutline from 'vue-material-design-icons/BriefcaseClockOutline.vue'
 import BriefcaseOutline from 'vue-material-design-icons/BriefcaseOutline.vue'
+import BriefcaseUpload from 'vue-material-design-icons/BriefcaseUpload.vue'
+import BullseyeArrow from 'vue-material-design-icons/BullseyeArrow.vue'
 import Calculator from 'vue-material-design-icons/Calculator.vue'
 import CalculatorVariantOutline from 'vue-material-design-icons/CalculatorVariantOutline.vue'
+import Calendar from 'vue-material-design-icons/Calendar.vue'
+import CalendarAccountOutline from 'vue-material-design-icons/CalendarAccountOutline.vue'
 import CalendarCheckOutline from 'vue-material-design-icons/CalendarCheckOutline.vue'
 import CalendarClock from 'vue-material-design-icons/CalendarClock.vue'
 import CalendarClockOutline from 'vue-material-design-icons/CalendarClockOutline.vue'
 import CalendarLock from 'vue-material-design-icons/CalendarLock.vue'
+import CalendarMinusOutline from 'vue-material-design-icons/CalendarMinusOutline.vue'
 import CalendarMultiselect from 'vue-material-design-icons/CalendarMultiselect.vue'
 import CalendarOutline from 'vue-material-design-icons/CalendarOutline.vue'
 import CalendarRange from 'vue-material-design-icons/CalendarRange.vue'
+import CalendarRangeOutline from 'vue-material-design-icons/CalendarRangeOutline.vue'
 import CalendarRemoveOutline from 'vue-material-design-icons/CalendarRemoveOutline.vue'
 import CalendarSync from 'vue-material-design-icons/CalendarSync.vue'
+import CalendarSyncOutline from 'vue-material-design-icons/CalendarSyncOutline.vue'
+import CalendarTextOutline from 'vue-material-design-icons/CalendarTextOutline.vue'
+import CalendarWeekOutline from 'vue-material-design-icons/CalendarWeekOutline.vue'
 import CallSplit from 'vue-material-design-icons/CallSplit.vue'
+import Cancel from 'vue-material-design-icons/Cancel.vue'
 import CarOutline from 'vue-material-design-icons/CarOutline.vue'
+import CardAccountDetailsOutline from 'vue-material-design-icons/CardAccountDetailsOutline.vue'
 import CartArrowDown from 'vue-material-design-icons/CartArrowDown.vue'
 import CartOutline from 'vue-material-design-icons/CartOutline.vue'
+import Cash from 'vue-material-design-icons/Cash.vue'
+import CashCheck from 'vue-material-design-icons/CashCheck.vue'
+import CashClock from 'vue-material-design-icons/CashClock.vue'
+import CashFast from 'vue-material-design-icons/CashFast.vue'
+import CashLock from 'vue-material-design-icons/CashLock.vue'
+import CashMinus from 'vue-material-design-icons/CashMinus.vue'
 import CashMultiple from 'vue-material-design-icons/CashMultiple.vue'
+import CashPlus from 'vue-material-design-icons/CashPlus.vue'
 import CashRefund from 'vue-material-design-icons/CashRefund.vue'
+import CashSync from 'vue-material-design-icons/CashSync.vue'
+import CertificateOutline from 'vue-material-design-icons/CertificateOutline.vue'
 import ChartBar from 'vue-material-design-icons/ChartBar.vue'
 import ChartBarStacked from 'vue-material-design-icons/ChartBarStacked.vue'
 import ChartBellCurve from 'vue-material-design-icons/ChartBellCurve.vue'
@@ -69,22 +112,48 @@ import ChartBubble from 'vue-material-design-icons/ChartBubble.vue'
 import ChartDonutVariant from 'vue-material-design-icons/ChartDonutVariant.vue'
 import ChartLine from 'vue-material-design-icons/ChartLine.vue'
 import ChartLineVariant from 'vue-material-design-icons/ChartLineVariant.vue'
+import ChartPie from 'vue-material-design-icons/ChartPie.vue'
+import ChartScatterPlot from 'vue-material-design-icons/ChartScatterPlot.vue'
 import ChartTimelineVariant from 'vue-material-design-icons/ChartTimelineVariant.vue'
 import ChartTimelineVariantShimmer from 'vue-material-design-icons/ChartTimelineVariantShimmer.vue'
+import ChartWaterfall from 'vue-material-design-icons/ChartWaterfall.vue'
+import CheckCircleOutline from 'vue-material-design-icons/CheckCircleOutline.vue'
 import CheckDecagramOutline from 'vue-material-design-icons/CheckDecagramOutline.vue'
+import CheckboxMarkedOutline from 'vue-material-design-icons/CheckboxMarkedOutline.vue'
+import ClipboardArrowDownOutline from 'vue-material-design-icons/ClipboardArrowDownOutline.vue'
+import ClipboardArrowRightOutline from 'vue-material-design-icons/ClipboardArrowRightOutline.vue'
+import ClipboardCheckMultipleOutline from 'vue-material-design-icons/ClipboardCheckMultipleOutline.vue'
 import ClipboardCheckOutline from 'vue-material-design-icons/ClipboardCheckOutline.vue'
+import ClipboardList from 'vue-material-design-icons/ClipboardList.vue'
 import ClipboardListOutline from 'vue-material-design-icons/ClipboardListOutline.vue'
 import ClipboardTextClockOutline from 'vue-material-design-icons/ClipboardTextClockOutline.vue'
 import ClipboardTextOutline from 'vue-material-design-icons/ClipboardTextOutline.vue'
 import ClipboardTextSearchOutline from 'vue-material-design-icons/ClipboardTextSearchOutline.vue'
+import ClockAlertOutline from 'vue-material-design-icons/ClockAlertOutline.vue'
+import ClockCheckOutline from 'vue-material-design-icons/ClockCheckOutline.vue'
 import ClockOutline from 'vue-material-design-icons/ClockOutline.vue'
+import ClockTimeFourOutline from 'vue-material-design-icons/ClockTimeFourOutline.vue'
+import CloseCircleOutline from 'vue-material-design-icons/CloseCircleOutline.vue'
+import CloudUploadOutline from 'vue-material-design-icons/CloudUploadOutline.vue'
+import CoffeeOutline from 'vue-material-design-icons/CoffeeOutline.vue'
 import Cog from 'vue-material-design-icons/Cog.vue'
 import CogOutline from 'vue-material-design-icons/CogOutline.vue'
+import CommentOutline from 'vue-material-design-icons/CommentOutline.vue'
+import Compare from 'vue-material-design-icons/Compare.vue'
+import Counter from 'vue-material-design-icons/Counter.vue'
 import CreditCardOutline from 'vue-material-design-icons/CreditCardOutline.vue'
 import CubeOutline from 'vue-material-design-icons/CubeOutline.vue'
 import CurrencyEur from 'vue-material-design-icons/CurrencyEur.vue'
 import CurrencyUsd from 'vue-material-design-icons/CurrencyUsd.vue'
+import DatabaseArrowDown from 'vue-material-design-icons/DatabaseArrowDown.vue'
+import DatabaseClock from 'vue-material-design-icons/DatabaseClock.vue'
+import DatabaseExportOutline from 'vue-material-design-icons/DatabaseExportOutline.vue'
+import DatabaseImportOutline from 'vue-material-design-icons/DatabaseImportOutline.vue'
+import DatabaseOutline from 'vue-material-design-icons/DatabaseOutline.vue'
 import DeleteSweepOutline from 'vue-material-design-icons/DeleteSweepOutline.vue'
+import DesktopTowerMonitor from 'vue-material-design-icons/DesktopTowerMonitor.vue'
+import DiamondStone from 'vue-material-design-icons/DiamondStone.vue'
+import Domain from 'vue-material-design-icons/Domain.vue'
 import DownloadOutline from 'vue-material-design-icons/DownloadOutline.vue'
 import Earth from 'vue-material-design-icons/Earth.vue'
 import EarthArrowRight from 'vue-material-design-icons/EarthArrowRight.vue'
@@ -94,87 +163,161 @@ import EmailCheckOutline from 'vue-material-design-icons/EmailCheckOutline.vue'
 import EmailFastOutline from 'vue-material-design-icons/EmailFastOutline.vue'
 import EmailOutline from 'vue-material-design-icons/EmailOutline.vue'
 import EmailRemoveOutline from 'vue-material-design-icons/EmailRemoveOutline.vue'
+import Factory from 'vue-material-design-icons/Factory.vue'
+import FamilyTree from 'vue-material-design-icons/FamilyTree.vue'
+import FileAlertOutline from 'vue-material-design-icons/FileAlertOutline.vue'
 import FileCertificateOutline from 'vue-material-design-icons/FileCertificateOutline.vue'
 import FileChartCheckOutline from 'vue-material-design-icons/FileChartCheckOutline.vue'
 import FileChartOutline from 'vue-material-design-icons/FileChartOutline.vue'
+import FileCheckOutline from 'vue-material-design-icons/FileCheckOutline.vue'
+import FileClockOutline from 'vue-material-design-icons/FileClockOutline.vue'
+import FileCogOutline from 'vue-material-design-icons/FileCogOutline.vue'
+import FileCompare from 'vue-material-design-icons/FileCompare.vue'
+import FileDocument from 'vue-material-design-icons/FileDocument.vue'
 import FileDocumentCheckOutline from 'vue-material-design-icons/FileDocumentCheckOutline.vue'
+import FileDocumentEdit from 'vue-material-design-icons/FileDocumentEdit.vue'
 import FileDocumentEditOutline from 'vue-material-design-icons/FileDocumentEditOutline.vue'
+import FileDocumentMinusOutline from 'vue-material-design-icons/FileDocumentMinusOutline.vue'
 import FileDocumentMultiple from 'vue-material-design-icons/FileDocumentMultiple.vue'
 import FileDocumentMultipleOutline from 'vue-material-design-icons/FileDocumentMultipleOutline.vue'
 import FileDocumentOutline from 'vue-material-design-icons/FileDocumentOutline.vue'
+import FileDocumentPlus from 'vue-material-design-icons/FileDocumentPlus.vue'
+import FileDocumentRemoveOutline from 'vue-material-design-icons/FileDocumentRemoveOutline.vue'
+import FileDownloadOutline from 'vue-material-design-icons/FileDownloadOutline.vue'
 import FileExportOutline from 'vue-material-design-icons/FileExportOutline.vue'
+import FileImportOutline from 'vue-material-design-icons/FileImportOutline.vue'
+import FileLockOutline from 'vue-material-design-icons/FileLockOutline.vue'
 import FileRemoveOutline from 'vue-material-design-icons/FileRemoveOutline.vue'
+import FileReplaceOutline from 'vue-material-design-icons/FileReplaceOutline.vue'
+import FileSendOutline from 'vue-material-design-icons/FileSendOutline.vue'
 import FileSign from 'vue-material-design-icons/FileSign.vue'
 import FileTreeOutline from 'vue-material-design-icons/FileTreeOutline.vue'
 import FileXmlBox from 'vue-material-design-icons/FileXmlBox.vue'
 import FilterCogOutline from 'vue-material-design-icons/FilterCogOutline.vue'
 import Finance from 'vue-material-design-icons/Finance.vue'
+import FlagVariantOutline from 'vue-material-design-icons/FlagVariantOutline.vue'
+import FlashOutline from 'vue-material-design-icons/FlashOutline.vue'
 import FlaskOutline from 'vue-material-design-icons/FlaskOutline.vue'
 import FolderLockOutline from 'vue-material-design-icons/FolderLockOutline.vue'
 import FolderOpenOutline from 'vue-material-design-icons/FolderOpenOutline.vue'
+import FolderOutline from 'vue-material-design-icons/FolderOutline.vue'
+import FolderTextOutline from 'vue-material-design-icons/FolderTextOutline.vue'
+import FolderZipOutline from 'vue-material-design-icons/FolderZipOutline.vue'
+import FormatListBulleted from 'vue-material-design-icons/FormatListBulleted.vue'
+import FormatListBulletedSquare from 'vue-material-design-icons/FormatListBulletedSquare.vue'
+import FormatListBulletedType from 'vue-material-design-icons/FormatListBulletedType.vue'
 import FormatListChecks from 'vue-material-design-icons/FormatListChecks.vue'
 import FormatListNumbered from 'vue-material-design-icons/FormatListNumbered.vue'
+import FormatListNumberedRtl from 'vue-material-design-icons/FormatListNumberedRtl.vue'
+import Gauge from 'vue-material-design-icons/Gauge.vue'
 import GaugeFull from 'vue-material-design-icons/GaugeFull.vue'
+import GaugeLow from 'vue-material-design-icons/GaugeLow.vue'
 import Gavel from 'vue-material-design-icons/Gavel.vue'
 import HandCoinOutline from 'vue-material-design-icons/HandCoinOutline.vue'
 import HandHeartOutline from 'vue-material-design-icons/HandHeartOutline.vue'
+import HandshakeOutline from 'vue-material-design-icons/HandshakeOutline.vue'
 import HelpRhombusOutline from 'vue-material-design-icons/HelpRhombusOutline.vue'
 import History from 'vue-material-design-icons/History.vue'
+import InboxArrowDown from 'vue-material-design-icons/InboxArrowDown.vue'
 import KeyOutline from 'vue-material-design-icons/KeyOutline.vue'
 import Leaf from 'vue-material-design-icons/Leaf.vue'
+import LeafCircleOutline from 'vue-material-design-icons/LeafCircleOutline.vue'
+import Lightbulb from 'vue-material-design-icons/Lightbulb.vue'
+import LightbulbOnOutline from 'vue-material-design-icons/LightbulbOnOutline.vue'
+import LightbulbOutline from 'vue-material-design-icons/LightbulbOutline.vue'
 import LinkVariant from 'vue-material-design-icons/LinkVariant.vue'
+import Lock from 'vue-material-design-icons/Lock.vue'
 import LockOutline from 'vue-material-design-icons/LockOutline.vue'
 import MapMarkerOutline from 'vue-material-design-icons/MapMarkerOutline.vue'
+import MapMarkerPath from 'vue-material-design-icons/MapMarkerPath.vue'
 import MapOutline from 'vue-material-design-icons/MapOutline.vue'
 import MessageTextOutline from 'vue-material-design-icons/MessageTextOutline.vue'
 import Molecule from 'vue-material-design-icons/Molecule.vue'
+import NoteTextOutline from 'vue-material-design-icons/NoteTextOutline.vue'
 import NotebookOutline from 'vue-material-design-icons/NotebookOutline.vue'
 import OfficeBuilding from 'vue-material-design-icons/OfficeBuilding.vue'
+import OfficeBuildingMarkerOutline from 'vue-material-design-icons/OfficeBuildingMarkerOutline.vue'
 import OfficeBuildingOutline from 'vue-material-design-icons/OfficeBuildingOutline.vue'
 import PackageVariant from 'vue-material-design-icons/PackageVariant.vue'
 import PackageVariantClosed from 'vue-material-design-icons/PackageVariantClosed.vue'
+import PauseCircleOutline from 'vue-material-design-icons/PauseCircleOutline.vue'
+import Percent from 'vue-material-design-icons/Percent.vue'
 import PercentOutline from 'vue-material-design-icons/PercentOutline.vue'
 import PiggyBankOutline from 'vue-material-design-icons/PiggyBankOutline.vue'
+import PlayCircleOutline from 'vue-material-design-icons/PlayCircleOutline.vue'
 import PlusCircle from 'vue-material-design-icons/PlusCircle.vue'
 import Poll from 'vue-material-design-icons/Poll.vue'
 import Pulse from 'vue-material-design-icons/Pulse.vue'
 import ReceiptOutline from 'vue-material-design-icons/ReceiptOutline.vue'
+import ReceiptTextMinusOutline from 'vue-material-design-icons/ReceiptTextMinusOutline.vue'
 import ReceiptTextOutline from 'vue-material-design-icons/ReceiptTextOutline.vue'
+import Refresh from 'vue-material-design-icons/Refresh.vue'
 import RepeatVariant from 'vue-material-design-icons/RepeatVariant.vue'
 import Restore from 'vue-material-design-icons/Restore.vue'
+import RoadVariant from 'vue-material-design-icons/RoadVariant.vue'
 import RssBox from 'vue-material-design-icons/RssBox.vue'
+import RunFast from 'vue-material-design-icons/RunFast.vue'
+import SaleOutline from 'vue-material-design-icons/SaleOutline.vue'
 import Scale from 'vue-material-design-icons/Scale.vue'
 import ScaleBalance from 'vue-material-design-icons/ScaleBalance.vue'
+import SendOutline from 'vue-material-design-icons/SendOutline.vue'
+import ShapeOutline from 'vue-material-design-icons/ShapeOutline.vue'
+import ShieldAccountOutline from 'vue-material-design-icons/ShieldAccountOutline.vue'
 import ShieldAlertOutline from 'vue-material-design-icons/ShieldAlertOutline.vue'
 import ShieldCheckOutline from 'vue-material-design-icons/ShieldCheckOutline.vue'
 import ShieldCrownOutline from 'vue-material-design-icons/ShieldCrownOutline.vue'
+import ShieldEditOutline from 'vue-material-design-icons/ShieldEditOutline.vue'
 import ShieldHalfFull from 'vue-material-design-icons/ShieldHalfFull.vue'
+import ShieldOutline from 'vue-material-design-icons/ShieldOutline.vue'
 import ShieldPlusOutline from 'vue-material-design-icons/ShieldPlusOutline.vue'
 import ShieldRemoveOutline from 'vue-material-design-icons/ShieldRemoveOutline.vue'
 import ShieldSearch from 'vue-material-design-icons/ShieldSearch.vue'
 import ShoppingOutline from 'vue-material-design-icons/ShoppingOutline.vue'
+import Sigma from 'vue-material-design-icons/Sigma.vue'
 import SignatureFreehand from 'vue-material-design-icons/SignatureFreehand.vue'
 import Sitemap from 'vue-material-design-icons/Sitemap.vue'
+import SitemapOutline from 'vue-material-design-icons/SitemapOutline.vue'
+import SolarPower from 'vue-material-design-icons/SolarPower.vue'
 import SourceBranch from 'vue-material-design-icons/SourceBranch.vue'
 import SpeedometerSlow from 'vue-material-design-icons/SpeedometerSlow.vue'
 import StairsUp from 'vue-material-design-icons/StairsUp.vue'
 import StoreOutline from 'vue-material-design-icons/StoreOutline.vue'
 import SwapHorizontal from 'vue-material-design-icons/SwapHorizontal.vue'
 import SwapHorizontalBold from 'vue-material-design-icons/SwapHorizontalBold.vue'
+import SwapVerticalBold from 'vue-material-design-icons/SwapVerticalBold.vue'
 import Sync from 'vue-material-design-icons/Sync.vue'
 import TableAccount from 'vue-material-design-icons/TableAccount.vue'
 import TableArrowRight from 'vue-material-design-icons/TableArrowRight.vue'
+import TableClock from 'vue-material-design-icons/TableClock.vue'
 import TableLarge from 'vue-material-design-icons/TableLarge.vue'
 import TableMergeCells from 'vue-material-design-icons/TableMergeCells.vue'
+import TableRow from 'vue-material-design-icons/TableRow.vue'
+import TableRowPlusAfter from 'vue-material-design-icons/TableRowPlusAfter.vue'
 import TagCheckOutline from 'vue-material-design-icons/TagCheckOutline.vue'
+import TagMultipleOutline from 'vue-material-design-icons/TagMultipleOutline.vue'
 import TagOutline from 'vue-material-design-icons/TagOutline.vue'
+import TextBoxCheckOutline from 'vue-material-design-icons/TextBoxCheckOutline.vue'
+import TextBoxOutline from 'vue-material-design-icons/TextBoxOutline.vue'
+import TicketConfirmationOutline from 'vue-material-design-icons/TicketConfirmationOutline.vue'
+import TimerSandEmpty from 'vue-material-design-icons/TimerSandEmpty.vue'
 import TransferRight from 'vue-material-design-icons/TransferRight.vue'
 import TransitConnectionVariant from 'vue-material-design-icons/TransitConnectionVariant.vue'
+import TrayArrowDown from 'vue-material-design-icons/TrayArrowDown.vue'
+import TrendingDown from 'vue-material-design-icons/TrendingDown.vue'
+import TrendingUp from 'vue-material-design-icons/TrendingUp.vue'
+import TrophyOutline from 'vue-material-design-icons/TrophyOutline.vue'
 import Truck from 'vue-material-design-icons/Truck.vue'
+import TruckDeliveryOutline from 'vue-material-design-icons/TruckDeliveryOutline.vue'
 import TruckOutline from 'vue-material-design-icons/TruckOutline.vue'
+import Tune from 'vue-material-design-icons/Tune.vue'
+import TuneVariant from 'vue-material-design-icons/TuneVariant.vue'
+import UndoVariant from 'vue-material-design-icons/UndoVariant.vue'
+import Upload from 'vue-material-design-icons/Upload.vue'
 import VectorDifference from 'vue-material-design-icons/VectorDifference.vue'
 import VectorIntersection from 'vue-material-design-icons/VectorIntersection.vue'
 import ViewDashboardOutline from 'vue-material-design-icons/ViewDashboardOutline.vue'
+import ViewListOutline from 'vue-material-design-icons/ViewListOutline.vue'
+import VoteOutline from 'vue-material-design-icons/VoteOutline.vue'
 import Wallet from 'vue-material-design-icons/Wallet.vue'
 import WalletOutline from 'vue-material-design-icons/WalletOutline.vue'
 import Warehouse from 'vue-material-design-icons/Warehouse.vue'
@@ -182,57 +325,97 @@ import WaterCheckOutline from 'vue-material-design-icons/WaterCheckOutline.vue'
 import WaterOutline from 'vue-material-design-icons/WaterOutline.vue'
 
 export default {
+	AccountArrowRightOutline,
+	AccountCancelOutline,
 	AccountCashOutline,
+	AccountCheckOutline,
 	AccountGroup,
 	AccountGroupOutline,
 	AccountHardHatOutline,
 	AccountKey,
+	AccountKeyOutline,
+	AccountLockOutline,
 	AccountMultipleOutline,
+	AccountStarOutline,
 	AccountSwitch,
 	AccountSwitchOutline,
 	AccountTie,
 	AccountTieOutline,
 	AlertCircleOutline,
 	AlertOctagonOutline,
+	AlertOutline,
+	ArchiveArrowDownOutline,
+	ArchiveArrowUpOutline,
 	ArrowDecisionOutline,
 	ArrowDownBoldOutline,
 	ArrowRightBoldOutline,
 	ArrowUpDown,
+	AutoFix,
 	Bank,
 	BankCheck,
+	BankCircle,
+	BankMinus,
 	BankOutline,
 	BankTransfer,
+	BankTransferIn,
+	BankTransferOut,
 	Barcode,
 	BarcodeScan,
+	Bell,
+	BellOffOutline,
+	BellOutline,
 	BellRingOutline,
 	BookEditOutline,
+	BookMinusOutline,
 	BookOpenPageVariantOutline,
 	BookOpenVariant,
 	BookOpenVariantOutline,
 	BookOutline,
+	BookRemoveOutline,
 	BookmarkCheckOutline,
 	BookmarkOutline,
+	Briefcase,
 	BriefcaseAccountOutline,
 	BriefcaseCheckOutline,
 	BriefcaseClockOutline,
 	BriefcaseOutline,
+	BriefcaseUpload,
+	BullseyeArrow,
 	Calculator,
 	CalculatorVariantOutline,
+	Calendar,
+	CalendarAccountOutline,
 	CalendarCheckOutline,
 	CalendarClock,
 	CalendarClockOutline,
 	CalendarLock,
+	CalendarMinusOutline,
 	CalendarMultiselect,
 	CalendarOutline,
 	CalendarRange,
+	CalendarRangeOutline,
 	CalendarRemoveOutline,
 	CalendarSync,
+	CalendarSyncOutline,
+	CalendarTextOutline,
+	CalendarWeekOutline,
 	CallSplit,
+	Cancel,
 	CarOutline,
+	CardAccountDetailsOutline,
 	CartArrowDown,
 	CartOutline,
+	Cash,
+	CashCheck,
+	CashClock,
+	CashFast,
+	CashLock,
+	CashMinus,
 	CashMultiple,
+	CashPlus,
 	CashRefund,
+	CashSync,
+	CertificateOutline,
 	ChartBar,
 	ChartBarStacked,
 	ChartBellCurve,
@@ -242,22 +425,48 @@ export default {
 	ChartDonutVariant,
 	ChartLine,
 	ChartLineVariant,
+	ChartPie,
+	ChartScatterPlot,
 	ChartTimelineVariant,
 	ChartTimelineVariantShimmer,
+	ChartWaterfall,
+	CheckCircleOutline,
 	CheckDecagramOutline,
+	CheckboxMarkedOutline,
+	ClipboardArrowDownOutline,
+	ClipboardArrowRightOutline,
+	ClipboardCheckMultipleOutline,
 	ClipboardCheckOutline,
+	ClipboardList,
 	ClipboardListOutline,
 	ClipboardTextClockOutline,
 	ClipboardTextOutline,
 	ClipboardTextSearchOutline,
+	ClockAlertOutline,
+	ClockCheckOutline,
 	ClockOutline,
+	ClockTimeFourOutline,
+	CloseCircleOutline,
+	CloudUploadOutline,
+	CoffeeOutline,
 	Cog,
 	CogOutline,
+	CommentOutline,
+	Compare,
+	Counter,
 	CreditCardOutline,
 	CubeOutline,
 	CurrencyEur,
 	CurrencyUsd,
+	DatabaseArrowDown,
+	DatabaseClock,
+	DatabaseExportOutline,
+	DatabaseImportOutline,
+	DatabaseOutline,
 	DeleteSweepOutline,
+	DesktopTowerMonitor,
+	DiamondStone,
+	Domain,
 	DownloadOutline,
 	Earth,
 	EarthArrowRight,
@@ -267,119 +476,164 @@ export default {
 	EmailFastOutline,
 	EmailOutline,
 	EmailRemoveOutline,
+	Factory,
+	FamilyTree,
+	FileAlertOutline,
 	FileCertificateOutline,
 	FileChartCheckOutline,
 	FileChartOutline,
+	FileCheckOutline,
+	FileClockOutline,
+	FileCogOutline,
+	FileCompare,
+	FileDocument,
 	FileDocumentCheckOutline,
+	FileDocumentEdit,
 	FileDocumentEditOutline,
+	FileDocumentMinusOutline,
 	FileDocumentMultiple,
 	FileDocumentMultipleOutline,
 	FileDocumentOutline,
+	FileDocumentPlus,
+	FileDocumentRemoveOutline,
+	FileDownloadOutline,
 	FileExportOutline,
+	FileImportOutline,
+	FileLockOutline,
 	FileRemoveOutline,
+	FileReplaceOutline,
+	FileSendOutline,
 	FileSign,
 	FileTreeOutline,
 	FileXmlBox,
 	FilterCogOutline,
 	Finance,
+	FlagVariantOutline,
+	FlashOutline,
 	FlaskOutline,
 	FolderLockOutline,
 	FolderOpenOutline,
+	FolderOutline,
+	FolderTextOutline,
+	FolderZipOutline,
+	FormatListBulleted,
+	FormatListBulletedSquare,
+	FormatListBulletedType,
 	FormatListChecks,
 	FormatListNumbered,
+	FormatListNumberedRtl,
+	Gauge,
 	GaugeFull,
+	GaugeLow,
 	Gavel,
 	HandCoinOutline,
 	HandHeartOutline,
+	HandshakeOutline,
 	HelpRhombusOutline,
 	History,
+	InboxArrowDown,
 	KeyOutline,
 	Leaf,
+	LeafCircleOutline,
+	Lightbulb,
+	LightbulbOnOutline,
+	LightbulbOutline,
 	LinkVariant,
+	Lock,
 	LockOutline,
 	MapMarkerOutline,
+	MapMarkerPath,
 	MapOutline,
 	MessageTextOutline,
 	Molecule,
+	NoteTextOutline,
 	NotebookOutline,
 	OfficeBuilding,
+	OfficeBuildingMarkerOutline,
 	OfficeBuildingOutline,
 	PackageVariant,
 	PackageVariantClosed,
+	PauseCircleOutline,
+	Percent,
 	PercentOutline,
 	PiggyBankOutline,
+	PlayCircleOutline,
 	PlusCircle,
 	Poll,
 	Pulse,
 	ReceiptOutline,
+	ReceiptTextMinusOutline,
 	ReceiptTextOutline,
+	Refresh,
 	RepeatVariant,
 	Restore,
+	RoadVariant,
 	RssBox,
+	RunFast,
+	SaleOutline,
 	Scale,
 	ScaleBalance,
+	SendOutline,
+	ShapeOutline,
+	ShieldAccountOutline,
 	ShieldAlertOutline,
 	ShieldCheckOutline,
 	ShieldCrownOutline,
+	ShieldEditOutline,
 	ShieldHalfFull,
+	ShieldOutline,
 	ShieldPlusOutline,
 	ShieldRemoveOutline,
 	ShieldSearch,
 	ShoppingOutline,
+	Sigma,
 	SignatureFreehand,
 	Sitemap,
+	SitemapOutline,
+	SolarPower,
 	SourceBranch,
 	SpeedometerSlow,
 	StairsUp,
 	StoreOutline,
 	SwapHorizontal,
 	SwapHorizontalBold,
+	SwapVerticalBold,
 	Sync,
 	TableAccount,
 	TableArrowRight,
+	TableClock,
 	TableLarge,
 	TableMergeCells,
+	TableRow,
+	TableRowPlusAfter,
 	TagCheckOutline,
+	TagMultipleOutline,
 	TagOutline,
+	TextBoxCheckOutline,
+	TextBoxOutline,
+	TicketConfirmationOutline,
+	TimerSandEmpty,
 	TransferRight,
 	TransitConnectionVariant,
+	TrayArrowDown,
+	TrendingDown,
+	TrendingUp,
+	TrophyOutline,
 	Truck,
+	TruckDeliveryOutline,
 	TruckOutline,
+	Tune,
+	TuneVariant,
+	UndoVariant,
+	Upload,
 	VectorDifference,
 	VectorIntersection,
 	ViewDashboardOutline,
+	ViewListOutline,
+	VoteOutline,
 	Wallet,
 	WalletOutline,
 	Warehouse,
 	WaterCheckOutline,
 	WaterOutline,
-
-	// ALIASES — names referenced by manifest fragments that do not exist in
-	// vue-material-design-icons, mapped to the closest real icon.
-	BankCheckOutline: BankCheck,
-	BankTransferOutline: BankTransfer,
-	BarcodeOutline: Barcode,
-	CalculatorOutline: Calculator,
-	CartArrowDownOutline: CartArrowDown,
-	ChartBarOutline: ChartBar,
-	ChartLineVariantOutline: ChartLineVariant,
-	ChartTimelineVariantOutline: ChartTimelineVariant,
-	ClipboardQuestionOutline: ClipboardTextSearchOutline,
-	EmailClockOutline: EmailOutline,
-	FileSignOutline: FileSign,
-	FileXmlBoxOutline: FileXmlBox,
-	FinanceOutline: Finance,
-	GavelOutline: Gavel,
-	HistoryIcon: History,
-	LeafOutline: Leaf,
-	LedgerOutline: NotebookOutline,
-	PackageVariantOutline: PackageVariant,
-	PollOutline: Poll,
-	PulseOutline: Pulse,
-	RssBoxOutline: RssBox,
-	ScaleBalanceOutline: ScaleBalance,
-	SwapHorizontalBoldOutline: SwapHorizontalBold,
-	TableAccountOutline: TableAccount,
-	TableMergeCellsOutline: TableMergeCells,
-	WarehouseOutline: Warehouse,
 }

--- a/src/manifest.d/10-bookings-resource-calendar.json
+++ b/src/manifest.d/10-bookings-resource-calendar.json
@@ -9,7 +9,7 @@
 				{
 					"id": "Resources",
 					"label": "Resources",
-					"icon": "AccountHardHatOutline",
+					"icon": "SourceBranch",
 					"route": "Resources",
 					"order": 10
 				},

--- a/src/manifest.d/20-tenderned-integratie.json
+++ b/src/manifest.d/20-tenderned-integratie.json
@@ -3,27 +3,27 @@
 		{
 			"id": "Purchasing",
 			"label": "Purchasing & Inventory",
-			"icon": "CartArrowDownOutline",
+			"icon": "CartArrowDown",
 			"order": 35,
 			"children": [
 				{
 					"id": "TenderNedAanbestedingen",
 					"label": "TenderNed tenders",
-					"icon": "GavelOutline",
+					"icon": "Gavel",
 					"route": "TenderNedAanbestedingen",
 					"order": 10
 				},
 				{
 					"id": "Verplichtingen",
 					"label": "Commitments",
-					"icon": "FileSignOutline",
+					"icon": "FileSign",
 					"route": "Verplichtingen",
 					"order": 20
 				},
 				{
 					"id": "MijnContracten",
 					"label": "My contracts",
-					"icon": "BriefcaseCheckOutline",
+					"icon": "FileSign",
 					"route": "MijnContracten",
 					"order": 30
 				}

--- a/src/manifest.d/30-bookkeeping-ib-aangifte-zzp.json
+++ b/src/manifest.d/30-bookkeeping-ib-aangifte-zzp.json
@@ -30,7 +30,7 @@
 				{
 					"id": "IbBox3Vermogen",
 					"label": "Box 3 assets",
-					"icon": "BankOutline",
+					"icon": "DesktopTowerMonitor",
 					"route": "IbBox3Vermogen",
 					"order": 40
 				}
@@ -141,7 +141,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
@@ -267,7 +267,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
@@ -333,7 +333,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
@@ -404,7 +404,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }

--- a/src/manifest.d/30-bookkeeping-kor-kleine-ondernemersregeling.json
+++ b/src/manifest.d/30-bookkeeping-kor-kleine-ondernemersregeling.json
@@ -189,7 +189,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90
 						}
 					]

--- a/src/manifest.d/30-treasury-ihb.json
+++ b/src/manifest.d/30-treasury-ihb.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Treasury",
 			"label": "Treasury",
-			"icon": "BankTransfer",
+			"icon": "BankOutline",
 			"order": 38,
 			"children": [
 				{
@@ -30,14 +30,14 @@
 				{
 					"id": "CashflowForecast",
 					"label": "Cashflow Forecast",
-					"icon": "CalendarMultiselect",
+					"icon": "ChartTimelineVariant",
 					"route": "CashflowForecast",
 					"order": 40
 				},
 				{
 					"id": "GroupLiquidityDashboard",
 					"label": "Group Liquidity Dashboard",
-					"icon": "SpeedometerSlow",
+					"icon": "ViewDashboardOutline",
 					"route": "GroupLiquidityDashboard",
 					"order": 50
 				}
@@ -103,7 +103,7 @@
 				"auditTrail": true,
 				"sidebarProps": {
 					"tabs": [
-						{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
 						] }
 					]
@@ -175,7 +175,7 @@
 						{ "id": "documents", "label": "Transfer pricing docs", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{ "type": "data", "componentName": "openregister-file-references", "props": { "register": "shillinq", "schema": "IntercompanyLoan", "objectId": ":id" } }
 						] },
-						{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
 						] }
 					]
@@ -238,7 +238,7 @@
 						{ "id": "documents", "label": "Confirmations", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{ "type": "data", "componentName": "openregister-file-references", "props": { "register": "shillinq", "schema": "FXContract", "objectId": ":id" } }
 						] },
-						{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
 						] }
 					]

--- a/src/manifest.d/35-procurement-governance.json
+++ b/src/manifest.d/35-procurement-governance.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Purchasing",
 			"label": "Purchasing & Inventory",
-			"icon": "CartArrowDownOutline",
+			"icon": "CartArrowDown",
 			"order": 35,
 			"children": [
 				{
@@ -16,7 +16,7 @@
 				{
 					"id": "FrameworkAgreements",
 					"label": "Framework Agreements",
-					"icon": "FileSignOutline",
+					"icon": "FileSign",
 					"route": "FrameworkAgreements",
 					"order": 9
 				}

--- a/src/manifest.d/40-bookings-cancellation-rules.json
+++ b/src/manifest.d/40-bookings-cancellation-rules.json
@@ -9,7 +9,7 @@
 				{
 					"id": "Annuleringsbeleid",
 					"label": "Cancellation policy",
-					"icon": "CalendarRemoveOutline",
+					"icon": "ShieldCheckOutline",
 					"route": "Annuleringsbeleid",
 					"order": 20
 				}
@@ -133,7 +133,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/40-eu-fondsen.json
+++ b/src/manifest.d/40-eu-fondsen.json
@@ -23,7 +23,7 @@
 				{
 					"id": "EuBewijsstukken",
 					"label": "Supporting documents",
-					"icon": "FileCertificateOutline",
+					"icon": "FileDocumentMultipleOutline",
 					"route": "EuBewijsstukken",
 					"order": 30
 				},

--- a/src/manifest.d/50-bookings-deposits.json
+++ b/src/manifest.d/50-bookings-deposits.json
@@ -133,7 +133,7 @@
 						{ "id": "documents", "label": "Receipts", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{ "type": "data", "componentName": "openregister-file-references", "props": { "register": "shillinq", "schema": "DepositPayment", "objectId": ":id" } }
 						] },
-						{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
 						] }
 					]

--- a/src/manifest.d/add-shillinq-detachering-payroll-administratie.json
+++ b/src/manifest.d/add-shillinq-detachering-payroll-administratie.json
@@ -6,7 +6,7 @@
 				{
 					"id": "DetacheringPayroll",
 					"label": "Secondment & payroll",
-					"icon": "AccountCashOutline",
+					"icon": "CashSync",
 					"order": 45,
 					"featureFlag": "mkb-detachering",
 					"children": [
@@ -20,7 +20,7 @@
 						{
 							"id": "OpdrachtgeversVerklaringen",
 							"label": "Client statements",
-							"icon": "FileSignOutline",
+							"icon": "AccountStarOutline",
 							"route": "OpdrachtgeversVerklaringen",
 							"order": 20
 						},
@@ -158,7 +158,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -300,7 +300,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -428,7 +428,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/add-shillinq-multi-currency-t4.json
+++ b/src/manifest.d/add-shillinq-multi-currency-t4.json
@@ -9,7 +9,7 @@
 		{
 			"id": "BookkeepingMultiCurrency",
 			"label": "Multi-currency",
-			"icon": "LedgerOutline",
+			"icon": "CurrencyEur",
 			"order": 11,
 			"children": [
 				{
@@ -82,7 +82,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/administration-import-migration.json
+++ b/src/manifest.d/administration-import-migration.json
@@ -16,7 +16,7 @@
 				{
 					"id": "ImportWizard",
 					"label": "Import wizard",
-					"icon": "ImportOutline",
+					"icon": "DatabaseImportOutline",
 					"route": "ImportWizard",
 					"order": 10
 				},
@@ -30,7 +30,7 @@
 				{
 					"id": "ImportMappings",
 					"label": "Mapping",
-					"icon": "SwapHorizontalBoldOutline",
+					"icon": "SwapHorizontal",
 					"route": "ImportMappings",
 					"order": 30
 				}
@@ -138,7 +138,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -214,7 +214,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/ar-invoice-payment-links.json
+++ b/src/manifest.d/ar-invoice-payment-links.json
@@ -93,7 +93,7 @@
 					{
 						"id": "regenerate",
 						"label": "Regenerate payment link",
-						"icon": "RefreshOutline",
+						"icon": "Refresh",
 						"description": "Per REQ-APL-008: creates a NEW pending payment request with the current outstanding amount; the panel shows its link and the expired request remains visible in history. History is preserved (a new record, not a mutation)."
 					}
 				],
@@ -102,7 +102,7 @@
 						{
 							"id": "history",
 							"label": "Request history",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 10,
 							"widgets": [
 								{
@@ -135,7 +135,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bank-import-settings.json
+++ b/src/manifest.d/bank-import-settings.json
@@ -10,7 +10,7 @@
 		{
 			"id": "BankImportPage",
 			"label": "Import bank statements",
-			"icon": "BankTransferIn",
+			"icon": "DatabaseImportOutline",
 			"route": "BankImportPage",
 			"order": 40
 		}

--- a/src/manifest.d/bookings-email-templates.json
+++ b/src/manifest.d/bookings-email-templates.json
@@ -3,27 +3,27 @@
 		{
 			"id": "Communicatie",
 			"label": "Communication",
-			"icon": "icon-comment",
+			"icon": "CommentOutline",
 			"order": 36,
 			"children": [
 				{
 					"id": "ConfirmationTemplates",
 					"label": "Confirmation Templates",
-					"icon": "EmailCheckOutline",
+					"icon": "FileReplaceOutline",
 					"route": "ConfirmationTemplates",
 					"order": 20
 				},
 				{
 					"id": "ReminderTemplates",
 					"label": "Reminder Templates",
-					"icon": "EmailClockOutline",
+					"icon": "FileReplaceOutline",
 					"route": "ReminderTemplates",
 					"order": 30
 				},
 				{
 					"id": "CancellationTemplates",
 					"label": "Cancellation Templates",
-					"icon": "EmailRemoveOutline",
+					"icon": "FileReplaceOutline",
 					"route": "CancellationTemplates",
 					"order": 40
 				}
@@ -105,7 +105,7 @@
 				"indexRoute": "ConfirmationTemplates",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -177,7 +177,7 @@
 				"indexRoute": "ReminderTemplates",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -249,7 +249,7 @@
 				"indexRoute": "CancellationTemplates",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]

--- a/src/manifest.d/bookings-notification-triggers.json
+++ b/src/manifest.d/bookings-notification-triggers.json
@@ -3,20 +3,20 @@
 		{
 			"id": "Communicatie",
 			"label": "Communication",
-			"icon": "icon-comment",
+			"icon": "CommentOutline",
 			"order": 36,
 			"children": [
 				{
 					"id": "NotificationTriggers",
 					"label": "Notification Triggers",
-					"icon": "BellRingOutline",
+					"icon": "BellOutline",
 					"route": "NotificationTriggers",
 					"order": 10
 				},
 				{
 					"id": "NotificationMonitor",
 					"label": "Notification Monitor",
-					"icon": "ChartLine",
+					"icon": "BellOutline",
 					"route": "NotificationMonitor",
 					"order": 50
 				}
@@ -97,7 +97,7 @@
 				"indexRoute": "NotificationTriggers",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -182,7 +182,7 @@
 				"indexRoute": "NotificationMonitor",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]

--- a/src/manifest.d/bookings-service-catalog.json
+++ b/src/manifest.d/bookings-service-catalog.json
@@ -155,7 +155,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookings-sms-reminder-channel.json
+++ b/src/manifest.d/bookings-sms-reminder-channel.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Communicatie",
 			"label": "Communication",
-			"icon": "icon-comment",
+			"icon": "CommentOutline",
 			"order": 36,
 			"children": [
 				{
@@ -102,7 +102,7 @@
 				"indexRoute": "SmsReminderChannels",
 				"sidebarProps": {
 					"tabs": [
-						{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
 						] }
 					]

--- a/src/manifest.d/bookkeeping-accounts-payable-core.json
+++ b/src/manifest.d/bookkeeping-accounts-payable-core.json
@@ -44,7 +44,7 @@
 				{
 					"id": "PaymentRuns",
 					"label": "Payment Runs",
-					"icon": "BankTransferOutline",
+					"icon": "CreditCardOutline",
 					"route": "PaymentRuns",
 					"order": 50
 				}
@@ -123,7 +123,7 @@
 						{
 							"id": "openApBalance",
 							"label": "Open AP Balance",
-							"icon": "CashCheckOutline",
+							"icon": "CashCheck",
 							"order": 10,
 							"widgets": [
 								{
@@ -141,7 +141,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -247,7 +247,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -379,7 +379,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -488,7 +488,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookkeeping-bado-controleprotocol.json
+++ b/src/manifest.d/bookkeeping-bado-controleprotocol.json
@@ -97,7 +97,7 @@
 				"auditTrail": true,
 				"sidebarProps": {
 					"tabs": [
-						{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
 						] }
 					]
@@ -145,7 +145,7 @@
 				"auditTrail": true,
 				"sidebarProps": {
 					"tabs": [
-						{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
 						] }
 					]
@@ -202,7 +202,7 @@
 						{ "id": "documents", "label": "Evidence", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{ "type": "data", "componentName": "openregister-file-references", "props": { "register": "shillinq", "schema": "AuditFinding", "objectId": ":id" } }
 						] },
-						{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
 						] }
 					]
@@ -247,7 +247,7 @@
 						{ "id": "documents", "label": "Signed statement", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{ "type": "data", "componentName": "openregister-file-references", "props": { "register": "shillinq", "schema": "VerklaringDraft", "objectId": ":id" } }
 						] },
-						{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
 						] }
 					]

--- a/src/manifest.d/bookkeeping-btw-oss-eu.json
+++ b/src/manifest.d/bookkeeping-btw-oss-eu.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Bookkeeping",
 			"label": "Bookkeeping",
-			"icon": "icon-category-organization",
+			"icon": "NotebookOutline",
 			"order": 20,
 			"children": [
 				{
@@ -83,7 +83,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -164,7 +164,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookkeeping-cbs-bestanden-extended.json
+++ b/src/manifest.d/bookkeeping-cbs-bestanden-extended.json
@@ -141,7 +141,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookkeeping-ccm-rule-engine.json
+++ b/src/manifest.d/bookkeeping-ccm-rule-engine.json
@@ -44,7 +44,7 @@
 				{
 					"id": "CcmAuditCommitteeReports",
 					"label": "Audit Committee Reports",
-					"icon": "FileChartOutline",
+					"icon": "AccountGroupOutline",
 					"route": "CcmAuditCommitteeReports",
 					"order": 60
 				}
@@ -101,7 +101,7 @@
 						{"id": "documents", "label": "Evidence", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "CcmFinding", "objectId": ":id"}}
 						]},
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -163,7 +163,7 @@
 				"auditTrail": true,
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -206,7 +206,7 @@
 				"auditTrail": true,
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -252,7 +252,7 @@
 				"auditTrail": true,
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -304,7 +304,7 @@
 				"auditTrail": true,
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -364,7 +364,7 @@
 						{"id": "documents", "label": "Report documents", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "CcmAuditCommitteeReport", "objectId": ":id"}}
 						]},
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]

--- a/src/manifest.d/bookkeeping-consolidation-commercial.json
+++ b/src/manifest.d/bookkeeping-consolidation-commercial.json
@@ -9,7 +9,7 @@
 				{
 					"id": "ConsolidationGroups",
 					"label": "Consolidation Groups",
-					"icon": "Sitemap",
+					"icon": "AccountGroupOutline",
 					"route": "ConsolidationGroups",
 					"order": 10
 				},
@@ -23,7 +23,7 @@
 				{
 					"id": "ConsolidatedReports",
 					"label": "Consolidated Reports",
-					"icon": "FileChartOutline",
+					"icon": "ChartBoxOutline",
 					"route": "ConsolidatedReports",
 					"order": 30
 				}
@@ -95,7 +95,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/ConsolidationGroup/:id/audit-trails", "collapsed": true}}
@@ -180,7 +180,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/ConsolidationPeriod/:id/audit-trails", "collapsed": true}}
@@ -234,7 +234,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/ConsolidatedBalance/:id/audit-trails", "collapsed": true}}

--- a/src/manifest.d/bookkeeping-cost-centers-dimensions.json
+++ b/src/manifest.d/bookkeeping-cost-centers-dimensions.json
@@ -9,7 +9,7 @@
 		{
 			"id": "Bookkeeping",
 			"label": "Bookkeeping",
-			"icon": "icon-category-organization",
+			"icon": "NotebookOutline",
 			"order": 20,
 			"children": [
 				{
@@ -18,14 +18,14 @@
 					"i18n": {
 						"nl": "Analytische dimensies"
 					},
-					"icon": "ChartBoxOutline",
+					"icon": "ChartLineVariant",
 					"route": "AnalyticalDimensions",
 					"order": 92
 				},
 				{
 					"id": "SegmentPnLDashboard",
 					"label": "Segment P&L",
-					"icon": "PollOutline",
+					"icon": "Poll",
 					"route": "SegmentPnLDashboard",
 					"order": 93
 				}
@@ -92,7 +92,7 @@
 				"indexRoute": "AnalyticalDimensions",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]

--- a/src/manifest.d/bookkeeping-csrd-esrs.json
+++ b/src/manifest.d/bookkeeping-csrd-esrs.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Sustainability",
 			"label": "Sustainability",
-			"icon": "LeafOutline",
+			"icon": "Leaf",
 			"order": 70,
 			"children": [
 				{
@@ -16,14 +16,14 @@
 				{
 					"id": "EsrsDataPoints",
 					"label": "ESRS Data Points",
-					"icon": "TableLarge",
+					"icon": "DatabaseOutline",
 					"route": "EsrsDataPoints",
 					"order": 20
 				},
 				{
 					"id": "GhgInventories",
 					"label": "GHG Inventory",
-					"icon": "Molecule",
+					"icon": "Warehouse",
 					"route": "GhgInventories",
 					"order": 30
 				},
@@ -109,7 +109,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -194,7 +194,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -256,7 +256,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -320,7 +320,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -401,7 +401,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookkeeping-fixed-assets-depreciation.json
+++ b/src/manifest.d/bookkeeping-fixed-assets-depreciation.json
@@ -16,7 +16,7 @@
 		{
 			"id": "DepreciationExpense",
 			"label": "Depreciation Expense",
-			"icon": "ChartBoxOutline",
+			"icon": "ReceiptOutline",
 			"route": "DepreciationExpense",
 			"order": 40
 		}
@@ -99,7 +99,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookkeeping-ifrs-16-lease.json
+++ b/src/manifest.d/bookkeeping-ifrs-16-lease.json
@@ -9,7 +9,7 @@
 				{
 					"id": "LeaseRegister",
 					"label": "Lease Register",
-					"icon": "FileSign",
+					"icon": "DatabaseOutline",
 					"route": "LeaseRegister",
 					"order": 10
 				},
@@ -114,7 +114,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }

--- a/src/manifest.d/bookkeeping-ifrs-rj-dual-gaap.json
+++ b/src/manifest.d/bookkeeping-ifrs-rj-dual-gaap.json
@@ -9,7 +9,7 @@
 				{
 					"id": "AccountingFrameworks",
 					"label": "Framework Configuration",
-					"icon": "Earth",
+					"icon": "CogOutline",
 					"route": "AccountingFrameworks",
 					"order": 10
 				},
@@ -37,7 +37,7 @@
 				{
 					"id": "FrameworkElections",
 					"label": "Framework Election",
-					"icon": "GavelOutline",
+					"icon": "Gavel",
 					"route": "FrameworkElections",
 					"order": 50
 				}
@@ -83,7 +83,7 @@
 				"auditTrail": true,
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -136,7 +136,7 @@
 				"auditTrail": true,
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -195,7 +195,7 @@
 						{"id": "documents", "label": "Workpapers", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "ReconciliationBridge", "objectId": ":id"}}
 						]},
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -248,7 +248,7 @@
 				"auditTrail": true,
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -303,7 +303,7 @@
 						{"id": "documents", "label": "AVA-besluit & evidence", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "FrameworkElection", "objectId": ":id"}}
 						]},
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]

--- a/src/manifest.d/bookkeeping-ifrs15-revenue.json
+++ b/src/manifest.d/bookkeeping-ifrs15-revenue.json
@@ -3,13 +3,13 @@
 		{
 			"id": "Ifrs15Revenue",
 			"label": "Revenue Recognition (IFRS 15)",
-			"icon": "FinanceOutline",
+			"icon": "CurrencyEur",
 			"order": 85,
 			"children": [
 				{
 					"id": "RevenueContracts",
 					"label": "Contracts",
-					"icon": "FileDocumentOutline",
+					"icon": "FileSign",
 					"route": "RevenueContracts",
 					"order": 10
 				},
@@ -23,28 +23,28 @@
 				{
 					"id": "RevenueWaterfall",
 					"label": "Revenue Waterfall",
-					"icon": "ChartTimelineVariant",
+					"icon": "CurrencyEur",
 					"route": "RevenueWaterfall",
 					"order": 30
 				},
 				{
 					"id": "ContractBalances",
 					"label": "Contract Balances",
-					"icon": "Scale",
+					"icon": "FileSign",
 					"route": "ContractBalances",
 					"order": 40
 				},
 				{
 					"id": "ContractModifications",
 					"label": "Contract Modifications",
-					"icon": "FileDocumentEditOutline",
+					"icon": "FileSign",
 					"route": "ContractModifications",
 					"order": 50
 				},
 				{
 					"id": "ContractCostAssets",
 					"label": "Contract Cost Assets",
-					"icon": "Wallet",
+					"icon": "FileSign",
 					"route": "ContractCostAssets",
 					"order": 60
 				}
@@ -116,7 +116,7 @@
 						{ "id": "documents", "label": "Signed contract", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{ "type": "data", "componentName": "openregister-file-references", "props": { "register": "shillinq", "schema": "Contract", "objectId": ":id" } }
 						] },
-						{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
 						] }
 					]

--- a/src/manifest.d/bookkeeping-market-government-separation.json
+++ b/src/manifest.d/bookkeeping-market-government-separation.json
@@ -3,7 +3,7 @@
 		{
 			"id": "WmoCompliance",
 			"label": "WMO Compliance",
-			"icon": "StoreOutline",
+			"icon": "ClipboardCheckOutline",
 			"order": 42,
 			"children": [
 				{
@@ -23,35 +23,35 @@
 				{
 					"id": "ActivityCostAllocations",
 					"label": "Activity Cost Allocations",
-					"icon": "CallSplit",
+					"icon": "MapMarkerOutline",
 					"route": "ActivityCostAllocations",
 					"order": 30
 				},
 				{
 					"id": "PublicInterestDecisions",
 					"label": "Public Interest Decisions",
-					"icon": "GavelOutline",
+					"icon": "Gavel",
 					"route": "PublicInterestDecisions",
 					"order": 40
 				},
 				{
 					"id": "AcmReports",
 					"label": "ACM Reports",
-					"icon": "FileDocumentMultipleOutline",
+					"icon": "ChartBoxOutline",
 					"route": "AcmReports",
 					"order": 50
 				},
 				{
 					"id": "CrossSubsidyAlerts",
 					"label": "Cross-Subsidy Alerts",
-					"icon": "AlertOctagonOutline",
+					"icon": "HandHeartOutline",
 					"route": "CrossSubsidyAlerts",
 					"order": 60
 				},
 				{
 					"id": "WmoAuditLog",
 					"label": "WMO Audit Log",
-					"icon": "ClipboardTextClockOutline",
+					"icon": "History",
 					"route": "WmoAuditLog",
 					"order": 70
 				},
@@ -178,7 +178,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
@@ -252,7 +252,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
@@ -311,7 +311,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
@@ -383,7 +383,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
@@ -454,7 +454,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
@@ -511,7 +511,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
@@ -608,7 +608,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }

--- a/src/manifest.d/bookkeeping-multi-administratie.json
+++ b/src/manifest.d/bookkeeping-multi-administratie.json
@@ -16,21 +16,21 @@
 				{
 					"id": "AdministrationSwitcher",
 					"label": "Switch administration",
-					"icon": "SwapHorizontal",
+					"icon": "ShieldAccountOutline",
 					"route": "AdministrationSwitcher",
 					"order": 1
 				},
 				{
 					"id": "Administraties",
 					"label": "Administrations",
-					"icon": "OfficeBuilding",
+					"icon": "OfficeBuildingOutline",
 					"route": "Administraties",
 					"order": 5
 				},
 				{
 					"id": "AdministratieLidmaatschappen",
 					"label": "Access & roles",
-					"icon": "AccountMultipleOutline",
+					"icon": "AccountKeyOutline",
 					"route": "AdministratieLidmaatschappen",
 					"order": 6
 				},
@@ -44,14 +44,14 @@
 				{
 					"id": "ConsolidatieMappings",
 					"label": "Consolidation mapping",
-					"icon": "Sitemap",
+					"icon": "SwapHorizontal",
 					"route": "ConsolidatieMappings",
 					"order": 8
 				},
 				{
 					"id": "AdministratieMigraties",
 					"label": "Asset transfer",
-					"icon": "TransferRight",
+					"icon": "DesktopTowerMonitor",
 					"route": "AdministratieMigraties",
 					"order": 9
 				}
@@ -151,7 +151,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -212,7 +212,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -281,7 +281,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -340,7 +340,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -427,7 +427,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookkeeping-multi-currency.json
+++ b/src/manifest.d/bookkeeping-multi-currency.json
@@ -3,13 +3,13 @@
 		{
 			"id": "Bookkeeping",
 			"label": "Bookkeeping",
-			"icon": "LedgerOutline",
+			"icon": "NotebookOutline",
 			"order": 11,
 			"children": [
 				{
 					"id": "BankAccounts",
 					"label": "Bank Accounts",
-					"icon": "Bank",
+					"icon": "BankOutline",
 					"route": "BankAccounts",
 					"order": 26
 				},
@@ -88,7 +88,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -153,7 +153,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookkeeping-payroll-engine-nl.json
+++ b/src/manifest.d/bookkeeping-payroll-engine-nl.json
@@ -3,15 +3,15 @@
 		{
 			"id": "Loonadministratie",
 			"label": "Payroll",
-			"icon": "AccountTie",
+			"icon": "CashSync",
 			"order": 80,
 			"children": [
 				{"id": "Werkgevers", "label": "Employers", "icon": "OfficeBuilding", "route": "Werkgevers", "order": 10},
-				{"id": "Werknemers", "label": "Employees", "icon": "AccountTie", "route": "Werknemers", "order": 20},
+				{"id": "Werknemers", "label": "Employees", "icon": "AccountTieOutline", "route": "Werknemers", "order": 20},
 				{"id": "Loonperiodes", "label": "Pay periods", "icon": "CalendarRange", "route": "Loonperiodes", "order": 30},
 				{"id": "Loonstroken", "label": "Payslips", "icon": "FileDocumentOutline", "route": "Loonstroken", "order": 40},
 				{"id": "LHAfdrachten", "label": "LH remittances", "icon": "BankTransfer", "route": "LHAfdrachten", "order": 50},
-				{"id": "Loonjournaalposten", "label": "Payroll journal entries", "icon": "BookOpenVariant", "route": "Loonjournaalposten", "order": 60}
+				{"id": "Loonjournaalposten", "label": "Payroll journal entries", "icon": "CashSync", "route": "Loonjournaalposten", "order": 60}
 			]
 		}
 	],
@@ -85,7 +85,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -166,7 +166,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -265,7 +265,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -324,7 +324,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -385,7 +385,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -439,7 +439,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookkeeping-period-close.json
+++ b/src/manifest.d/bookkeeping-period-close.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Bookkeeping",
 			"label": "Bookkeeping",
-			"icon": "icon-category-organization",
+			"icon": "NotebookOutline",
 			"order": 20,
 			"children": [
 				{

--- a/src/manifest.d/bookkeeping-provincies-bbv-variant.json
+++ b/src/manifest.d/bookkeeping-provincies-bbv-variant.json
@@ -14,14 +14,14 @@
 				{
 					"id": "BbvComplianceDashboard",
 					"label": "BBV Compliance Dashboard",
-					"icon": "ChartBoxOutline",
+					"icon": "ViewDashboardOutline",
 					"route": "BbvComplianceDashboard",
 					"order": 10
 				},
 				{
 					"id": "BudgetToProgrammeLinker",
 					"label": "Budget Links",
-					"icon": "LinkVariant",
+					"icon": "CalculatorVariantOutline",
 					"route": "BudgetToProgrammeLinker",
 					"order": 20
 				}
@@ -61,7 +61,7 @@
 						{
 							"id": "committed",
 							"label": "Committed",
-							"icon": "FileSignOutline",
+							"icon": "FileSign",
 							"source": "GLLine",
 							"aggregation": "programmeBudgetVsActuals",
 							"field": "netSpent",
@@ -415,7 +415,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookkeeping-purchase-order-3way-06-matching-engine.json
+++ b/src/manifest.d/bookkeeping-purchase-order-3way-06-matching-engine.json
@@ -10,7 +10,7 @@
 		{
 			"id": "PurchaseOrders",
 			"label": "Purchase Orders",
-			"icon": "FileDocumentMultiple",
+			"icon": "ClipboardListOutline",
 			"order": 90,
 			"children": [
 				{"id": "ThreeWayMatchIndex", "label": "Three-way matches", "icon": "VectorIntersection", "route": "ThreeWayMatchIndex", "order": 30}

--- a/src/manifest.d/bookkeeping-purchase-order-3way-10-vendor-performance.json
+++ b/src/manifest.d/bookkeeping-purchase-order-3way-10-vendor-performance.json
@@ -10,7 +10,7 @@
 		{
 			"id": "PurchaseOrders",
 			"label": "Purchase Orders",
-			"icon": "FileDocumentMultiple",
+			"icon": "ClipboardListOutline",
 			"order": 90,
 			"children": [
 				{"id": "VendorPerformanceIndex", "label": "Vendor performance", "icon": "ChartTimelineVariant", "route": "VendorPerformanceIndex", "order": 50}

--- a/src/manifest.d/bookkeeping-rechtmatigheidsverantwoording.json
+++ b/src/manifest.d/bookkeeping-rechtmatigheidsverantwoording.json
@@ -30,14 +30,14 @@
 				{
 					"id": "Rechtmatigheidsparagraaf",
 					"label": "Lawfulness paragraph",
-					"icon": "FileDocumentCheckOutline",
+					"icon": "ClipboardCheckOutline",
 					"route": "Rechtmatigheidsparagraaf",
 					"order": 40
 				},
 				{
 					"id": "RechtmatigheidAuditExport",
 					"label": "Audit Export",
-					"icon": "DownloadOutline",
+					"icon": "DatabaseExportOutline",
 					"route": "RechtmatigheidAuditExport",
 					"order": 50
 				}
@@ -95,7 +95,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -164,7 +164,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -227,7 +227,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -291,7 +291,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookkeeping-schatkistbankieren.json
+++ b/src/manifest.d/bookkeeping-schatkistbankieren.json
@@ -23,14 +23,14 @@
 				{
 					"id": "BankingRules",
 					"label": "Banking Rules",
-					"icon": "ShieldCheckOutline",
+					"icon": "BankOutline",
 					"route": "BankingRules",
 					"order": 20
 				},
 				{
 					"id": "ComplianceReports",
 					"label": "Compliance Reports",
-					"icon": "FileChartOutline",
+					"icon": "ChartBoxOutline",
 					"route": "ComplianceReports",
 					"order": 30
 				}
@@ -105,7 +105,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -167,7 +167,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -250,7 +250,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookkeeping-soft-close-flux.json
+++ b/src/manifest.d/bookkeeping-soft-close-flux.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Bookkeeping",
 			"label": "Bookkeeping",
-			"icon": "icon-category-organization",
+			"icon": "NotebookOutline",
 			"order": 20,
 			"children": [
 				{
@@ -81,7 +81,7 @@
 				"auditTrail": true,
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -144,7 +144,7 @@
 				"auditTrail": true,
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -207,7 +207,7 @@
 				"auditTrail": true,
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]

--- a/src/manifest.d/bookkeeping-titel-9-jaarrekening.json
+++ b/src/manifest.d/bookkeeping-titel-9-jaarrekening.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Bookkeeping",
 			"label": "Bookkeeping",
-			"icon": "icon-category-organization",
+			"icon": "NotebookOutline",
 			"order": 20,
 			"children": [
 				{
@@ -161,7 +161,7 @@
 						{"id": "documents", "label": "Filed documents", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "AnnualReport", "objectId": ":id"}}
 						]},
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -193,7 +193,7 @@
 				"auditTrail": true,
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]

--- a/src/manifest.d/bookkeeping-vat-btw-filing.json
+++ b/src/manifest.d/bookkeeping-vat-btw-filing.json
@@ -10,14 +10,14 @@
 		{
 			"id": "VATReturns",
 			"label": "BTW return",
-			"icon": "FileDocumentCheckOutline",
+			"icon": "PercentOutline",
 			"route": "VATReturns",
 			"order": 70
 		},
 		{
 			"id": "VATReports",
 			"label": "BTW report",
-			"icon": "ChartBoxOutline",
+			"icon": "PercentOutline",
 			"route": "VATReports",
 			"order": 71
 		}
@@ -131,7 +131,7 @@
 						{"id": "documents", "label": "Source documents", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "VATReturn", "objectId": ":id"}}
 						]},
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]

--- a/src/manifest.d/bookkeeping-verplichtingenadministratie.json
+++ b/src/manifest.d/bookkeeping-verplichtingenadministratie.json
@@ -9,7 +9,7 @@
 				{
 					"id": "Verplichtingenregister",
 					"label": "Commitments register",
-					"icon": "FileSign",
+					"icon": "DatabaseOutline",
 					"route": "Verplichtingenregister",
 					"order": 10
 				},
@@ -23,7 +23,7 @@
 				{
 					"id": "Goedkeuringsstappen",
 					"label": "Approvals",
-					"icon": "ClipboardCheckOutline",
+					"icon": "CheckDecagramOutline",
 					"route": "Goedkeuringsstappen",
 					"order": 30
 				},
@@ -127,7 +127,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -197,7 +197,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -258,7 +258,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookkeeping-voorzieningen-claims.json
+++ b/src/manifest.d/bookkeeping-voorzieningen-claims.json
@@ -9,7 +9,7 @@
 		{
 			"id": "Bookkeeping",
 			"label": "Bookkeeping",
-			"icon": "icon-category-organization",
+			"icon": "NotebookOutline",
 			"order": 20,
 			"children": [
 				{

--- a/src/manifest.d/bookkeeping-vpb-corporate-tax-balans.json
+++ b/src/manifest.d/bookkeeping-vpb-corporate-tax-balans.json
@@ -3,7 +3,7 @@
 		{
 			"id": "VennootschapsbelastingBalans",
 			"label": "Corporate income tax (Vpb)",
-			"icon": "BankCheck",
+			"icon": "PercentOutline",
 			"order": 36,
 			"featureFlag": "mkb-vpb",
 			"children": [
@@ -110,7 +110,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookkeeping-vpb-corporate-tax.json
+++ b/src/manifest.d/bookkeeping-vpb-corporate-tax.json
@@ -3,20 +3,20 @@
 		{
 			"id": "Vpb",
 			"label": "Corporate tax (Vpb)",
-			"icon": "BankOutline",
+			"icon": "PercentOutline",
 			"order": 35,
 			"children": [
 				{
 					"id": "VpbDeadlines",
 					"label": "Tax deadlines",
-					"icon": "CalendarClock",
+					"icon": "ClockAlertOutline",
 					"route": "VpbDeadlines",
 					"order": 10
 				},
 				{
 					"id": "VpbPayments",
 					"label": "Tax payments",
-					"icon": "CashMultiple",
+					"icon": "CreditCardOutline",
 					"route": "VpbPayments",
 					"order": 20
 				},
@@ -96,7 +96,7 @@
 				"indexRoute": "VpbDeadlines",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -164,7 +164,7 @@
 						{"id": "documents", "label": "Payment proof", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "TaxPaymentTracking", "objectId": ":id"}}
 						]},
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]

--- a/src/manifest.d/bookkeeping-waterschappen-bbv-variant-04-manifest-routes.json
+++ b/src/manifest.d/bookkeeping-waterschappen-bbv-variant-04-manifest-routes.json
@@ -30,7 +30,7 @@
 				{
 					"id": "BudgetBBVMappings",
 					"label": "Budget Mapping",
-					"icon": "TableArrowRight",
+					"icon": "SwapHorizontal",
 					"route": "BudgetBBVMappings",
 					"order": 20
 				}
@@ -107,7 +107,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/bookkeeping-wbso-sno-administratie.json
+++ b/src/manifest.d/bookkeeping-wbso-sno-administratie.json
@@ -3,14 +3,14 @@
 		{
 			"id": "Bookkeeping",
 			"label": "Bookkeeping",
-			"icon": "BookOpenPageVariantOutline",
+			"icon": "NotebookOutline",
 			"order": 20,
 			"featureFlag": "bookkeeping",
 			"children": [
 				{
 					"id": "WbsoChartOfAccounts",
 					"label": "Chart of Accounts",
-					"icon": "FileTreeOutline",
+					"icon": "NotebookOutline",
 					"route": "WbsoChartOfAccounts",
 					"order": 10
 				},
@@ -24,7 +24,7 @@
 				{
 					"id": "WbsoDocuments",
 					"label": "Documents",
-					"icon": "FileDocumentOutline",
+					"icon": "FileDocumentMultipleOutline",
 					"route": "WbsoDocuments",
 					"order": 30
 				}

--- a/src/manifest.d/bookkeeping-wet-fido-treasury.json
+++ b/src/manifest.d/bookkeeping-wet-fido-treasury.json
@@ -23,7 +23,7 @@
 				{
 					"id": "Treasurystatuten",
 					"label": "Treasurystatuut",
-					"icon": "FileDocumentOutline",
+					"icon": "BankOutline",
 					"route": "Treasurystatuten",
 					"order": 20
 				},
@@ -44,7 +44,7 @@
 				{
 					"id": "QuartaalrapportagesFido",
 					"label": "Quarterly Fido Reports",
-					"icon": "FileChartOutline",
+					"icon": "ChartBoxOutline",
 					"route": "QuartaalrapportagesFido",
 					"order": 50
 				}
@@ -167,7 +167,7 @@
 						{"id": "documents", "label": "Documents", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "Treasurystatuut", "objectId": ":id"}}
 						]},
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -228,7 +228,7 @@
 						{"id": "documents", "label": "Documents", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "Lening", "objectId": ":id"}}
 						]},
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -286,7 +286,7 @@
 						{"id": "documents", "label": "Documents", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "Derivaat", "objectId": ":id"}}
 						]},
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -351,7 +351,7 @@
 						{"id": "documents", "label": "Filed report", "icon": "FileChartOutline", "order": 80, "widgets": [
 							{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "QuartaalrapportageFido", "objectId": ":id"}}
 						]},
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]

--- a/src/manifest.d/compliance-deadline-calendar.json
+++ b/src/manifest.d/compliance-deadline-calendar.json
@@ -10,12 +10,12 @@
 		{
 			"id": "Settings",
 			"label": "Settings",
-			"icon": "icon-settings",
+			"icon": "CogOutline",
 			"children": [
 				{
 					"id": "DeadlineCalendarSettings",
 					"label": "Deadline calendar",
-					"icon": "CalendarClock",
+					"icon": "ClockAlertOutline",
 					"route": "DeadlineCalendarSettings",
 					"order": 30
 				}

--- a/src/manifest.d/consume-platform-abstractions-missing-document-worklist.json
+++ b/src/manifest.d/consume-platform-abstractions-missing-document-worklist.json
@@ -13,7 +13,7 @@
 				{
 					"id": "SupplierInvoicesMissingDocument",
 					"label": "Missing Supplier Documents",
-					"icon": "FileAlertOutline",
+					"icon": "FileDocumentMultipleOutline",
 					"route": "SupplierInvoicesMissingDocument",
 					"order": 29
 				},

--- a/src/manifest.d/contract-lifecycle-management.json
+++ b/src/manifest.d/contract-lifecycle-management.json
@@ -10,13 +10,13 @@
 		{
 			"id": "Contracts",
 			"label": "Contracts",
-			"icon": "FileSignOutline",
+			"icon": "FileSign",
 			"order": 25,
 			"children": [
 				{
 					"id": "Contracts",
 					"label": "Contracts",
-					"icon": "FileSignOutline",
+					"icon": "FileSign",
 					"route": "Contracts",
 					"order": 10
 				},
@@ -30,7 +30,7 @@
 				{
 					"id": "ContractSpend",
 					"label": "Contract Spend",
-					"icon": "ChartLineVariant",
+					"icon": "FileSign",
 					"route": "ContractSpendDashboard",
 					"order": 30
 				}
@@ -180,7 +180,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -270,7 +270,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/dba-compliance-marker.json
+++ b/src/manifest.d/dba-compliance-marker.json
@@ -3,7 +3,7 @@
 		{
 			"id": "DBACompliance",
 			"label": "DBA Compliance",
-			"icon": "ShieldAccountOutline",
+			"icon": "ClipboardCheckOutline",
 			"order": 55,
 			"children": [
 				{
@@ -23,14 +23,14 @@
 				{
 					"id": "DBAModelovereenkomsten",
 					"label": "Model agreement register",
-					"icon": "FileDocumentCheckOutline",
+					"icon": "DatabaseOutline",
 					"route": "DBAModelovereenkomsten",
 					"order": 30
 				},
 				{
 					"id": "DBAPortfolioRisicos",
 					"label": "DBA Portfolio Dashboard",
-					"icon": "ChartArc",
+					"icon": "ViewDashboardOutline",
 					"route": "DBAPortfolioRisicos",
 					"order": 40
 				},
@@ -44,7 +44,7 @@
 				{
 					"id": "DBARisicoflags",
 					"label": "Risk Flags",
-					"icon": "FlagAlertOutline",
+					"icon": "FlagVariantOutline",
 					"route": "DBARisicoflags",
 					"order": 60
 				}
@@ -129,7 +129,7 @@
 						{"id": "documents", "label": "Documents", "icon": "FolderOutline", "order": 80, "widgets": [
 							{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "DBAOpdracht", "objectId": ":id"}}
 						]},
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -192,7 +192,7 @@
 				"indexRoute": "DBAIntakes",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -245,7 +245,7 @@
 						{"id": "documents", "label": "Document", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "DBAModelovereenkomst", "objectId": ":id"}}
 						]},
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -303,7 +303,7 @@
 				"indexRoute": "DBAPortfolioRisicos",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -354,7 +354,7 @@
 						{"id": "documents", "label": "Evidence documents", "icon": "FolderZipOutline", "order": 80, "widgets": [
 							{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "DBAEvidenceDossier", "objectId": ":id"}}
 						]},
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -403,7 +403,7 @@
 				"indexRoute": "DBARisicoflags",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]

--- a/src/manifest.d/expense-reimbursement-or-passthrough.json
+++ b/src/manifest.d/expense-reimbursement-or-passthrough.json
@@ -10,7 +10,7 @@
 		{
 			"id": "ExpenseSettlement",
 			"label": "Expense Settlement",
-			"icon": "ScaleBalance",
+			"icon": "ReceiptOutline",
 			"order": 80,
 			"children": [
 				{
@@ -183,7 +183,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -279,7 +279,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/external-adapters-w8.json
+++ b/src/manifest.d/external-adapters-w8.json
@@ -10,7 +10,7 @@
 				{
 					"id": "ExternalAdaptersStatus",
 					"label": "Adapter Status",
-					"icon": "PulseOutline",
+					"icon": "Pulse",
 					"route": "ExternalAdaptersStatus",
 					"order": 5
 				},
@@ -24,7 +24,7 @@
 				{
 					"id": "ExternalAdapterSalarisbureau",
 					"label": "Payroll bureau",
-					"icon": "AccountGroupOutline",
+					"icon": "CashSync",
 					"route": "ExternalAdapterSalarisbureau",
 					"order": 15
 				},
@@ -80,21 +80,21 @@
 				{
 					"id": "ExternalAdapterKvk",
 					"label": "KvK Trade Register",
-					"icon": "OfficeBuildingOutline",
+					"icon": "DatabaseOutline",
 					"route": "ExternalAdapterKvk",
 					"order": 50
 				},
 				{
 					"id": "ExternalAdapterUwv",
 					"label": "UWV payroll filing",
-					"icon": "AccountGroupOutline",
+					"icon": "CashSync",
 					"route": "ExternalAdapterUwv",
 					"order": 55
 				},
 				{
 					"id": "ExternalAdapterTreasuryRates",
 					"label": "Treasury Rates",
-					"icon": "CurrencyUsd",
+					"icon": "BankOutline",
 					"route": "ExternalAdapterTreasuryRates",
 					"order": 60
 				},
@@ -108,7 +108,7 @@
 				{
 					"id": "ExternalAdapterCsrd",
 					"label": "CSRD ESRS XBRL",
-					"icon": "LeafOutline",
+					"icon": "Leaf",
 					"route": "ExternalAdapterCsrd",
 					"order": 70
 				},

--- a/src/manifest.d/inventory-cycle-count.json
+++ b/src/manifest.d/inventory-cycle-count.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Inventory",
 			"label": "Inventory",
-			"icon": "icon-category-customization",
+			"icon": "Warehouse",
 			"order": 22,
 			"children": [
 				{
@@ -16,14 +16,14 @@
 				{
 					"id": "CountTemplates",
 					"label": "Count Templates",
-					"icon": "FormatListChecks",
+					"icon": "FileReplaceOutline",
 					"route": "CountTemplates",
 					"order": 51
 				},
 				{
 					"id": "VarianceReports",
 					"label": "Variance Reports",
-					"icon": "ChartLineVariantOutline",
+					"icon": "ChartBoxOutline",
 					"route": "VarianceReports",
 					"order": 52
 				}
@@ -79,7 +79,7 @@
 				],
 				"sidebarProps": {
 					"tabs": [
-						{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [ { "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } } ] }
+						{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [ { "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } } ] }
 					]
 				},
 				"fields": [

--- a/src/manifest.d/inventory-mobile-scanner.json
+++ b/src/manifest.d/inventory-mobile-scanner.json
@@ -3,7 +3,7 @@
 		{
 			"id": "Inventory",
 			"label": "Inventory",
-			"icon": "icon-category-files",
+			"icon": "Warehouse",
 			"order": 38,
 			"children": [
 				{

--- a/src/manifest.d/inventory-stock-movement-ledger.json
+++ b/src/manifest.d/inventory-stock-movement-ledger.json
@@ -3,13 +3,13 @@
 		{
 			"id": "Inventory",
 			"label": "Inventory",
-			"icon": "icon-category-customization",
+			"icon": "Warehouse",
 			"order": 22,
 			"children": [
 				{
 					"id": "StockMovements",
 					"label": "Stock Movements",
-					"icon": "SwapHorizontalBoldOutline",
+					"icon": "SwapHorizontalBold",
 					"route": "StockMovements",
 					"order": 45
 				},
@@ -105,7 +105,7 @@
 						{ "id": "documents", "label": "Reference documents", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 							{ "type": "data", "componentName": "openregister-file-references", "props": { "register": "shillinq", "schema": "StockMove", "objectId": ":id" } }
 						] },
-						{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{ "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } }
 						] }
 					]

--- a/src/manifest.d/inventory-valuation-fifo-avg.json
+++ b/src/manifest.d/inventory-valuation-fifo-avg.json
@@ -6,7 +6,7 @@
 				{
 					"id": "InventoryValuations",
 					"label": "Valuations",
-					"icon": "CalculatorOutline",
+					"icon": "Calculator",
 					"route": "InventoryValuations",
 					"order": 30
 				}
@@ -63,7 +63,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{

--- a/src/manifest.d/invoice-from-time-and-expense.json
+++ b/src/manifest.d/invoice-from-time-and-expense.json
@@ -10,20 +10,20 @@
 		{
 			"id": "BillableInvoices",
 			"label": "Invoices",
-			"icon": "FileDocumentEditOutline",
+			"icon": "ReceiptTextOutline",
 			"order": 36,
 			"children": [
 				{
 					"id": "BillableInvoiceList",
 					"label": "All invoices",
-					"icon": "FileDocumentMultipleOutline",
+					"icon": "ReceiptTextOutline",
 					"route": "BillableInvoiceList",
 					"order": 10
 				},
 				{
 					"id": "BillableInvoiceGenerate",
 					"label": "Generate invoice",
-					"icon": "FileDocumentEditOutline",
+					"icon": "ReceiptTextOutline",
 					"route": "BillableInvoiceGenerate",
 					"order": 20
 				}

--- a/src/manifest.d/order-workspace.json
+++ b/src/manifest.d/order-workspace.json
@@ -6,7 +6,7 @@
 		"adr": "ADR-037 modular manifest fragment — the unified Order workspace that replaces the scattered Subsidie / Purchase Order / Quote / Sales Order pages. One Order index (filterable by orderType) + an Order detail that auto-renders the schema and its related Payments + OrderLines."
 	},
 	"menu": [
-		{ "id": "Orders", "label": "Orders", "icon": "FileDocumentMultipleOutline", "route": "Orders", "order": 28 }
+		{ "id": "Orders", "label": "Orders", "icon": "ClipboardListOutline", "route": "Orders", "order": 28 }
 	],
 	"pages": [
 		{
@@ -55,7 +55,7 @@
 					{"id": "documents", "label": "Documents", "icon": "FileDocumentOutline", "order": 80, "widgets": [
 						{"type": "data", "componentName": "openregister-file-references", "props": {"register": "shillinq", "schema": "OrderPrimitive", "objectId": ":id"}}
 					]},
-					{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+					{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 						{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 					]}
 				]

--- a/src/manifest.d/recurring-invoicing.json
+++ b/src/manifest.d/recurring-invoicing.json
@@ -10,7 +10,7 @@
         {
             "id": "RecurringInvoicing",
             "label": "Recurring Invoices",
-            "icon": "CalendarSync",
+            "icon": "ReceiptTextOutline",
             "route": "RecurringInvoiceProfiles",
             "order": 46
         }

--- a/src/manifest.d/retainer-billing-engine.json
+++ b/src/manifest.d/retainer-billing-engine.json
@@ -137,7 +137,7 @@
 				],
 				"indexRoute": "RetainerPools",
 				"sidebarProps": { "tabs": [
-					{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90,
+					{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90,
 						"widgets": [ { "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } } ] }
 				] }
 			}
@@ -221,7 +221,7 @@
 				],
 				"indexRoute": "RetainerDrawdowns",
 				"sidebarProps": { "tabs": [
-					{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90,
+					{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90,
 						"widgets": [ { "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } } ] }
 				] }
 			}
@@ -276,7 +276,7 @@
 				],
 				"indexRoute": "RetainerRollovers",
 				"sidebarProps": { "tabs": [
-					{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90,
+					{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90,
 						"widgets": [ { "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } } ] }
 				] }
 			}
@@ -337,7 +337,7 @@
 				"lifecycleActions": true,
 				"indexRoute": "RetainerTrueUps",
 				"sidebarProps": { "tabs": [
-					{ "id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90,
+					{ "id": "audit", "label": "Audit Trail", "icon": "History", "order": 90,
 						"widgets": [ { "type": "data", "componentName": "openregister-audit-trail", "props": { "source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true } } ] }
 				] }
 			}

--- a/src/manifest.d/zzp-cashflow-13wk.json
+++ b/src/manifest.d/zzp-cashflow-13wk.json
@@ -9,7 +9,7 @@
 				{
 					"id": "CashflowDashboard",
 					"label": "Cashflow Dashboard",
-					"icon": "ChartTimelineVariant",
+					"icon": "ViewDashboardOutline",
 					"route": "CashflowDashboard",
 					"order": 10
 				},
@@ -37,7 +37,7 @@
 				{
 					"id": "CashflowCalibration",
 					"label": "Calibration Report",
-					"icon": "ChartBellCurveCumulative",
+					"icon": "ChartBoxOutline",
 					"route": "CashflowCalibration",
 					"order": 50
 				}
@@ -92,7 +92,7 @@
 				"indexRoute": "CashflowDashboard",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -126,7 +126,7 @@
 				"indexRoute": "CashflowRecurring",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -158,7 +158,7 @@
 				"indexRoute": "CashflowBufferPolicy",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -186,7 +186,7 @@
 				"indexRoute": "CashflowScenarios",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]
@@ -240,7 +240,7 @@
 				"indexRoute": "CashflowCalibration",
 				"sidebarProps": {
 					"tabs": [
-						{"id": "audit", "label": "Audit Trail", "icon": "HistoryIcon", "order": 90, "widgets": [
+						{"id": "audit", "label": "Audit Trail", "icon": "History", "order": 90, "widgets": [
 							{"type": "data", "componentName": "openregister-audit-trail", "props": {"source": "/index.php/apps/openregister/api/objects/shillinq/:schema/:id/audit-trails", "collapsed": true}}
 						]}
 					]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -87,7 +87,7 @@
 		{
 			"id": "Dashboard",
 			"label": "Dashboard",
-			"icon": "icon-category-dashboard",
+			"icon": "ViewDashboardOutline",
 			"route": "Dashboard",
 			"order": 10,
 			"children": []
@@ -109,7 +109,7 @@
 		{
 			"id": "Payroll",
 			"label": "People & Projects",
-			"icon": "TableAccountOutline",
+			"icon": "AccountMultipleOutline",
 			"order": 55,
 			"children": []
 		},
@@ -123,20 +123,20 @@
 		{
 			"id": "ExternalConnections",
 			"label": "External Connections",
-			"icon": "SwapHorizontalBoldOutline",
+			"icon": "TransitConnectionVariant",
 			"order": 80,
 			"children": []
 		},
 		{
 			"id": "Bookkeeping",
 			"label": "Bookkeeping",
-			"icon": "icon-category-organization",
+			"icon": "NotebookOutline",
 			"order": 20,
 			"children": [
 				{
 					"id": "ChartOfAccounts",
 					"label": "Chart of Accounts",
-					"icon": "LedgerOutline",
+					"icon": "NotebookOutline",
 					"route": "ChartOfAccounts",
 					"order": 10
 				},
@@ -150,7 +150,7 @@
 				{
 					"id": "EmuRapportage",
 					"label": "EMU reporting",
-					"icon": "ChartBarOutline",
+					"icon": "ChartBoxOutline",
 					"route": "EmuRapportage",
 					"order": 20
 				},
@@ -171,7 +171,7 @@
 				{
 					"id": "BankReconciliation",
 					"label": "Bank Reconciliation",
-					"icon": "BankCheckOutline",
+					"icon": "BankOutline",
 					"route": "BankReconciliation",
 					"order": 26
 				},
@@ -199,14 +199,14 @@
 				{
 					"id": "Aansluitingen",
 					"label": "Aansluitingen",
-					"icon": "FileCompareOutline",
+					"icon": "FileCompare",
 					"route": "Aansluitingen",
 					"order": 29
 				},
 				{
 					"id": "FixedAssets",
 					"label": "Fixed Assets",
-					"icon": "OfficeBuildingOutline",
+					"icon": "DesktopTowerMonitor",
 					"route": "FixedAssets",
 					"order": 30
 				},
@@ -241,7 +241,7 @@
 				{
 					"id": "DunningKlantOverrides",
 					"label": "Customer overrides",
-					"icon": "AccountSwitchOutline",
+					"icon": "AccountStarOutline",
 					"route": "DunningKlantOverrides",
 					"order": 36
 				},
@@ -269,14 +269,14 @@
 				{
 					"id": "Waterschapsbelastingen",
 					"label": "Water authority taxes",
-					"icon": "WaterOutline",
+					"icon": "PercentOutline",
 					"route": "Waterschapsbelastingen",
 					"order": 40
 				},
 				{
 					"id": "Customers",
 					"label": "Customers",
-					"icon": "AccountTieOutline",
+					"icon": "AccountStarOutline",
 					"route": "Customers",
 					"order": 41
 				},
@@ -304,7 +304,7 @@
 				{
 					"id": "VarianceReport",
 					"label": "Variance Report",
-					"icon": "ChartTimelineVariantShimmer",
+					"icon": "ChartBoxOutline",
 					"route": "VarianceReport",
 					"order": 45
 				},
@@ -318,28 +318,28 @@
 				{
 					"id": "GRVerdeelsleutels",
 					"label": "Allocation keys",
-					"icon": "ScaleBalanceOutline",
+					"icon": "MapMarkerOutline",
 					"route": "GRVerdeelsleutels",
 					"order": 60
 				},
 				{
 					"id": "GRConsolidated",
 					"label": "Consolidated view",
-					"icon": "TableMergeCellsOutline",
+					"icon": "TableMergeCells",
 					"route": "GRConsolidated",
 					"order": 70
 				},
 				{
 					"id": "BalanceSheet",
 					"label": "Balance Sheet",
-					"icon": "TableAccountOutline",
+					"icon": "TableAccount",
 					"route": "BalanceSheet",
 					"order": 80
 				},
 				{
 					"id": "TrialBalance",
 					"label": "Trial Balance",
-					"icon": "ScaleBalanceOutline",
+					"icon": "ScaleBalance",
 					"route": "TrialBalance",
 					"order": 81
 				},
@@ -353,7 +353,7 @@
 				{
 					"id": "ConsolidatedReport",
 					"label": "Consolidated Report",
-					"icon": "FileChartOutline",
+					"icon": "ChartBoxOutline",
 					"route": "ConsolidatedReport",
 					"order": 83
 				},
@@ -374,14 +374,14 @@
 				{
 					"id": "XBRLTaxonomies",
 					"label": "XBRL Taxonomies",
-					"icon": "FileTreeOutline",
+					"icon": "PercentOutline",
 					"route": "XBRLTaxonomies",
 					"order": 85
 				},
 				{
 					"id": "SBRDocuments",
 					"label": "SBR Documents",
-					"icon": "FileDocumentEditOutline",
+					"icon": "FileDocumentMultipleOutline",
 					"route": "SBRDocuments",
 					"order": 86
 				},
@@ -395,7 +395,7 @@
 				{
 					"id": "XBRLMappingValidation",
 					"label": "Mapping Validation",
-					"icon": "ArrowDecisionOutline",
+					"icon": "SwapHorizontal",
 					"route": "XBRLMappingValidation",
 					"order": 87
 				},
@@ -416,7 +416,7 @@
 				{
 					"id": "WBSOExport",
 					"label": "WBSO Export Dashboard",
-					"icon": "FileExportOutline",
+					"icon": "ViewDashboardOutline",
 					"route": "WBSOExport",
 					"order": 88
 				},
@@ -458,56 +458,56 @@
 				{
 					"id": "AllocationRules",
 					"label": "Allocation Rules",
-					"icon": "TransferRight",
+					"icon": "MapMarkerOutline",
 					"route": "AllocationRules",
 					"order": 91
 				},
 				{
 					"id": "SbrXbrlFilings",
 					"label": "SBR/XBRL Filings",
-					"icon": "FileXmlBoxOutline",
+					"icon": "FileXmlBox",
 					"route": "SbrXbrlFilings",
 					"order": 92
 				},
 				{
 					"id": "BookkeepingAuditTrail",
 					"label": "Audit Trail",
-					"icon": "HistoryIcon",
+					"icon": "History",
 					"route": "BookkeepingAuditTrail",
 					"order": 95
 				},
 				{
 					"id": "BookkeepingSigningTrail",
 					"label": "Signing audit trail",
-					"icon": "SignatureFreehand",
+					"icon": "History",
 					"route": "BookkeepingSigningTrail",
 					"order": 96
 				},
 				{
 					"id": "BookkeepingDestructionReport",
 					"label": "Destruction report",
-					"icon": "DeleteSweepOutline",
+					"icon": "ChartBoxOutline",
 					"route": "BookkeepingDestructionReport",
 					"order": 97
 				},
 				{
 					"id": "BookkeepingChangeHistory",
 					"label": "Change history",
-					"icon": "HistoryIcon",
+					"icon": "History",
 					"route": "BookkeepingChangeHistory",
 					"order": 98
 				},
 				{
 					"id": "BookkeepingComplianceExport",
 					"label": "Compliance export",
-					"icon": "FileExportOutline",
+					"icon": "DatabaseExportOutline",
 					"route": "BookkeepingComplianceExport",
 					"order": 99
 				},
 				{
 					"id": "BookkeepingActivityFeed",
 					"label": "Activity feed",
-					"icon": "RssBoxOutline",
+					"icon": "RssBox",
 					"route": "BookkeepingActivityFeed",
 					"order": 100
 				},
@@ -523,13 +523,13 @@
 		{
 			"id": "Inventory",
 			"label": "Inventory",
-			"icon": "icon-category-customization",
+			"icon": "Warehouse",
 			"order": 40,
 			"children": [
 				{
 					"id": "ReorderRules",
 					"label": "Reorder Rules",
-					"icon": "CartArrowDownOutline",
+					"icon": "ClipboardListOutline",
 					"route": "ReorderRules",
 					"order": 30
 				},
@@ -543,14 +543,14 @@
 				{
 					"id": "StockLevelsDashboard",
 					"label": "Stock Levels Dashboard",
-					"icon": "ChartBarOutline",
+					"icon": "ViewDashboardOutline",
 					"route": "StockLevelsDashboard",
 					"order": 50
 				},
 				{
 					"id": "StockLevels",
 					"label": "Stock Levels",
-					"icon": "WarehouseOutline",
+					"icon": "Warehouse",
 					"route": "StockLevels",
 					"order": 51
 				},
@@ -571,7 +571,7 @@
 				{
 					"id": "Barcodes",
 					"label": "Barcodes",
-					"icon": "BarcodeOutline",
+					"icon": "Barcode",
 					"route": "Barcodes",
 					"order": 60
 				},
@@ -585,7 +585,7 @@
 				{
 					"id": "InventoryLots",
 					"label": "Lots & Batches",
-					"icon": "BarcodeOutline",
+					"icon": "Barcode",
 					"route": "InventoryLots",
 					"order": 70
 				},
@@ -599,7 +599,7 @@
 				{
 					"id": "InventoryGLConfig",
 					"label": "Posting configuration",
-					"icon": "BankTransferOutline",
+					"icon": "CogOutline",
 					"route": "InventoryGLConfig",
 					"order": 95
 				},
@@ -615,7 +615,7 @@
 		{
 			"id": "Belastingen",
 			"label": "Taxes",
-			"icon": "icon-category-monitoring",
+			"icon": "PercentOutline",
 			"order": 50,
 			"children": [
 				{
@@ -628,14 +628,14 @@
 				{
 					"id": "TaxFilingPrep",
 					"label": "Tax Filing Prep",
-					"icon": "FileDocumentCheckOutline",
+					"icon": "PercentOutline",
 					"route": "TaxFilingPrep",
 					"order": 20
 				},
 				{
 					"id": "TaxEstimates",
 					"label": "Tax Estimates",
-					"icon": "CalculatorOutline",
+					"icon": "PercentOutline",
 					"route": "TaxEstimates",
 					"order": 30
 				},
@@ -649,14 +649,14 @@
 				{
 					"id": "BtwAangiften",
 					"label": "BTW returns",
-					"icon": "FileDocumentOutline",
+					"icon": "PercentOutline",
 					"route": "BtwAangiften",
 					"order": 50
 				},
 				{
 					"id": "VATByPeriod",
 					"label": "VAT by Period",
-					"icon": "ChartTimelineVariantOutline",
+					"icon": "ChartTimelineVariant",
 					"route": "VATByPeriod",
 					"order": 55
 				},
@@ -670,7 +670,7 @@
 				{
 					"id": "BtwCorrecties",
 					"label": "BTW corrections",
-					"icon": "FileDocumentEditOutline",
+					"icon": "PercentOutline",
 					"route": "BtwCorrecties",
 					"order": 70
 				},
@@ -698,7 +698,7 @@
 				{
 					"id": "TaxProvisions",
 					"label": "Deferred tax",
-					"icon": "CurrencyEur",
+					"icon": "PercentOutline",
 					"route": "TaxProvisions",
 					"order": 110
 				},
@@ -712,7 +712,7 @@
 				{
 					"id": "DeferredTaxMovements",
 					"label": "Movement overview",
-					"icon": "ArrowUpDown",
+					"icon": "ViewDashboardOutline",
 					"route": "DeferredTaxMovements",
 					"order": 112
 				},
@@ -735,13 +735,13 @@
 		{
 			"id": "Administratie",
 			"label": "Administration",
-			"icon": "icon-category-organization",
+			"icon": "ShieldAccountOutline",
 			"order": 30,
 			"children": [
 				{
 					"id": "Bewaartermijnen",
 					"label": "Retention periods",
-					"icon": "ShieldCheckOutline",
+					"icon": "CalendarRemoveOutline",
 					"route": "Bewaartermijnen",
 					"order": 10
 				}
@@ -750,7 +750,7 @@
 		{
 			"id": "Overheid",
 			"label": "Government",
-			"icon": "icon-category-organization",
+			"icon": "Domain",
 			"order": 30,
 			"children": [
 				{
@@ -763,14 +763,14 @@
 				{
 					"id": "Iv3Rapportages",
 					"label": "IV3 reports",
-					"icon": "FileChartOutline",
+					"icon": "ChartBoxOutline",
 					"route": "Iv3Rapportages",
 					"order": 10
 				},
 				{
 					"id": "BbvMapping",
 					"label": "BBV-mapping",
-					"icon": "TableArrowRight",
+					"icon": "SwapHorizontal",
 					"route": "BbvMapping",
 					"order": 20
 				},
@@ -799,7 +799,7 @@
 				{
 					"id": "SubsidiesOverzicht",
 					"label": "Overview",
-					"icon": "TableLarge",
+					"icon": "ViewDashboardOutline",
 					"route": "SubsidiesOverzicht",
 					"order": 10
 				},
@@ -822,20 +822,20 @@
 		{
 			"id": "Compliance",
 			"label": "Reporting & Compliance",
-			"icon": "icon-category-monitoring",
+			"icon": "ChartBoxOutline",
 			"order": 70,
 			"children": [
 				{
 					"id": "SisaRapportages",
 					"label": "SiSa reports",
-					"icon": "FileDocumentCheckOutline",
+					"icon": "ChartBoxOutline",
 					"route": "SisaRapportages",
 					"order": 10
 				},
 				{
 					"id": "ComplianceAuditTrails",
 					"label": "Compliance audit trail",
-					"icon": "ClipboardCheckOutline",
+					"icon": "History",
 					"route": "ComplianceAuditTrails",
 					"order": 20
 				},
@@ -849,7 +849,7 @@
 				{
 					"id": "AuditDocuments",
 					"label": "Audit documents",
-					"icon": "FileSignOutline",
+					"icon": "FileDocumentMultipleOutline",
 					"route": "AuditDocuments",
 					"order": 40
 				},
@@ -863,7 +863,7 @@
 				{
 					"id": "ENSIAEvaluations",
 					"label": "ENSIA Evaluations",
-					"icon": "ClipboardQuestionOutline",
+					"icon": "ClipboardCheckOutline",
 					"route": "ENSIAEvaluations",
 					"order": 45
 				},
@@ -877,14 +877,14 @@
 				{
 					"id": "ENSIAAuditTrail",
 					"label": "ENSIA Audit Trail",
-					"icon": "ClipboardCheckOutline",
+					"icon": "History",
 					"route": "ENSIAAuditTrail",
 					"order": 46
 				},
 				{
 					"id": "ENSIACollegeVerklaring",
 					"label": "ENSIA Executive Board Declaration",
-					"icon": "FileSignOutline",
+					"icon": "ReceiptOutline",
 					"route": "ENSIACollegeVerklaring",
 					"order": 46
 				},
@@ -898,7 +898,7 @@
 				{
 					"id": "DBAPortfolioDashboard",
 					"label": "DBA Portfolio Dashboard",
-					"icon": "ChartDonutVariant",
+					"icon": "ViewDashboardOutline",
 					"route": "DBAPortfolioDashboard",
 					"order": 51
 				},
@@ -912,7 +912,7 @@
 				{
 					"id": "DBAModelovereenkomstRegister",
 					"label": "DBA Model Agreement Register",
-					"icon": "FileDocumentMultipleOutline",
+					"icon": "DatabaseOutline",
 					"route": "DBAModelovereenkomstRegister",
 					"order": 53
 				}
@@ -921,7 +921,7 @@
 		{
 			"id": "Documentation",
 			"label": "Documentation",
-			"icon": "icon-info",
+			"icon": "BookOpenVariantOutline",
 			"href": "https://shillinq.conduction.nl",
 			"section": "footer",
 			"order": 90,
@@ -930,7 +930,7 @@
 		{
 			"id": "FeaturesRoadmapMenu",
 			"label": "Features & roadmap",
-			"icon": "icon-toggle",
+			"icon": "MapMarkerPath",
 			"route": "FeaturesRoadmap",
 			"section": "footer",
 			"order": 91,
@@ -939,7 +939,7 @@
 		{
 			"id": "Settings",
 			"label": "Settings",
-			"icon": "icon-settings",
+			"icon": "CogOutline",
 			"route": "Settings",
 			"section": "settings",
 			"order": 99,
@@ -954,7 +954,7 @@
 				{
 					"id": "ProjectenOverzicht",
 					"label": "Overview",
-					"icon": "TableLarge",
+					"icon": "ViewDashboardOutline",
 					"route": "ProjectenOverzicht",
 					"order": 10
 				},
@@ -977,7 +977,7 @@
 		{
 			"id": "Purchasing",
 			"label": "Purchasing & Inventory",
-			"icon": "CartArrowDownOutline",
+			"icon": "CartArrowDown",
 			"order": 35,
 			"children": [
 				{
@@ -1004,7 +1004,7 @@
 				{
 					"id": "SupplierInvoices",
 					"label": "Supplier Invoices",
-					"icon": "FileDocumentMultipleOutline",
+					"icon": "ReceiptTextOutline",
 					"route": "SupplierInvoices",
 					"order": 7
 				},
@@ -1032,7 +1032,7 @@
 				{
 					"id": "ExpenseClaims",
 					"label": "Expense Claims",
-					"icon": "ClipboardTextOutline",
+					"icon": "ReceiptOutline",
 					"route": "ExpenseClaims",
 					"order": 20
 				},
@@ -1054,7 +1054,7 @@
 				{
 					"id": "CashflowDashboard",
 					"label": "Cashflow Dashboard",
-					"icon": "ChartBarStacked",
+					"icon": "ViewDashboardOutline",
 					"route": "CashflowDashboard",
 					"order": 10
 				},
@@ -1068,7 +1068,7 @@
 				{
 					"id": "CashflowBufferPolicy",
 					"label": "Buffer Policy",
-					"icon": "ShieldHalfFull",
+					"icon": "ShieldCheckOutline",
 					"route": "CashflowBufferPolicy",
 					"order": 30
 				},
@@ -1201,7 +1201,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -1382,7 +1382,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -1500,7 +1500,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -1642,7 +1642,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -1832,7 +1832,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -2115,7 +2115,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -2258,7 +2258,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -2450,7 +2450,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -2583,7 +2583,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -2742,7 +2742,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -2935,7 +2935,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -3070,7 +3070,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -3265,7 +3265,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -3560,7 +3560,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -3693,7 +3693,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -3830,7 +3830,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -3991,7 +3991,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -4320,7 +4320,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -4485,7 +4485,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -4622,7 +4622,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -4713,7 +4713,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -4868,7 +4868,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -5107,7 +5107,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -5633,7 +5633,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -5787,7 +5787,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -5987,7 +5987,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -6132,7 +6132,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -6299,7 +6299,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -6415,7 +6415,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -6588,7 +6588,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -6740,7 +6740,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -6883,7 +6883,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -7031,7 +7031,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -7172,7 +7172,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -7553,7 +7553,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -7662,7 +7662,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -8431,7 +8431,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -8669,7 +8669,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -8798,7 +8798,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -9041,7 +9041,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -9144,7 +9144,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -9314,7 +9314,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -9519,7 +9519,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -9659,7 +9659,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -9833,7 +9833,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -9984,7 +9984,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -10181,7 +10181,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -10474,7 +10474,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -10662,7 +10662,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -10794,7 +10794,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -11027,7 +11027,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -11113,7 +11113,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -11178,7 +11178,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -11246,7 +11246,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -11358,7 +11358,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -11515,7 +11515,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -11682,7 +11682,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -11810,7 +11810,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -12184,7 +12184,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -12494,7 +12494,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -12695,7 +12695,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -12823,7 +12823,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -12997,7 +12997,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -13104,7 +13104,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -13238,7 +13238,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -13521,7 +13521,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -13731,7 +13731,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -13905,7 +13905,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -14116,7 +14116,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -14264,7 +14264,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -14793,7 +14793,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -14954,7 +14954,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -15100,7 +15100,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -15241,7 +15241,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -15373,7 +15373,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -15489,7 +15489,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -15773,7 +15773,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -16020,7 +16020,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -16150,7 +16150,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -16263,7 +16263,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -16498,7 +16498,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -16595,7 +16595,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -16745,7 +16745,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -16918,7 +16918,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -17031,7 +17031,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -17273,7 +17273,7 @@
 					{
 						"id": "cancel",
 						"label": "Cancel",
-						"icon": "CancelOutline",
+						"icon": "Cancel",
 						"visibleWhen": {
 							"field": "reconciliationStatus",
 							"in": [
@@ -17396,7 +17396,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -17620,7 +17620,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -17735,7 +17735,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -17887,7 +17887,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -18014,7 +18014,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -18151,7 +18151,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -18425,7 +18425,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -18612,7 +18612,7 @@
 						{
 							"id": "audit",
 							"label": "Change History",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -18684,7 +18684,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{
@@ -19089,7 +19089,7 @@
 						{
 							"id": "audit",
 							"label": "Audit Trail",
-							"icon": "HistoryIcon",
+							"icon": "History",
 							"order": 90,
 							"widgets": [
 								{


### PR DESCRIPTION
## Why

Menu icons across the fleet had drifted into meaninglessness. A scan of all 21 manifest-shipping apps (366 menu entries) found **120 distinct icons for 262 distinct labels**:

| Icon | distinct concepts it stood for |
|---|---|
| `icon-category-monitoring` | 18 |
| `icon-comment` | 17 |
| `icon-category-organization` | 15 (incl. **Store**, Cases, Contracts, Pipeline) |

…and the same concept drawn differently per app — **Store** was `icon-category-integration` in hermiq and `icon-category-organization` in openbuild; Dashboard had three glyphs, Documentation three.

## What

Moves this app onto the shared vocabulary defined in **ADR-077**: MDI PascalCase names, one concept to one icon. Tier A entries (Dashboard, Documentation, Settings, Store, Features & roadmap) now match every other Conduction app — which is the point: a glyph should mean the same thing wherever a user meets it.

Two defect classes fixed along the way:

- **Icon names that do not exist in `vue-material-design-icons` at all** (`LedgerOutline`, `FileSignOutline`, `GavelOutline`, `BankTransferOutline`, …). They could never resolve — a help-circle at best, nothing in the navigation.
- **Menu entries that rendered with NO icon.** `CnAppNav` resolves an MDI name only through the registry `registerIcons()` populates, with no fallback and no CSS class for non-`icon-*` values. Apps that relied on legacy `icon-*` registered nothing at all and were fine right up until the first MDI name appeared. Live-verified on hrmq before this change: **29 of 72 nav entries rendered blank**.

`src/icons.js` is generated from this app’s own manifests and register files, so every referenced name is registered and the migration **stands on its own against the currently released `@conduction/nextcloud-vue`** — it does not wait on the library-side vocabulary (ConductionNL/nextcloud-vue#563).

## Verification

- **0** menu entries render without an icon (was 51 fleet-wide).
- Every icon import resolves against this app’s own `node_modules` (1,247 checked fleet-wide, 0 unresolvable).
- hydra **gate-60 `icon-vocabulary`** passes: 0 failures, 0 warnings.
- ESLint clean on every changed file.

Spec: ADR-077 — ConductionNL/hydra#408.