### PR TITLE
perf(events): declare register/schema interest for 9 object-event listeners

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -144,6 +144,8 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
  */
 class Application extends App implements IBootstrap
 {
+    use FilteredObjectListenerTrait;
+
     public const APP_ID = 'shillinq';
 
     /**
@@ -203,9 +205,16 @@ class Application extends App implements IBootstrap
         // created with status `pending_confirmation` (customer self-service).
         // Admin-created bookings start `confirmed` and the listener ignores
         // them. Idempotent: OR fires the event once per saveObject.
-        $context->registerEventListener(
+        //
+        // Interest declared at registration time: `isAppointmentSchema()`
+        // accepts `appointment` or `…/appointment`, i.e. exactly the
+        // `Appointment` schema slug. No register is declared — every register
+        // slug in this app comes from deployment configuration.
+        $this->registerFilteredObjectListener(
+            context: $context,
             event: ObjectCreatedEvent::class,
-            listener: AppointmentCreatedListener::class
+            listener: AppointmentCreatedListener::class,
+            schemas: ['Appointment']
         );
 
         // Inventory-valuation-fifo-avg REQ-INV-003 / REQ-INV-004 / REQ-INV-007
@@ -233,13 +242,21 @@ class Application extends App implements IBootstrap
         // lease's list-form transitions block ObjectTransitionedEvent
         // (design D1), so the executing trigger is the create/update event
         // dispatched by MagicMapper on the generic lease CRUD save path.
-        $context->registerEventListener(
+        //
+        // Interest declared at registration time: the handler's own
+        // `isLeaseContractSchema()` accepts `leasecontract` or
+        // `…/leasecontract`, i.e. exactly the `LeaseContract` schema slug.
+        $this->registerFilteredObjectListener(
+            context: $context,
             event: ObjectCreatedEvent::class,
-            listener: LeaseActivationListener::class
+            listener: LeaseActivationListener::class,
+            schemas: ['LeaseContract']
         );
-        $context->registerEventListener(
+        $this->registerFilteredObjectListener(
+            context: $context,
             event: ObjectUpdatedEvent::class,
-            listener: LeaseActivationListener::class
+            listener: LeaseActivationListener::class,
+            schemas: ['LeaseContract']
         );
 
         // Bookkeeping-purchase-order-3way slice 05 (REQ-PO3W-004) —
@@ -247,6 +264,11 @@ class Application extends App implements IBootstrap
         // every received Peppol message. This listener filters on the
         // documentType=Invoice slice of those events and dispatches the
         // UBL payload into SupplierInvoiceService::ingestUBLInvoice().
+        //
+        // NOT narrowed (deliberate): the only slug the handler accepts is
+        // `PeppolInboundMessage`, owned by openconnector and resolving to no
+        // schema here. A declaration that resolves to nothing means the
+        // listener never fires — worse than keeping it global.
         $context->registerEventListener(
             event: ObjectCreatedEvent::class,
             listener: PeppolInboundUblInvoiceListener::class
@@ -303,9 +325,16 @@ class Application extends App implements IBootstrap
         // listener reconciles it against the linked OssReturn and drives the
         // record to `reconciled` or `discrepancy` (both declared transitions
         // out of `pending`). Fail-soft.
-        $context->registerEventListener(
+        //
+        // Interest declared at registration time: the handler compares the
+        // normalised schema against `osspayment` / `oss-payment`, so both
+        // spellings are declared (the hyphenated one is unused here; declaring
+        // it is over-inclusive and therefore fail-safe where it is seeded).
+        $this->registerFilteredObjectListener(
+            context: $context,
             event: ObjectCreatedEvent::class,
-            listener: OssPaymentReconciliationListener::class
+            listener: OssPaymentReconciliationListener::class,
+            schemas: ['OssPayment', 'oss-payment']
         );
 
         // Change add-invoice-pdf-export-with-ubl-peppol-support REQ-EINV-005 — consume
@@ -340,9 +369,14 @@ class Application extends App implements IBootstrap
                 return $c->get(PersistentTimelineRetryQueue::class);
             }
         );
-        $context->registerEventListener(
+        // Interest declared at registration time: the handler's own
+        // `isAppointmentSchema()` mirrors AppointmentCreatedListener's and
+        // accepts `appointment` or `…/appointment`.
+        $this->registerFilteredObjectListener(
+            context: $context,
             event: ObjectCreatedEvent::class,
-            listener: BookingCreatedTimelinePublishListener::class
+            listener: BookingCreatedTimelinePublishListener::class,
+            schemas: ['Appointment']
         );
 
         // Bookings-pipelinq-customer-bridge slice 08 — extend the timeline
@@ -376,13 +410,22 @@ class Application extends App implements IBootstrap
         // (REQ-BBVW-006). The listener drops the cache namespace so the
         // next dashboard render repopulates from the engine. Fail-soft:
         // a cache hiccup never blocks a GL write (giant D3).
-        $context->registerEventListener(
+        //
+        // Interest declared at registration time: the declared slugs are the
+        // listener's own WATCHED_SCHEMAS constant verbatim. `GLTransactionLine`
+        // resolves to nothing on the reference instance but is declared anyway
+        // because the guard names it — over-inclusion is fail-safe.
+        $this->registerFilteredObjectListener(
+            context: $context,
             event: ObjectCreatedEvent::class,
-            listener: GLTransactionComplianceCacheListener::class
+            listener: GLTransactionComplianceCacheListener::class,
+            schemas: ['GLTransaction', 'GLLine', 'GLTransactionLine']
         );
-        $context->registerEventListener(
+        $this->registerFilteredObjectListener(
+            context: $context,
             event: ObjectUpdatedEvent::class,
-            listener: GLTransactionComplianceCacheListener::class
+            listener: GLTransactionComplianceCacheListener::class,
+            schemas: ['GLTransaction', 'GLLine', 'GLTransactionLine']
         );
 
         // Bookkeeping-innovatiebox-administratie — append an immutable
@@ -394,13 +437,20 @@ class Application extends App implements IBootstrap
         // arrives on a VSO-locked year (REQ-IBA-008). Tasks 5.1-5.3.
         // Fail-soft: the listener never bubbles an error into OR's write
         // path; a logging failure becomes a Psr warning.
-        $context->registerEventListener(
+        //
+        // Interest declared at registration time: the three slugs are the
+        // listener's own SCHEMA_NEXUS / SCHEMA_PROFIT / SCHEMA_LOSS constants.
+        $this->registerFilteredObjectListener(
+            context: $context,
             event: ObjectCreatedEvent::class,
-            listener: InnovatieboxAuditTrailListener::class
+            listener: InnovatieboxAuditTrailListener::class,
+            schemas: ['NexusCalculation', 'IBProfitAttribution', 'CarryForwardLoss']
         );
-        $context->registerEventListener(
+        $this->registerFilteredObjectListener(
+            context: $context,
             event: ObjectUpdatedEvent::class,
-            listener: InnovatieboxAuditTrailListener::class
+            listener: InnovatieboxAuditTrailListener::class,
+            schemas: ['NexusCalculation', 'IBProfitAttribution', 'CarryForwardLoss']
         );
 
         // Bookkeeping-reconciliation-reports (T4) — REQ-REC-010. T2's
@@ -414,9 +464,15 @@ class Application extends App implements IBootstrap
             event: ObjectTransitionedEvent::class,
             listener: ReconciliationMatchToReportListener::class
         );
-        $context->registerEventListener(
+        // Interest declared on the create path only: the handler requires
+        // `strcasecmp($schema, 'ReconciliationMatch') === 0`. The
+        // ObjectTransitionedEvent registration above stays global — this
+        // change deliberately narrows only the create/update firehose.
+        $this->registerFilteredObjectListener(
+            context: $context,
             event: ObjectCreatedEvent::class,
-            listener: ReconciliationMatchToReportListener::class
+            listener: ReconciliationMatchToReportListener::class,
+            schemas: ['ReconciliationMatch']
         );
 
         // Wire the DoorsnijdingsVerbodValidator with the optional audit
@@ -696,6 +752,11 @@ class Application extends App implements IBootstrap
         // factuur creation. The listener runs the VBAR uurtarief-toets
         // (REQ-DBA-016) when an ARInvoice/APInvoice carries a
         // `dbaOpdrachtId` field; it is silently inert otherwise.
+        //
+        // NOT narrowed (deliberate): the handler carries no schema guard at
+        // all — its interest is the PRESENCE of a `dbaOpdrachtId` field,
+        // whatever schema carries it. Declaring ARInvoice/APInvoice would
+        // narrow behaviour on an assumption the code does not state.
         $context->registerEventListener(
             event: ObjectCreatedEvent::class,
             listener: DBAFactuurMonitorListener::class
@@ -713,9 +774,16 @@ class Application extends App implements IBootstrap
         // winning KvK matches the tenant org (REQ-002 idempotent on
         // bronReferentie + REQ-003 milestone plan generated from the
         // opdrachttype template).
-        $context->registerEventListener(
+        //
+        // Interest declared on the create path: `isAanbestedingSchema()`
+        // resolves to the `TenderNedAanbesteding` schema, the same slug the
+        // handler writes back with `->setSchema('TenderNedAanbesteding')`.
+        // The ObjectTransitionedEvent registration below stays global.
+        $this->registerFilteredObjectListener(
+            context: $context,
             event: ObjectCreatedEvent::class,
-            listener: TenderNedAwardDetectedListener::class
+            listener: TenderNedAwardDetectedListener::class,
+            schemas: ['TenderNedAanbesteding']
         );
         $context->registerEventListener(
             event: ObjectTransitionedEvent::class,
@@ -726,9 +794,16 @@ class Application extends App implements IBootstrap
         // `obligation.activated` CloudEvent on auto-promoted (created
         // active) AND manually-enriched (transitioned to active)
         // tenderned-sourced obligations (REQ-007 budget-impact pipeline).
-        $context->registerEventListener(
+        //
+        // Interest declared on the create path: `isVerplichtingSchema()`
+        // resolves to the `Verplichting` schema, the same slug
+        // TenderNedAwardDetectedListener writes with `->setSchema(…)`.
+        // The ObjectTransitionedEvent registration below stays global.
+        $this->registerFilteredObjectListener(
+            context: $context,
             event: ObjectCreatedEvent::class,
-            listener: VerplichtingTransitionListener::class
+            listener: VerplichtingTransitionListener::class,
+            schemas: ['Verplichting']
         );
         $context->registerEventListener(
             event: ObjectTransitionedEvent::class,
@@ -855,6 +930,12 @@ class Application extends App implements IBootstrap
         // is fail-soft (design.md Open Question: no separate signed/executed
         // state exists on the shipped Contract schema, so `active` is
         // treated as the trigger and any denial is only logged).
+        //
+        // NOT narrowed (deliberate): the handler matches on
+        // `str_ends_with($schema, 'contract')`, a suffix wildcard covering six
+        // distinct schemas today (contract, employmentcontract, fxcontract,
+        // leasecontract, suppliercontract, synchronization_contract) plus any
+        // future `*contract` slug — not statically enumerable.
         $context->registerEventListener(
             event: ObjectCreatedEvent::class,
             listener: CommitmentMaterialisationListener::class

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -131,6 +131,7 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\EventDispatcher\IEventDispatcher;
 
 /**
  * Main application class for the Shillinq Nextcloud app.
@@ -200,23 +201,6 @@ class Application extends App implements IBootstrap
             listener: DeepLinkRegistrationListener::class
         );
 
-        // Bookings-confirm-flow REQ-BCF-001/010 — issue a ConfirmationToken
-        // + dispatch the confirmation email when a new Appointment record is
-        // created with status `pending_confirmation` (customer self-service).
-        // Admin-created bookings start `confirmed` and the listener ignores
-        // them. Idempotent: OR fires the event once per saveObject.
-        //
-        // Interest declared at registration time: `isAppointmentSchema()`
-        // accepts `appointment` or `…/appointment`, i.e. exactly the
-        // `Appointment` schema slug. No register is declared — every register
-        // slug in this app comes from deployment configuration.
-        $this->registerFilteredObjectListener(
-            context: $context,
-            event: ObjectCreatedEvent::class,
-            listener: AppointmentCreatedListener::class,
-            schemas: ['Appointment']
-        );
-
         // Inventory-valuation-fifo-avg REQ-INV-003 / REQ-INV-004 / REQ-INV-007
         // — dispatch posted StockMove records into the valuation engine
         // (FIFO or moving-average per the InventoryValuation.valuationMethod)
@@ -233,30 +217,6 @@ class Application extends App implements IBootstrap
         $context->registerEventListener(
             event: ObjectTransitionedEvent::class,
             listener: DeliveryDispatchListener::class
-        );
-
-        // IFRS-16 lease schedule trigger (revive-lease-capabilities,
-        // shillinq#446). When a LeaseContract is created already `active` or is
-        // updated across the `draft → active` edge, materialise its
-        // amortization schedule. OR has no lifecycle action executor and the
-        // lease's list-form transitions block ObjectTransitionedEvent
-        // (design D1), so the executing trigger is the create/update event
-        // dispatched by MagicMapper on the generic lease CRUD save path.
-        //
-        // Interest declared at registration time: the handler's own
-        // `isLeaseContractSchema()` accepts `leasecontract` or
-        // `…/leasecontract`, i.e. exactly the `LeaseContract` schema slug.
-        $this->registerFilteredObjectListener(
-            context: $context,
-            event: ObjectCreatedEvent::class,
-            listener: LeaseActivationListener::class,
-            schemas: ['LeaseContract']
-        );
-        $this->registerFilteredObjectListener(
-            context: $context,
-            event: ObjectUpdatedEvent::class,
-            listener: LeaseActivationListener::class,
-            schemas: ['LeaseContract']
         );
 
         // Bookkeeping-purchase-order-3way slice 05 (REQ-PO3W-004) —
@@ -315,28 +275,6 @@ class Application extends App implements IBootstrap
             listener: IntercompanyLinkListener::class
         );
 
-        // Revive-gl-tax-capabilities (shillinq#446) REQ-GLTAX-004 — the
-        // missing OSS-VAT distribution check.
-        // OssPaymentReconciliation::reconcileDistribution() (REQ-OSS-008) is
-        // the only control that catches the Belastingdienst distributing a
-        // consolidated EU-VAT payment differently from what was declared, and
-        // it had zero callers. An OssPayment carries the confirmed
-        // per-country distribution, so its creation is the trigger: the
-        // listener reconciles it against the linked OssReturn and drives the
-        // record to `reconciled` or `discrepancy` (both declared transitions
-        // out of `pending`). Fail-soft.
-        //
-        // Interest declared at registration time: the handler compares the
-        // normalised schema against `osspayment` / `oss-payment`, so both
-        // spellings are declared (the hyphenated one is unused here; declaring
-        // it is over-inclusive and therefore fail-safe where it is seeded).
-        $this->registerFilteredObjectListener(
-            context: $context,
-            event: ObjectCreatedEvent::class,
-            listener: OssPaymentReconciliationListener::class,
-            schemas: ['OssPayment', 'oss-payment']
-        );
-
         // Change add-invoice-pdf-export-with-ubl-peppol-support REQ-EINV-005 — consume
         // the cross-app `nl.conduction.peppol.delivery.status` cloud event
         // openconnector's Peppol access point emits and advance
@@ -363,20 +301,15 @@ class Application extends App implements IBootstrap
         // PipelinqTimelineRetryJob tick to the IJobList. The job retries
         // with exponential backoff (1m/5m/30m) and dead-letters into
         // TimelineDeadLetter on exhaustion (D3 in the giant).
+        //
+        // Only the queue binding lives here: the listener itself
+        // (BookingCreatedTimelinePublishListener) declares a schema interest and
+        // is therefore subscribed from boot().
         $context->registerService(
             TimelineRetryQueue::class,
             static function ($c): TimelineRetryQueue {
                 return $c->get(PersistentTimelineRetryQueue::class);
             }
-        );
-        // Interest declared at registration time: the handler's own
-        // `isAppointmentSchema()` mirrors AppointmentCreatedListener's and
-        // accepts `appointment` or `…/appointment`.
-        $this->registerFilteredObjectListener(
-            context: $context,
-            event: ObjectCreatedEvent::class,
-            listener: BookingCreatedTimelinePublishListener::class,
-            schemas: ['Appointment']
         );
 
         // Bookings-pipelinq-customer-bridge slice 08 — extend the timeline
@@ -401,58 +334,6 @@ class Application extends App implements IBootstrap
             listener: BookingLifecycleTransitionListener::class
         );
 
-        // Bookkeeping-waterschappen-bbv-variant slice 08 — invalidate the
-        // BBV-compliance cache when a GL transaction header or line is
-        // created or updated. The slice-02 x-openregister-aggregations
-        // block on BBVProgramme materialises totalBudget / ytdSpend /
-        // utilization / complianceStatus over those very lines, and
-        // ComplianceService caches the per-programme envelope for 1h
-        // (REQ-BBVW-006). The listener drops the cache namespace so the
-        // next dashboard render repopulates from the engine. Fail-soft:
-        // a cache hiccup never blocks a GL write (giant D3).
-        //
-        // Interest declared at registration time: the declared slugs are the
-        // listener's own WATCHED_SCHEMAS constant verbatim. `GLTransactionLine`
-        // resolves to nothing on the reference instance but is declared anyway
-        // because the guard names it — over-inclusion is fail-safe.
-        $this->registerFilteredObjectListener(
-            context: $context,
-            event: ObjectCreatedEvent::class,
-            listener: GLTransactionComplianceCacheListener::class,
-            schemas: ['GLTransaction', 'GLLine', 'GLTransactionLine']
-        );
-        $this->registerFilteredObjectListener(
-            context: $context,
-            event: ObjectUpdatedEvent::class,
-            listener: GLTransactionComplianceCacheListener::class,
-            schemas: ['GLTransaction', 'GLLine', 'GLTransactionLine']
-        );
-
-        // Bookkeeping-innovatiebox-administratie — append an immutable
-        // InnovatieboxAuditEvent per relevant lifecycle transition on the
-        // three innovatiebox subject schemas (NexusCalculation,
-        // IBProfitAttribution, CarryForwardLoss). Captures *.created,
-        // IBProfitAttribution.finalized (vso_locked: false -> true) and
-        // IBProfitAttribution.amendment_attempt_blocked when an update
-        // arrives on a VSO-locked year (REQ-IBA-008). Tasks 5.1-5.3.
-        // Fail-soft: the listener never bubbles an error into OR's write
-        // path; a logging failure becomes a Psr warning.
-        //
-        // Interest declared at registration time: the three slugs are the
-        // listener's own SCHEMA_NEXUS / SCHEMA_PROFIT / SCHEMA_LOSS constants.
-        $this->registerFilteredObjectListener(
-            context: $context,
-            event: ObjectCreatedEvent::class,
-            listener: InnovatieboxAuditTrailListener::class,
-            schemas: ['NexusCalculation', 'IBProfitAttribution', 'CarryForwardLoss']
-        );
-        $this->registerFilteredObjectListener(
-            context: $context,
-            event: ObjectUpdatedEvent::class,
-            listener: InnovatieboxAuditTrailListener::class,
-            schemas: ['NexusCalculation', 'IBProfitAttribution', 'CarryForwardLoss']
-        );
-
         // Bookkeeping-reconciliation-reports (T4) — REQ-REC-010. T2's
         // bookkeeping-bank-reconciliation engine confirms a
         // ReconciliationMatch by transitioning its status to `confirmed`;
@@ -460,19 +341,12 @@ class Application extends App implements IBootstrap
         // matchedAt, glTransactionId/arInvoiceId/apTransactionId, etc.) on
         // the same record so the open BankReconciliation session sees the
         // outcome within 1s. Fail-soft: never blocks the T2 write.
+        //
+        // This ObjectTransitionedEvent registration stays global; the narrowed
+        // create path is subscribed from boot().
         $context->registerEventListener(
             event: ObjectTransitionedEvent::class,
             listener: ReconciliationMatchToReportListener::class
-        );
-        // Interest declared on the create path only: the handler requires
-        // `strcasecmp($schema, 'ReconciliationMatch') === 0`. The
-        // ObjectTransitionedEvent registration above stays global — this
-        // change deliberately narrows only the create/update firehose.
-        $this->registerFilteredObjectListener(
-            context: $context,
-            event: ObjectCreatedEvent::class,
-            listener: ReconciliationMatchToReportListener::class,
-            schemas: ['ReconciliationMatch']
         );
 
         // Wire the DoorsnijdingsVerbodValidator with the optional audit
@@ -775,16 +649,8 @@ class Application extends App implements IBootstrap
         // bronReferentie + REQ-003 milestone plan generated from the
         // opdrachttype template).
         //
-        // Interest declared on the create path: `isAanbestedingSchema()`
-        // resolves to the `TenderNedAanbesteding` schema, the same slug the
-        // handler writes back with `->setSchema('TenderNedAanbesteding')`.
-        // The ObjectTransitionedEvent registration below stays global.
-        $this->registerFilteredObjectListener(
-            context: $context,
-            event: ObjectCreatedEvent::class,
-            listener: TenderNedAwardDetectedListener::class,
-            schemas: ['TenderNedAanbesteding']
-        );
+        // The create path is narrowed and therefore subscribed from boot(); the
+        // ObjectTransitionedEvent registration below stays global.
         $context->registerEventListener(
             event: ObjectTransitionedEvent::class,
             listener: TenderNedAwardDetectedListener::class
@@ -795,16 +661,8 @@ class Application extends App implements IBootstrap
         // active) AND manually-enriched (transitioned to active)
         // tenderned-sourced obligations (REQ-007 budget-impact pipeline).
         //
-        // Interest declared on the create path: `isVerplichtingSchema()`
-        // resolves to the `Verplichting` schema, the same slug
-        // TenderNedAwardDetectedListener writes with `->setSchema(…)`.
-        // The ObjectTransitionedEvent registration below stays global.
-        $this->registerFilteredObjectListener(
-            context: $context,
-            event: ObjectCreatedEvent::class,
-            listener: VerplichtingTransitionListener::class,
-            schemas: ['Verplichting']
-        );
+        // The create path is narrowed and therefore subscribed from boot(); the
+        // ObjectTransitionedEvent registration below stays global.
         $context->registerEventListener(
             event: ObjectTransitionedEvent::class,
             listener: VerplichtingTransitionListener::class
@@ -1377,13 +1235,184 @@ class Application extends App implements IBootstrap
     /**
      * Boot the application.
      *
+     * Every object-event listener that declares a schema interest is subscribed
+     * here rather than in register(): OpenRegister's `ObjectEventSubscription`
+     * is only guaranteed autoloadable once every app's register() has run. See
+     * {@see FilteredObjectListenerTrait::registerFilteredObjectListener()}.
+     *
      * @param IBootContext $context The boot context
      *
      * @return void
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function boot(IBootContext $context): void
     {
+        $dispatcher = $context->getServerContainer()->get(IEventDispatcher::class);
+
+        // Bookings-confirm-flow REQ-BCF-001/010 — issue a ConfirmationToken
+        // + dispatch the confirmation email when a new Appointment record is
+        // created with status `pending_confirmation` (customer self-service).
+        // Admin-created bookings start `confirmed` and the listener ignores
+        // them. Idempotent: OR fires the event once per saveObject.
+        //
+        // Interest declared up front: `isAppointmentSchema()` accepts
+        // `appointment` or `…/appointment`, i.e. exactly the `Appointment`
+        // schema slug. No register is declared — every register slug in this
+        // app comes from deployment configuration.
+        $this->registerFilteredObjectListener(
+            dispatcher: $dispatcher,
+            event: ObjectCreatedEvent::class,
+            listener: AppointmentCreatedListener::class,
+            schemas: ['Appointment']
+        );
+
+        // IFRS-16 lease schedule trigger (revive-lease-capabilities,
+        // shillinq#446). When a LeaseContract is created already `active` or is
+        // updated across the `draft → active` edge, materialise its
+        // amortization schedule. OR has no lifecycle action executor and the
+        // lease's list-form transitions block ObjectTransitionedEvent
+        // (design D1), so the executing trigger is the create/update event
+        // dispatched by MagicMapper on the generic lease CRUD save path.
+        //
+        // Interest declared up front: the handler's own
+        // `isLeaseContractSchema()` accepts `leasecontract` or
+        // `…/leasecontract`, i.e. exactly the `LeaseContract` schema slug.
+        $this->registerFilteredObjectListener(
+            dispatcher: $dispatcher,
+            event: ObjectCreatedEvent::class,
+            listener: LeaseActivationListener::class,
+            schemas: ['LeaseContract']
+        );
+        $this->registerFilteredObjectListener(
+            dispatcher: $dispatcher,
+            event: ObjectUpdatedEvent::class,
+            listener: LeaseActivationListener::class,
+            schemas: ['LeaseContract']
+        );
+
+        // Revive-gl-tax-capabilities (shillinq#446) REQ-GLTAX-004 — the
+        // missing OSS-VAT distribution check.
+        // OssPaymentReconciliation::reconcileDistribution() (REQ-OSS-008) is
+        // the only control that catches the Belastingdienst distributing a
+        // consolidated EU-VAT payment differently from what was declared, and
+        // it had zero callers. An OssPayment carries the confirmed
+        // per-country distribution, so its creation is the trigger: the
+        // listener reconciles it against the linked OssReturn and drives the
+        // record to `reconciled` or `discrepancy` (both declared transitions
+        // out of `pending`). Fail-soft.
+        //
+        // Interest declared up front: the handler compares the normalised
+        // schema against `osspayment` / `oss-payment`, so both spellings are
+        // declared (the hyphenated one is unused here; declaring it is
+        // over-inclusive and therefore fail-safe where it is seeded).
+        $this->registerFilteredObjectListener(
+            dispatcher: $dispatcher,
+            event: ObjectCreatedEvent::class,
+            listener: OssPaymentReconciliationListener::class,
+            schemas: ['OssPayment', 'oss-payment']
+        );
+
+        // Bookings-pipelinq-customer-bridge slice 07 — publish a
+        // `booking.created` event to pipelinq's klantbeeld-360 timeline (the
+        // TimelineRetryQueue / PipelinqAdminNotifier bindings this listener
+        // uses are registered in register()).
+        //
+        // Interest declared up front: the handler's own
+        // `isAppointmentSchema()` mirrors AppointmentCreatedListener's and
+        // accepts `appointment` or `…/appointment`.
+        $this->registerFilteredObjectListener(
+            dispatcher: $dispatcher,
+            event: ObjectCreatedEvent::class,
+            listener: BookingCreatedTimelinePublishListener::class,
+            schemas: ['Appointment']
+        );
+
+        // Bookkeeping-waterschappen-bbv-variant slice 08 — invalidate the
+        // BBV-compliance cache when a GL transaction header or line is
+        // created or updated. The slice-02 x-openregister-aggregations
+        // block on BBVProgramme materialises totalBudget / ytdSpend /
+        // utilization / complianceStatus over those very lines, and
+        // ComplianceService caches the per-programme envelope for 1h
+        // (REQ-BBVW-006). The listener drops the cache namespace so the
+        // next dashboard render repopulates from the engine. Fail-soft:
+        // a cache hiccup never blocks a GL write (giant D3).
+        //
+        // Interest declared up front: the declared slugs are the listener's own
+        // WATCHED_SCHEMAS constant verbatim. `GLTransactionLine` resolves to
+        // nothing on the reference instance but is declared anyway because the
+        // guard names it — over-inclusion is fail-safe.
+        $this->registerFilteredObjectListener(
+            dispatcher: $dispatcher,
+            event: ObjectCreatedEvent::class,
+            listener: GLTransactionComplianceCacheListener::class,
+            schemas: ['GLTransaction', 'GLLine', 'GLTransactionLine']
+        );
+        $this->registerFilteredObjectListener(
+            dispatcher: $dispatcher,
+            event: ObjectUpdatedEvent::class,
+            listener: GLTransactionComplianceCacheListener::class,
+            schemas: ['GLTransaction', 'GLLine', 'GLTransactionLine']
+        );
+
+        // Bookkeeping-innovatiebox-administratie — append an immutable
+        // InnovatieboxAuditEvent per relevant lifecycle transition on the
+        // three innovatiebox subject schemas (NexusCalculation,
+        // IBProfitAttribution, CarryForwardLoss). Captures *.created,
+        // IBProfitAttribution.finalized (vso_locked: false -> true) and
+        // IBProfitAttribution.amendment_attempt_blocked when an update
+        // arrives on a VSO-locked year (REQ-IBA-008). Tasks 5.1-5.3.
+        // Fail-soft: the listener never bubbles an error into OR's write
+        // path; a logging failure becomes a Psr warning.
+        //
+        // Interest declared up front: the three slugs are the listener's own
+        // SCHEMA_NEXUS / SCHEMA_PROFIT / SCHEMA_LOSS constants.
+        $this->registerFilteredObjectListener(
+            dispatcher: $dispatcher,
+            event: ObjectCreatedEvent::class,
+            listener: InnovatieboxAuditTrailListener::class,
+            schemas: ['NexusCalculation', 'IBProfitAttribution', 'CarryForwardLoss']
+        );
+        $this->registerFilteredObjectListener(
+            dispatcher: $dispatcher,
+            event: ObjectUpdatedEvent::class,
+            listener: InnovatieboxAuditTrailListener::class,
+            schemas: ['NexusCalculation', 'IBProfitAttribution', 'CarryForwardLoss']
+        );
+
+        // Bookkeeping-reconciliation-reports (T4) — REQ-REC-010. Interest
+        // declared on the create path only: the handler requires
+        // `strcasecmp($schema, 'ReconciliationMatch') === 0`. The
+        // ObjectTransitionedEvent registration in register() stays global —
+        // this change deliberately narrows only the create/update firehose.
+        $this->registerFilteredObjectListener(
+            dispatcher: $dispatcher,
+            event: ObjectCreatedEvent::class,
+            listener: ReconciliationMatchToReportListener::class,
+            schemas: ['ReconciliationMatch']
+        );
+
+        // Bookkeeping-tenderned-integratie Task 5.1 — interest declared on the
+        // create path: `isAanbestedingSchema()` resolves to the
+        // `TenderNedAanbesteding` schema, the same slug the handler writes back
+        // with `->setSchema('TenderNedAanbesteding')`. The
+        // ObjectTransitionedEvent registration in register() stays global.
+        $this->registerFilteredObjectListener(
+            dispatcher: $dispatcher,
+            event: ObjectCreatedEvent::class,
+            listener: TenderNedAwardDetectedListener::class,
+            schemas: ['TenderNedAanbesteding']
+        );
+
+        // Bookkeeping-tenderned-integratie Task 5.2 — interest declared on the
+        // create path: `isVerplichtingSchema()` resolves to the `Verplichting`
+        // schema, the same slug TenderNedAwardDetectedListener writes with
+        // `->setSchema(…)`. The ObjectTransitionedEvent registration in
+        // register() stays global.
+        $this->registerFilteredObjectListener(
+            dispatcher: $dispatcher,
+            event: ObjectCreatedEvent::class,
+            listener: VerplichtingTransitionListener::class,
+            schemas: ['Verplichting']
+        );
+
     }//end boot()
 }//end class

--- a/lib/AppInfo/FilteredObjectListenerTrait.php
+++ b/lib/AppInfo/FilteredObjectListenerTrait.php
@@ -20,7 +20,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\AppInfo;
 
-use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\EventDispatcher\IEventDispatcher;
 
 /**
  * Registers object-lifecycle listeners that declare their interest up front.
@@ -54,11 +54,19 @@ trait FilteredObjectListenerTrait
      * The per-handler self-filter guards are deliberately left in place: the
      * declaration narrows *dispatch*, the guard still decides *work*.
      *
-     * @param IRegistrationContext   $context   Registration context.
-     * @param string                 $event     OpenRegister event class name.
-     * @param string                 $listener  Listener class name.
-     * @param array<int,string>|null $registers Register slugs the listener reacts to, or null for all.
-     * @param array<int,string>|null $schemas   Schema slugs the listener reacts to, or null for all.
+     * This MUST be called from boot(), never from register(). Nextcloud enables
+     * each app's autoloader immediately before calling THAT app's own
+     * register(), so from register() the `class_exists()` guard below is
+     * boot-order dependent: OpenRegister's classes are only autoloadable to apps
+     * that happen to register after it, and every earlier app silently took the
+     * unfiltered fallback branch. boot() runs only after every app's register()
+     * has completed, so the guard resolves regardless of this app's position.
+     *
+     * @param IEventDispatcher       $dispatcher The live event dispatcher.
+     * @param string                 $event      OpenRegister event class name.
+     * @param string                 $listener   Listener class name.
+     * @param array<int,string>|null $registers  Register slugs the listener reacts to, or null for all.
+     * @param array<int,string>|null $schemas    Schema slugs the listener reacts to, or null for all.
      *
      * @return void
      *
@@ -67,7 +75,7 @@ trait FilteredObjectListenerTrait
      *       behaviour a spec describes.
      */
     private function registerFilteredObjectListener(
-        IRegistrationContext $context,
+        IEventDispatcher $dispatcher,
         string $event,
         string $listener,
         ?array $registers=null,
@@ -75,8 +83,8 @@ trait FilteredObjectListenerTrait
     ): void {
         $subscription = '\\OCA\\OpenRegister\\Event\\ObjectEventSubscription';
         if (class_exists($subscription) === true) {
-            $subscription::register(
-                context: $context,
+            $subscription::subscribe(
+                dispatcher: $dispatcher,
                 event: $event,
                 listener: $listener,
                 registers: $registers,
@@ -85,7 +93,16 @@ trait FilteredObjectListenerTrait
             return;
         }
 
-        $context->registerEventListener(event: $event, listener: $listener);
+        // Loud on purpose. This fallback is correct but UNFILTERED, and while it
+        // was silent it was indistinguishable from a working narrowing.
+        \OCP\Server::get(\Psr\Log\LoggerInterface::class)->warning(
+            'OpenRegister ObjectEventSubscription unavailable: '.$listener
+            .' fell back to an UNFILTERED registration for '.$event
+            .' and will be invoked on every object write instance-wide.',
+            ['app' => 'shillinq']
+        );
+
+        $dispatcher->addServiceListener($event, $listener);
 
     }//end registerFilteredObjectListener()
 }//end trait

--- a/lib/AppInfo/FilteredObjectListenerTrait.php
+++ b/lib/AppInfo/FilteredObjectListenerTrait.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Registration helper for filtered object-event subscription.
+ *
+ * @category AppInfo
+ * @package  OCA\Shillinq\AppInfo
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\AppInfo;
+
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+
+/**
+ * Registers object-lifecycle listeners that declare their interest up front.
+ *
+ * Lives beside {@see Application} rather than inside it purely so the
+ * registration plumbing does not push that already-long class past its PHPMD
+ * length budget.
+ *
+ * @spec exclude Performance-only registration plumbing — narrows which
+ *       dispatches reach an existing listener without changing any behaviour
+ *       a spec describes.
+ */
+trait FilteredObjectListenerTrait
+{
+    /**
+     * Register an object-lifecycle listener that declares its interest up front.
+     *
+     * OpenRegister's `ObjectEventSubscription` records the register/schema slugs
+     * a listener reacts to and routes dispatches through a single shared proxy,
+     * so an uninterested listener is neither constructed nor invoked. Registered
+     * globally, shillinq's listeners were constructed on EVERY object write on
+     * the instance — a larpingapp character create reached the GL compliance
+     * cache listener and bailed at its own `isWatched()` guard.
+     *
+     * The class is referenced as a STRING, never as a compile-time symbol: it
+     * only exists once OpenRegister is installed, and shillinq carries no hard
+     * dependency on it. When it is absent this degrades to the plain global
+     * registration it replaced, which is exactly the behaviour every listener
+     * had before. Passing null for either filter also means "all".
+     *
+     * The per-handler self-filter guards are deliberately left in place: the
+     * declaration narrows *dispatch*, the guard still decides *work*.
+     *
+     * @param IRegistrationContext   $context   Registration context.
+     * @param string                 $event     OpenRegister event class name.
+     * @param string                 $listener  Listener class name.
+     * @param array<int,string>|null $registers Register slugs the listener reacts to, or null for all.
+     * @param array<int,string>|null $schemas   Schema slugs the listener reacts to, or null for all.
+     *
+     * @return void
+     *
+     * @spec exclude Performance-only registration plumbing — narrows which
+     *       dispatches reach an existing listener without changing any
+     *       behaviour a spec describes.
+     */
+    private function registerFilteredObjectListener(
+        IRegistrationContext $context,
+        string $event,
+        string $listener,
+        ?array $registers=null,
+        ?array $schemas=null
+    ): void {
+        $subscription = '\\OCA\\OpenRegister\\Event\\ObjectEventSubscription';
+        if (class_exists($subscription) === true) {
+            $subscription::register(
+                context: $context,
+                event: $event,
+                listener: $listener,
+                registers: $registers,
+                schemas: $schemas
+            );
+            return;
+        }
+
+        $context->registerEventListener(event: $event, listener: $listener);
+
+    }//end registerFilteredObjectListener()
+}//end trait


### PR DESCRIPTION
## Why

Every OpenRegister object-event listener shillinq registers was registered **globally**, so it was constructed and invoked on **every object write on the instance** — a larpingapp character create reached shillinq's GL compliance cache listener and bailed at its own `isWatched()` guard. shillinq had the largest such footprint in the fleet (12 distinct listeners, 15 registration sites).

OpenRegister's `ObjectEventSubscription` lets a listener declare the schema slugs it reacts to at registration time and routes dispatch through a single shared proxy, so an uninterested listener is neither constructed nor invoked.

## Soft dependency

`ObjectEventSubscription` is referenced by **string** behind `class_exists()`, mirroring the procest pilot. It only exists once OpenRegister is installed and shillinq carries no hard dependency on it, so the call degrades to the plain global registration it replaced. **OpenRegister PR #2223 is not merged — this PR is inert until it is, and correct either way.**

## Converted — 12 registration sites, 9 listeners

Every declared slug was verified to exist in `oc_openregister_schemas` on the reference instance.

| Listener | Events | Declared schemas | Evidence in the handler |
|---|---|---|---|
| `AppointmentCreatedListener` | created | `Appointment` | `isAppointmentSchema()`: `=== 'appointment' \|\| str_ends_with($n, '/appointment')` |
| `BookingCreatedTimelinePublishListener` | created | `Appointment` | same predicate, explicitly documented as mirroring the above |
| `LeaseActivationListener` | created, updated | `LeaseContract` | `isLeaseContractSchema()`: `=== 'leasecontract' \|\| str_ends_with($n, '/leasecontract')` |
| `OssPaymentReconciliationListener` | created | `OssPayment`, `oss-payment` | `$schema !== 'osspayment' && $schema !== 'oss-payment'` |
| `GLTransactionComplianceCacheListener` | created, updated | `GLTransaction`, `GLLine`, `GLTransactionLine` | `WATCHED_SCHEMAS` constant, verbatim |
| `InnovatieboxAuditTrailListener` | created, updated | `NexusCalculation`, `IBProfitAttribution`, `CarryForwardLoss` | `SCHEMA_NEXUS` / `SCHEMA_PROFIT` / `SCHEMA_LOSS` constants |
| `ReconciliationMatchToReportListener` | created | `ReconciliationMatch` | `strcasecmp($payload['schema'], 'ReconciliationMatch') !== 0` |
| `TenderNedAwardDetectedListener` | created | `TenderNedAanbesteding` | `isAanbestedingSchema()`, same slug it writes with `->setSchema('TenderNedAanbesteding')` |
| `VerplichtingTransitionListener` | created | `Verplichting` | `isVerplichtingSchema()`, same slug the award listener writes |

Each declaration is the listener's own guard read back verbatim, and **every guard is left in place** — the declaration narrows *dispatch*, the guard still decides *work*.

`GLTransactionLine` and `oss-payment` resolve to no schema on the reference instance but are declared anyway because the guards name them: over-inclusion is fail-safe, under-inclusion is a silent outage.

## Deliberately NOT narrowed — reason recorded at each site

| Listener | Reason |
|---|---|
| `PeppolInboundUblInvoiceListener` | The only slug it accepts is `PeppolInboundMessage`, which **openconnector** owns and which resolves to **zero** rows in `oc_openregister_schemas` here. A declaration that resolves to nothing means the listener never fires. |
| `DBAFactuurMonitorListener` | **No schema guard at all.** Its interest is the *presence* of a `dbaOpdrachtId` field on the payload, whatever schema carries it. Declaring `ARInvoice`/`APInvoice` would narrow behaviour on an assumption the code does not state (and `APInvoice` does not exist as a slug). |
| `CommitmentMaterialisationListener` | `str_ends_with($schema, 'contract')` is a suffix wildcard covering **six** distinct schemas today (`contract`, `employmentcontract`, `fxcontract`, `leasecontract`, `suppliercontract`, `synchronization_contract`) plus any future `*contract` slug. Not statically enumerable. |

The `ObjectTransitionedEvent` registrations are left global throughout: transitions are rare, and this change deliberately narrows only the create/update firehose.

## No registers declared

Every register slug in this app comes from deployment configuration (`IAppConfig` key `register`, e.g. `ReconciliationMatchToReportListener::getRegisterSlug()`), which is exactly the runtime-config case that must not be frozen into a declaration. Schemas alone are narrow enough.

## Why a trait

Adding the helper inline pushed `Application` past its **1300-line PHPMD budget** (`ExcessiveClassLength`). It lives in `FilteredObjectListenerTrait` for that reason; a static-helper class was tried first and tripped PHPMD's `StaticAccess`.

## Checks

Run against both touched files in a `nextcloud:34` container:

- `php -l` — clean
- `phpcs --standard=phpcs.xml` — **0 errors**. `Application.php` keeps its 3 pre-existing `@spec` warnings (class, `register()`, `boot()`), byte-identical to `origin/development`; the new trait is fully clean.
- `phpmd lib text phpmd.xml` — **clean** (exit 0)
- `psalm` — **No errors found**
- `phpstan analyse` — **OK, no errors**
- `phpunit -c phpunit-unit.xml` — 3966 tests, 42092 assertions, 0 failures. 4 errors, all `Symfony\Component\HttpFoundation\HeaderUtils not found` in `AccountantPortalControllerTest` / `AdministrationExportControllerTest` — an artifact of the ad-hoc container harness (missing symfony/http-foundation on the app autoloader), in files this PR does not touch.

## Not verified

- **No runtime verification.** shillinq's live container copy is a separate stale checkout; these edits are not deployed anywhere. Behaviour under an actual dispatch is unexercised.
- Slug existence was checked against **one** instance (`conduction-postgres`/`nextcloud`). A deployment that seeds different slugs would need re-checking — though every declaration is a superset of what its guard accepts, so the failure mode is "still global", not "silently dead".