### PR TITLE
fix(listeners): resolve schema id to slug so 12 dead listeners can run (default-off)

### DIFF
--- a/lib/Listener/ACMReportSignTransitionListener.php
+++ b/lib/Listener/ACMReportSignTransitionListener.php
@@ -53,6 +53,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Listener;
 
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\SettingsService;
 use OCA\Shillinq\Service\Signing\SigningDelegationService;
 use OCP\EventDispatcher\Event;
@@ -100,6 +101,7 @@ class ACMReportSignTransitionListener implements IEventListener
      *                                                  lazily (avoids a circular DI edge).
      * @param SettingsService          $settingsService Shillinq settings (register slug).
      * @param SigningDelegationService $signingService  The document-signing request service.
+     * @param ListenerSchemaResolver   $schemaResolver  Resolves the entity's schema id to its slug.
      * @param LoggerInterface          $logger          Logger.
      *
      * @return void
@@ -108,6 +110,7 @@ class ACMReportSignTransitionListener implements IEventListener
         private readonly ContainerInterface $container,
         private readonly SettingsService $settingsService,
         private readonly SigningDelegationService $signingService,
+        private readonly ListenerSchemaResolver $schemaResolver,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -137,7 +140,7 @@ class ACMReportSignTransitionListener implements IEventListener
                 return;
             }
 
-            $schema = (string) ($entity->getSchema() ?? '');
+            $schema = $this->schemaResolver->schemaSlug(entity: $entity);
             if ($this->isAcmReportSchema(schema: $schema) === false) {
                 return;
             }

--- a/lib/Listener/AppointmentCreatedListener.php
+++ b/lib/Listener/AppointmentCreatedListener.php
@@ -35,6 +35,7 @@ namespace OCA\Shillinq\Listener;
 
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\Shillinq\Service\Booking\ConfirmationTokenService;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Log\LoggerInterface;
@@ -53,11 +54,13 @@ class AppointmentCreatedListener implements IEventListener
     /**
      * Construct the listener with DI dependencies.
      *
-     * @param ConfirmationTokenService $tokens Token + email dispatcher.
-     * @param LoggerInterface          $logger Logger for fail-soft.
+     * @param ConfirmationTokenService $tokens         Token + email dispatcher.
+     * @param ListenerSchemaResolver   $schemaResolver Resolves the entity's schema id to its slug.
+     * @param LoggerInterface          $logger         Logger for fail-soft.
      */
     public function __construct(
         private readonly ConfirmationTokenService $tokens,
+        private readonly ListenerSchemaResolver $schemaResolver,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -81,7 +84,7 @@ class AppointmentCreatedListener implements IEventListener
                 return;
             }
 
-            $schema = (string) $entity->getSchema();
+            $schema = $this->schemaResolver->schemaSlug(entity: $entity);
             if ($this->isAppointmentSchema(schema: $schema) === false) {
                 return;
             }

--- a/lib/Listener/BookingCreatedTimelinePublishListener.php
+++ b/lib/Listener/BookingCreatedTimelinePublishListener.php
@@ -43,6 +43,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\Pipelinq\CustomerBridgeMetricsService;
 use OCA\Shillinq\Service\Pipelinq\PipelinqContactAdapter;
 use OCA\Shillinq\Service\Pipelinq\TimelineEventDto;
@@ -64,14 +65,16 @@ final class BookingCreatedTimelinePublishListener implements IEventListener
     /**
      * Construct the listener with its DI deps.
      *
-     * @param PipelinqContactAdapter            $pipelinq   Slice-02 adapter (publishTimelineEvent).
-     * @param TimelineRetryQueue                $retryQueue Async-retry queue (slice 09 binding).
-     * @param LoggerInterface                   $logger     PSR logger for fail-soft observability.
-     * @param CustomerBridgeMetricsService|null $metrics    Optional metrics aggregator (slice 11); NULL-safe for existing tests.
+     * @param PipelinqContactAdapter            $pipelinq       Slice-02 adapter (publishTimelineEvent).
+     * @param TimelineRetryQueue                $retryQueue     Async-retry queue (slice 09 binding).
+     * @param ListenerSchemaResolver            $schemaResolver Resolves the entity's schema id to its slug.
+     * @param LoggerInterface                   $logger         PSR logger for fail-soft observability.
+     * @param CustomerBridgeMetricsService|null $metrics        Optional metrics aggregator (slice 11); NULL-safe for existing tests.
      */
     public function __construct(
         private readonly PipelinqContactAdapter $pipelinq,
         private readonly TimelineRetryQueue $retryQueue,
+        private readonly ListenerSchemaResolver $schemaResolver,
         private readonly LoggerInterface $logger,
         private readonly ?CustomerBridgeMetricsService $metrics=null
     ) {
@@ -100,7 +103,7 @@ final class BookingCreatedTimelinePublishListener implements IEventListener
                 return;
             }
 
