### PR TITLE
ci(quality): move hydra-gates-ref to v1.5.0 — restore the gates

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -162,4 +162,4 @@ jobs:
       # reproducible and a later gate change cannot move this repo's verdict
       # without a commit here.
       enable-hydra-gates: true
-      hydra-gates-ref: v1.3.0
+      hydra-gates-ref: v1.5.0


### PR DESCRIPTION
`quality.yml` is consumed `@main` and executes three scripts **by path** inside the **pinned** hydra-gates package:

```
scripts/lib/check_spec_anchors.py
scripts/lib/check_form_labels.py
scripts/lib/check_license_triangle.py
```

Verified by recursive tree listing per ref:

| ref | scripts present |
|---|---|
| v1.0.1 · v1.2.0 · v1.3.0 · v1.4.0 | **0 of 3** |
| v1.5.0 · main | **3 of 3** |

So every consumer below v1.5.0 fails with `exit 1`, and the workflow says so itself:

```
::error::hydra-gates-ref does not contain: ...
::error::This workflow floats on @main and executes those paths by name inside the PINNED package.
```

**This is not a code-quality finding about this repository.** It is the floating-caller / pinned-callee split — the third occurrence today, after the `require-full-coverage` default change reaching old runners and `#168` executing `axe-run.cjs` by path.

## What v1.5.0 also brings

Measured across the same 22 fleet trees, each version running its own code (no CI output read, so a split fleet cannot skew it):

| gate | v1.3.0 | v1.5.0 |
|---|---:|---:|
| 46 spec-anchor-existence | 2,228 | **918** |
| 40 form-label-association | 1,211 | **517** |
| 9 semantic-auth | 45 | **11** |

Every relaxed predicate was mutation-checked **both** ways — always-true and always-false must each fail — so the reduction is precision, not blindness.

It also fixes the `SCOPE WAS EMPTY` reporting bug (an unanchored `grep -q "0 changed file(s)"`, which `10 changed file(s)` also matched), the hardcoded `/tmp/hydra-gate-*.log` collision that produced cross-repo false findings, and a gate-28 NUL-byte hole that could yield a false **green**.

## Scope

**Exactly one line.** No other change.

⚠️ Known follow-up, tracked separately: on a push to `development` the gate diffs against `origin/development` — itself — so scope is 0 files and v1.5.0 exits 99. A scoping fix (against `github.event.before`) is in progress. That is a true statement replacing a vacuous pass, and strictly better than failing because a script is missing.