### PR TITLE
ci(quality): stop the release PR cancelling every push run on development

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,8 +7,39 @@ on:
     branches: [main, master, development, beta]
   workflow_dispatch:
 
+# Deduplicating a `push` run against the `pull_request` run for the SAME head
+# ref is the point of this block, and for a feature branch it is exactly right:
+# two runs of identical jobs, one of them wasted.
+#
+# It is wrong for `main` and `development`, because the push run there is NOT a
+# duplicate — it is the only carrier of the push-only jobs: "Coverage Baseline
+# Check" (`github.event_name == 'push'`), "SBOM" and "Features Extract". And
+# those two branches always have an open PR whose `head_ref` IS the branch
+# name: the standing "Release: merge development into beta" (#63 here).
+# `github.head_ref` on that PR run and `github.ref_name` on the push run both
+# render `development`, so both landed in the identical group
+# `quality-development`, and `cancel-in-progress` killed whichever started
+# first — always the push run, by a few seconds.
+#
+# Measured on this repo: 3 of the last 20 `development` push runs were
+# cancelled within ~80s of starting — 31045614488 (79s), 30880585906 (37s),
+# 30822103065 (51s). That duration is the discriminator: the shared workflow's
+# `timeout-minutes: 45` cancellation lands at 45m16s–45m28s, so these are
+# concurrency kills.
+#
+# On the surviving PR run "Coverage Baseline Check" reports `skipped`, which is
+# CORRECT for a pull_request event and renders exactly like a pass. So the gate
+# appears on both runs and executes on neither — a dead gate of the
+# permanently-pending shape.
+#
+# Suffixing only the default-branch push keeps feature-branch dedup untouched
+# (`quality-feature/x` for both events, exactly as before) and gives the two
+# default branches' push runs a lane of their own.
+#
+# Proven in openconnector#1158: its first-ever completed `development` push run
+# (31048998594) executed Coverage Baseline Check, SBOM and Features Extract.
 concurrency:
-  group: quality-${{ github.head_ref || github.ref_name }}
+  group: quality-${{ github.head_ref || github.ref_name }}${{ (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'development')) && '-push' || '' }}
   cancel-in-progress: true
 
 # Permission CEILING for the called quality pipeline. GitHub statically


### PR DESCRIPTION
## The defect

```yaml
concurrency:
  group: quality-${{ github.head_ref || github.ref_name }}
  cancel-in-progress: true
```

A push to `development` has no head ref, so the group renders `quality-development`.

`development` also permanently has an open PR — the standing **"Release: merge development into beta"** — and that PR's `head_ref` is literally `development`. Its run renders the **same** group. `cancel-in-progress` then kills whichever started first, and that is always the push run: it is created a few seconds earlier.

The push run is the **only** carrier of the push-only jobs in the shared `quality.yml`:

| job | condition |
|---|---|
| `Coverage Baseline Check` | `github.event_name == 'push'` && ref is main/development |
| `SBOM` | ref is main/beta/development |
| `Features Extract` | `github.event_name != 'pull_request'` |

On the surviving PR run `Coverage Baseline Check` reports `skipped` — which is *correct*, it is a push-only job on a `pull_request` event — and a skipped job renders just like a passing one. So the gate appears on both runs and executes on neither. That is the permanently-pending shape of a dead gate, and a cancelled run is no verdict at all.

## Fix

The dedup is worth keeping. For a feature branch the push run and the PR run genuinely are the same jobs twice, and cancelling one is the point of the block. It is only wrong for `main` and `development`, where the push run is not a duplicate.

| trigger | group before | group after |
|---|---|---|
| push `development` | `quality-development` | **`quality-development-push`** |
| release PR (head `development`) | `quality-development` | `quality-development` |
| push `main` | `quality-main` | **`quality-main-push`** |
| push `feature/x` | `quality-feature/x` | `quality-feature/x` |
| PR head `feature/x` | `quality-feature/x` | `quality-feature/x` |

Feature-branch dedup is untouched, so this adds no CI cost there. It adds one extra run per merge to `main`/`development` — the run that was supposed to exist all along.

## Precedent

Identical to openconnector#1158, whose proof was that repo's **first-ever completed `development` push run** (`31048998594`), where `Coverage Baseline Check`, `SBOM` and `Features Extract` all executed and reported `success`.

## Verification

Reading the expression is not evidence. The check is end-to-end: **after this lands, the `development` push run must complete rather than be cancelled, and the push-only jobs must execute rather than skip.** I will confirm on the merge commit and report the run id. If the push run is still cancelled, this fix is wrong and should be reverted rather than papered over.

Nothing here weakens a gate: no baseline widened, no waiver, no threshold moved, no `continue-on-error`, no skip.
