### PR TITLE
fix(manifest): six pages declared a type CnPageRenderer cannot dispatch

### DIFF
--- a/src/manifest.d/bookkeeping-accounts-payable-core.json
+++ b/src/manifest.d/bookkeeping-accounts-payable-core.json
@@ -267,7 +267,7 @@
 		{
 			"id": "APAgingT2",
 			"route": "/bookkeeping/ap-aging-t2",
-			"type": "aggregate",
+			"type": "index",
 			"title": "AP Aging",
 			"config": {
 				"register": "shillinq",

--- a/src/manifest.d/bookkeeping-provincies-bbv-variant.json
+++ b/src/manifest.d/bookkeeping-provincies-bbv-variant.json
@@ -32,7 +32,7 @@
 		{
 			"id": "BbvComplianceDashboard",
 			"route": "/bbv-provincie/compliance-dashboard",
-			"type": "report",
+			"type": "dashboard",
 			"title": "BBV Compliance Dashboard",
 			"visibility": {
 				"field": "administrationType",

--- a/src/manifest.d/bookkeeping-vat-btw-filing.json
+++ b/src/manifest.d/bookkeeping-vat-btw-filing.json
@@ -196,7 +196,7 @@
 		{
 			"id": "VATReturnCreateDialog",
 			"route": "/vat-returns/new",
-			"type": "dialog",
+			"type": "form",
 			"title": "New BTW return",
 			"config": {
 				"register": "shillinq",

--- a/src/manifest.d/expense-reimbursement-or-passthrough.json
+++ b/src/manifest.d/expense-reimbursement-or-passthrough.json
@@ -203,7 +203,7 @@
 		{
 			"id": "ReimbursementPolicyCreateDialog",
 			"route": "/reimbursement-policies/new",
-			"type": "dialog",
+			"type": "form",
 			"title": "New Reimbursement Policy",
 			"config": {
 				"register": "shillinq",
@@ -299,7 +299,7 @@
 		{
 			"id": "PassThroughMarkupRuleCreateDialog",
 			"route": "/passthrough-markup-rules/new",
-			"type": "dialog",
+			"type": "form",
 			"title": "New Pass-through Markup Rule",
 			"config": {
 				"register": "shillinq",

--- a/src/manifest.d/retainer-billing-engine.json
+++ b/src/manifest.d/retainer-billing-engine.json
@@ -145,7 +145,7 @@
 		{
 			"id": "RetainerPoolCreateDialog",
 			"route": "/retainer-pools/new",
-			"type": "dialog",
+			"type": "form",
 			"title": "New retainer pool",
 			"config": {
 				"register": "shillinq",


### PR DESCRIPTION
Six pages used a page `type` that does not exist. The renderer resolves the body via `effectivePageTypes[page.type]`; for an unrecognised value that is `undefined`, so it logs a console warning and returns null, `hasRenderableBody()` is false, and **the page renders no body**. These six routes have been navigable and blank.

`pageTypes.js` registers exactly `chat, dashboard, detail, files, form, index, logs, map, roadmap, search, settings, wiki`, plus `custom` handled separately. Everything else falls through.

## The fix

Each page is retyped to the type **its own config already describes**. No config was touched — in every case the config was already correct and only the label was wrong.

| page | was | now | config that decided it |
|---|---|---|---|
| `APAgingT2` | `aggregate` | `index` | register/schema/variants/defaultVariant |
| `BbvComplianceDashboard` | `report` | `dashboard` | register/schema/**dashboard** |
| `VATReturnCreateDialog` | `dialog` | `form` | register/schema/action/**fields**/onSuccess |
| `ReimbursementPolicyCreateDialog` | `dialog` | `form` | idem, 7 fields |
| `PassThroughMarkupRuleCreateDialog` | `dialog` | `form` | idem, 10 fields |
| `RetainerPoolCreateDialog` | `dialog` | `form` | idem, 14 fields |

Retyping is **not free** — it activates the type-specific rules the schema applies via `if/then`, so a wrong choice would have *added* violations rather than removed them. It did not: **gate-53 goes 246 → 240**, exactly the six removed, none added. The four form pages already carry `config.fields`, which is what `type: form` requires.

## Not fixed, deliberately

`ExpenseSettlementClassifier` (`bulk-form`) is a genuinely bespoke multi-source screen — `config.sources[]` over Receipt, MileageEntry and PerDiem, each with its own filter and columns, plus a shared form and submit block. No standard type fits it, and it declares no `component` — so retyping it to `custom` would satisfy the schema **while the page stayed just as blank**. That is a green that means nothing. It needs a component, which is feature work, not a manifest edit. Left failing so the gate keeps saying so.

## Verification

- `npm run check:manifest` passes: 229 pages, 0 ajv errors, 0 consistency issues.
- All five touched files still parse as JSON; the diff is 6 changed lines.
- The remaining 240 gate-53 findings are pre-existing and unrelated to page types — 102 of them are `type: custom` pages missing the `_note` that documents why a standard type was not feasible.
