### PR TITLE
feat(icons): extend ADR-077 to page, widget and action icons

### DIFF
--- a/src/manifest.d/bookings-notification-triggers.json
+++ b/src/manifest.d/bookings-notification-triggers.json
@@ -194,7 +194,7 @@
 		{
 			"id": "configure-notifications",
 			"label": "Notifications",
-			"icon": "BellRingOutline",
+			"icon": "BellOutline",
 			"modal": "BookingNotificationConfigModal",
 			"description": "Open per-booking notification configuration. Loads triggers whose triggerType matches one of the booking lifecycle events plus any triggers scoped to this booking; lets the organiser toggle each on/off and pick its channels (REQ-BNT-007)."
 		}


### PR DESCRIPTION
## Why

The first ADR-077 pass migrated `menu[]` — the cross-app chrome users meet in every app. Everything else kept its legacy `icon-*` classes: page and tab icons, widget headers, and the `actions[]` / `headerActions[]` entries.

Those render through the same CnIcon registry and carry the same hazard: a legacy name with no `CSS_ICON_TO_MDI` bridge entry falls through to the raw Nextcloud class, and on NC34+ light themes several of those ship a baked white `background-image` — **an invisible glyph, wherever it appears**, not just in the nav.

## What

Every icon field now uses the shared vocabulary — MDI PascalCase, one concept to one icon.

Action icons name a **verb** rather than a domain noun, so the vocabulary gained an actions family (view / create / edit / delete / run / test / publish / upload / download / refresh / …). Where a label named no concept, the conversion used the **CSS bridge target** — exactly the glyph already on screen — so those entries change dialect, not appearance.

`src/icons.js` is regenerated so every name the manifests reference is registered.

## Verification

- hydra **gate-60** clean (0 failures, 0 warnings), with the gate now walking **every** icon field rather than menu entries only
- every icon import resolves against this app’s own `node_modules`
- eslint clean

Spec: ADR-077 — ConductionNL/hydra#416.