### PR TITLE
fix(icons): AppointmentSeries used a kebab-cased icon name that resolves to nothing

### DIFF
--- a/lib/Settings/register.d/60-bookings-depth.json
+++ b/lib/Settings/register.d/60-bookings-depth.json
@@ -3,7 +3,7 @@
         "schemas": {
             "AppointmentSeries": {
                 "slug": "AppointmentSeries",
-                "icon": "calendar-sync",
+                "icon": "CalendarSync",
                 "version": "1.0.0",
                 "title": "Appointment Series",
                 "description": "A recurring appointment series (bookings-depth, recurring-appointment-series). Holds the RRULE-style recurrence definition and the base occurrence template (service, resource, first start, duration). The RecurringSeriesService expands the rule into individual Appointment records, each carrying seriesId + recurrenceIndex, skipping occurrences that violate the existing availability/conflict rules (SlotService). Per bookings/spec.md this realises the Tier-2 recurring-bookings enhancement deferred by the foundation change.",


### PR DESCRIPTION
`AppointmentSeries` carried `"icon": "calendar-sync"`. The MDI name is `CalendarSync` — the kebab-case spelling matches nothing in the registry, so the schema's icon fell back to the help-circle in index and detail headers.

It survived the ADR-077 sweep twice over: gate-60 read manifests but not the OpenRegister register files, and it skipped every lowercase icon value wholesale in order to leave softwarecatalog's ContentBlocks set alone. Both are fixed in ConductionNL/hydra#421 — registers are scanned, and lowercase values are validated against the declared ContentBlocks list rather than ignored.

`CalendarSync` is already registered in `src/icons.js`, so this is the only change needed.