### PR TITLE
ci: rename branch-protection caller job id to `branch-protection`

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -5,6 +5,11 @@ on:
     branches: [main, beta]
 
 jobs:
-  check:
-    uses: Conduction/.github/.github/workflows/branch-protection.yml@main
+  # Job id must stay `branch-protection` so the check reports as
+  # `branch-protection / check-branch`, which is the context name the org
+  # ruleset requires. GitHub names a reusable-workflow context
+  # `<caller-job-id> / <called-job-name>`, so renaming this job silently
+  # detaches the required status check and leaves PRs permanently pending.
+  branch-protection:
+    uses: ConductionNL/.github/.github/workflows/branch-protection.yml@main
     secrets: inherit


### PR DESCRIPTION
GitHub names a reusable-workflow status context `<caller-job-id> / <called-job-name>`.

This branch's caller job id was **not** `branch-protection`, so the shared branch-protection
workflow reported under the wrong context name, and the org ruleset requirement
`branch-protection / check-branch` never reported at all — not as a failure, as *nothing*.

**Several of these beta branches carry a second, independent fault**: the reusable workflow was
referenced as `Conduction/.github` instead of `ConductionNL/.github`. The `Conduction` org does not
exist (`GET /repos/Conduction/.github` -> 404), so on those branches the workflow could not even
resolve. Where present, that is fixed here too — renaming the job id alone would not have made the
context appear.

This matters for `beta -> main` promotion PRs, whose head is `beta`, so beta's tip is what
decides the context name and the workflow reference.

Does **not** change what is required and does **not** touch any ruleset or branch protection.