### PR TITLE
chore(deps): @conduction/nextcloud-vue 3.0.0-vue3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.1",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@conduction/nextcloud-vue": "3.0.0-vue3.4",
+        "@conduction/nextcloud-vue": "3.0.0-vue3.6",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "~2.5.2",
         "@nextcloud/capabilities": "^1.2.1",
@@ -551,9 +551,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "3.0.0-vue3.4",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.4.tgz",
-      "integrity": "sha512-+x6lUVhpoZsozAW5S20C9Y3KHhLo5+0MIqKi00lJlK+yOHuJxBoZlra7ijaY0Wk0TOs6iBdhmbGNYptJa1Pkwg==",
+      "version": "3.0.0-vue3.6",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.6.tgz",
+      "integrity": "sha512-6x8VapVLF22eCQB+CdoC1OkB3oLiIM31OceexDrvu/L++8Z5HYV2X3Xcgl8ZGy29jcqbtrjDNaZ5WbaDrzm8fA==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "dependencies": {
-    "@conduction/nextcloud-vue": "3.0.0-vue3.4",
+    "@conduction/nextcloud-vue": "3.0.0-vue3.6",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "~2.5.2",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
## What

Bumps `@conduction/nextcloud-vue` from `3.0.0-vue3.4` to `3.0.0-vue3.6` (exact pin, fleet convention).

## Why — nc-vue #596, a real WCAG 2.4.6 / 1.3.1 fix

Five page primitives (`CnIndexPage`, `CnSettingsPage`, `CnChatPage`, `CnFilesPage`, `CnLogsPage`) gated their `<h1>` behind `v-if="showTitle"`, and `showTitle` defaults to `false`. The title was surfaced in the sidebar instead — which sits **outside** the `<main>` landmark — so the main content region carried no heading at all:

- a screen-reader user gets no announcement of which list they are on;
- "skip to main content" lands on an unlabelled region.

Measured blast radius: **608 of 625 index-page surfaces across 19 of 20 apps.**

`3.0.0-vue3.6` renders the `<h1>` unconditionally and visually-clips it when `showTitle` is false (`position:absolute` + 1px + `clip-path: inset(50%)` — **not** `display:none`, which would remove it from the accessibility tree too). It is always in the DOM and the accessibility tree. **Zero visual change.**

Checked across all 21 fleet repos (`src/manifest.json` + `src/manifest.d/*.json`): of **1489** declared pages, exactly **3** set a page-level `showTitle` (docudesk `Templates`/`SigningRequests`, petstore `Orders`) — and all 3 set it to `true`, so they already rendered a visible `<h1>` and are unchanged by this bump. The other **1486** inherit the `false` default and are fixed by the version bump alone — no source change needed here.

## Verified: rendered-DOM A/B, not a version string

The same mount + query run against both versions, with the header markup and the `showTitle` default extracted programmatically from each version's own source (arms differ **only** by library version, so `.4` is the negative control for the query itself):

```
===== 3.0.0-vue3.4 =====                  ===== 3.0.0-vue3.6 =====
  showTitle default : false                 showTitle default : false
  <h1> INSIDE <main>: NO                     <h1> INSIDE <main>: YES
                                             h1: <h1 class="cn-page-header__title"
                                                  data-testid="cn-page-title">Registers</h1>
                                             aria-hidden ancestor: NONE (in a11y tree)
                                             header class: cn-page-header--visually-hidden
```

## `.5` is crossed on the way — no regression

`3.0.0-vue3.5` (ADR-079 Step 2) **removed** the generic admin-settings modal from `CnAppRoot` and moved the organisation credential broker to `CnAdminSettingsShell`'s new opt-in `show-organisation-credentials` prop.

That removed surface was gated on `isOwner && manifest.adminSettings[].length > 0`. Verified across all 20 fleet repos (`src/manifest.json` **and** `src/manifest.d/*.json` fragments **and** all JS/Vue source, with a passing positive control):

- **0 apps** declare `manifest.adminSettings[]`
- **0 apps** call the removed `cnOpenAdminSettings` inject
- **0 apps** use `action: "admin-settings"`

So the org credential broker rendered in **zero** apps before this bump and renders in zero after — the removal is dead-code removal, not a UI regression. (OpenRegister's `CnCredentials` in `PersonalRoot.vue` is the separate **personal**-scope surface and is untouched.)

## Lockfile

Regenerated with **npm 10.9.9** (matching `engines.npm: ^10`) via `npm install --package-lock-only`, then verified with `npm ci`. Diff is the minimal 4 insertions / 4 deletions — version, resolved URL and integrity hash only.
