### PR TITLE
fix(registers): make the AppointmentSeries semantic marker a CURIE (fixes check:markers)

### DIFF
--- a/lib/Settings/register.d/60-bookings-depth.json
+++ b/lib/Settings/register.d/60-bookings-depth.json
@@ -7,7 +7,7 @@
                 "version": "1.0.0",
                 "title": "Appointment Series",
                 "description": "A recurring appointment series (bookings-depth, recurring-appointment-series). Holds the RRULE-style recurrence definition and the base occurrence template (service, resource, first start, duration). The RecurringSeriesService expands the rule into individual Appointment records, each carrying seriesId + recurrenceIndex, skipping occurrences that violate the existing availability/conflict rules (SlotService). Per bookings/spec.md this realises the Tier-2 recurring-bookings enhancement deferred by the foundation change.",
-                "x-schema-org": "https://schema.org/Schedule",
+                "x-schema-org": "schema:Schedule",
                 "type": "object",
                 "required": [
                     "administrationId",


### PR DESCRIPTION
## The defect

`lib/Settings/register.d/60-bookings-depth.json` declares

```json
"x-schema-org": "https://schema.org/Schedule"
```

`tests/validate-semantic-markers.js` requires a CURIE:

```js
const CURIE_RE = /^([A-Za-z][A-Za-z0-9_-]*:[A-Za-z0-9_.-]+|ns#[A-Za-z0-9_.-]+)$/
```

A full IRI fails it, because the local part contains `/`. This is why `quality / Frontend Check (check:markers)` is **red on `development`** — verified on run 31045641292, which is a genuinely red baseline, not a vacuous green.

**It is not a style preference.** The validator's own header records that the downstream mapper resolves markers *by their CURIE prefix*, so an un-prefixed marker is **silently skipped**: the semantic annotation does not exist for any consumer, while the JSON looks perfectly reasonable to a human reader.

## The fix

`schema:Schedule` — one line. Not a guess: every one of the other **518** markers in this tree already uses the `schema:` prefix (`schema:MonetaryAmount` ×75, `schema:Action` ×34, `schema:Report` ×31, …). This was the single outlier.

Verified by running the exact script CI runs:

```
before:  [validate-semantic-markers] FAIL — bare / malformed x-schema-org markers:
           lib/Settings/register.d/60-bookings-depth.json — AppointmentSeries: "https://schema.org/Schedule"
         1 offending marker(s).

after:   [validate-semantic-markers] OK — 519 x-schema-org marker(s) are valid CURIEs.
```

## ⚠️ Why this is its own PR — read before merging

This started life inside #440 (the E2E enablement PR) and was **deliberately split out**, because a one-line annotation change has a large, non-obvious CI consequence that only a real run revealed.

**Touching any register JSON changes how hydra `gate-53` scopes itself.** From run 31052498432's own output:

```
[gate-53] diff scope is INDETERMINATE for this PR
          (new/untracked manifest input, or a register JSON changed)
          — every finding blocks.
[gate-53] effective-manifest-crossref: FAIL — 246 structural violation(s)
          in the ASSEMBLED manifest (base+fragments+menu-layout)
```

So this one line switches gate-53 out of diff-scoped mode into whole-manifest mode, where the repository's **entire pre-existing backlog of 246 structural violations becomes blocking.**

Confirmed by comparison rather than assumed: gate-53 **PASSED** on run 31047984852 — the immediately preceding run, whose only relevant difference is that no register JSON was in its diff. And it PASSED on the `development` baseline run too, but that one is worthless as evidence: it reported `Scope: diff vs origin/development — 0 changed file(s). Base resolves; this PR changes nothing`, so it inspected nothing.

**Whoever merges this is accepting the 246-violation triage**, or should pair it with that work. That decision belongs with whoever owns the assembled manifest — which is exactly why it is not riding along on a PR about making the E2E suite run.

Merging this fixes `check:markers`. It will make `Hydra Gates` red until the 246 are addressed.
