### PR TITLE
fix(ui): NcButton `native-type` is inert on @nextcloud/vue 9 — six forms never submitted

### DIFF
--- a/src/components/goods-receipt-note/GoodsReceiptNoteForm.vue
+++ b/src/components/goods-receipt-note/GoodsReceiptNoteForm.vue
@@ -149,7 +149,7 @@
 			<div class="grn-form__actions">
 				<NcButton
 					variant="primary"
-					native-type="submit"
+					type="submit"
 					:disabled="submitting || !canSubmit"
 					data-testid="grn-form-submit">
 					{{ submitting ? t('shillinq', 'Saving...') : t('shillinq', 'Save goods receipt') }}

--- a/src/components/purchase-order/PurchaseOrderForm.vue
+++ b/src/components/purchase-order/PurchaseOrderForm.vue
@@ -157,7 +157,7 @@
 			<div class="po-form__actions">
 				<NcButton
 					variant="primary"
-					native-type="submit"
+					type="submit"
 					:disabled="submitting"
 					data-testid="po-form-submit">
 					{{ submitting ? t('shillinq', 'Creating...') : t('shillinq', 'Create purchase order') }}

--- a/src/views/DeadlineCalendarSettings.vue
+++ b/src/views/DeadlineCalendarSettings.vue
@@ -54,7 +54,7 @@
 
 					<div class="deadline-calendar-settings__actions">
 						<NcButton variant="primary"
-							native-type="submit"
+							type="submit"
 							:disabled="saving"
 							data-testid="deadline-settings-save">
 							{{ saving ? t('shillinq', 'Saving…') : t('shillinq', 'Save') }}

--- a/src/views/bookings/BookingForm.vue
+++ b/src/views/bookings/BookingForm.vue
@@ -60,7 +60,7 @@
 		</p>
 
 		<div class="booking-form__actions">
-			<NcButton variant="primary" native-type="submit" :disabled="submitting">
+			<NcButton variant="primary" type="submit" :disabled="submitting">
 				{{ submitting ? t('shillinq', 'Saving…') : t('shillinq', 'Create Booking') }}
 			</NcButton>
 		</div>

--- a/src/views/settings/PipelinqIntegration.vue
+++ b/src/views/settings/PipelinqIntegration.vue
@@ -35,7 +35,7 @@
 			<div class="actions">
 				<NcButton
 					variant="primary"
-					native-type="submit"
+					type="submit"
 					:disabled="saving">
 					{{ saving ? t('shillinq', 'Saving…') : t('shillinq', 'Save') }}
 				</NcButton>

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -18,7 +18,7 @@
 
 			<NcButton
 				variant="primary"
-				native-type="submit"
+				type="submit"
 				:disabled="saving">
 				{{ saving ? t('shillinq', 'Saving...') : t('shillinq', 'Save') }}
 			</NcButton>


### PR DESCRIPTION
## The defect

`@nextcloud/vue` 9 renamed `NcButton`'s visual prop `type` → `variant` and **repurposed `type` as the native button type**, with `default: "button"`. `nativeType` was removed outright — it was the v8 name.

So `native-type="submit"` on v9 is an **undeclared prop**: it falls through to the DOM as an inert attribute while the button keeps `type="button"`. A `type="button"` inside a `<form>` raises no submit event, so `@submit.prevent` never runs.

**No console warning, no lint error, no failed request.** User-facing: someone fills in a purchase order, clicks **Create purchase order**, sees no error, and nothing was ever sent.

This repo is on `@nextcloud/vue` `^9.9.0`, lockfile-resolved to **9.9.0** — checked in the lockfile, not the caret.

## The six sites

Every one already used `variant=` (the v9 visual prop), so these were **half-finished v8→v9 migrations** where only the button type was missed. Each verified per-site to sit inside a form with a submit handler — not blanket-rewritten:

| site | enclosing form |
|---|---|
| `src/components/goods-receipt-note/GoodsReceiptNoteForm.vue:152` | `<form @submit.prevent="onSubmit">` |
| `src/components/purchase-order/PurchaseOrderForm.vue:160` | `<form @submit.prevent="onSubmit">` |
| `src/views/DeadlineCalendarSettings.vue:57` | `<form @submit.prevent="save">` |
| `src/views/bookings/BookingForm.vue:63` | `<form @submit.prevent="submit">` |
| `src/views/settings/PipelinqIntegration.vue:38` | `<form @submit.prevent="save">` |
| `src/views/settings/Settings.vue:21` | `<form @submit.prevent="save">` |

Each is `native-type="submit"` → `type="submit"`; the diff is exactly 6 changed lines in 6 files. `git grep native-type -- src` now returns nothing.

## Evidence

Behaviour is proven in **ConductionNL/openconnector#1140**, which mounts the *real* `NcButton` from the installed 9.9.0 and asserts DOM behaviour, with negative controls:

| spelling | renders | submit handler |
|---|---|---|
| `type="submit"` (the fix) | `type=submit` | **fires** |
| `native-type="submit"` (the bug) | `type=button` | **never fires** |

That test is mutation-checked: flipping the fix assertion back to the broken spelling makes it fail, so the assertion is shown capable of failing rather than merely passing.

The component-level mechanism is shared by all six sites here. What is verified by reading rather than execution is that each of these *specific* forms wraps its button — the table above — which is why every site was confirmed individually.

## Coordination note

Peer agents were reported to have fixed some of these files earlier. At the time this branch was cut, **all six were still present on `origin/development`** and no remote branch had them fixed, so all six are included here. If a peer PR lands first, this rebases down to whatever remains rather than conflicting on content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)