### PR TITLE
fix(ci): pin OpenRegister to development — `main` ships no AppHost, so every shillinq route answered 500

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -46,5 +46,17 @@ jobs:
       # `Conduction`, which does not exist — the same wrong-org bug that kept the
       # whole workflow from resolving, hiding in a comment where a `uses:` grep
       # could not see it.
-      additional-apps: '[{"repo":"ConductionNL/openregister","app":"openregister","ref":"main"}]'
+      #
+      # `ref` MUST be `development`, not `main`. shillinq's appinfo/routes.php
+      # is `return \OCA\OpenRegister\AppHost\Routes::standard(...)` — an
+      # unguarded static call to a class that lives ONLY on OpenRegister
+      # `development`. OpenRegister `main` is 0.2.19 and ships no `lib/AppHost`
+      # at all, so Nextcloud's router fataled while *including* routes.php and
+      # answered EVERY shillinq endpoint with 500 — "Class
+      # \"OCA\\OpenRegister\\AppHost\\Routes\" not found", thrown from
+      # appinfo/routes.php:39. That is the whole of the 45-of-51 Newman failure
+      # in run 30896861325: not one of those endpoints was ever reached.
+      # `development` is also what the rest of the fleet pins (opencatalogi,
+      # openconnector, procest, softwarecatalog, scholiq, pipelinq).
+      additional-apps: '[{"repo":"ConductionNL/openregister","app":"openregister","ref":"development"}]'
       enable-sbom: true

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -169,6 +169,28 @@ Vrij en open source onder de EUPL-1.2-licentie.
                  and been confirmed for at least one release, and the delete has itself been live-verified on real data. -->
             <step>OCA\Shillinq\Repair\RematerialiseConvertedCalculations</step>
         </post-migration>
+
+        <!-- FRESH INSTALL. Nextcloud does NOT run `post-migration` on a first
+             install: `Installer::installAppLastSteps()` guards both the
+             pre-migration and post-migration blocks with
+             `if ($previousVersion !== '')`, and only `repair-steps/install`
+             runs unconditionally afterwards. Until this block existed, a
+             brand-new shillinq install ran NONE of the steps above, so
+             InitializeSettings never fired and the `shillinq` REGISTER was
+             never imported. Every controller that resolves the register then
+             threw `Did expect one result but found none ... FROM
+             oc_openregister_registers`, which surfaces as HTTP 500 on
+             /api/vat-returns and /api/period-close/* and HTTP 503 on
+             /api/v2/calendars — on a clean install, for the admin, on every
+             request. Measured in run 30903201789 (job 91972751340).
+
+             Only InitializeSettings belongs here. Every other step above is a
+             migration or backfill over data that a fresh install does not yet
+             have; they stay upgrade-only so a first install does not pay for
+             folds and rematerialisations that can have nothing to fold. -->
+        <install>
+            <step>OCA\Shillinq\Repair\InitializeSettings</step>
+        </install>
     </repair-steps>
 
     <commands>

--- a/tests/integration/VAT_Filings.postman_collection.json
+++ b/tests/integration/VAT_Filings.postman_collection.json
@@ -46,10 +46,15 @@
 								"type": "text/javascript",
 								"exec": [
 									"pm.test('status 201', () => pm.response.to.have.status(201));",
-									"const data = pm.response.json().data;",
-									"pm.test('return id present', () => pm.expect(data.id || data['@self']?.id).to.be.a('string'));",
-									"pm.test('statusCode is draft', () => pm.expect(data.statusCode).to.eql('draft'));",
-									"pm.collectionVariables.set('return_id', data.id || data['@self'].id);"
+									"// `data` is a RESERVED global in the Postman/Newman sandbox (the data-file variables).",
+										"// Declaring `const data` at script top level throws SyntaxError: Identifier 'data'",
+										"// has already been declared BEFORE the first pm.test() runs, so none of the three",
+										"// assertions below executed and `return_id` was never set — which is why every",
+										"// later request ran against an unresolved `/api/vat-returns/{{return_id}}`.",
+										"const created = pm.response.json().data;",
+									"pm.test('return id present', () => pm.expect(created.id || created['@self']?.id).to.be.a('string'));",
+									"pm.test('statusCode is draft', () => pm.expect(created.statusCode).to.eql('draft'));",
+									"pm.collectionVariables.set('return_id', created.id || created['@self'].id);"
 								]
 							}
 						}


### PR DESCRIPTION
## Baseline

Run `30896861325`, job `91952018098` (`Integration Tests (Newman)`), 1m52s — **51 assertions executed, 48 failed** across 4 collections. `Quality Report` (`91955199472`) is red only because Newman is.

## One cause

`appinfo/routes.php:39` is `return \OCA\OpenRegister\AppHost\Routes::standard(...)` — an unguarded static call into another app, in the file Nextcloud's router `include`s on **every** shillinq request. The workflow pinned `openregister` at `ref: main`, which is 0.2.19 and has no `lib/AppHost` directory at all. The router therefore fataled during route matching:

```
Class "OCA\OpenRegister\AppHost\Routes" not found
  at server/apps/shillinq/appinfo/routes.php:39
  OC\Route\Router::requireRouteFile -> loadRoutes -> findMatchingRoute -> match
```

Every `/index.php/apps/shillinq/api/*` request in the run returned **500** with an identically-sized body; the only assertion that passed against the server was `GET /status.php`. Not one shillinq endpoint was entered, so none of those failures is evidence about shillinq's behaviour.

`development` is what the rest of the fleet pins (opencatalogi, openconnector, procest, softwarecatalog, scholiq, pipelinq).

## Known remainder

The three `TenderNedIntegratie` failures are a **different** cause — OpenRegister was up, but the `shillinq` register/schemas were not seeded, so `POST /apps/openregister/api/objects/shillinq/TenderNedAanbesteding` was a genuine 404. Tracked separately; this PR does not claim to fix it.

## Not done

No assertion weakened, no test skipped, no retry/timeout added, no suppression or baseline. phpmd is untouched (already 0).
