### PR TITLE
ci: align workflows with fleet standard (ConductionNL/.github)

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     branches: [main, beta]
 
+permissions: {}
+
 jobs:
-  check:
+  branch-protection:
     uses: ConductionNL/.github/.github/workflows/branch-protection.yml@main
-    secrets: inherit

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,6 +7,18 @@ on:
     branches: [main, master, development, beta]
   workflow_dispatch:
 
+concurrency:
+  group: quality-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+# Least privilege for the called quality pipeline: the Quality Report job
+# posts a sticky PR comment (issues/pull-requests write); everything else
+# only reads the checkout.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   quality:
     uses: ConductionNL/.github/.github/workflows/quality.yml@main


### PR DESCRIPTION
## What

Aligns this repo's CI with the fleet standard shared workflows in `ConductionNL/.github`
(reference: [openregister](https://github.com/ConductionNL/openregister/tree/main/.github/workflows)).

Depending on the branch this fixes/adds:
- `branch-protection.yml` with caller job id `branch-protection` → check reports as
  `branch-protection / check-branch` (required by the org ruleset)
- `code-quality.yml` as a thin wrapper around the shared `quality.yml` → checks report as
  `quality / …`
- broken `Conduction/.github` references (org doesn't exist; correct org is `ConductionNL`)
- removal of superseded legacy workflows

## Why

Required checks match on exact names. Wrong job ids, the org typo, and legacy workflow
names left PRs hanging on *"Expected — waiting for status to be reported"*.

The corrected checks run **on this PR itself** (PR workflows run from the source branch),
so a green merge box here is the proof it works.

## After merge

Update the branch protection of `main`/`beta` to require the new `quality / …` contexts
and remove any stale `PHP Quality` / `Frontend Quality` entries.