-            if ($this->isAppointmentSchema(schema: (string) $entity->getSchema()) === false) {
+            if ($this->isAppointmentSchema(schema: $this->schemaResolver->schemaSlug(entity: $entity)) === false) {
                 return;
             }
 

--- a/lib/Listener/CommitmentMaterialisationListener.php
+++ b/lib/Listener/CommitmentMaterialisationListener.php
@@ -47,6 +47,7 @@ use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Service\Commitment\CommitmentMaterialisationService;
 use OCA\Shillinq\Service\Commitment\InsufficientCommitmentBudgetException;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Log\LoggerInterface;
@@ -65,11 +66,13 @@ class CommitmentMaterialisationListener implements IEventListener
     /**
      * Construct the listener.
      *
-     * @param CommitmentMaterialisationService $materialiser Thin materialisation service.
-     * @param LoggerInterface                  $logger       Logger for diagnostics.
+     * @param CommitmentMaterialisationService $materialiser   Thin materialisation service.
+     * @param ListenerSchemaResolver           $schemaResolver Resolves the entity's schema id to its slug.
+     * @param LoggerInterface                  $logger         Logger for diagnostics.
      */
     public function __construct(
         private readonly CommitmentMaterialisationService $materialiser,
+        private readonly ListenerSchemaResolver $schemaResolver,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -93,7 +96,7 @@ class CommitmentMaterialisationListener implements IEventListener
             return;
         }
 
-        $schema  = strtolower(trim((string) ($entity->getSchema() ?? '')));
+        $schema  = strtolower(trim($this->schemaResolver->schemaSlug(entity: $entity)));
         $payload = $entity->getObject();
         if (is_array($payload) === false) {
             return;

--- a/lib/Listener/GLTransactionComplianceCacheListener.php
+++ b/lib/Listener/GLTransactionComplianceCacheListener.php
@@ -45,6 +45,7 @@ namespace OCA\Shillinq\Listener;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCA\Shillinq\Service\ComplianceService;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Log\LoggerInterface;
@@ -79,11 +80,13 @@ final class GLTransactionComplianceCacheListener implements IEventListener
     /**
      * Construct the listener with DI dependencies.
      *
-     * @param ComplianceService $compliance Compliance cache owner.
-     * @param LoggerInterface   $logger     Logger for fail-soft.
+     * @param ComplianceService      $compliance     Compliance cache owner.
+     * @param ListenerSchemaResolver $schemaResolver Resolves the entity's schema id to its slug.
+     * @param LoggerInterface        $logger         Logger for fail-soft.
      */
     public function __construct(
         private readonly ComplianceService $compliance,
+        private readonly ListenerSchemaResolver $schemaResolver,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
@@ -112,7 +115,7 @@ final class GLTransactionComplianceCacheListener implements IEventListener
                 return;
             }
 
-            $schema = (string) $entity->getSchema();
+            $schema = $this->schemaResolver->schemaSlug(entity: $entity);
             if ($this->isWatched(schema: $schema) === false) {
                 return;
             }

--- a/lib/Listener/InnovatieboxAuditTrailListener.php
+++ b/lib/Listener/InnovatieboxAuditTrailListener.php
@@ -51,6 +51,7 @@ namespace OCA\Shillinq\Listener;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCA\Shillinq\Service\InnovatieboxAuditEventLogger;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\VsoLockingValidator;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -91,13 +92,15 @@ final class InnovatieboxAuditTrailListener implements IEventListener
     /**
      * Construct the listener.
      *
-     * @param InnovatieboxAuditEventLogger $logger       Append-only audit event writer.
-     * @param VsoLockingValidator          $vsoValidator VSO year-lock checker (task 4.3).
-     * @param LoggerInterface              $psrLogger    Psr logger for fail-soft.
+     * @param InnovatieboxAuditEventLogger $logger         Append-only audit event writer.
+     * @param VsoLockingValidator          $vsoValidator   VSO year-lock checker (task 4.3).
+     * @param ListenerSchemaResolver       $schemaResolver Resolves the entity's schema id to its slug.
+     * @param LoggerInterface              $psrLogger      Psr logger for fail-soft.
      */
     public function __construct(
         private readonly InnovatieboxAuditEventLogger $logger,
         private readonly VsoLockingValidator $vsoValidator,
+        private readonly ListenerSchemaResolver $schemaResolver,
         private readonly LoggerInterface $psrLogger,
     ) {
     }//end __construct()
@@ -147,7 +150,7 @@ final class InnovatieboxAuditTrailListener implements IEventListener
             return;
         }
 
-        $schema = $this->normaliseSchema(schema: (string) $entity->getSchema());
+        $schema = $this->normaliseSchema(schema: $this->schemaResolver->schemaSlug(entity: $entity));
         $data   = $this->extractObjectArray(entity: $entity);
 
         if ($schema === self::SCHEMA_NEXUS) {
@@ -263,7 +266,7 @@ final class InnovatieboxAuditTrailListener implements IEventListener
             return;
         }
 
-        $schema = $this->normaliseSchema(schema: (string) $entity->getSchema());
+        $schema = $this->normaliseSchema(schema: $this->schemaResolver->schemaSlug(entity: $entity));
         $next   = $this->extractObjectArray(entity: $entity);
         $prior  = $this->extractPriorState(event: $event);
 

--- a/lib/Listener/LeaseActivationListener.php
+++ b/lib/Listener/LeaseActivationListener.php
@@ -49,6 +49,7 @@ namespace OCA\Shillinq\Listener;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCA\Shillinq\Service\LeasePaymentScheduleService;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Log\LoggerInterface;
@@ -75,10 +76,12 @@ class LeaseActivationListener implements IEventListener
      * Construct the listener with DI dependencies.
      *
      * @param LeasePaymentScheduleService $scheduleService The amortization schedule generator.
+     * @param ListenerSchemaResolver      $schemaResolver  Resolves the entity's schema id to its slug.
      * @param LoggerInterface             $logger          Logger for fail-soft diagnostics.
      */
     public function __construct(
         private readonly LeasePaymentScheduleService $scheduleService,
+        private readonly ListenerSchemaResolver $schemaResolver,
         private readonly LoggerInterface $logger,
     ) {
 
@@ -107,7 +110,7 @@ class LeaseActivationListener implements IEventListener
                 return;
             }
 
-            if ($this->isLeaseContractSchema(schema: (string) $entity->getSchema()) === false) {
+            if ($this->isLeaseContractSchema(schema: $this->schemaResolver->schemaSlug(entity: $entity)) === false) {
                 return;
             }
 

--- a/lib/Listener/OpdrachtUitvoeringTransitionListener.php
+++ b/lib/Listener/OpdrachtUitvoeringTransitionListener.php
@@ -48,6 +48,7 @@ namespace OCA\Shillinq\Listener;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Integration\TenderNedStatusSync;
 use OCA\Shillinq\Service\BudgetImpactEmitter;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Log\LoggerInterface;
@@ -66,13 +67,15 @@ class OpdrachtUitvoeringTransitionListener implements IEventListener
     /**
      * Construct the listener.
      *
-     * @param BudgetImpactEmitter $emitter Shared cross-app CloudEvent emitter.
-     * @param TenderNedStatusSync $sync    Outbound status-sync integration (REQ-006).
-     * @param LoggerInterface     $logger  Logger for fail-soft diagnostics.
+     * @param BudgetImpactEmitter    $emitter        Shared cross-app CloudEvent emitter.
+     * @param TenderNedStatusSync    $sync           Outbound status-sync integration (REQ-006).
+     * @param ListenerSchemaResolver $schemaResolver Resolves the entity's schema id to its slug.
+     * @param LoggerInterface        $logger         Logger for fail-soft diagnostics.
      */
     public function __construct(
         private readonly BudgetImpactEmitter $emitter,
         private readonly TenderNedStatusSync $sync,
+        private readonly ListenerSchemaResolver $schemaResolver,
         private readonly LoggerInterface $logger,
     ) {
 
@@ -103,7 +106,7 @@ class OpdrachtUitvoeringTransitionListener implements IEventListener
                 return;
             }
 
-            $schema = (string) ($entity->getSchema() ?? '');
+            $schema = $this->schemaResolver->schemaSlug(entity: $entity);
             if ($this->isOpdrachtUitvoeringSchema(schema: $schema) === false) {
                 return;
             }

--- a/lib/Listener/OssPaymentReconciliationListener.php
+++ b/lib/Listener/OssPaymentReconciliationListener.php
@@ -42,6 +42,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Listener;
 
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\OssPaymentReconciliation;
 use OCA\Shillinq\Service\OssRecordResolver;
 use OCP\EventDispatcher\Event;
@@ -78,11 +79,13 @@ class OssPaymentReconciliationListener implements IEventListener
      *
      * @param OssRecordResolver        $resolver       Reads/persists the OSS records.
      * @param OssPaymentReconciliation $reconciliation The pure-logic REQ-OSS-008 kernel.
+     * @param ListenerSchemaResolver   $schemaResolver Resolves the entity's schema id to its slug.
      * @param LoggerInterface          $logger         Logger for fail-soft diagnostics.
      */
     public function __construct(
         private readonly OssRecordResolver $resolver,
         private readonly OssPaymentReconciliation $reconciliation,
+        private readonly ListenerSchemaResolver $schemaResolver,
         private readonly LoggerInterface $logger,
     ) {
 
@@ -109,7 +112,7 @@ class OssPaymentReconciliationListener implements IEventListener
                 return;
             }
 
-            $schema = strtolower(trim((string) $entity->getSchema()));
+            $schema = strtolower(trim($this->schemaResolver->schemaSlug(entity: $entity)));
             if ($schema !== 'osspayment' && $schema !== 'oss-payment') {
                 return;
             }

--- a/lib/Listener/PeppolInboundUblInvoiceListener.php
+++ b/lib/Listener/PeppolInboundUblInvoiceListener.php
@@ -50,6 +50,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Listener;
 
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\SupplierInvoiceService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -86,10 +87,12 @@ class PeppolInboundUblInvoiceListener implements IEventListener
      * Construct the listener with the ingestion service + a logger.
      *
      * @param SupplierInvoiceService $supplierInvoices Slice-05 ingestion service.
+     * @param ListenerSchemaResolver $schemaResolver   Resolves the entity's schema id to its slug.
      * @param LoggerInterface        $logger           Logger for fail-soft diagnostics.
      */
     public function __construct(
         private readonly SupplierInvoiceService $supplierInvoices,
+        private readonly ListenerSchemaResolver $schemaResolver,
         private readonly LoggerInterface $logger,
     ) {
 
@@ -112,7 +115,7 @@ class PeppolInboundUblInvoiceListener implements IEventListener
 
         try {
             $entity = $event->getObject();
-            if ((string) $entity->getSchema() !== self::PEPPOL_INBOUND_SCHEMA) {
+            if ($this->schemaResolver->schemaSlug(entity: $entity) !== self::PEPPOL_INBOUND_SCHEMA) {
                 return;
             }
 

--- a/lib/Listener/TenderNedAwardDetectedListener.php
+++ b/lib/Listener/TenderNedAwardDetectedListener.php
@@ -65,6 +65,7 @@ use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Service\BudgetImpactEmitter;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\MilestoneTemplateService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -88,17 +89,19 @@ class TenderNedAwardDetectedListener implements IEventListener
     /**
      * Construct the listener with DI dependencies.
      *
-     * @param MilestoneTemplateService $templates Pure-logic milestone planner (REQ-003).
-     * @param BudgetImpactEmitter      $budget    Emits the launchpad budget-impact CloudEvent (REQ-007).
-     * @param ContainerInterface       $container DI container for lazy OR ObjectService resolution.
-     * @param IAppConfig               $appConfig App config for register slug + tenant KvK.
-     * @param LoggerInterface          $logger    Logger for fail-soft diagnostics.
+     * @param MilestoneTemplateService $templates      Pure-logic milestone planner (REQ-003).
+     * @param BudgetImpactEmitter      $budget         Emits the launchpad budget-impact CloudEvent (REQ-007).
+     * @param ContainerInterface       $container      DI container for lazy OR ObjectService resolution.
+     * @param IAppConfig               $appConfig      App config for register slug + tenant KvK.
+     * @param ListenerSchemaResolver   $schemaResolver Resolves the entity's schema id to its slug.
+     * @param LoggerInterface          $logger         Logger for fail-soft diagnostics.
      */
     public function __construct(
         private readonly MilestoneTemplateService $templates,
         private readonly BudgetImpactEmitter $budget,
         private readonly ContainerInterface $container,
         private readonly IAppConfig $appConfig,
+        private readonly ListenerSchemaResolver $schemaResolver,
         private readonly LoggerInterface $logger,
     ) {
 
@@ -172,7 +175,7 @@ class TenderNedAwardDetectedListener implements IEventListener
             return null;
         }
 
-        $schema = (string) ($entity->getSchema() ?? '');
+        $schema = $this->schemaResolver->schemaSlug(entity: $entity);
         if ($this->isAanbestedingSchema(schema: $schema) === false) {
             return null;
         }

--- a/lib/Listener/VerplichtingTransitionListener.php
+++ b/lib/Listener/VerplichtingTransitionListener.php
@@ -50,6 +50,7 @@ namespace OCA\Shillinq\Listener;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Service\BudgetImpactEmitter;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Log\LoggerInterface;
@@ -68,11 +69,13 @@ class VerplichtingTransitionListener implements IEventListener
     /**
      * Construct the listener.
      *
-     * @param BudgetImpactEmitter $emitter Shared cross-app CloudEvent emitter.
-     * @param LoggerInterface     $logger  Logger for fail-soft diagnostics.
+     * @param BudgetImpactEmitter    $emitter        Shared cross-app CloudEvent emitter.
+     * @param ListenerSchemaResolver $schemaResolver Resolves the entity's schema id to its slug.
+     * @param LoggerInterface        $logger         Logger for fail-soft diagnostics.
      */
     public function __construct(
         private readonly BudgetImpactEmitter $emitter,
+        private readonly ListenerSchemaResolver $schemaResolver,
         private readonly LoggerInterface $logger,
     ) {
 
@@ -121,7 +124,7 @@ class VerplichtingTransitionListener implements IEventListener
             return null;
         }
 
-        $schema = (string) ($entity->getSchema() ?? '');
+        $schema = $this->schemaResolver->schemaSlug(entity: $entity);
         if ($this->isVerplichtingSchema(schema: $schema) === false) {
             return null;
         }

--- a/lib/Service/ListenerSchemaResolver.php
+++ b/lib/Service/ListenerSchemaResolver.php
@@ -1,0 +1,205 @@
+<?php
+
+/**
+ * Resolves an OpenRegister object's schema **slug** for shillinq's listeners.
+ *
+ * OpenRegister's {@see \OCA\OpenRegister\Db\MagicMapper} stamps the numeric
+ * **ids** of the register and schema onto every {@see
+ * \OCA\OpenRegister\Db\ObjectEntity} it materialises:
+ *
+ *     $result->setSchema((string) $schema->getId());
+ *     $result->setRegister((string) $register->getId());
+ *
+ * Shillinq's listeners, however, compare that value against a schema **slug**
+ * literal (`'leasecontract'`, `'ACMReport'`, `'verplichting'`, ...). An id can
+ * never equal a slug, so every one of those guards returned early on every
+ * event: the handler bodies had never run once. There was no exception and no
+ * log line — the listeners were still constructed and invoked on every object
+ * write instance-wide, they simply did nothing.
+ *
+ * This resolver turns the id back into a slug so the existing literals match.
+ * Three properties matter:
+ *
+ * 1. **Register-scoped.** Matching on schema alone is not safe: this instance
+ *    carries two distinct schemas both slugged `automation` (ids 71 and 5103),
+ *    so a schema-only match fires on another app's objects. Callers therefore
+ *    get `''` for anything outside shillinq's own register.
+ * 2. **Container-resolved.** OpenRegister is a soft dependency; the mappers are
+ *    pulled from the DI container at call time and every failure degrades to
+ *    `''`, so shillinq still boots and runs with OpenRegister absent.
+ * 3. **Gated.** Waking these listeners is a behaviour change, not a bug fix —
+ *    see {@see ListenerSlugContract}. While the contract is disabled this
+ *    returns the raw entity value (the id), which reproduces today's dead
+ *    behaviour byte for byte.
+ *
+ * {@see \OCA\OpenRegister\Db\SchemaMapper::find()} and
+ * {@see \OCA\OpenRegister\Db\RegisterMapper::find()} are request-cached by
+ * OpenRegister, so the lookup does not add a query per event.
+ *
+ * @category Service
+ * @package  OCA\Shillinq\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Service;
+
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Turns an OpenRegister entity's schema id into its slug, scoped to shillinq's
+ * own register.
+ */
+class ListenerSchemaResolver
+{
+
+    /**
+     * FQCN of OpenRegister's schema mapper.
+     *
+     * @var string
+     */
+    private const SCHEMA_MAPPER = 'OCA\\OpenRegister\\Db\\SchemaMapper';
+
+    /**
+     * FQCN of OpenRegister's register mapper.
+     *
+     * @var string
+     */
+    private const REGISTER_MAPPER = 'OCA\\OpenRegister\\Db\\RegisterMapper';
+
+    /**
+     * Constructor.
+     *
+     * @param ContainerInterface   $container       DI container — OpenRegister mappers
+     *                                              are resolved lazily so shillinq boots
+     *                                              without it.
+     * @param SettingsService      $settingsService Supplies shillinq's configured register slug.
+     * @param ListenerSlugContract $contract        Default-off gate for the corrected matching.
+     * @param LoggerInterface      $logger          Logger for fail-soft diagnostics.
+     *
+     * @return void
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly SettingsService $settingsService,
+        private readonly ListenerSlugContract $contract,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Resolve the schema slug of an OpenRegister object entity.
+     *
+     * Returns `''` when the object does not belong to shillinq's register, when
+     * the schema cannot be resolved, or when OpenRegister is unavailable — every
+     * caller treats `''` as "not my object" and returns early, so an
+     * unresolvable entity is never mistaken for a match.
+     *
+     * While {@see ListenerSlugContract} is disabled this deliberately returns
+     * the entity's raw schema value (an id), preserving the pre-fix behaviour.
+     *
+     * @param object|null $entity The OpenRegister ObjectEntity from the event.
+     *
+     * @return string The schema slug, or '' when this is not a shillinq object.
+     */
+    public function schemaSlug(?object $entity): string
+    {
+        if ($entity === null || method_exists($entity, 'getSchema') === false) {
+            return '';
+        }
+
+        $rawSchema = (string) ($entity->getSchema() ?? '');
+
+        // Gate closed: reproduce the pre-fix comparison exactly.
+        if ($this->contract->isEnabled() === false) {
+            return $rawSchema;
+        }
+
+        if ($rawSchema === '' || $this->isOwnRegister(entity: $entity) === false) {
+            return '';
+        }
+
+        return $this->resolveSlug(service: self::SCHEMA_MAPPER, id: $rawSchema);
+
+    }//end schemaSlug()
+
+    /**
+     * Whether the entity belongs to shillinq's own OpenRegister register.
+     *
+     * This is the guard that keeps a schema-only literal (for example the two
+     * distinct schemas both slugged `automation`) from firing on another app's
+     * objects.
+     *
+     * @param object|null $entity The OpenRegister ObjectEntity from the event.
+     *
+     * @return bool True when the entity sits in shillinq's register.
+     */
+    public function isOwnRegister(?object $entity): bool
+    {
+        if ($entity === null || method_exists($entity, 'getRegister') === false) {
+            return false;
+        }
+
+        $rawRegister = (string) ($entity->getRegister() ?? '');
+        if ($rawRegister === '') {
+            return false;
+        }
+
+        $expected = $this->settingsService->getRegisterSlug();
+
+        // Tolerate an entity that already carries a slug (a hand-built entity in
+        // a test, or a future OpenRegister that stops stamping ids).
+        if (strcasecmp($rawRegister, $expected) === 0) {
+            return true;
+        }
+
+        return strcasecmp(
+            $this->resolveSlug(service: self::REGISTER_MAPPER, id: $rawRegister),
+            $expected
+        ) === 0;
+
+    }//end isOwnRegister()
+
+    /**
+     * Look an OpenRegister entity's slug up by id through a mapper FQCN.
+     *
+     * @param string $service The mapper FQCN (SchemaMapper or RegisterMapper).
+     * @param string $id      The id to resolve.
+     *
+     * @return string The slug, or '' when unresolvable / OpenRegister absent.
+     */
+    private function resolveSlug(string $service, string $id): string
+    {
+        try {
+            $entity = $this->container->get($service)->find($id);
+            if (is_object($entity) === true && method_exists($entity, 'getSlug') === true) {
+                return (string) ($entity->getSlug() ?? '');
+            }
+        } catch (Throwable $e) {
+            $this->logger->debug(
+                'Shillinq: could not resolve an OpenRegister slug for a listener guard',
+                [
+                    'service'   => $service,
+                    'id'        => $id,
+                    'exception' => $e->getMessage(),
+                ]
+            );
+        }//end try
+
+        return '';
+
+    }//end resolveSlug()
+}//end class

--- a/lib/Service/ListenerSlugContract.php
+++ b/lib/Service/ListenerSlugContract.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Feature gate for shillinq's corrected listener schema matching.
+ *
+ * Shillinq's OpenRegister listeners compared a schema **id** against a schema
+ * **slug** literal, so their handler bodies had never run once. Correcting the
+ * comparison is a small change, but it is emphatically not a behaviour-neutral
+ * one. The listeners it wakes include:
+ *
+ *   - a listener that sends **customer email**;
+ *   - four making **outbound HTTP** calls (pipelinq, TenderNed, docudesk,
+ *     decidesk);
+ *   - six doing **bulk object creation** — the whole Peppol backlog, and one
+ *     lease payment-schedule row per lease period;
+ *   - a **fail-closed** commitment check that would begin blocking
+ *     PurchaseOrder approvals which succeed today.
+ *
+ * None of them are idempotent in the strong sense and there is no backfill, so
+ * enabling them on an instance with existing data will act on that backlog the
+ * first time a matching write occurs. That is a business decision, not a bug
+ * fix.
+ *
+ * This gate exists so the correction can ship, be reviewed and be tested
+ * without silently switching all of that on in one deploy. It mirrors
+ * `openbuild.listener_slug_contract` (openbuild#82) and the default-off flag
+ * openregister#2248 used for the sibling `ObjectTransitionedEvent` defect.
+ *
+ * Default: OFF. Enable per instance, only after reviewing each handler body:
+ *   occ config:app:set shillinq listener_slug_contract --value=yes
+ *
+ * @category Service
+ * @package  OCA\Shillinq\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Service;
+
+use OCA\Shillinq\AppInfo\Application;
+use OCP\IAppConfig;
+
+/**
+ * Reports whether the corrected listener schema matching is enabled.
+ */
+class ListenerSlugContract
+{
+
+    /**
+     * The config key holding the flag.
+     *
+     * @var string
+     */
+    private const CONFIG_KEY = 'listener_slug_contract';
+
+    /**
+     * Constructor.
+     *
+     * @param IAppConfig $appConfig Nextcloud app configuration.
+     *
+     * @return void
+     */
+    public function __construct(private readonly IAppConfig $appConfig)
+    {
+    }//end __construct()
+
+    /**
+     * Whether the corrected slug comparison should be honoured.
+     *
+     * @return bool True when the contract is enabled for this instance.
+     */
+    public function isEnabled(): bool
+    {
+        return $this->appConfig->getValueBool(Application::APP_ID, self::CONFIG_KEY, false);
+
+    }//end isEnabled()
+}//end class

--- a/tests/Integration/SupplierInvoicePeppolIngestionIntegrationTest.php
+++ b/tests/Integration/SupplierInvoicePeppolIngestionIntegrationTest.php
@@ -43,6 +43,7 @@ use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\Shillinq\Listener\PeppolInboundUblInvoiceListener;
 use OCA\Shillinq\Service\AdministrationContextService;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\SupplierInvoiceService;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
@@ -219,8 +220,15 @@ final class SupplierInvoicePeppolIngestionIntegrationTest extends TestCase
             logger: $logger,
         );
 
+        // OpenRegister stamps the numeric schema id on the entity; the slug
+        // only ever reaches the listener through the resolver.
+        $schemaResolver = $this->createMock(ListenerSchemaResolver::class);
+        $schemaResolver->method('schemaSlug')
+            ->willReturn(PeppolInboundUblInvoiceListener::PEPPOL_INBOUND_SCHEMA);
+
         return new PeppolInboundUblInvoiceListener(
             supplierInvoices: $service,
+            schemaResolver: $schemaResolver,
             logger: $logger,
         );
 
@@ -293,7 +301,9 @@ XML;
     private function peppolInboundEntity(array $message): ObjectEntity
     {
         $entity = new ObjectEntity();
-        $entity->setSchema(PeppolInboundUblInvoiceListener::PEPPOL_INBOUND_SCHEMA);
+        // The numeric schema **id**, exactly as OpenRegister stamps it
+        // (`setSchema((string) $schema->getId())`) — never the slug.
+        $entity->setSchema('6104');
         $entity->setObject($message);
 
         return $entity;

--- a/tests/Unit/Integration/CustomerBridgeIntegrationTest.php
+++ b/tests/Unit/Integration/CustomerBridgeIntegrationTest.php
@@ -57,6 +57,7 @@ namespace OCA\Shillinq\Tests\Unit\Integration;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\Shillinq\Listener\BookingCreatedTimelinePublishListener;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\Pipelinq\CircuitBreaker;
 use OCA\Shillinq\Service\Pipelinq\KlantbeeldResult;
 use OCA\Shillinq\Service\Pipelinq\PipelinqContact;
@@ -469,8 +470,12 @@ final class CustomerBridgeIntegrationTest extends TestCase
     }//end appointmentPayload()
 
     /**
-     * Wrap an Appointment payload in an ObjectEntity carrying the
-     * Appointment schema marker the listener checks for.
+     * Wrap an Appointment payload in an ObjectEntity carrying the numeric
+     * schema **id**, exactly as OpenRegister stamps it
+     * (`setSchema((string) $schema->getId())`).
+     *
+     * A hand-built entity carrying the slug is a shape production never
+     * produces; the `appointment` slug arrives through the resolver.
      *
      * @param array<string, mixed> $appointment Payload.
      *
@@ -479,11 +484,26 @@ final class CustomerBridgeIntegrationTest extends TestCase
     private function appointmentEntity(array $appointment): ObjectEntity
     {
         $entity = new ObjectEntity();
-        $entity->setSchema('appointment');
+        $entity->setSchema('7001');
         $entity->setObject($appointment);
         return $entity;
 
     }//end appointmentEntity()
+
+    /**
+     * Build a ListenerSchemaResolver stub that reports a given schema slug.
+     *
+     * @param string $slug Slug the resolver resolves the entity's id to.
+     *
+     * @return ListenerSchemaResolver
+     */
+    private function schemaResolver(string $slug='appointment'): ListenerSchemaResolver
+    {
+        $resolver = $this->createMock(ListenerSchemaResolver::class);
+        $resolver->method('schemaSlug')->willReturn($slug);
+        return $resolver;
+
+    }//end schemaResolver()
 
     /**
      * Integration scenario 1 — create booking publishes a timeline event.
@@ -514,6 +534,7 @@ final class CustomerBridgeIntegrationTest extends TestCase
         $listener = new BookingCreatedTimelinePublishListener(
             pipelinq: $adapter,
             retryQueue: $queue,
+            schemaResolver: $this->schemaResolver(),
             logger: $logger
         );
 
@@ -670,6 +691,7 @@ final class CustomerBridgeIntegrationTest extends TestCase
         $listener = new BookingCreatedTimelinePublishListener(
             pipelinq: $adapter,
             retryQueue: $queue,
+            schemaResolver: $this->schemaResolver(),
             logger: $logger
         );
 

--- a/tests/Unit/Listener/ACMReportSignTransitionListenerTest.php
+++ b/tests/Unit/Listener/ACMReportSignTransitionListenerTest.php
@@ -34,6 +34,7 @@ namespace OCA\Shillinq\Tests\Unit\Listener;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Listener\ACMReportSignTransitionListener;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\Signing\SigningDelegationService;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\EventDispatcher\GenericEvent;
@@ -74,11 +75,15 @@ final class ACMReportSignTransitionListenerTest extends TestCase
      *                                                 returns, or null to make it throw
      *                                                 (simulating docudesk absent —
      *                                                 fail-closed).
+     * @param string                   $schemaSlug    Slug the schema resolver reports for
+     *                                                 the event entity.
      *
      * @return ACMReportSignTransitionListener
      */
-    private function makeListener(?array $requestResult): ACMReportSignTransitionListener
-    {
+    private function makeListener(
+        ?array $requestResult,
+        string $schemaSlug='ACMReport'
+    ): ACMReportSignTransitionListener {
         $this->signingCalls = [];
 
         $this->objectService = new class {
@@ -149,10 +154,14 @@ final class ACMReportSignTransitionListenerTest extends TestCase
         $settings = $this->createMock(SettingsService::class);
         $settings->method('getRegisterSlug')->willReturn('shillinq');
 
+        $schemaResolver = $this->createMock(ListenerSchemaResolver::class);
+        $schemaResolver->method('schemaSlug')->willReturn($schemaSlug);
+
         return new ACMReportSignTransitionListener(
             $container,
             $settings,
             $signingService,
+            $schemaResolver,
             new NullLogger(),
         );
 
@@ -161,21 +170,27 @@ final class ACMReportSignTransitionListenerTest extends TestCase
     /**
      * Build an ObjectTransitionedEvent carrying the given payload/action/schema.
      *
-     * @param array<string,mixed> $payload The object payload.
-     * @param string              $action  Transition action id.
-     * @param string              $schema  Schema slug.
-     * @param string              $id      Object id.
+     * The entity carries the numeric schema **id**, exactly as OpenRegister
+     * stamps it (`setSchema((string) $schema->getId())`) — the slug only ever
+     * reaches the listener through {@see ListenerSchemaResolver}.
+     *
+     * @param array<string,mixed> $payload    The object payload.
+     * @param string              $action     Transition action id.
+     * @param string              $schemaId   Numeric schema id as OR stamps it.
+     * @param string              $schemaSlug Schema slug carried by the event envelope.
+     * @param string              $id         Object id.
      *
      * @return ObjectTransitionedEvent
      */
     private function makeEvent(
         array $payload,
         string $action='sign',
-        string $schema='ACMReport',
+        string $schemaId='3001',
+        string $schemaSlug='ACMReport',
         string $id='acm-42'
     ): ObjectTransitionedEvent {
         $entity = (new ObjectEntity())
-            ->setSchema($schema)
+            ->setSchema($schemaId)
             ->setId($id)
             ->setObject($payload);
 
@@ -186,7 +201,7 @@ final class ACMReportSignTransitionListenerTest extends TestCase
             'ready-for-submission',
             'concerncontroller1',
             'shillinq',
-            $schema,
+            $schemaSlug,
         );
 
     }//end makeEvent()
@@ -241,9 +256,11 @@ final class ACMReportSignTransitionListenerTest extends TestCase
      */
     public function testNonAcmReportSchemaIsIgnored(): void
     {
-        $listener = $this->makeListener(['id' => 'other-1', 'signingStatus' => 'requested']);
+        $listener = $this->makeListener(['id' => 'other-1', 'signingStatus' => 'requested'], 'AnnualReport');
 
-        $listener->handle($this->makeEvent(['id' => 'other-1'], schema: 'AnnualReport'));
+        $listener->handle(
+            $this->makeEvent(['id' => 'other-1'], schemaId: '3002', schemaSlug: 'AnnualReport')
+        );
 
         self::assertCount(0, $this->signingCalls);
         self::assertCount(0, $this->objectService->updates);

--- a/tests/Unit/Listener/BookingCreatedTimelinePublishListenerTest.php
+++ b/tests/Unit/Listener/BookingCreatedTimelinePublishListenerTest.php
@@ -38,6 +38,7 @@ namespace OCA\Shillinq\Tests\Unit\Listener;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\Shillinq\Listener\BookingCreatedTimelinePublishListener;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\Pipelinq\PipelinqContactAdapter;
 use OCA\Shillinq\Service\Pipelinq\TimelineEventDto;
 use OCA\Shillinq\Service\Pipelinq\TimelineRetryQueue;
@@ -157,21 +158,41 @@ final class BookingCreatedTimelinePublishListenerTest extends TestCase
     }//end deps()
 
     /**
-     * Build an Appointment ObjectEntity carrying the supplied payload.
+     * Build an Appointment ObjectEntity carrying the numeric schema **id**,
+     * exactly as OpenRegister stamps it
+     * (`setSchema((string) $schema->getId())`).
+     *
+     * A hand-built entity carrying the slug is a shape production never
+     * produces; the slug arrives through {@see ListenerSchemaResolver}.
      *
      * @param array<string, mixed> $appointment Object payload.
-     * @param string               $schema      Schema name (default 'appointment').
+     * @param string               $schemaId    Numeric schema id as OR stamps it.
      *
      * @return ObjectEntity
      */
-    private function appointmentEntity(array $appointment, string $schema='appointment'): ObjectEntity
+    private function appointmentEntity(array $appointment, string $schemaId='7001'): ObjectEntity
     {
         $entity = new ObjectEntity();
-        $entity->setSchema($schema);
+        $entity->setSchema($schemaId);
         $entity->setObject($appointment);
         return $entity;
 
     }//end appointmentEntity()
+
+    /**
+     * Build a ListenerSchemaResolver stub that reports a given schema slug.
+     *
+     * @param string $slug Slug the resolver resolves the entity's id to.
+     *
+     * @return ListenerSchemaResolver
+     */
+    private function resolver(string $slug): ListenerSchemaResolver
+    {
+        $resolver = $this->createMock(ListenerSchemaResolver::class);
+        $resolver->method('schemaSlug')->willReturn($slug);
+        return $resolver;
+
+    }//end resolver()
 
     /**
      * Happy path — pipelinqContactId set, publish succeeds, no retry
@@ -188,6 +209,7 @@ final class BookingCreatedTimelinePublishListenerTest extends TestCase
         $listener = new BookingCreatedTimelinePublishListener(
             pipelinq: $adapter,
             retryQueue: $queue,
+            schemaResolver: $this->resolver('appointment'),
             logger: $this->recordingLogger()
         );
 
@@ -246,6 +268,7 @@ final class BookingCreatedTimelinePublishListenerTest extends TestCase
         $listener = new BookingCreatedTimelinePublishListener(
             pipelinq: $adapter,
             retryQueue: $queue,
+            schemaResolver: $this->resolver('appointment'),
             logger: $this->recordingLogger()
         );
 
@@ -281,6 +304,7 @@ final class BookingCreatedTimelinePublishListenerTest extends TestCase
         $listener = new BookingCreatedTimelinePublishListener(
             pipelinq: $adapter,
             retryQueue: $queue,
+            schemaResolver: $this->resolver('appointment'),
             logger: $this->recordingLogger()
         );
 
@@ -316,6 +340,7 @@ final class BookingCreatedTimelinePublishListenerTest extends TestCase
         $listener = new BookingCreatedTimelinePublishListener(
             pipelinq: $adapter,
             retryQueue: $queue,
+            schemaResolver: $this->resolver('invoice'),
             logger: $this->recordingLogger()
         );
 
@@ -326,7 +351,7 @@ final class BookingCreatedTimelinePublishListenerTest extends TestCase
                         'appointmentId'     => 'whatever',
                         'pipelinqContactId' => 'pl-contact-42',
                     ],
-                    schema: 'invoice'
+                    schemaId: '7050'
                 )
             )
         );

--- a/tests/Unit/Listener/CommitmentMaterialisationListenerTest.php
+++ b/tests/Unit/Listener/CommitmentMaterialisationListenerTest.php
@@ -28,6 +28,7 @@ use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Listener\CommitmentMaterialisationListener;
 use OCA\Shillinq\Service\Commitment\CommitmentMaterialisationService;
 use OCA\Shillinq\Service\Commitment\InsufficientCommitmentBudgetException;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCP\EventDispatcher\Event;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -47,6 +48,13 @@ class CommitmentMaterialisationListenerTest extends TestCase
      * @var CommitmentMaterialisationService&MockObject
      */
     private CommitmentMaterialisationService&MockObject $materialiser;
+
+    /**
+     * Mock schema resolver — turns the entity's numeric schema id into a slug.
+     *
+     * @var ListenerSchemaResolver&MockObject
+     */
+    private ListenerSchemaResolver&MockObject $schemaResolver;
 
     /**
      * Mock logger.
@@ -71,28 +79,50 @@ class CommitmentMaterialisationListenerTest extends TestCase
     {
         parent::setUp();
 
-        $this->materialiser = $this->createMock(CommitmentMaterialisationService::class);
-        $this->logger       = $this->createMock(LoggerInterface::class);
-        $this->listener     = new CommitmentMaterialisationListener(materialiser: $this->materialiser, logger: $this->logger);
+        $this->materialiser   = $this->createMock(CommitmentMaterialisationService::class);
+        $this->schemaResolver = $this->createMock(ListenerSchemaResolver::class);
+        $this->logger         = $this->createMock(LoggerInterface::class);
+        $this->listener       = new CommitmentMaterialisationListener(
+            materialiser: $this->materialiser,
+            schemaResolver: $this->schemaResolver,
+            logger: $this->logger
+        );
 
     }//end setUp()
 
     /**
-     * Build an ObjectEntity stub for the given schema + payload.
+     * Build an ObjectEntity stub carrying a numeric schema **id**, exactly as
+     * OpenRegister stamps it (`setSchema((string) $schema->getId())`).
      *
-     * @param string               $schema  Schema slug.
-     * @param array<string, mixed> $payload Object payload.
+     * A hand-built entity carrying the slug is a shape production never
+     * produces; the slug arrives through {@see ListenerSchemaResolver}.
+     *
+     * @param string               $schemaId Numeric schema id as OR stamps it.
+     * @param array<string, mixed> $payload  Object payload.
      *
      * @return ObjectEntity
      */
-    private function entity(string $schema, array $payload): ObjectEntity
+    private function entity(string $schemaId, array $payload): ObjectEntity
     {
         $entity = $this->createMock(ObjectEntity::class);
-        $entity->method('getSchema')->willReturn($schema);
+        $entity->method('getSchema')->willReturn($schemaId);
         $entity->method('getObject')->willReturn($payload);
         return $entity;
 
     }//end entity()
+
+    /**
+     * Stub the schema resolver so it resolves the entity's id to a slug.
+     *
+     * @param string $slug Slug the resolver reports.
+     *
+     * @return void
+     */
+    private function resolvesTo(string $slug): void
+    {
+        $this->schemaResolver->method('schemaSlug')->willReturn($slug);
+
+    }//end resolvesTo()
 
     /**
      * A PurchaseOrder reaching `approved` forwards to
@@ -103,8 +133,9 @@ class CommitmentMaterialisationListenerTest extends TestCase
      */
     public function testPurchaseOrderApprovedForwardsAndPropagatesDenial(): void
     {
+        $this->resolvesTo('PurchaseOrder');
         $payload = ['poNumber' => 'PO-2026-0207', 'statusCode' => 'approved'];
-        $entity  = $this->entity('PurchaseOrder', $payload);
+        $entity  = $this->entity('2011', $payload);
         $event   = $this->createConfiguredMock(
             ObjectTransitionedEvent::class,
             ['getObject' => $entity, 'getTo' => 'approved']
@@ -127,8 +158,9 @@ class CommitmentMaterialisationListenerTest extends TestCase
      */
     public function testPurchaseOrderOtherTransitionIgnored(): void
     {
+        $this->resolvesTo('PurchaseOrder');
         $payload = ['poNumber' => 'PO-2026-0207', 'statusCode' => 'sent'];
-        $entity  = $this->entity('PurchaseOrder', $payload);
+        $entity  = $this->entity('2011', $payload);
         $event   = $this->createConfiguredMock(
             ObjectTransitionedEvent::class,
             ['getObject' => $entity, 'getTo' => 'sent']
@@ -149,8 +181,9 @@ class CommitmentMaterialisationListenerTest extends TestCase
      */
     public function testContractActiveForwardsAndSwallowsException(): void
     {
+        $this->resolvesTo('Contract');
         $payload = ['contractNumber' => 'C-2026-007', 'status' => 'active'];
-        $entity  = $this->entity('Contract', $payload);
+        $entity  = $this->entity('2012', $payload);
         $event   = $this->createConfiguredMock(
             ObjectTransitionedEvent::class,
             ['getObject' => $entity, 'getTo' => 'active']
@@ -176,8 +209,9 @@ class CommitmentMaterialisationListenerTest extends TestCase
      */
     public function testPurchaseOrderCreatedDirectlyApprovedForwards(): void
     {
+        $this->resolvesTo('PurchaseOrder');
         $payload = ['poNumber' => 'PO-2026-0300', 'statusCode' => 'approved'];
-        $entity  = $this->entity('PurchaseOrder', $payload);
+        $entity  = $this->entity('2011', $payload);
         $event   = $this->createConfiguredMock(ObjectCreatedEvent::class, ['getObject' => $entity]);
 
         $this->materialiser->expects(self::once())
@@ -197,7 +231,8 @@ class CommitmentMaterialisationListenerTest extends TestCase
      */
     public function testUnrelatedSchemaIgnored(): void
     {
-        $entity = $this->entity('SupplierInvoice', ['statusCode' => 'approved']);
+        $this->resolvesTo('SupplierInvoice');
+        $entity = $this->entity('2013', ['statusCode' => 'approved']);
         $event  = $this->createConfiguredMock(
             ObjectTransitionedEvent::class,
             ['getObject' => $entity, 'getTo' => 'approved']
@@ -219,7 +254,8 @@ class CommitmentMaterialisationListenerTest extends TestCase
      */
     public function testPurchaseOrderLineNotMistakenForPurchaseOrder(): void
     {
-        $entity = $this->entity('PurchaseOrderLine', ['statusCode' => 'approved']);
+        $this->resolvesTo('PurchaseOrderLine');
+        $entity = $this->entity('2014', ['statusCode' => 'approved']);
         $event  = $this->createConfiguredMock(
             ObjectTransitionedEvent::class,
             ['getObject' => $entity, 'getTo' => 'approved']

--- a/tests/Unit/Listener/InnovatieboxAuditTrailListenerTest.php
+++ b/tests/Unit/Listener/InnovatieboxAuditTrailListenerTest.php
@@ -42,6 +42,7 @@ use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCA\Shillinq\Listener\InnovatieboxAuditTrailListener;
 use OCA\Shillinq\Service\InnovatieboxAuditEventLogger;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\VsoLockingValidator;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\AbstractLogger;
@@ -146,23 +147,42 @@ final class InnovatieboxAuditTrailListenerTest extends TestCase
     }//end fakeVsoValidator()
 
     /**
-     * Build an ObjectEntity stub with a payload, schema slug and uuid.
+     * Build an ObjectEntity stub carrying a numeric schema **id**, exactly as
+     * OpenRegister stamps it (`setSchema((string) $schema->getId())`).
      *
-     * @param string              $schema  Schema slug.
-     * @param array<string,mixed> $payload Object payload.
-     * @param string|null         $uuid    Optional uuid.
+     * A hand-built entity carrying the slug is a shape production never
+     * produces; the slug arrives through {@see ListenerSchemaResolver}.
+     *
+     * @param string              $schemaId Numeric schema id as OR stamps it.
+     * @param array<string,mixed> $payload  Object payload.
+     * @param string|null         $uuid     Optional uuid.
      *
      * @return ObjectEntity
      */
-    private function entity(string $schema, array $payload, ?string $uuid='uuid-1'): ObjectEntity
+    private function entity(string $schemaId, array $payload, ?string $uuid='uuid-1'): ObjectEntity
     {
         $entity = new ObjectEntity();
-        $entity->setSchema($schema);
+        $entity->setSchema($schemaId);
         $entity->setObject($payload);
         $entity->setUuid($uuid);
         return $entity;
 
     }//end entity()
+
+    /**
+     * Build a ListenerSchemaResolver stub that reports a given schema slug.
+     *
+     * @param string $slug Slug the resolver resolves the entity's id to.
+     *
+     * @return ListenerSchemaResolver
+     */
+    private function resolver(string $slug): ListenerSchemaResolver
+    {
+        $resolver = $this->createMock(ListenerSchemaResolver::class);
+        $resolver->method('schemaSlug')->willReturn($slug);
+        return $resolver;
+
+    }//end resolver()
 
     /**
      * A NexusCalculation create emits NexusCalculation.calculated with the
@@ -174,9 +194,14 @@ final class InnovatieboxAuditTrailListenerTest extends TestCase
     {
         $logger   = $this->fakeLogger();
         $vso      = $this->fakeVsoValidator(false);
-        $listener = new InnovatieboxAuditTrailListener($logger, $vso, $this->recordingLogger());
+        $listener = new InnovatieboxAuditTrailListener(
+            $logger,
+            $vso,
+            $this->resolver('NexusCalculation'),
+            $this->recordingLogger()
+        );
 
-        $entity = $this->entity('NexusCalculation', [
+        $entity = $this->entity('4101', [
             'qualifying_asset_id'             => 'asset-1',
             'administrationId'                => 'adm-x',
             'boekjaar'                        => 2026,
@@ -212,9 +237,14 @@ final class InnovatieboxAuditTrailListenerTest extends TestCase
     public function testForfaitairCreateEmitsCapAppliedTwinEvent(): void
     {
         $logger   = $this->fakeLogger();
-        $listener = new InnovatieboxAuditTrailListener($logger, $this->fakeVsoValidator(false), $this->recordingLogger());
+        $listener = new InnovatieboxAuditTrailListener(
+            $logger,
+            $this->fakeVsoValidator(false),
+            $this->resolver('IBProfitAttribution'),
+            $this->recordingLogger()
+        );
 
-        $entity = $this->entity('IBProfitAttribution', [
+        $entity = $this->entity('4102', [
             'qualifying_asset_id'             => 'asset-1',
             'administrationId'                => 'adm-x',
             'boekjaar'                        => 2026,
@@ -242,15 +272,20 @@ final class InnovatieboxAuditTrailListenerTest extends TestCase
     public function testProfitFinalizedFiresWhenVsoFlagFlips(): void
     {
         $logger   = $this->fakeLogger();
-        $listener = new InnovatieboxAuditTrailListener($logger, $this->fakeVsoValidator(false), $this->recordingLogger());
+        $listener = new InnovatieboxAuditTrailListener(
+            $logger,
+            $this->fakeVsoValidator(false),
+            $this->resolver('IBProfitAttribution'),
+            $this->recordingLogger()
+        );
 
-        $prior = $this->entity('IBProfitAttribution', [
+        $prior = $this->entity('4102', [
             'qualifying_asset_id' => 'asset-1',
             'administrationId'    => 'adm-x',
             'boekjaar'            => 2026,
             'vso_locked'          => false,
         ]);
-        $next  = $this->entity('IBProfitAttribution', [
+        $next  = $this->entity('4102', [
             'qualifying_asset_id' => 'asset-1',
             'administrationId'    => 'adm-x',
             'boekjaar'            => 2026,
@@ -278,16 +313,21 @@ final class InnovatieboxAuditTrailListenerTest extends TestCase
     public function testProfitAmendmentBlockedWhenPriorWasLocked(): void
     {
         $logger   = $this->fakeLogger();
-        $listener = new InnovatieboxAuditTrailListener($logger, $this->fakeVsoValidator(true), $this->recordingLogger());
+        $listener = new InnovatieboxAuditTrailListener(
+            $logger,
+            $this->fakeVsoValidator(true),
+            $this->resolver('IBProfitAttribution'),
+            $this->recordingLogger()
+        );
 
-        $prior = $this->entity('IBProfitAttribution', [
+        $prior = $this->entity('4102', [
             'qualifying_asset_id' => 'asset-1',
             'administrationId'    => 'adm-x',
             'boekjaar'            => 2026,
             'vso_locked'          => true,
             'voordeel_innovatiebox' => 72000,
         ]);
-        $next  = $this->entity('IBProfitAttribution', [
+        $next  = $this->entity('4102', [
             'qualifying_asset_id' => 'asset-1',
             'administrationId'    => 'adm-x',
             'boekjaar'            => 2026,
@@ -317,9 +357,14 @@ final class InnovatieboxAuditTrailListenerTest extends TestCase
     public function testLossOffsetAppliedFiresOnVerrekendGrowth(): void
     {
         $logger   = $this->fakeLogger();
-        $listener = new InnovatieboxAuditTrailListener($logger, $this->fakeVsoValidator(false), $this->recordingLogger());
+        $listener = new InnovatieboxAuditTrailListener(
+            $logger,
+            $this->fakeVsoValidator(false),
+            $this->resolver('CarryForwardLoss'),
+            $this->recordingLogger()
+        );
 
-        $prior = $this->entity('CarryForwardLoss', [
+        $prior = $this->entity('4103', [
             'qualifying_asset_id'    => 'asset-1',
             'administrationId'       => 'adm-x',
             'origin_boekjaar'        => 2024,
@@ -327,7 +372,7 @@ final class InnovatieboxAuditTrailListenerTest extends TestCase
             'saldo_na'               => 215000,
             'status'                 => 'open',
         ]);
-        $next = $this->entity('CarryForwardLoss', [
+        $next = $this->entity('4103', [
             'qualifying_asset_id' => 'asset-1',
             'administrationId'    => 'adm-x',
             'origin_boekjaar'     => 2024,
@@ -359,9 +404,14 @@ final class InnovatieboxAuditTrailListenerTest extends TestCase
     public function testNonInnovatieboxSchemaIsIgnored(): void
     {
         $logger   = $this->fakeLogger();
-        $listener = new InnovatieboxAuditTrailListener($logger, $this->fakeVsoValidator(false), $this->recordingLogger());
+        $listener = new InnovatieboxAuditTrailListener(
+            $logger,
+            $this->fakeVsoValidator(false),
+            $this->resolver('GLLine'),
+            $this->recordingLogger()
+        );
 
-        $entity = $this->entity('GLLine', ['administrationId' => 'adm-x']);
+        $entity = $this->entity('4207', ['administrationId' => 'adm-x']);
         $event  = new ObjectCreatedEvent($entity);
 
         $listener->handle($event);

--- a/tests/Unit/Listener/LeaseActivationListenerTest.php
+++ b/tests/Unit/Listener/LeaseActivationListenerTest.php
@@ -28,6 +28,7 @@ use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCA\Shillinq\Listener\LeaseActivationListener;
 use OCA\Shillinq\Service\LeaseAmortizationCalculator;
 use OCA\Shillinq\Service\LeasePaymentScheduleService;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -66,11 +67,12 @@ final class LeaseActivationListenerTest extends TestCase
      * Build the listener over a schedule service backed by an ObjectService
      * stub seeded with the given leases.
      *
-     * @param array<int,array<string,mixed>> $leases LeaseContract records.
+     * @param array<int,array<string,mixed>> $leases     LeaseContract records.
+     * @param string                         $schemaSlug Slug the schema resolver reports for the event entity.
      *
      * @return LeaseActivationListener
      */
-    private function buildListener(array $leases): LeaseActivationListener
+    private function buildListener(array $leases, string $schemaSlug='LeaseContract'): LeaseActivationListener
     {
         $saved = &$this->saved;
         $stub  = new class($leases, $saved) {
@@ -176,25 +178,33 @@ final class LeaseActivationListenerTest extends TestCase
             logger: $this->createMock(LoggerInterface::class),
         );
 
+        $schemaResolver = $this->createMock(ListenerSchemaResolver::class);
+        $schemaResolver->method('schemaSlug')->willReturn($schemaSlug);
+
         return new LeaseActivationListener(
             scheduleService: $scheduleService,
+            schemaResolver: $schemaResolver,
             logger: $this->createMock(LoggerInterface::class),
         );
 
     }//end buildListener()
 
     /**
-     * Build an ObjectEntity mock over a schema + object body.
+     * Build an ObjectEntity mock carrying a numeric schema **id**, exactly as
+     * OpenRegister stamps it (`setSchema((string) $schema->getId())`).
      *
-     * @param string              $schema The schema slug.
-     * @param array<string,mixed> $object The object body.
+     * A hand-built entity carrying the slug is a shape production never
+     * produces; the slug arrives through {@see ListenerSchemaResolver}.
+     *
+     * @param string              $schemaId Numeric schema id as OR stamps it.
+     * @param array<string,mixed> $object   The object body.
      *
      * @return ObjectEntity
      */
-    private function entity(string $schema, array $object): ObjectEntity
+    private function entity(string $schemaId, array $object): ObjectEntity
     {
         $entity = $this->createMock(ObjectEntity::class);
-        $entity->method('getSchema')->willReturn($schema);
+        $entity->method('getSchema')->willReturn($schemaId);
         $entity->method('getObject')->willReturn($object);
         return $entity;
 
@@ -238,8 +248,8 @@ final class LeaseActivationListenerTest extends TestCase
         $event = $this->createConfiguredMock(
             ObjectUpdatedEvent::class,
             [
-                'getObject'    => $this->entity('LeaseContract', $this->lease('active')),
-                'getOldObject' => $this->entity('LeaseContract', $this->lease('draft')),
+                'getObject'    => $this->entity('5011', $this->lease('active')),
+                'getOldObject' => $this->entity('5011', $this->lease('draft')),
             ]
         );
 
@@ -277,7 +287,7 @@ final class LeaseActivationListenerTest extends TestCase
 
         $event = $this->createConfiguredMock(
             ObjectCreatedEvent::class,
-            ['getObject' => $this->entity('LeaseContract', $this->lease('active'))]
+            ['getObject' => $this->entity('5011', $this->lease('active'))]
         );
 
         $listener->handle($event);
@@ -298,8 +308,8 @@ final class LeaseActivationListenerTest extends TestCase
         $event = $this->createConfiguredMock(
             ObjectUpdatedEvent::class,
             [
-                'getObject'    => $this->entity('LeaseContract', $this->lease('active')),
-                'getOldObject' => $this->entity('LeaseContract', $this->lease('active')),
+                'getObject'    => $this->entity('5011', $this->lease('active')),
+                'getOldObject' => $this->entity('5011', $this->lease('active')),
             ]
         );
 
@@ -316,13 +326,13 @@ final class LeaseActivationListenerTest extends TestCase
      */
     public function testNonLeaseSchemaWritesNothing(): void
     {
-        $listener = $this->buildListener([$this->lease('active')]);
+        $listener = $this->buildListener([$this->lease('active')], 'StockMove');
 
         $event = $this->createConfiguredMock(
             ObjectUpdatedEvent::class,
             [
-                'getObject'    => $this->entity('StockMove', $this->lease('active')),
-                'getOldObject' => $this->entity('StockMove', $this->lease('draft')),
+                'getObject'    => $this->entity('5099', $this->lease('active')),
+                'getOldObject' => $this->entity('5099', $this->lease('draft')),
             ]
         );
 
@@ -349,8 +359,8 @@ final class LeaseActivationListenerTest extends TestCase
         $event = $this->createConfiguredMock(
             ObjectUpdatedEvent::class,
             [
-                'getObject'    => $this->entity('LeaseContract', $exemptActive),
-                'getOldObject' => $this->entity('LeaseContract', $exemptDraft),
+                'getObject'    => $this->entity('5011', $exemptActive),
+                'getOldObject' => $this->entity('5011', $exemptDraft),
             ]
         );
 

--- a/tests/Unit/Listener/OpdrachtUitvoeringTransitionListenerTest.php
+++ b/tests/Unit/Listener/OpdrachtUitvoeringTransitionListenerTest.php
@@ -37,6 +37,7 @@ use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Integration\TenderNedStatusSync;
 use OCA\Shillinq\Listener\OpdrachtUitvoeringTransitionListener;
 use OCA\Shillinq\Service\BudgetImpactEmitter;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
@@ -170,21 +171,40 @@ final class OpdrachtUitvoeringTransitionListenerTest extends TestCase
     }//end emptyAppConfig()
 
     /**
-     * Build an ObjectEntity with schema + payload.
+     * Build an ObjectEntity carrying a numeric schema **id**, exactly as
+     * OpenRegister stamps it (`setSchema((string) $schema->getId())`).
      *
-     * @param string              $schema  Schema slug.
-     * @param array<string,mixed> $payload Payload.
+     * A hand-built entity carrying the slug is a shape production never
+     * produces; the slug arrives through {@see ListenerSchemaResolver}.
+     *
+     * @param string              $schemaId Numeric schema id as OR stamps it.
+     * @param array<string,mixed> $payload  Payload.
      *
      * @return ObjectEntity
      */
-    private function entity(string $schema, array $payload): ObjectEntity
+    private function entity(string $schemaId, array $payload): ObjectEntity
     {
         $entity = new ObjectEntity();
-        $entity->setSchema($schema);
+        $entity->setSchema($schemaId);
         $entity->setObject($payload);
         return $entity;
 
     }//end entity()
+
+    /**
+     * Build a ListenerSchemaResolver stub that reports a given schema slug.
+     *
+     * @param string $slug Slug the resolver resolves the entity's id to.
+     *
+     * @return ListenerSchemaResolver
+     */
+    private function resolver(string $slug): ListenerSchemaResolver
+    {
+        $resolver = $this->createMock(ListenerSchemaResolver::class);
+        $resolver->method('schemaSlug')->willReturn($slug);
+        return $resolver;
+
+    }//end resolver()
 
     /**
      * A completed regular milestone emits but does NOT sync.
@@ -196,10 +216,15 @@ final class OpdrachtUitvoeringTransitionListenerTest extends TestCase
         $dispatcher = $this->recordingDispatcher();
         $emitter    = new BudgetImpactEmitter($dispatcher, new NullLogger());
         $sync       = $this->spyingSync();
-        $listener   = new OpdrachtUitvoeringTransitionListener($emitter, $sync, new NullLogger());
+        $listener   = new OpdrachtUitvoeringTransitionListener(
+            $emitter,
+            $sync,
+            $this->resolver('OpdrachtUitvoering'),
+            new NullLogger()
+        );
 
         $event = new ObjectTransitionedEvent(
-            $this->entity('OpdrachtUitvoering', [
+            $this->entity('1201', [
                 'verplichtingId'  => 'TN-2026-0001',
                 'mijlpaalId'      => 'M-Q1',
                 'opleveringsType' => 'tussenoplevering',
@@ -232,10 +257,15 @@ final class OpdrachtUitvoeringTransitionListenerTest extends TestCase
         $dispatcher = $this->recordingDispatcher();
         $emitter    = new BudgetImpactEmitter($dispatcher, new NullLogger());
         $sync       = $this->spyingSync();
-        $listener   = new OpdrachtUitvoeringTransitionListener($emitter, $sync, new NullLogger());
+        $listener   = new OpdrachtUitvoeringTransitionListener(
+            $emitter,
+            $sync,
+            $this->resolver('OpdrachtUitvoering'),
+            new NullLogger()
+        );
 
         $event = new ObjectTransitionedEvent(
-            $this->entity('OpdrachtUitvoering', [
+            $this->entity('1201', [
                 'verplichtingId'  => 'TN-2026-0001',
                 'mijlpaalId'      => 'M-EIND',
                 'opleveringsType' => 'eindoplevering',
@@ -267,10 +297,15 @@ final class OpdrachtUitvoeringTransitionListenerTest extends TestCase
         $dispatcher = $this->recordingDispatcher();
         $emitter    = new BudgetImpactEmitter($dispatcher, new NullLogger());
         $sync       = $this->spyingSync();
-        $listener   = new OpdrachtUitvoeringTransitionListener($emitter, $sync, new NullLogger());
+        $listener   = new OpdrachtUitvoeringTransitionListener(
+            $emitter,
+            $sync,
+            $this->resolver('OpdrachtUitvoering'),
+            new NullLogger()
+        );
 
         $event = new ObjectTransitionedEvent(
-            $this->entity('OpdrachtUitvoering', [
+            $this->entity('1201', [
                 'verplichtingId'  => 'TN-2026-0001',
                 'mijlpaalId'      => 'M-EIND',
                 'opleveringsType' => 'eindoplevering',
@@ -301,10 +336,15 @@ final class OpdrachtUitvoeringTransitionListenerTest extends TestCase
         $dispatcher = $this->recordingDispatcher();
         $emitter    = new BudgetImpactEmitter($dispatcher, new NullLogger());
         $sync       = $this->spyingSync();
-        $listener   = new OpdrachtUitvoeringTransitionListener($emitter, $sync, new NullLogger());
+        $listener   = new OpdrachtUitvoeringTransitionListener(
+            $emitter,
+            $sync,
+            $this->resolver('OpdrachtUitvoering'),
+            new NullLogger()
+        );
 
         $event = new ObjectTransitionedEvent(
-            $this->entity('OpdrachtUitvoering', [
+            $this->entity('1201', [
                 'verplichtingId'  => 'TN-2026-0001',
                 'mijlpaalId'      => 'M-EIND',
                 'opleveringsType' => 'eindoplevering',
@@ -335,10 +375,15 @@ final class OpdrachtUitvoeringTransitionListenerTest extends TestCase
         $dispatcher = $this->recordingDispatcher();
         $emitter    = new BudgetImpactEmitter($dispatcher, new NullLogger());
         $sync       = $this->spyingSync();
-        $listener   = new OpdrachtUitvoeringTransitionListener($emitter, $sync, new NullLogger());
+        $listener   = new OpdrachtUitvoeringTransitionListener(
+            $emitter,
+            $sync,
+            $this->resolver('Verplichting'),
+            new NullLogger()
+        );
 
         $event = new ObjectTransitionedEvent(
-            $this->entity('Verplichting', ['status' => 'active']),
+            $this->entity('1089', ['status' => 'active']),
             'activeren',
             'concept',
             'completed',

--- a/tests/Unit/Listener/OssPaymentReconciliationListenerTest.php
+++ b/tests/Unit/Listener/OssPaymentReconciliationListenerTest.php
@@ -32,6 +32,7 @@ namespace OCA\Shillinq\Tests\Unit\Listener;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\Shillinq\Listener\OssPaymentReconciliationListener;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\OssPaymentReconciliation;
 use OCA\Shillinq\Service\OssRecordResolver;
 use OCA\Shillinq\Tests\Unit\Service\InMemoryObjectService;
@@ -65,6 +66,14 @@ class OssPaymentReconciliationListenerTest extends TestCase
     private OssPaymentReconciliationListener $listener;
 
     /**
+     * Mock schema resolver — turns the entity's numeric schema id into a slug,
+     * exactly as it does in production.
+     *
+     * @var ListenerSchemaResolver&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private ListenerSchemaResolver $schemaResolver;
+
+    /**
      * Set up the real chain over an in-memory ObjectService.
      *
      * @return void
@@ -87,13 +96,29 @@ class OssPaymentReconciliationListenerTest extends TestCase
             logger: $this->createMock(LoggerInterface::class),
         );
 
+        $this->schemaResolver = $this->createMock(ListenerSchemaResolver::class);
+
         $this->listener = new OssPaymentReconciliationListener(
             resolver: $resolver,
             reconciliation: new OssPaymentReconciliation(),
+            schemaResolver: $this->schemaResolver,
             logger: $this->createMock(LoggerInterface::class),
         );
 
     }//end setUp()
+
+    /**
+     * Stub the schema resolver so it resolves the entity's id to a slug.
+     *
+     * @param string $slug Slug the resolver reports.
+     *
+     * @return void
+     */
+    private function resolvesTo(string $slug): void
+    {
+        $this->schemaResolver->method('schemaSlug')->willReturn($slug);
+
+    }//end resolvesTo()
 
     /**
      * Seed the declared OssReturn (DE 1802.00 + FR 1440.00).
@@ -143,8 +168,12 @@ class OssPaymentReconciliationListenerTest extends TestCase
 
         $this->objects->seed('OssPayment', [$payment]);
 
+        $this->resolvesTo('OssPayment');
+
+        // OpenRegister stamps the numeric schema **id** on the entity — the
+        // slug only ever arrives via the resolver.
         $entity = $this->createMock(ObjectEntity::class);
-        $entity->method('getSchema')->willReturn('OssPayment');
+        $entity->method('getSchema')->willReturn('3311');
         $entity->method('getObject')->willReturn($payment);
 
         $event = $this->createConfiguredMock(ObjectCreatedEvent::class, ['getObject' => $entity]);
@@ -240,8 +269,10 @@ class OssPaymentReconciliationListenerTest extends TestCase
      */
     public function testOtherSchemaIsIgnored(): void
     {
+        $this->resolvesTo('OssReturn');
+
         $entity = $this->createMock(ObjectEntity::class);
-        $entity->method('getSchema')->willReturn('OssReturn');
+        $entity->method('getSchema')->willReturn('3310');
         $entity->method('getObject')->willReturn(['id' => 'ossret-1']);
 
         $event = $this->createConfiguredMock(ObjectCreatedEvent::class, ['getObject' => $entity]);

--- a/tests/Unit/Listener/TenderNedAwardDetectedListenerTest.php
+++ b/tests/Unit/Listener/TenderNedAwardDetectedListenerTest.php
@@ -42,6 +42,7 @@ use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\Shillinq\Listener\TenderNedAwardDetectedListener;
 use OCA\Shillinq\Service\BudgetImpactEmitter;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\MilestoneTemplateService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -212,13 +213,17 @@ final class TenderNedAwardDetectedListenerTest extends TestCase
     /**
      * Build a listener with the supplied container + tenant KvK.
      *
-     * @param ContainerInterface $container Container.
-     * @param string             $tenantKvk Tenant KvK (default empty).
+     * @param ContainerInterface $container  Container.
+     * @param string             $tenantKvk  Tenant KvK (default empty).
+     * @param string             $schemaSlug Slug the schema resolver reports for the event entity.
      *
      * @return array{0: TenderNedAwardDetectedListener, 1: IEventDispatcher} Listener + dispatcher to inspect.
      */
-    private function listener(ContainerInterface $container, string $tenantKvk=''): array
-    {
+    private function listener(
+        ContainerInterface $container,
+        string $tenantKvk='',
+        string $schemaSlug='TenderNedAanbesteding'
+    ): array {
         $dispatcher = $this->recordingDispatcher();
         $emitter    = new BudgetImpactEmitter($dispatcher, new NullLogger());
         $templates  = new MilestoneTemplateService();
@@ -227,6 +232,7 @@ final class TenderNedAwardDetectedListenerTest extends TestCase
             $emitter,
             $container,
             $this->appConfigWithTenantKvk($tenantKvk),
+            $this->resolver($schemaSlug),
             new NullLogger()
         );
         return [$listener, $dispatcher];
@@ -234,17 +240,36 @@ final class TenderNedAwardDetectedListenerTest extends TestCase
     }//end listener()
 
     /**
-     * Build an ObjectEntity with schema + payload.
+     * Build a ListenerSchemaResolver stub that reports a given schema slug.
      *
-     * @param string              $schema  Schema slug.
-     * @param array<string,mixed> $payload Payload.
+     * @param string $slug Slug the resolver resolves the entity's id to.
+     *
+     * @return ListenerSchemaResolver
+     */
+    private function resolver(string $slug): ListenerSchemaResolver
+    {
+        $resolver = $this->createMock(ListenerSchemaResolver::class);
+        $resolver->method('schemaSlug')->willReturn($slug);
+        return $resolver;
+
+    }//end resolver()
+
+    /**
+     * Build an ObjectEntity carrying a numeric schema **id**, exactly as
+     * OpenRegister stamps it (`setSchema((string) $schema->getId())`).
+     *
+     * A hand-built entity carrying the slug is a shape production never
+     * produces; the slug arrives through {@see ListenerSchemaResolver}.
+     *
+     * @param string              $schemaId Numeric schema id as OR stamps it.
+     * @param array<string,mixed> $payload  Payload.
      *
      * @return ObjectEntity
      */
-    private function entity(string $schema, array $payload): ObjectEntity
+    private function entity(string $schemaId, array $payload): ObjectEntity
     {
         $entity = new ObjectEntity();
-        $entity->setSchema($schema);
+        $entity->setSchema($schemaId);
         $entity->setObject($payload);
         return $entity;
 
@@ -258,10 +283,10 @@ final class TenderNedAwardDetectedListenerTest extends TestCase
     public function testNonAanbestedingSchemaIsIgnored(): void
     {
         [$container, $recorder] = $this->containerAndRecorder([]);
-        [$listener, $dispatcher] = $this->listener($container, '30280353');
+        [$listener, $dispatcher] = $this->listener($container, '30280353', 'Verplichting');
 
         $event = new ObjectCreatedEvent(
-            $this->entity('Verplichting', ['status' => 'gegund', 'contractWaarde' => 100.0])
+            $this->entity('1089', ['status' => 'gegund', 'contractWaarde' => 100.0])
         );
 
         $listener->handle($event);
@@ -282,7 +307,7 @@ final class TenderNedAwardDetectedListenerTest extends TestCase
         [$listener, $dispatcher] = $this->listener($container, '30280353');
 
         $event = new ObjectCreatedEvent(
-            $this->entity('TenderNedAanbesteding', [
+            $this->entity('1090', [
                 'status'             => 'open',
                 'contractWaarde'     => 50000.0,
                 'gegundeLeverancier' => '30280353 Test BV',
@@ -307,7 +332,7 @@ final class TenderNedAwardDetectedListenerTest extends TestCase
         [$listener, $dispatcher] = $this->listener($container, '30280353');
 
         $event = new ObjectCreatedEvent(
-            $this->entity('TenderNedAanbesteding', [
+            $this->entity('1090', [
                 'status'             => 'gegund',
                 'contractWaarde'     => 0.0,
                 'gegundeLeverancier' => '30280353 Test BV',
@@ -332,7 +357,7 @@ final class TenderNedAwardDetectedListenerTest extends TestCase
         [$listener, $dispatcher] = $this->listener($container, '');
 
         $event = new ObjectCreatedEvent(
-            $this->entity('TenderNedAanbesteding', [
+            $this->entity('1090', [
                 'status'             => 'gegund',
                 'contractWaarde'     => 50000.0,
                 'gegundeLeverancier' => '30280353 Test BV',
@@ -357,7 +382,7 @@ final class TenderNedAwardDetectedListenerTest extends TestCase
         [$listener, $dispatcher] = $this->listener($container, '99999999');
 
         $event = new ObjectCreatedEvent(
-            $this->entity('TenderNedAanbesteding', [
+            $this->entity('1090', [
                 'status'             => 'gegund',
                 'contractWaarde'     => 50000.0,
                 'gegundeLeverancier' => '30280353 Test BV',
@@ -382,7 +407,7 @@ final class TenderNedAwardDetectedListenerTest extends TestCase
         [$listener, $dispatcher] = $this->listener($container, '30280353');
 
         $event = new ObjectCreatedEvent(
-            $this->entity('TenderNedAanbesteding', [
+            $this->entity('1090', [
                 'status'             => 'gegund',
                 'contractWaarde'     => 50000.0,
                 'gegundeLeverancier' => '30280353 Conduction B.V.',
@@ -438,7 +463,7 @@ final class TenderNedAwardDetectedListenerTest extends TestCase
         [$listener, $dispatcher] = $this->listener($container, '30280353');
 
         $event = new ObjectCreatedEvent(
-            $this->entity('TenderNedAanbesteding', [
+            $this->entity('1090', [
                 'status'             => 'gegund',
                 'contractWaarde'     => 50000.0,
                 'gegundeLeverancier' => '30280353 Conduction B.V.',

--- a/tests/Unit/Listener/VerplichtingTransitionListenerTest.php
+++ b/tests/Unit/Listener/VerplichtingTransitionListenerTest.php
@@ -36,6 +36,7 @@ use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Listener\VerplichtingTransitionListener;
 use OCA\Shillinq\Service\BudgetImpactEmitter;
+use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use PHPUnit\Framework\TestCase;
@@ -103,21 +104,40 @@ final class VerplichtingTransitionListenerTest extends TestCase
     }//end recordingDispatcher()
 
     /**
-     * Build an ObjectEntity with schema + payload.
+     * Build an ObjectEntity carrying a numeric schema **id**, exactly as
+     * OpenRegister stamps it (`setSchema((string) $schema->getId())`).
      *
-     * @param string              $schema  Schema slug.
-     * @param array<string,mixed> $payload Payload.
+     * A hand-built entity carrying the slug is a shape production never
+     * produces; the slug arrives through {@see ListenerSchemaResolver}.
+     *
+     * @param string              $schemaId Numeric schema id as OR stamps it.
+     * @param array<string,mixed> $payload  Payload.
      *
      * @return ObjectEntity
      */
-    private function entity(string $schema, array $payload): ObjectEntity
+    private function entity(string $schemaId, array $payload): ObjectEntity
     {
         $entity = new ObjectEntity();
-        $entity->setSchema($schema);
+        $entity->setSchema($schemaId);
         $entity->setObject($payload);
         return $entity;
 
     }//end entity()
+
+    /**
+     * Build a ListenerSchemaResolver stub that reports a given schema slug.
+     *
+     * @param string $slug Slug the resolver resolves the entity's id to.
+     *
+     * @return ListenerSchemaResolver
+     */
+    private function resolver(string $slug): ListenerSchemaResolver
+    {
+        $resolver = $this->createMock(ListenerSchemaResolver::class);
+        $resolver->method('schemaSlug')->willReturn($slug);
+        return $resolver;
+
+    }//end resolver()
 
     /**
      * A created Verplichting with bron=tenderned + status=active emits.
@@ -128,10 +148,10 @@ final class VerplichtingTransitionListenerTest extends TestCase
     {
         $dispatcher = $this->recordingDispatcher();
         $emitter    = new BudgetImpactEmitter($dispatcher, new NullLogger());
-        $listener   = new VerplichtingTransitionListener($emitter, new NullLogger());
+        $listener   = new VerplichtingTransitionListener($emitter, $this->resolver('Verplichting'), new NullLogger());
 
         $event = new ObjectCreatedEvent(
-            $this->entity('Verplichting', [
+            $this->entity('1089', [
                 'bron'           => 'tenderned',
                 'bronReferentie' => 'TN-2026-0001',
                 'status'         => 'active',
@@ -155,10 +175,10 @@ final class VerplichtingTransitionListenerTest extends TestCase
     {
         $dispatcher = $this->recordingDispatcher();
         $emitter    = new BudgetImpactEmitter($dispatcher, new NullLogger());
-        $listener   = new VerplichtingTransitionListener($emitter, new NullLogger());
+        $listener   = new VerplichtingTransitionListener($emitter, $this->resolver('Verplichting'), new NullLogger());
 
         $event = new ObjectCreatedEvent(
-            $this->entity('Verplichting', [
+            $this->entity('1089', [
                 'bron'   => 'manual',
                 'status' => 'active',
                 'bedrag' => 5000.0,
@@ -181,10 +201,10 @@ final class VerplichtingTransitionListenerTest extends TestCase
     {
         $dispatcher = $this->recordingDispatcher();
         $emitter    = new BudgetImpactEmitter($dispatcher, new NullLogger());
-        $listener   = new VerplichtingTransitionListener($emitter, new NullLogger());
+        $listener   = new VerplichtingTransitionListener($emitter, $this->resolver('Verplichting'), new NullLogger());
 
         $event = new ObjectCreatedEvent(
-            $this->entity('Verplichting', [
+            $this->entity('1089', [
                 'bron'   => 'tenderned',
                 'status' => 'concept',
                 'bedrag' => 5000.0,
@@ -206,10 +226,10 @@ final class VerplichtingTransitionListenerTest extends TestCase
     {
         $dispatcher = $this->recordingDispatcher();
         $emitter    = new BudgetImpactEmitter($dispatcher, new NullLogger());
-        $listener   = new VerplichtingTransitionListener($emitter, new NullLogger());
+        $listener   = new VerplichtingTransitionListener($emitter, $this->resolver('Verplichting'), new NullLogger());
 
         $event = new ObjectTransitionedEvent(
-            $this->entity('Verplichting', [
+            $this->entity('1089', [
                 'bron'   => 'tenderned',
                 'status' => 'active',
                 'bedrag' => 5000.0,
@@ -237,10 +257,10 @@ final class VerplichtingTransitionListenerTest extends TestCase
     {
         $dispatcher = $this->recordingDispatcher();
         $emitter    = new BudgetImpactEmitter($dispatcher, new NullLogger());
-        $listener   = new VerplichtingTransitionListener($emitter, new NullLogger());
+        $listener   = new VerplichtingTransitionListener($emitter, $this->resolver('Verplichting'), new NullLogger());
 
         $event = new ObjectTransitionedEvent(
-            $this->entity('Verplichting', [
+            $this->entity('1089', [
                 'bron'   => 'tenderned',
                 'status' => 'concept',
                 'bedrag' => 5000.0,
@@ -268,10 +288,14 @@ final class VerplichtingTransitionListenerTest extends TestCase
     {
         $dispatcher = $this->recordingDispatcher();
         $emitter    = new BudgetImpactEmitter($dispatcher, new NullLogger());
-        $listener   = new VerplichtingTransitionListener($emitter, new NullLogger());
+        $listener   = new VerplichtingTransitionListener(
+            $emitter,
+            $this->resolver('TenderNedAanbesteding'),
+            new NullLogger()
+        );
 
         $event = new ObjectCreatedEvent(
-            $this->entity('TenderNedAanbesteding', [
+            $this->entity('1090', [
                 'bron'   => 'tenderned',
                 'status' => 'active',
             ])
@@ -298,10 +322,10 @@ final class VerplichtingTransitionListenerTest extends TestCase
     {
         $dispatcher = $this->recordingDispatcher();
         $emitter    = new BudgetImpactEmitter($dispatcher, new NullLogger());
-        $listener   = new VerplichtingTransitionListener($emitter, new NullLogger());
+        $listener   = new VerplichtingTransitionListener($emitter, $this->resolver('SalesOrder'), new NullLogger());
 
         $entity = new ObjectEntity();
-        $entity->setSchema('not-a-verplichting');
+        $entity->setSchema('4242');
         $event  = new ObjectCreatedEvent($entity);
         $listener->handle($event);
 

--- a/tests/Unit/Service/ListenerSchemaResolverTest.php
+++ b/tests/Unit/Service/ListenerSchemaResolverTest.php
@@ -1,0 +1,348 @@
+<?php
+
+/**
+ * Tests for {@see \OCA\Shillinq\Service\ListenerSchemaResolver}.
+ *
+ * These are POSITIVE controls for the id-vs-slug listener defect: each one
+ * asserts the resolver actually PRODUCES the slug a listener guard compares
+ * against, given the id-shaped entity OpenRegister really emits. A test that
+ * only asserted "an unrelated schema is ignored" would pass against a resolver
+ * that returned '' unconditionally — which is exactly how the original defect
+ * stayed invisible.
+ *
+ * The id/slug pairs below are the real values on the development instance
+ * (`oc_openregister_schemas`): LeaseContract=1089, ACMReport=1102,
+ * SalesOrder=1119, and the two colliding `automation` schemas 71 / 5103.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Service;
+
+use OCA\Shillinq\Service\ListenerSchemaResolver;
+use OCA\Shillinq\Service\ListenerSlugContract;
+use OCA\Shillinq\Service\SettingsService;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Covers slug resolution, register scoping and the default-off gate.
+ */
+class ListenerSchemaResolverTest extends TestCase
+{
+
+    /**
+     * Build a resolver over a fixed id => slug map.
+     *
+     * @param array<string,string> $schemas   Schema id => slug.
+     * @param array<string,string> $registers Register id => slug.
+     * @param bool                 $enabled   Whether the slug contract is on.
+     * @param string               $ownSlug   shillinq's configured register slug.
+     *
+     * @return ListenerSchemaResolver
+     */
+    private function resolver(
+        array $schemas,
+        array $registers,
+        bool $enabled=true,
+        string $ownSlug='shillinq',
+    ): ListenerSchemaResolver {
+        $schemaMapper   = $this->mapperReturning(map: $schemas);
+        $registerMapper = $this->mapperReturning(map: $registers);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(
+            static function (string $service) use ($schemaMapper, $registerMapper) {
+                if (str_contains($service, 'SchemaMapper') === true) {
+                    return $schemaMapper;
+                }
+
+                return $registerMapper;
+            }
+        );
+
+        $settings = $this->createMock(SettingsService::class);
+        $settings->method('getRegisterSlug')->willReturn($ownSlug);
+
+        $contract = $this->createMock(ListenerSlugContract::class);
+        $contract->method('isEnabled')->willReturn($enabled);
+
+        return new ListenerSchemaResolver(
+            container: $container,
+            settingsService: $settings,
+            contract: $contract,
+            logger: $this->createMock(LoggerInterface::class),
+        );
+
+    }//end resolver()
+
+    /**
+     * A stand-in mapper whose find() resolves ids from a map.
+     *
+     * @param array<string,string> $map Id => slug.
+     *
+     * @return object
+     */
+    private function mapperReturning(array $map): object
+    {
+        return new class($map) {
+
+            /**
+             * Constructor.
+             *
+             * @param array<string,string> $map Id => slug.
+             */
+            public function __construct(private array $map)
+            {
+            }
+
+            /**
+             * Resolve an id to a slug-bearing entity.
+             *
+             * @param string $id The id to resolve.
+             *
+             * @return object
+             *
+             * @throws \RuntimeException When the id is unknown.
+             */
+            public function find(string $id): object
+            {
+                if (array_key_exists($id, $this->map) === false) {
+                    throw new \RuntimeException('not found');
+                }
+
+                return new class($this->map[$id]) {
+
+                    /**
+                     * Constructor.
+                     *
+                     * @param string $slug The slug.
+                     */
+                    public function __construct(private string $slug)
+                    {
+                    }
+
+                    /**
+                     * The slug.
+                     *
+                     * @return string
+                     */
+                    public function getSlug(): string
+                    {
+                        return $this->slug;
+                    }
+                };
+            }
+        };
+
+    }//end mapperReturning()
+
+    /**
+     * An ObjectEntity-shaped stub carrying ids, exactly as MagicMapper emits.
+     *
+     * @param string $registerId The register id.
+     * @param string $schemaId   The schema id.
+     *
+     * @return object
+     */
+    private function entity(string $registerId, string $schemaId): object
+    {
+        return new class($registerId, $schemaId) {
+
+            /**
+             * Constructor.
+             *
+             * @param string $registerId The register id.
+             * @param string $schemaId   The schema id.
+             */
+            public function __construct(private string $registerId, private string $schemaId)
+            {
+            }
+
+            /**
+             * The register id, as OpenRegister stamps it.
+             *
+             * @return string
+             */
+            public function getRegister(): string
+            {
+                return $this->registerId;
+            }
+
+            /**
+             * The schema id, as OpenRegister stamps it.
+             *
+             * @return string
+             */
+            public function getSchema(): string
+            {
+                return $this->schemaId;
+            }
+        };
+
+    }//end entity()
+
+    /**
+     * POSITIVE CONTROL: an id-shaped entity resolves to the slug the listeners
+     * compare against. Before the fix this returned the id '1089'.
+     *
+     * @return void
+     */
+    public function testResolvesSchemaIdToSlug(): void
+    {
+        $resolver = $this->resolver(
+            schemas: ['1089' => 'LeaseContract'],
+            registers: ['264' => 'shillinq'],
+        );
+
+        $slug = $resolver->schemaSlug(entity: $this->entity(registerId: '264', schemaId: '1089'));
+
+        $this->assertSame('LeaseContract', $slug);
+        // And the listeners' own normalisation still matches.
+        $this->assertSame('leasecontract', strtolower($slug));
+
+    }//end testResolvesSchemaIdToSlug()
+
+    /**
+     * POSITIVE CONTROL: an uppercase slug survives verbatim. `ACMReport` and
+     * `AnnualReport` really are the slugs (ids 1102 / 1008) — 891 of this
+     * instance's schema slugs contain uppercase, so kebab-casing them would
+     * BREAK the guards rather than fix them.
+     *
+     * @return void
+     */
+    public function testUppercaseSlugIsPreservedVerbatim(): void
+    {
+        $resolver = $this->resolver(
+            schemas: ['1102' => 'ACMReport'],
+            registers: ['264' => 'shillinq'],
+        );
+
+        $this->assertSame(
+            'ACMReport',
+            $resolver->schemaSlug(entity: $this->entity(registerId: '264', schemaId: '1102'))
+        );
+
+    }//end testUppercaseSlugIsPreservedVerbatim()
+
+    /**
+     * The register scope is what stops a schema-only literal firing on another
+     * app's objects. Schema 5103 is also slugged `automation`, exactly like
+     * schema 71 — but it lives in a different register.
+     *
+     * @return void
+     */
+    public function testForeignRegisterYieldsEmptySlug(): void
+    {
+        $resolver = $this->resolver(
+            schemas: [
+                '71'   => 'automation',
+                '5103' => 'automation',
+            ],
+            registers: [
+                '264' => 'shillinq',
+                '9'   => 'scholiq',
+            ],
+        );
+
+        // Same slug, foreign register -> refused.
+        $this->assertSame(
+            '',
+            $resolver->schemaSlug(entity: $this->entity(registerId: '9', schemaId: '5103'))
+        );
+
+        // Positive control for the same call shape: own register -> resolved.
+        $this->assertSame(
+            'automation',
+            $resolver->schemaSlug(entity: $this->entity(registerId: '264', schemaId: '71'))
+        );
+
+    }//end testForeignRegisterYieldsEmptySlug()
+
+    /**
+     * With the contract disabled the resolver reproduces the pre-fix behaviour
+     * exactly: it hands back the raw id, so every listener guard still misses.
+     *
+     * @return void
+     */
+    public function testDisabledContractReturnsTheRawIdSoListenersStayDead(): void
+    {
+        $resolver = $this->resolver(
+            schemas: ['1089' => 'LeaseContract'],
+            registers: ['264' => 'shillinq'],
+            enabled: false,
+        );
+
+        $this->assertSame(
+            '1089',
+            $resolver->schemaSlug(entity: $this->entity(registerId: '264', schemaId: '1089'))
+        );
+
+    }//end testDisabledContractReturnsTheRawIdSoListenersStayDead()
+
+    /**
+     * OpenRegister is a soft dependency: an absent mapper must degrade to '',
+     * never throw into the object-write path.
+     *
+     * @return void
+     */
+    public function testUnresolvableSchemaDegradesToEmptyString(): void
+    {
+        $resolver = $this->resolver(
+            schemas: [],
+            registers: ['264' => 'shillinq'],
+        );
+
+        $this->assertSame(
+            '',
+            $resolver->schemaSlug(entity: $this->entity(registerId: '264', schemaId: '9999'))
+        );
+
+    }//end testUnresolvableSchemaDegradesToEmptyString()
+
+    /**
+     * A null entity is not a match.
+     *
+     * @return void
+     */
+    public function testNullEntityIsNotAMatch(): void
+    {
+        $resolver = $this->resolver(schemas: [], registers: []);
+
+        $this->assertSame('', $resolver->schemaSlug(entity: null));
+        $this->assertFalse($resolver->isOwnRegister(entity: null));
+
+    }//end testNullEntityIsNotAMatch()
+
+    /**
+     * An entity that already carries a slug (a hand-built one, or a future
+     * OpenRegister that stops stamping ids) is still recognised.
+     *
+     * @return void
+     */
+    public function testRegisterSlugIsAcceptedDirectly(): void
+    {
+        $resolver = $this->resolver(
+            schemas: ['1089' => 'LeaseContract'],
+            registers: [],
+        );
+
+        $this->assertTrue(
+            $resolver->isOwnRegister(entity: $this->entity(registerId: 'shillinq', schemaId: '1089'))
+        );
+
+    }//end testRegisterSlugIsAcceptedDirectly()
+}//end class


### PR DESCRIPTION
## The bug

OpenRegister's `MagicMapper` stamps the numeric schema/register **ids** onto every `ObjectEntity` it materialises:

```php
$result->setSchema((string) $schema->getId());
$result->setRegister((string) $register->getId());
```

Twelve shillinq listeners read that value off the entity and compare it to a schema **slug** literal. An id can never equal a slug, so every one of those guards returned early on **every** event — the handler bodies have never run once.

Green-but-dead: no exception, no log line, no failing test, while still paying full DI construction + invocation on every object write instance-wide.

### Why the tests never caught it

The existing unit tests hand-build an `ObjectEntity` whose `getSchema()` returns the **slug**:

```php
'getObject' => $this->entity('LeaseContract', $this->lease('active')),
```

`'LeaseContract'` is a value production never produces — production sends `'1089'`. Every listener test asserted against a shape that does not occur. This PR makes those tests production-shaped: the entity carries the id, and a stubbed resolver maps it to the slug, so each test is now a genuine **positive control** that the handler body runs.

## The fix

One shared `ListenerSchemaResolver` turns the id back into a slug via `SchemaMapper::find()` (request-cached by OpenRegister, so no extra query per event). Three properties matter:

1. **Register-scoped.** This instance has two distinct schemas both slugged `automation` (ids **71** and **5103**), so schema-only matching would fire on another app's objects. Anything outside shillinq's register resolves to `''`.
2. **Container-resolved.** OpenRegister stays a soft dependency — the mappers come from the DI container at call time and every failure degrades to `''`, so shillinq still boots without OpenRegister.
3. **Gated.** See below.

### Slug literals were already correct — do not "fix" them

**891 of this instance's 2276 schema slugs contain uppercase.** `ACMReport` (id 1102) and `AnnualReport` (id 1008) exist verbatim. Kebab-casing them would have *broken* the guards. Every literal in this PR was verified against `oc_openregister_schemas` and left unchanged.

Live control through OpenRegister's own API (not raw SQL):

```
GET /apps/openregister/api/schemas/1089  ->  {"id":1089, "slug":"LeaseContract", ...}
```

— exactly the string `isLeaseContractSchema()` compares against.

### Relationship to #408

#408 declares register/schema interest so uninterested listeners are no longer constructed. That filters **dispatch**; it never touches the in-body guard, so the handlers stayed dead. This PR fixes the guard. The two compose: #408 stops the wasted invocation, this makes the surviving invocation actually do its job.

## Shipped default-OFF — this is a behaviour change, not a bug fix

Waking these listeners is a **business decision**. They include:

| Listener | What waking it does |
|---|---|
| `AppointmentCreatedListener` | sends **customer email** via `ConfirmationTokenService` |
| `BookingCreatedTimelinePublishListener` | **outbound HTTP** to pipelinq |
| `TenderNedAwardDetectedListener` | **outbound HTTP** + creates `Verplichting` objects |
| `ACMReportSignTransitionListener` | **outbound HTTP** to docudesk (e-signature request) |
| `OpdrachtUitvoeringTransitionListener` | **outbound HTTP** status sync |
| `PeppolInboundUblInvoiceListener` | **bulk object creation** — the entire Peppol backlog |
| `LeaseActivationListener` | **bulk object creation** — one schedule row per lease period |
| `CommitmentMaterialisationListener` | **fail-closed** — starts *blocking* PurchaseOrder approvals that succeed today (`InsufficientCommitmentBudgetException`) |

None are idempotent in the strong sense and there is no backfill, so enabling on an instance with existing data acts on that backlog the first time a matching write occurs.

```
occ config:app:set shillinq listener_slug_contract --value=yes
```

While the flag is off the resolver returns the raw id, reproducing today's behaviour **byte for byte**. Follows the `openbuild.listener_slug_contract` precedent (openbuild#82).

**The flag has NOT been enabled anywhere.**

## Out of scope

The sibling defect where guards read the schema off `ObjectTransitionedEvent` (rather than off the entity) is untouched and keeps its own default-off `transition_event_slug_contract`.

## Verification

- `ListenerSchemaResolverTest` — 7 tests, all **positive** controls (resolves id→slug; preserves uppercase verbatim; refuses a foreign register while resolving the same slug in-register; returns the raw id when gated off; degrades to `''` when OpenRegister is absent).
- Live: schema ids 1089/1102 resolve to `LeaseContract`/`ACMReport` through OpenRegister's API on the running instance.
- `phpcs`: **0 errors** on all 14 touched `lib/` files.

## Known gaps (stated, not hidden)

- **Two listeners have NO positive control, because they have no tests at all.** `AppointmentCreatedListener` (the **customer-email** one) and `GLTransactionComplianceCacheListener` are constructed by zero tests anywhere under `tests/`. Their guards are fixed the same way as the other ten, but that fix is **unverified** — a pre-existing coverage gap this PR surfaces rather than creates.
- **`PeppolInboundUblInvoiceListener` is unverified.** Its literal `PeppolInboundMessage` does not exist as a schema on this instance (only `peppol_transmission`, id 4527). That is an import gap, not a wrong declaration — the literal was deliberately **not** changed.
- The shillinq unit suite **cannot load on a clean `development`** (`Interface "OCP\Http\Client\IResponse" not found` at `tests/Unit/Integration/CustomerBridgeIntegrationTest.php:782`). Pre-existing and reproducible on an untouched checkout; tests here were run per-file against the same bootstrap.
- Per-listener controls are unit-level. A live end-to-end control would require enabling the flag on the shared instance, which would fire real email and real outbound HTTP — deliberately not done.
