### PR TITLE
fix(tests): never default the Newman runner to the shared :8080 container

### DIFF
--- a/tests/integration/run-newman.sh
+++ b/tests/integration/run-newman.sh
@@ -17,9 +17,23 @@
 # tears it down. Collection variables are parameterised (base_url / admin_user /
 # admin_password) so the suite is portable across environments.
 #
+# Target instance:
+#   There is deliberately NO default base URL. This runner PERFORMS WRITES —
+#   every collection seeds objects, posts filings and tears them down again.
+#   The previous default was `http://localhost:8080`, which on a developer box
+#   is the *shared* Nextcloud dev container, so an invocation with no
+#   environment set silently created and deleted fixtures in an instance other
+#   sessions were using. Failing loudly on an unset variable is strictly better
+#   than writing into someone else's environment.
+#
+#   The URL is resolved from the first of these that is set and non-empty:
+#     PLAYWRIGHT_BASE_URL, BASE_URL, NEXTCLOUD_URL, NC_BASE_URL
+#   `BASE_URL` is the name the shared ConductionNL/.github quality workflow
+#   exports, so it MUST stay accepted: a resolver that honours only
+#   PLAYWRIGHT_BASE_URL hard-fails every CI run.
+#
 # Usage:
-#   ./run-newman.sh                                  # defaults to localhost:8080, admin:admin
-#   BASE_URL=http://localhost:8080 ./run-newman.sh
+#   BASE_URL=http://localhost:8097 ./run-newman.sh   # your own isolated instance
 #   ADMIN_USER=admin ADMIN_PASS=admin ./run-newman.sh
 #
 # Uses a globally-installed `newman` if present, otherwise falls back to
@@ -40,7 +54,37 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-BASE_URL="${BASE_URL:-http://localhost:8080}"
+# Resolve the instance under test. No default: see the "Target instance" note
+# above. Order matters only in that the most specific name wins; every one of
+# them is honoured because different callers export different names (CI exports
+# BASE_URL, the Playwright suites export PLAYWRIGHT_BASE_URL, the docker-compose
+# helpers export NEXTCLOUD_URL / NC_BASE_URL).
+BASE_URL="${PLAYWRIGHT_BASE_URL:-${BASE_URL:-${NEXTCLOUD_URL:-${NC_BASE_URL:-}}}}"
+
+if [ -z "${BASE_URL}" ]; then
+  cat >&2 <<'EOF'
+ERROR: no target instance configured.
+
+None of PLAYWRIGHT_BASE_URL, BASE_URL, NEXTCLOUD_URL or NC_BASE_URL is set.
+
+This runner deliberately has no default: it used to fall back to
+http://localhost:8080, which is the SHARED dev container, and the collections
+it runs create and delete objects. Pointing them at the shared instance
+corrupts an environment other sessions are using.
+
+Point it at your own isolated instance, e.g.
+  BASE_URL=http://localhost:8097 ./run-newman.sh
+
+In CI the shared quality workflow exports BASE_URL, which is also accepted;
+if you are seeing this in CI, that export is missing.
+EOF
+  exit 2
+fi
+
+# Normalise away any trailing slashes so `${base_url}/index.php/...` in the
+# collections never produces a double slash.
+BASE_URL="${BASE_URL%"${BASE_URL##*[!/]}"}"
+
 ADMIN_USER="${ADMIN_USER:-admin}"
 ADMIN_PASS="${ADMIN_PASS:-admin}"
 


### PR DESCRIPTION
## Root cause

`tests/integration/run-newman.sh` resolved its target with:

```bash
BASE_URL="${BASE_URL:-http://localhost:8080}"
```

On a developer box `http://localhost:8080` is the **shared** Nextcloud dev container. This runner *writes*: all four Postman collections (`shillinq`, `bookings`, `VAT_Filings`, `TenderNedIntegratie`) seed objects, post filings and bookings, and tear them down again. An invocation with no environment set therefore created and deleted fixtures in an instance other sessions were using, and reported a contract result measured somewhere nobody intended.

## Fix

There is no default any more. The base URL is resolved from the first of `PLAYWRIGHT_BASE_URL`, `BASE_URL`, `NEXTCLOUD_URL`, `NC_BASE_URL` that is set and non-empty; with none of them set the script exits **2** with an error naming all four and explaining why there is no fallback. Trailing slashes are stripped so `${base_url}/index.php/...` cannot produce a double slash.

`BASE_URL` is deliberately still honoured — it is the name the shared `ConductionNL/.github` quality workflow exports, and a resolver that accepts only `PLAYWRIGHT_BASE_URL` hard-fails every CI run. Strict about never inventing a target; permissive about which variable names it.

## Deliberate-break control

A `newman` shim on `PATH` prints the `base_url` each collection would actually be run against.

**Before** — old script from the base SHA, all four variables unset:

```
$ env -u PLAYWRIGHT_BASE_URL -u BASE_URL -u NEXTCLOUD_URL -u NC_BASE_URL bash tests/integration/OLD-run-newman.sh
==> newman run TenderNedIntegratie.postman_collection.json
==> newman run VAT_Filings.postman_collection.json
==> newman run bookings.postman_collection.json
==> newman run shillinq.postman_collection.json
NEWMAN-WOULD-TARGET: base_url=http://localhost:8080
OLD exit=0
```

Silently targeted the shared container, exit 0. (The `==> newman run` lines are the positive control: the shim really was reached, so the `base_url` reading is not a false zero.)

**After** — same, all four unset:

```
$ env -u PLAYWRIGHT_BASE_URL -u BASE_URL -u NEXTCLOUD_URL -u NC_BASE_URL bash tests/integration/run-newman.sh
ERROR: no target instance configured.

None of PLAYWRIGHT_BASE_URL, BASE_URL, NEXTCLOUD_URL or NC_BASE_URL is set.
...
NEW exit=2
```

**After** — `BASE_URL` (the name CI exports) set to a non-8080 value, with a trailing slash:

```
$ env -u PLAYWRIGHT_BASE_URL -u NEXTCLOUD_URL -u NC_BASE_URL BASE_URL=http://localhost:8097/ bash tests/integration/run-newman.sh
NEWMAN-WOULD-TARGET: base_url=http://localhost:8097
NEW exit=0
```

**All four names honoured, in order:**

```
PLAYWRIGHT_BASE_URL  -> base_url=http://localhost:80919
BASE_URL             -> base_url=http://localhost:8098
NEXTCLOUD_URL        -> base_url=http://localhost:80913
NC_BASE_URL          -> base_url=http://localhost:80911
all four set         -> base_url=http://pw:1     (PLAYWRIGHT_BASE_URL wins)
```

## Notes

- No test is skipped, no assertion weakened, no timeout raised.
- The only behavioural change for an already-correct caller (`BASE_URL=... ./run-newman.sh`) is that trailing slashes are now normalised away.