### PR TITLE
fix(deps): move off @conduction/nextcloud-vue 3.0.0-vue3.6, which no longer exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.1",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@conduction/nextcloud-vue": "3.0.0-vue3.6",
+        "@conduction/nextcloud-vue": "2.2.0-vue3.2",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "~2.5.2",
         "@nextcloud/capabilities": "^1.2.1",
@@ -551,9 +551,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "3.0.0-vue3.6",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.6.tgz",
-      "integrity": "sha512-6x8VapVLF22eCQB+CdoC1OkB3oLiIM31OceexDrvu/L++8Z5HYV2X3Xcgl8ZGy29jcqbtrjDNaZ5WbaDrzm8fA==",
+      "version": "2.2.0-vue3.2",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.2.tgz",
+      "integrity": "sha512-U/3pRbbumvM3rek/x821KoeplbfH4Qtod3quF+6bFt1Vn8TzjMKtdN/lSQgLGP9BZF7mA6yNbU6UyWHW0pMjkg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "dependencies": {
-    "@conduction/nextcloud-vue": "3.0.0-vue3.6",
+    "@conduction/nextcloud-vue": "2.2.0-vue3.2",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "~2.5.2",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
`npm ci` cannot resolve the pinned version:

```
npm error 404 '@conduction/nextcloud-vue@...3.0.0-vue3.6.tgz' is not in this registry
```

Every `3.0.0-vue3.x` release has been **unpublished** from npm as part of moving the Vue 3 line back onto the 2.x chain. The `vue3` dist-tag now points at `2.2.0-vue3.2`. A pin to a 3.0.0-vue3.x is therefore not merely stale but **unresolvable** — any job whose npm cache misses fails at install, before a test runs.

Moves to `2.2.0-vue3.2`. Verified rather than assumed: `npm ci` completes (1421 packages) and `npm run build` succeeds.

Companion to ConductionNL/hrmq#70. openregister and opencatalogi are already on `2.2.0-vue3.1`; procest moved in #730.