### PR TITLE
chore(license): normalise licence declarations to EUPL-1.2 + remove a stray NUL byte

### DIFF
--- a/lib/Service/InventoryValuationReportService.php
+++ b/lib/Service/InventoryValuationReportService.php
@@ -512,7 +512,7 @@ class InventoryValuationReportService
     }//end movesFor()
 
     /**
-     * Grouped posted moves keyed by "sku warehouse" for the whole
+     * Grouped posted moves keyed by "sku\x00warehouse" for the whole
      * administration up to a cut-off, honouring optional filters.
      *
      * @param string      $administrationId Tenant scope.

--- a/lib/Settings/register.d/bookkeeping-cost-centers-dimensions.json
+++ b/lib/Settings/register.d/bookkeeping-cost-centers-dimensions.json
@@ -3,7 +3,7 @@
     "adr": "ADR-037",
     "change": "bookkeeping-cost-centers-dimensions + unify-analytical-dimensions",
     "description": "ONE canonical AnalyticalDimension register (discriminated by dimensionType: cost-center / cost-object / custom) replacing the prior CostCenter + KostenDrager + AnalyticalDimension triple. REQ-ADIM-001..008: dimensionType discriminator, cost-center-specific props (budget/spentToDate/allocatedBudget/organizationId/responsibleUser/ondernemingsActiviteit), shared hierarchy (parentCode) + lifecycle for all types, re-homed aggregations (segmentPnl/spentToDate/allocatedBudget scoped to cost-center; byCostCenter/byCostCenterHierarchy/byCostObject/byAnalyticalDimension on GLLine), idempotent migration via UnifyAnalyticalDimensions. Seeds carry dimensionType so greenfield installs land the unified shape. GLLine FK relations re-targeted (REQ-ADIM-101). Nav filtered views + label unification (REQ-ADIM-103).",
-    "license": "AGPL-3.0-or-later",
+    "license": "EUPL-1.2",
     "copyright": "Conduction B.V."
   },
   "components": {

--- a/tests/e2e/external-adapters.spec.ts
+++ b/tests/e2e/external-adapters.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * e2e for the W8 EXTERNAL-ADAPTER ADMIN UIs (this week's new surface).
  *

--- a/tests/e2e/visual/_visual-helpers.ts
+++ b/tests/e2e/visual/_visual-helpers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Shared helpers for the visual-regression layer (GAP-5).
  *

--- a/tests/e2e/visual/external-adapters.visual.spec.ts
+++ b/tests/e2e/visual/external-adapters.visual.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Visual-regression baselines for the Shillinq W8 External Adapters admin UI
  * (GAP-5) — the surfaces shipped with no visual coverage:

--- a/tests/e2e/visual/shillinq.visual.spec.ts
+++ b/tests/e2e/visual/shillinq.visual.spec.ts
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Visual-regression baselines for Shillinq's key surfaces (GAP-5).
  *


### PR DESCRIPTION
## What

The app is licensed **EUPL-1.2** — `composer.json`, `package.json`, `appinfo/info.xml` and `LICENSE` all agree — but five files still declared `AGPL-3.0-or-later`. A licence header is a legal claim, so a repo that states two different licences about itself is a real defect, not a lint nit.

### Licence normalisation (5 files)
| category | count | files |
|---|---|---|
| `SPDX-License-Identifier: AGPL-3.0-or-later` → `EUPL-1.2` | 4 | `tests/e2e/external-adapters.spec.ts`, `tests/e2e/visual/_visual-helpers.ts`, `tests/e2e/visual/external-adapters.visual.spec.ts`, `tests/e2e/visual/shillinq.visual.spec.ts` |
| register fragment `_meta.license` | 1 | `lib/Settings/register.d/bookkeeping-cost-centers-dimensions.json` — its two sibling `register.d` fragments already said `EUPL-1.2`, and its `_meta.copyright` is Conduction B.V. |

No `@copyright` / `SPDX-FileCopyrightText` line was touched.

## Separate finding: gate-28 was a FALSE RED caused by a NUL byte

`lib/Service/InventoryValuationReportService.php` **already declared EUPL-1.2 correctly**, both as `@license` and as `SPDX-License-Identifier`. It failed hydra gate-28 anyway:

- Line 515 documented the composite group key as `"sku<NUL>warehouse"` using the **actual 0x00 byte** instead of the escape sequence.
- `file` therefore classified the source as `data`, so grep treated it as **binary** and printed `Binary file ... matches` instead of the matched line.
- gate-28 runs `awk '{print $3}'` over that grep output, so it read the **file path** as the licence value and logged `file_license=lib/Service/InventoryValuationReportService.php`.

Fixed by replacing the raw NUL with the two characters `\x00`, matching how `makeKey()` actually writes the separator (`$sku."\x00".$warehouse`). It is inside a comment, so behaviour is unchanged. `file` now reports `PHP script, UTF-8 Unicode text`, `php -l` is clean, and gate-28 passes for a real reason rather than because a licence was "fixed" that was never wrong.

## Deliberately NOT changed

- `LICENSE` line 177 — *"GNU Affero General Public License (AGPL) v. 3"* is part of the **EUPL-1.2 text's own Appendix** of compatible licences.
- `composer.lock` / `package-lock.json` AGPL/GPL entries — upstream dependencies' own licences.
- `docs/Features/index.md` — `Bigcapital | Open Source (AGPLv3)` is a competitor comparison table describing a third-party product.
- `openspec/changes/archive/**` and `.claude/**` — historical prose and skill documentation, not licence declarations on this repo.

## Verification

| check | before | after |
|---|---|---|
| PHPUnit (PHP 8.4) | **OK — 3973 tests, 42124 assertions** | **OK — 3973 tests, 42124 assertions** |
| vitest | **167 passed (14 files)** | **167 passed (14 files)** |
| hydra gate-28 `license-triangle` | **FAIL (1 file)** | **PASS** |

PHPUnit was run under PHP 8.4 (host PHP is 8.2 and aborts on `platform_check` with exit 255 — a VOID run, not a verdict). gate-28 was run with an isolated findings log, because the gate hardcodes `/tmp/hydra-gate-license-triangle.log` and concurrent runs contaminate it.