### PR TITLE
fix(registers): every bookkeeping schema declares an audit trail (REQ-AT-001)

### DIFF
--- a/lib/Settings/register.d/20-bookkeeping-tenderned-integratie.json
+++ b/lib/Settings/register.d/20-bookkeeping-tenderned-integratie.json
@@ -226,6 +226,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a TenderNed Aanbesteding is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Verplichting": {
@@ -461,6 +465,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Verplichting is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "OpdrachtUitvoering": {
@@ -636,6 +644,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Opdracht Uitvoering is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/20-zzp-urencriterium-tracker.json
+++ b/lib/Settings/register.d/20-zzp-urencriterium-tracker.json
@@ -181,6 +181,10 @@
             "description": "Aantal onderneming-jaren per drempel-status.",
             "groupBy": "drempelStatus"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Urencriterium jaar is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "UrenDagregistratie": {
@@ -320,6 +324,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Uren dagregistratie is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "UrenCategorie": {
@@ -434,6 +442,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Uren categorie is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "UrenPrognose": {
@@ -539,6 +551,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Uren prognose is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "UrenAlert": {
@@ -674,6 +690,10 @@
             "description": "Aantal alerts per urgentie-niveau.",
             "groupBy": "urgentie"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Uren alert is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "UrenEvidence": {
@@ -793,6 +813,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Uren bewijsdossier is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/30-bookkeeping-ib-aangifte-zzp.json
+++ b/lib/Settings/register.d/30-bookkeeping-ib-aangifte-zzp.json
@@ -315,6 +315,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a IB-aangifte is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IBWinstOpgave": {
@@ -503,6 +507,10 @@
             "grondslag": "art. 3.15 Wet IB 2001",
             "guard": "OCA\\Shillinq\\Guard\\IbFiscalAdjustmentGuard::representatieDrempel"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a IB-winstopgave is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IBOndernemersaftrek": {
@@ -703,6 +711,10 @@
             "grondslag": "art. 3.79a Wet IB 2001",
             "parameterSource": "IBTaxParameterYear.mkbExemptionRate"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a IB-ondernemersaftrek is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IBHeffingskortingenAlgemeen": {
@@ -800,6 +812,10 @@
             "grondslag": "art. 8.10 Wet IB 2001",
             "parameterSource": "IBTaxParameterYear.ahkMax,ahkPhaseoutRate,ahkPhaseoutThreshold"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a IB-heffingskortingen is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IBLijfrenteAOV": {
@@ -907,6 +923,10 @@
             "grondslag": "art. 3.127 Wet IB 2001",
             "parameterSource": "IBTaxParameterYear.lijfrenteRate,lijfrenteFranchise,lijfrenteReserveringsruimteCap"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a IB-lijfrente & AOV is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IBBijtellingAuto": {
@@ -1031,6 +1051,10 @@
             "guard": "OCA\\Shillinq\\Guard\\IbBijtellingGuard::computeBijtelling",
             "parameterSource": "IBTaxParameterYear.evBijtellingStaffel1Pct,evBijtellingStaffel1Cap,evBijtellingStaffel2Pct"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a IB-bijtelling auto is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IBBox3Vermogen": {
@@ -1136,6 +1160,10 @@
             "grondslag": "Overbruggingswet box 3 / hoofdstuk 5 Wet IB 2001",
             "parameterSource": "IBTaxParameterYear.box3HeffingvrijVermogen"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a IB-box 3 vermogen is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IBAuditTrail": {
@@ -1244,6 +1272,10 @@
             "period": "P7Y",
             "description": "Audit trail retained 7 years per AWR art. 52."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a IB-audittrail is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IBTaxParameterYear": {
@@ -1356,6 +1388,10 @@
             "description": "Source / scheduled-change notes per Belastingplan.",
             "title": "Notes"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a IB-tariefparameters per jaar is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/40-bookings-cancellation-rules.json
+++ b/lib/Settings/register.d/40-bookings-cancellation-rules.json
@@ -205,6 +205,10 @@
               "description": "Customers may read the policy terms applicable to their bookings."
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Cancellation Policy is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "BookingCancellation": {
@@ -386,6 +390,10 @@
               "description": "Customers may self-cancel their own appointments and read the resulting record."
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Booking Cancellation is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Appointment": {

--- a/lib/Settings/register.d/add-shillinq-accounting-standards-policy.json
+++ b/lib/Settings/register.d/add-shillinq-accounting-standards-policy.json
@@ -94,6 +94,10 @@
             "example": "EU-listed group: IFRS consolidated accounts take precedence over Dutch GAAP.",
             "title": "Notes"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Standards policy is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/add-shillinq-bookkeeping-compliance.json
+++ b/lib/Settings/register.d/add-shillinq-bookkeeping-compliance.json
@@ -376,6 +376,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Customer Master is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ARInvoice": {
@@ -779,6 +783,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Dunning Record is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "BankStatement": {

--- a/lib/Settings/register.d/add-shillinq-detachering-payroll-administratie.json
+++ b/lib/Settings/register.d/add-shillinq-detachering-payroll-administratie.json
@@ -246,6 +246,10 @@
             "cardinality": "many-to-one",
             "description": "The JournalEntry materialised from this salaris-feed record after successful mapping."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Salaris Feed is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "OpdrachtgeversVerklaring": {
@@ -408,6 +412,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Opdrachtgevers Verklaring is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IB47Record": {
@@ -645,6 +653,10 @@
             "template": "ib47-batch-submitted",
             "description": "Notify the payroll-officer when the IB47 yearly batch has been transmitted to the Belastingdienst via openconnector. Declarative fan-out per ADR-031. KNOWN GAP (migrate-legacy-notification-dialect): trigger is still the bare-string legacy shape — IB47Record has no status/lifecycle field for a canonical `transition` trigger to hook into; the batch-submitted event is fired by the openconnector transmission step, not an object state change. Needs a schema decision (add a submission-status field, or a new non-transition trigger type) before this rule can dispatch through the declarative engine; tracked as follow-up, not fixed by this change."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a IB47 Record is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/add-shillinq-rj270-stages.json
+++ b/lib/Settings/register.d/add-shillinq-rj270-stages.json
@@ -80,6 +80,10 @@
             "example": "RJ 270 §3.2: revenue recognised only to the extent of recoverable costs in early stages.",
             "title": "Statutory Note"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a RJ-270 Stage is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/add-shillinq-sbr-xbrl-reporting.json
+++ b/lib/Settings/register.d/add-shillinq-sbr-xbrl-reporting.json
@@ -276,6 +276,10 @@
             "title": "SBR/XBRL afgewezen",
             "message": "XBRL-instance @self.instanceNumber (@self.entryPoint) is afgewezen door Digipoort: @self.rejectionReason."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a XBRL Instance is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/bookkeeping-bado-controleprotocol.json
+++ b/lib/Settings/register.d/bookkeeping-bado-controleprotocol.json
@@ -253,6 +253,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Controleprotocol is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ToleranceMatrix": {
@@ -356,6 +360,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Tolerantiematrix is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Materialiteit": {
@@ -474,6 +482,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Materialiteit is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "AuditSample": {
@@ -564,6 +576,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Steekproef is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "AuditFinding": {
@@ -785,6 +801,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Bevinding is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "VerklaringDraft": {
@@ -954,6 +974,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Controleverklaring is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "SiSaAssurance": {
@@ -1038,6 +1062,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a SiSa-assurance is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     },

--- a/lib/Settings/register.d/bookkeeping-bank-reconciliation.json
+++ b/lib/Settings/register.d/bookkeeping-bank-reconciliation.json
@@ -438,6 +438,10 @@
             "groupBy": "matchType",
             "description": "Number of matches per matchType, for the detail-page match summary."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Bank Reconciliation Match is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/bookkeeping-ccm-rule-engine.json
+++ b/lib/Settings/register.d/bookkeeping-ccm-rule-engine.json
@@ -16,7 +16,10 @@
         "description": "A Continuous Controls Monitoring rule definition (REQ-CCM-001). Carries the control family, objective, COSO assertion, severity, evaluation mode, trigger events, and the constrained JSON DSL logic (ruleLogic) evaluated by CcmRuleEngine (REQ-CCM-002). Parameters are tenant-configurable thresholds; ruleLogic is never arbitrary code. rule owner/reviewer are Nextcloud user ids (FK to the NC user directory). Immutable audit trail per REQ-CCM-009.",
         "x-schema-org": "schema:GovernmentService",
         "x-spec": "openspec/changes/bookkeeping-ccm-rule-engine/specs/bookkeeping-ccm-rule-engine/index.md",
-        "x-openregister-audit-trail": true,
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a CCM Rule is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
+        },
         "x-openregister-rbac": {
           "roles": {
             "internal-audit": {
@@ -251,7 +254,10 @@
         "description": "A single rule firing (REQ-CCM-004). Captures an immutable evidence snapshot at fire time (before/after, actor, approver chain, GL context) and transitions through a four-state triage workflow via x-openregister-lifecycle. Investigation notes and status history are append-only. Resolution requires a mandatory rationale (CcmFindingGuard). The assignee is a Nextcloud user id. Immutable audit trail per REQ-CCM-009.",
         "x-schema-org": "schema:GovernmentService",
         "x-spec": "openspec/changes/bookkeeping-ccm-rule-engine/specs/bookkeeping-ccm-rule-engine/index.md",
-        "x-openregister-audit-trail": true,
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a CCM Finding is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
+        },
         "x-openregister-rbac": {
           "roles": {
             "internal-audit": {
@@ -626,7 +632,10 @@
         "description": "Segregation-of-duties reference data (REQ-CCM-005). One row per function code, listing the conflicting function codes a single user may not also hold, with conflict severity, rationale (Dutch), and the compensating controls allowed. Pre-loaded with the standard SAP/Oracle function library, tenant-configurable.",
         "x-schema-org": "schema:DefinedTerm",
         "x-spec": "openspec/changes/bookkeeping-ccm-rule-engine/specs/bookkeeping-ccm-rule-engine/index.md",
-        "x-openregister-audit-trail": true,
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a CCM Segregation Matrix is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
+        },
         "x-openregister-unique": [
           "functionCode"
         ],
@@ -712,7 +721,10 @@
         "description": "Materialised mapping of a Nextcloud user to a SoD function code (REQ-CCM-005), recomputed nightly from roles + direct grants + temporary elevations by the ccm-sod-materialisation scheduled workflow. The user is a Nextcloud entity (FK to the NC user directory). conflictWith records the SoD conflicts the user currently holds.",
         "x-schema-org": "schema:Role",
         "x-spec": "openspec/changes/bookkeeping-ccm-rule-engine/specs/bookkeeping-ccm-rule-engine/index.md",
-        "x-openregister-audit-trail": true,
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a CCM User Function Assignment is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
+        },
         "x-openregister-rbac": {
           "roles": {
             "internal-audit": {
@@ -829,7 +841,10 @@
         "description": "A statistical baseline that anomalous-amount and Benford's-Law rules compare against (REQ-CCM-002). Materialised nightly (not computed per evaluation, REQ-CCM-003) by the ccm-baseline-materialisation scheduled workflow over a rolling window per scope. stable=false when the sample size or variance is too small to flag.",
         "x-schema-org": "schema:QuantitativeValue",
         "x-spec": "openspec/changes/bookkeeping-ccm-rule-engine/specs/bookkeeping-ccm-rule-engine/index.md",
-        "x-openregister-audit-trail": true,
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a CCM Baseline is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
+        },
         "x-openregister-rbac": {
           "roles": {
             "internal-audit": {
@@ -970,7 +985,10 @@
         "description": "The period-end audit-committee deliverable (REQ-CCM-006). Assembles rule-firings by family/severity, findings by status, top findings, trend analysis, SoD compliance scorecard, manual-JE summary, approver-bypass summary, and (when SOX mode is enabled) the SOX 404 deficiency log. The executive summary is LLM-drafted then human-edited; no report is published without approver sign-off (CcmFindingGuard::canApproveReport). Immutable audit trail per REQ-CCM-009.",
         "x-schema-org": "schema:Report",
         "x-spec": "openspec/changes/bookkeeping-ccm-rule-engine/specs/bookkeeping-ccm-rule-engine/index.md",
-        "x-openregister-audit-trail": true,
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a CCM Audit Committee Report is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
+        },
         "x-openregister-rbac": {
           "roles": {
             "internal-audit": {

--- a/lib/Settings/register.d/bookkeeping-consolidation-commercial.json
+++ b/lib/Settings/register.d/bookkeeping-consolidation-commercial.json
@@ -275,6 +275,10 @@
               "description": "Mark the entity as sold; recycle cumulative CTA (REQ-CONS-005)."
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Group Entity is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IntercompanyRelation": {
@@ -356,6 +360,10 @@
             "description": "Free-text remarks.",
             "title": "Notes"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Intercompany Relation is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ConsolidationPeriod": {
@@ -571,6 +579,10 @@
               "description": "Return to elimination phase to correct rejected entries."
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Consolidation Period is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "EliminationEntry": {
@@ -736,6 +748,10 @@
               "requires": "OCA\\Shillinq\\Lifecycle\\ConsolidationGuard::canRejectElimination"
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Elimination Entry is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "TranslationAdjustment": {
@@ -803,6 +819,10 @@
             "description": "Free-text remarks, e.g. rates applied.",
             "title": "Notes"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Translation Adjustment is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "MinorityInterest": {
@@ -865,6 +885,10 @@
             "description": "closingBalance = openingBalance + periodResultShare − dividendToMinority (REQ-CONS-006, design D6). Declarative per ADR-031 — no MinorityInterestCalculator.php.",
             "expr": "@self.openingBalance + @self.periodResultShare - @self.dividendToMinority"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Minority Interest is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Goodwill": {
@@ -974,6 +998,10 @@
             "description": "goodwillAmount = purchasePrice − fairValueNetAssetsAcquired (positive = goodwill, negative = badwill) per RJ 216 / IFRS 3 (REQ-CONS-007, design D5). Declarative per ADR-031 — no GoodwillCalculator.php.",
             "expr": "@self.purchasePrice - @self.fairValueNetAssetsAcquired"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Goodwill is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ConsolidatedBalance": {
@@ -1119,6 +1147,10 @@
               "label": "Publish balance"
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Consolidated Balance is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ConsolidatedIncomeStatement": {
@@ -1274,6 +1306,10 @@
               "label": "Publish income statement"
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Consolidated Income Statement is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     },

--- a/lib/Settings/register.d/bookkeeping-detachering-payroll-administratie.json
+++ b/lib/Settings/register.d/bookkeeping-detachering-payroll-administratie.json
@@ -212,6 +212,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Employee is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Payroll": {
@@ -545,6 +549,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Payroll is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Deduction": {
@@ -655,6 +663,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Deduction is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "DeterminationLetter": {
@@ -801,6 +813,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Determination Letter is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/bookkeeping-emu-reporting.json
+++ b/lib/Settings/register.d/bookkeeping-emu-reporting.json
@@ -286,6 +286,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a EMU-rapportage is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "EMUAdjustment": {
@@ -409,6 +413,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a EMU-correctie is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "CashFlowItem": {
@@ -520,6 +528,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Kasstroomregel is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "DebtPosition": {
@@ -703,6 +715,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Schuldpositie is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/bookkeeping-icp-opgaaf.json
+++ b/lib/Settings/register.d/bookkeeping-icp-opgaaf.json
@@ -88,6 +88,10 @@
             "example": "adm-smb-1",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a VIES Validation is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IcpSupply": {
@@ -211,6 +215,10 @@
               }
             ]
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a ICP Supply is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IcpOpgaaf": {
@@ -434,6 +442,10 @@
             "engine": "sbr-xbrl",
             "target": "xmlPayload"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a ICP-opgaaf (Recapitulative Statement) is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "PeriodicitySwitch": {
@@ -534,6 +546,10 @@
             "title": "Reversal Reason",
             "description": "The reversal reason."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Periodicity Switch is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ARInvoice": {

--- a/lib/Settings/register.d/bookkeeping-ifrs-16-lease.json
+++ b/lib/Settings/register.d/bookkeeping-ifrs-16-lease.json
@@ -333,6 +333,10 @@
             "example": "adm-smb-1",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Lease Contract is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "LeasePaymentSchedule": {
@@ -482,6 +486,10 @@
             "title": "Administration ID",
             "description": "The date and time for administration id."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Lease Payment Schedule is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "LeaseReassessmentEvent": {
@@ -650,6 +658,10 @@
             "title": "Administration ID",
             "description": "The date and time for administration id."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Lease Reassessment Event is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "LeaseDisclosureTable": {
@@ -809,6 +821,10 @@
             "title": "Administration ID",
             "description": "The date and time for administration id."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a IFRS 16 Disclosure Table is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "LeasePortfolioExemption": {
@@ -876,6 +892,10 @@
             "title": "Administration ID",
             "description": "The date and time for administration id."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Lease Portfolio Exemption Policy is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     },

--- a/lib/Settings/register.d/bookkeeping-innovatiebox-administratie.json
+++ b/lib/Settings/register.d/bookkeeping-innovatiebox-administratie.json
@@ -201,6 +201,10 @@
             "example": "adm-mkb-1",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Qualifying Asset is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "NexusCalculation": {
@@ -339,6 +343,10 @@
               }
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Nexus Calculation is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IBProfitAttribution": {
@@ -537,6 +545,10 @@
               }
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a IB Profit Attribution is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IBExpenseAllocation": {
@@ -681,6 +693,10 @@
             "title": "Administration ID",
             "description": "The date and time for administration id."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a IB Expense Allocation is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "CarryForwardLoss": {
@@ -779,6 +795,10 @@
             "title": "Administration ID",
             "description": "The date and time for administration id."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Carry Forward Loss is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "InnovatieboxAuditEvent": {
@@ -870,6 +890,10 @@
             "additionalProperties": true,
             "title": "Details"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Innovatiebox Audit Event is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     },

--- a/lib/Settings/register.d/bookkeeping-intercompany-elimination.json
+++ b/lib/Settings/register.d/bookkeeping-intercompany-elimination.json
@@ -397,6 +397,10 @@
               "requires": "OCA\\Shillinq\\Lifecycle\\IntercompanyToleranceGuard::isWithinTolerance"
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Intercompany Match is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IntercompanyMismatch": {
@@ -547,6 +551,10 @@
               "label": "Accept as difference"
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Intercompany Mismatch is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ToleranceRule": {
@@ -634,6 +642,10 @@
             "description": "FK to Administration (tenant scope).",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Tolerance Rule is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "CounterpartyBalance": {
@@ -771,6 +783,10 @@
               }
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Counterparty Balance is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "EliminationJournal": {
@@ -919,6 +935,10 @@
               "requires": "OCA\\Shillinq\\Lifecycle\\EliminationBalanceGuard::isBalanced"
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Elimination Journal is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     },

--- a/lib/Settings/register.d/bookkeeping-investeringsaftrek.json
+++ b/lib/Settings/register.d/bookkeeping-investeringsaftrek.json
@@ -207,6 +207,10 @@
             "example": "RVO-2026-EIA-00123",
             "title": "Rvo Referentie"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a InvestmentAsset is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "EnergielijstCode": {
@@ -285,6 +289,10 @@
             "title": "Vervaldatum",
             "description": "The date and time for vervaldatum."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a EnergielijstCode is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "MilieulijstCode": {
@@ -367,6 +375,10 @@
             "title": "Ingangsdatum",
             "description": "The date and time for ingangsdatum."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a MilieulijstCode is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "InvesteringsaftrekClaim": {
@@ -493,6 +505,10 @@
             "example": null,
             "title": "Verlagin Rationale"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a InvesteringsaftrekClaim is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "VamilDepreciation": {
@@ -578,6 +594,10 @@
             },
             "title": "Regulier Afschrijfschema"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a VamilDepreciation is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "KIATier": {
@@ -640,6 +660,10 @@
             "example": "28% over investering",
             "title": "Regel"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a KIATier is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/bookkeeping-market-government-separation.json
+++ b/lib/Settings/register.d/bookkeeping-market-government-separation.json
@@ -412,6 +412,10 @@
             },
             "handler": "OCA\\Shillinq\\Service\\CrossSubsidyDetector::composeAlert"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Commercial Activity is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IntegralCostPrice": {
@@ -643,6 +647,10 @@
             "enabled": true,
             "handler": "OCA\\Shillinq\\Service\\IntegralCostPriceLockService::lock"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Integral Cost Price is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ActivityCostAllocation": {
@@ -900,6 +908,10 @@
             "toState": "posted",
             "handler": "OCA\\Shillinq\\Service\\ActivityCostAllocationSplitter::compose"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Activity Cost Allocation is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "AlgemeenBelangBesluit": {
@@ -1285,6 +1297,10 @@
             "description": "When an ABB enters intrekking or herziening, flag dependent CommercialActivity records (those whose exemptionBesluitId points at this ABB) for operator review (REQ-WMO-005 §dependents).",
             "handler": "OCA\\Shillinq\\Service\\AbbLifecycleService::flagDependentActivities"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Public Interest Decision is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ACMReport": {
@@ -1742,6 +1758,10 @@
             },
             "metadataOnly": true
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a ACM Report is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "AlertLog": {
@@ -1941,6 +1961,10 @@
             "description": "Validate resolution notes are non-empty and write the operator's motivation onto resolutionNotes (REQ-WMO-007 §resolution).",
             "handler": "OCA\\Shillinq\\Service\\CrossSubsidyDetector::resolve"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Cross-Subsidy Alert is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "WMOAuditLog": {
@@ -2107,6 +2131,10 @@
             },
             "handler": "OCA\\Shillinq\\Service\\WmoAuditLogService::retentionExpiredState"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a WMO Audit Log is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "MarketBenchmark": {
@@ -2217,6 +2245,10 @@
             "description": "Phase 3 (REQ-WMO-012): when a MarketBenchmark is created, recompute the bevoordeling-risk for the linked CommercialActivity's most recent IKP. If gehanteerdTarief < benchmark median × 0.85 while gehanteerdTarief >= kostprijsPerEenheid, emit a HIGH-severity bevoordeling-risk AlertLog (Art. 25j Mededingingswet).",
             "handler": "OCA\\Shillinq\\Service\\CrossSubsidyDetector::detectBevoordelingRisk"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Market Benchmark is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/bookkeeping-multi-administratie.json
+++ b/lib/Settings/register.d/bookkeeping-multi-administratie.json
@@ -1068,6 +1068,10 @@
             "cardinality": "many-to-one",
             "description": "Administration covered by this backup run."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Administration Backup Run is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     },

--- a/lib/Settings/register.d/bookkeeping-pension-ias19.json
+++ b/lib/Settings/register.d/bookkeeping-pension-ias19.json
@@ -277,6 +277,10 @@
           },
           "lockGuard": "OCA\\Shillinq\\Lifecycle\\PensionIas19Guard::canLockValuation",
           "x-spec": "openspec/changes/bookkeeping-pension-ias19/specs/bookkeeping-pension-ias19/spec.md#REQ-PEN-010"
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Pension Plan is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ActuarialValuation": {
@@ -607,6 +611,10 @@
             },
             "metadataOnly": true
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Actuarial Valuation is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "PensionMovement": {
@@ -893,6 +901,10 @@
           "ociComponentSource": "netPensionMovementOCI",
           "reversalPattern": "long-term",
           "x-spec": "openspec/changes/bookkeeping-pension-ias19/specs/bookkeeping-pension-ias19/spec.md#REQ-PEN-003"
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Pension Movement is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "PensionAssumptionSensitivity": {
@@ -978,6 +990,10 @@
               "PensionAssumptionSensitivity.direction"
             ]
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Pension Assumption Sensitivity is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "PensionAssetDetail": {
@@ -1047,6 +1063,10 @@
             "example": "adm-1",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Pension Asset Detail is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "PensionDisclosureTabel": {
@@ -1156,6 +1176,10 @@
             "html"
           ],
           "x-spec": "openspec/changes/bookkeeping-pension-ias19/specs/bookkeeping-pension-ias19/spec.md#REQ-PEN-007"
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Pension Disclosure Table is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     },

--- a/lib/Settings/register.d/bookkeeping-programmabegroting.json
+++ b/lib/Settings/register.d/bookkeeping-programmabegroting.json
@@ -207,6 +207,10 @@
               }
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Programmabegroting is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Programma": {
@@ -473,6 +477,10 @@
             "example": "adm-gov-1",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Beleidsindicator is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Investering": {
@@ -554,6 +562,10 @@
             "example": "adm-gov-1",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Investering is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Reserve": {
@@ -879,6 +891,10 @@
             "example": "adm-gov-1",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Meerjarenraming is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Begrotingswijziging": {

--- a/lib/Settings/register.d/bookkeeping-provincies-bbv-variant.json
+++ b/lib/Settings/register.d/bookkeeping-provincies-bbv-variant.json
@@ -185,6 +185,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Budget is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/bookkeeping-quote-order-invoice.json
+++ b/lib/Settings/register.d/bookkeeping-quote-order-invoice.json
@@ -209,6 +209,10 @@
               "description": "Return to draft to issue a new version; the sent version is retained as an immutable snapshot (design D1)."
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Quote is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "QuoteLine": {
@@ -301,6 +305,10 @@
             "description": "lineNet = quantity * unitPrice * (1 - discount/100). Declarative per ADR-031 — no PHP pricing service.",
             "expr": "@self.quantity * @self.unitPrice * (1 - (@self.discount / 100))"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Quote Line is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "SalesOrder": {
@@ -749,6 +757,10 @@
               "description": "Record carrier hand-off."
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Delivery is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Invoice": {
@@ -1300,6 +1312,10 @@
             "default": 4,
             "title": "Priority"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Pricing Tier is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "VolumeDiscount": {
@@ -1393,6 +1409,10 @@
             "default": true,
             "title": "Automatic Application"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Volume Discount is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "BlanketOrder": {
@@ -1487,6 +1507,10 @@
             "description": "remainingQuantity = max(committedQuantity - calledOffQuantity, 0). Declarative per ADR-031 (design D8).",
             "expr": "max(@self.committedQuantity - @self.calledOffQuantity, 0)"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Blanket Order is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "CreditHold": {
@@ -1606,6 +1630,10 @@
               "requires": "OCA\\Shillinq\\Lifecycle\\QuoteOrderInvoiceGuard::canReleaseCreditHold"
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Credit Hold is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     },

--- a/lib/Settings/register.d/bookkeeping-rechtmatigheidsverantwoording.json
+++ b/lib/Settings/register.d/bookkeeping-rechtmatigheidsverantwoording.json
@@ -275,6 +275,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Rechtmatigheidstoets is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Rechtmatigheidsbevinding": {
@@ -514,6 +518,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Rechtmatigheidsbevinding is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Rechtmatigheidsparagraaf": {
@@ -719,6 +727,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Rechtmatigheidsparagraaf is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Tolerantiegrens": {
@@ -838,6 +850,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Tolerantiegrens is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/bookkeeping-sepa-direct-debit.json
+++ b/lib/Settings/register.d/bookkeeping-sepa-direct-debit.json
@@ -266,6 +266,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a SEPA Mandate is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "DirectDebitCollection": {
@@ -492,6 +496,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Direct Debit Collection is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "DirectDebitBatch": {
@@ -689,6 +697,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Direct Debit Batch is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "RTransaction": {
@@ -793,6 +805,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a R-Transaction is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "PreNotification": {
@@ -877,6 +893,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Pre-notification is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "CustomerMaster": {

--- a/lib/Settings/register.d/bookkeeping-single-audit-eu-fondsen.json
+++ b/lib/Settings/register.d/bookkeeping-single-audit-eu-fondsen.json
@@ -298,6 +298,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a EU-project is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "EligibilityRule": {
@@ -504,6 +508,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Eligibility-regel is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "SegregatedLedger": {
@@ -653,6 +661,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Gescheiden EU-administratie is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "EuExpenditure": {
@@ -947,6 +959,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a EU-uitgave is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "SupportingDocument": {
@@ -1140,6 +1156,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Bewijsstuk is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IrregularityReport": {
@@ -1346,6 +1366,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Onregelmatigheid-melding is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "AuditTrail": {
@@ -1510,6 +1534,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Audit-trail is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/bookkeeping-subsidie-verantwoording.json
+++ b/lib/Settings/register.d/bookkeeping-subsidie-verantwoording.json
@@ -9,6 +9,10 @@
   "components": {
     "schemas": {
       "AuditFindingTemplate": {
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of an Audit Finding Template is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
+        },
         "slug": "AuditFindingTemplate",
         "icon": "FormatListChecks",
         "version": "0.1.0",
@@ -75,6 +79,10 @@
         }
       },
       "SubsidieVerantwoording": {
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Subsidie Verantwoording is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
+        },
         "slug": "SubsidieVerantwoording",
         "icon": "FileDocumentCheckOutline",
         "version": "0.1.0",
@@ -370,6 +378,10 @@
         }
       },
       "AuditorStatement": {
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of an Auditor Statement is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
+        },
         "slug": "AuditorStatement",
         "icon": "ClipboardCheckOutline",
         "version": "0.1.0",

--- a/lib/Settings/register.d/bookkeeping-treasury-ihb.json
+++ b/lib/Settings/register.d/bookkeeping-treasury-ihb.json
@@ -204,6 +204,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Cash Pool is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "CashPoolMembership": {
@@ -309,6 +313,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Cash Pool Membership is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IntercompanyLoan": {
@@ -538,6 +546,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Intercompany Loan is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IntercompanyTransaction": {
@@ -910,6 +922,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a FX Contract is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "FXPosition": {
@@ -1016,6 +1032,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a FX Position is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "CashForecast": {
@@ -1177,6 +1197,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Cash Forecast is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "BankReconciliationGroup": {
@@ -1326,6 +1350,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Bank Reconciliation Group is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "LiquidityKPI": {
@@ -1444,6 +1472,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Liquidity KPI is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/bookkeeping-verplichtingenadministratie.json
+++ b/lib/Settings/register.d/bookkeeping-verplichtingenadministratie.json
@@ -578,6 +578,10 @@
               "gefactureerd_bedrag"
             ]
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Verplichtingsregel is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Verplichtingsmutatie": {
@@ -697,6 +701,10 @@
             "cardinality": "many-to-one",
             "description": "Parent commitment."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Verplichtingsmutatie is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Mandaat": {
@@ -844,6 +852,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Mandaat is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Goedkeuringsstap": {
@@ -951,6 +963,10 @@
             "cardinality": "many-to-one",
             "description": "The commitment awaiting approval."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Goedkeuringsstap is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Budget": {

--- a/lib/Settings/register.d/bookkeeping-voorzieningen-claims.json
+++ b/lib/Settings/register.d/bookkeeping-voorzieningen-claims.json
@@ -331,6 +331,10 @@
               "description": "Provision fully utilised or released; no further movements expected."
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Provision is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ProvisionMovement": {
@@ -514,6 +518,10 @@
               }
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Provision Movement is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ContingentLiability": {
@@ -639,6 +647,10 @@
               "description": "Publish the contingent liability into the jaarrekening notes (REQ-PROV-015)."
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Contingent Liability is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "PensioenvoorzieningDetail": {
@@ -724,6 +736,10 @@
             "example": "adm-1",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Pensioenvoorziening Detail is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "JubileumvoorzieningDetail": {
@@ -790,6 +806,10 @@
             "example": "adm-1",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Jubileumvoorziening Detail is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "HerstructureringsvoorzieningDetail": {
@@ -883,6 +903,10 @@
             "example": "adm-1",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Herstructureringsvoorziening Detail is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "GarantievoorzieningDetail": {
@@ -954,6 +978,10 @@
             "example": "adm-1",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Garantievoorziening Detail is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "MilieuvoorzieningDetail": {
@@ -1037,6 +1065,10 @@
             "example": "adm-1",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Milieuvoorziening Detail is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ClaimsVoorzieningDetail": {
@@ -1129,6 +1161,10 @@
             "example": "adm-1",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Claims Voorziening Detail is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ProvisionDisclosureTabel": {
@@ -1296,6 +1332,10 @@
               }
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Provision Disclosure Table is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     },

--- a/lib/Settings/register.d/bookkeeping-vpb-corporate-tax-balans.json
+++ b/lib/Settings/register.d/bookkeeping-vpb-corporate-tax-balans.json
@@ -192,6 +192,10 @@
         "x-openregister-rbac": {
           "read": "auth.administrationId == record.administrationId",
           "write": "auth.administrationId == record.administrationId && auth.role in ['bookkeeper','admin']"
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Vpb Balans Link is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/bookkeeping-vpb-corporate-tax.json
+++ b/lib/Settings/register.d/bookkeeping-vpb-corporate-tax.json
@@ -126,6 +126,10 @@
             ],
             "archived": []
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Tax Deadline is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "TaxPaymentTracking": {
@@ -216,6 +220,10 @@
             "example": "adm-1",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Tax Payment Tracking is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "QuarterlyTaxStatement": {
@@ -327,6 +335,10 @@
               "GLLine.taxTreatment"
             ]
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Quarterly Tax Statement is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     },

--- a/lib/Settings/register.d/bookkeeping-vpb-mkb.json
+++ b/lib/Settings/register.d/bookkeeping-vpb-mkb.json
@@ -147,6 +147,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Belastingplichtige is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "VpbTariefcatalogus": {
@@ -252,6 +256,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Vpb-tariefcatalogus is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "VpbAangifte": {
@@ -558,6 +566,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Vpb-aangifte is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "FiscaleCorrectie": {
@@ -665,6 +677,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Fiscale correctie is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Innovatiebox": {
@@ -811,6 +827,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Innovatiebox-claim is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Deelneming": {
@@ -955,6 +975,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Deelneming is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "FiscaleEenheid": {
@@ -1072,6 +1096,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Fiscale eenheid is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Voorvoegingsverlies": {
@@ -1202,6 +1230,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Voorvoegingsverlies is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "InvesteringsAftrek": {
@@ -1341,6 +1373,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Investeringsaftrek is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "VoorlopigeAanslag": {
@@ -1465,6 +1501,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Voorlopige aanslag is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "DefinitieveAanslag": {
@@ -1644,6 +1684,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Definitieve aanslag is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "BezwaarBeroep": {
@@ -1932,6 +1976,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Bezwaar / Beroep is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     },

--- a/lib/Settings/register.d/bookkeeping-wet-fido-treasury.json
+++ b/lib/Settings/register.d/bookkeeping-wet-fido-treasury.json
@@ -239,6 +239,10 @@
               "description": "Mark this version superseded when a newer version is adopted."
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Treasurystatuut is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "KasgeldLimiet": {
@@ -353,6 +357,10 @@
               }
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Kasgeldlimiet is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "RenteRisicoNorm": {
@@ -490,6 +498,10 @@
               }
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Rente-risiconorm is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "SchatkistbankierenSaldo": {
@@ -583,6 +595,10 @@
             "example": null,
             "title": "Notes"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Schatkistbankieren-saldo is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Lening": {
@@ -801,6 +817,10 @@
               "description": "Lock an overridden lening once it is included in a submitted rapportage."
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Lening is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Derivaat": {
@@ -949,6 +969,10 @@
               "description": "Mark the derivaat matured at the end of its hedge term."
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Derivaat is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "QuartaalrapportageFido": {
@@ -1173,6 +1197,10 @@
               }
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Kwartaalrapportage Fido is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "TreasuryParagraaf": {
@@ -1269,6 +1297,10 @@
             "example": "draft",
             "title": "Status"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Treasury-paragraaf is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     },

--- a/lib/Settings/register.d/checks-aml-banking.json
+++ b/lib/Settings/register.d/checks-aml-banking.json
@@ -181,6 +181,10 @@
             "description": "True when a Form 8300 was filed for this (or the related-transaction aggregate) cash receipt over USD 10 000.",
             "title": "Form8300Required"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Cash Transaction (AML) is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "AmlReport": {
@@ -281,6 +285,10 @@
             "description": "Reporting period the report covers.",
             "title": "Period"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a AML Report (CTR / SAR / 8300 / CMIR / FBAR / unusual) is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "SanctionsScreening": {
@@ -356,6 +364,10 @@
             "description": "Date a match was reported to the supervisor/OFAC (required when matched).",
             "title": "Reported Date"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Sanctions Screening (OFAC / EU / national) is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "CddRecord": {
@@ -432,6 +444,10 @@
             "description": "Date until which the CDD record is retained (at least five years after recordedDate).",
             "title": "Retention Until"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Customer Due Diligence Record is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "FundsTransfer": {
@@ -490,6 +506,10 @@
             "description": "Account/identifier of the payee/beneficiary (travel rule).",
             "title": "Beneficiary Account"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Funds Transfer (travel rule) is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "TrustLedger": {
@@ -551,6 +571,10 @@
             },
             "title": "Client Balances"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Trust / Escrow Ledger is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "CashCount": {
@@ -609,6 +633,10 @@
             "description": "ISO 4217 currency code.",
             "title": "Currency"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Cash Count (kasadministratie / Z-report) is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/checks-compliance-tail.json
+++ b/lib/Settings/register.d/checks-compliance-tail.json
@@ -360,6 +360,10 @@
             },
             "title": "Source Documents"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a SAF-T File (compliance) is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/checks-final-tail.json
+++ b/lib/Settings/register.d/checks-final-tail.json
@@ -97,6 +97,10 @@
             "description": "Member State of consumption (ISO 3166-1 alpha-2).",
             "title": "Destination Country"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a IOSS Import Consignment is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "TravelAgentMargin": {
@@ -142,6 +146,10 @@
             "description": "ISO 4217 currency.",
             "title": "Currency"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Travel-Agent Margin (art. 306) is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/checks-ifrsusgaap.json
+++ b/lib/Settings/register.d/checks-ifrsusgaap.json
@@ -392,6 +392,10 @@
             "description": "Date a contract modification or hedging relationship relies on ASC 848 reference-rate-reform relief. The relief sunsets after 31 December 2024.",
             "title": "Asc848Modification Date"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Financial Statement is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/checks-national-extra.json
+++ b/lib/Settings/register.d/checks-national-extra.json
@@ -142,6 +142,10 @@
             "example": "2024-01-01",
             "title": "Live From"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a E-Invoicing Mandate Profile is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "SaftExportProfile": {
@@ -188,6 +192,10 @@
             },
             "title": "Covered Areas"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a SAF-T Export Profile is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/checks-public-sector.json
+++ b/lib/Settings/register.d/checks-public-sector.json
@@ -701,6 +701,10 @@
             },
             "title": "Budgetary Comparison"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Public Sector Statement is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/checks-remaining-vat.json
+++ b/lib/Settings/register.d/checks-remaining-vat.json
@@ -270,6 +270,10 @@
             },
             "title": "Recap Lines"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a VAT Return Filing (compliance) is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/checks-sustainability.json
+++ b/lib/Settings/register.d/checks-sustainability.json
@@ -575,6 +575,10 @@
             },
             "title": "Targets"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a ESRS Statement is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/checks-vat-bbv-ledger-tail.json
+++ b/lib/Settings/register.d/checks-vat-bbv-ledger-tail.json
@@ -453,6 +453,10 @@
             },
             "title": "Taakvelden"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a BBV Statement is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/dba-compliance-marker.json
+++ b/lib/Settings/register.d/dba-compliance-marker.json
@@ -430,6 +430,10 @@
             "description": "Totale gerealiseerde omzet per klant (eurocenten); voedt concentratie-aggregatie REQ-DBA-005.",
             "groupBy": "klantId"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a DBA opdracht is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "DBAIntake": {
@@ -751,6 +755,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a DBA intake is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "DBAModelovereenkomst": {
@@ -884,6 +892,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a DBA modelovereenkomst is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "DBARisicoflag": {
@@ -1087,6 +1099,10 @@
             "description": "Aantal flags per type (voor dashboard).",
             "groupBy": "type"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a DBA risico-flag is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "DBAPortfolioRisico": {
@@ -1277,6 +1293,10 @@
             "description": "Aantal portfolio-records per overall-risico-niveau.",
             "groupBy": "overallRisico"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a DBA portfolio-risico is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "DBAEvidenceDossier": {
@@ -1435,6 +1455,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a DBA evidence-dossier is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/reporting-generated-report.json
+++ b/lib/Settings/register.d/reporting-generated-report.json
@@ -100,6 +100,10 @@
             "description": "System tags applied to the file for retrieval (report type, period, administration, category).",
             "title": "Tags"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Generated Report is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/register.d/time-expense-invoice-intake.json
+++ b/lib/Settings/register.d/time-expense-invoice-intake.json
@@ -126,6 +126,10 @@
             "example": "a3f1c9...",
             "title": "Payload Hash"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Time Intake Batch is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "UrenRegistratie": {

--- a/lib/Settings/register.d/usage-metered-billing.json
+++ b/lib/Settings/register.d/usage-metered-billing.json
@@ -9,6 +9,10 @@
     "components": {
         "schemas": {
             "UsageRatePlan": {
+                "x-openregister-audit-trail": {
+                    "enabled": true,
+                    "description": "Every create, update and delete of a Usage Rate Plan is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
+                },
                 "slug": "UsageRatePlan",
                 "icon": "Gauge",
                 "version": "0.1.0",
@@ -126,6 +130,10 @@
                 }
             },
             "MeterReading": {
+                "x-openregister-audit-trail": {
+                    "enabled": true,
+                    "description": "Every create, update and delete of a Meter Reading is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
+                },
                 "slug": "MeterReading",
                 "icon": "Counter",
                 "version": "0.1.0",

--- a/lib/Settings/register.d/zz-order-base.json
+++ b/lib/Settings/register.d/zz-order-base.json
@@ -86,6 +86,10 @@
             "description": "Owning administration.",
             "title": "Administration ID"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Payment is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "OrderLine": {
@@ -163,6 +167,10 @@
             "title": "Line Amount",
             "description": "The line amount as a numeric value."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Order Line is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       }
     }

--- a/lib/Settings/shillinq_register.json
+++ b/lib/Settings/shillinq_register.json
@@ -3266,6 +3266,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Core Data Configuration is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "BBVProgramma": {
@@ -5977,6 +5981,10 @@
               "description": "Full budget-allocation management per REQ-CPA-103."
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Project Budget is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "AllocationRule": {
@@ -8779,6 +8787,10 @@
             "field": "administrationId",
             "enforce": true
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Closing Entry is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "RetainedEarnings": {
@@ -8932,6 +8944,10 @@
             "field": "administrationId",
             "enforce": true
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Retained Earnings is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ClosingAccount": {
@@ -9019,6 +9035,10 @@
             "field": "administrationId",
             "enforce": true
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Closing Account is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ClosingEntryTemplate": {
@@ -9213,6 +9233,10 @@
             "field": "administrationId",
             "enforce": true
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Closing Entry Template is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Receipt": {
@@ -10517,6 +10541,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a ZZP Deduction Amounts is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "InventoryReorderRule": {
@@ -13115,6 +13143,10 @@
               "description": "Management acknowledges finding or remediation is complete."
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Compliance Audit Trail is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "DepreciationSchedule": {
@@ -13383,6 +13415,10 @@
             "cardinality": "many-to-one",
             "description": "The fixed asset this depreciation schedule belongs to."
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Depreciation Schedule is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Grant": {
@@ -13454,6 +13490,10 @@
             "example": true,
             "title": "Is Sisa Eligible"
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Grant is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "ManagementLetter": {
@@ -13588,6 +13628,10 @@
               "description": "Archive letter after remediation cycle is complete."
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Management Letter is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "SisaReport": {
@@ -13970,6 +14014,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a SiSa Report is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "BankingRule": {
@@ -16856,6 +16904,10 @@
               }
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Provincial Fund Posting is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IPAssetValuation": {
@@ -16953,6 +17005,7 @@
           }
         },
         "x-openregister-audit-trail": {
+          "enabled": true,
           "events": {
             "tariff-application": {
               "trigger": "onUpdate",
@@ -16966,7 +17019,8 @@
                 "valuationDate"
               ]
             }
-          }
+          },
+          "description": "Every create, update and delete of a IP Asset Valuation is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         },
         "x-openregister-rbac": {
           "roles": {
@@ -17200,6 +17254,7 @@
           }
         },
         "x-openregister-audit-trail": {
+          "enabled": true,
           "events": {
             "route-election": {
               "trigger": "onCreate",
@@ -17224,7 +17279,8 @@
                 "applicableTariff"
               ]
             }
-          }
+          },
+          "description": "Every create, update and delete of a Innovation Box Election is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         },
         "x-openregister-rbac": {
           "roles": {
@@ -17334,6 +17390,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Innovation Box Rate is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "WinstToerekening": {
@@ -17526,6 +17586,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Profit Allocation is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "IcpStatement": {
@@ -19478,6 +19542,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Budget Amendment is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "BeleidsIndicator": {
@@ -19552,6 +19620,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Policy Indicator is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "EconomischeCategorie": {
@@ -19638,6 +19710,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Economic Category is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "MaterieleVasteActiva": {
@@ -19784,6 +19860,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Tangible fixed assets is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "MeerjarenBudget": {
@@ -19935,6 +20015,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Multi-Year Budget is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Paragraaf": {
@@ -20012,6 +20096,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Paragraph is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Programma": {
@@ -20204,6 +20292,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Programme is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Reserve": {
@@ -20313,6 +20405,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Reserve is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Taakveld": {
@@ -20417,6 +20513,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Task Field is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "Voorziening": {
@@ -20524,6 +20624,10 @@
               ]
             }
           }
+        },
+        "x-openregister-audit-trail": {
+          "enabled": true,
+          "description": "Every create, update and delete of a Provision is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001)."
         }
       },
       "SalesOrder": {


### PR DESCRIPTION
`check:registers` has been red on `development`: **233 of 458** bookkeeping and procurement schemas did not declare `x-openregister-audit-trail.enabled=true`, so OpenRegister's immutable audit trail was not switched on for them. For a government ledger that is not a lint failure — REQ-AT-001 / REQ-RAP-001 exist so a Rekenkamer audit pack can show who changed what, when.

**225 → 458.** Three distinct causes, and only the first was the one advertised:

| n | cause | fix |
|---|---|---|
| 220 | **absent** — no annotation at all | added, with a description naming the schema |
| 6 | **wrong shape** — `"x-openregister-audit-trail": true` | rewritten to the object form |
| 2 | **rich shape, no flag** — a populated `{"events": {…}}` block that never declared `enabled` | flag prepended, event config preserved verbatim |
| 5 | in two fragments whose formatting does not round-trip | hand-edited so their style is untouched |

## The 6 are the ones worth naming

A bare boolean reads to a human as *"audit trail: on"*, and the six `Ccm*` schemas have looked correct in review for as long as they have existed. But both the validator and OpenRegister read `.enabled` — so `true` is **indistinguishable from absent** to everything that consumes it. An annotation in the wrong shape is worse than a missing one: it answers the reviewer's question and not the machine's.

## No reformatting churn

Each of the 50 bulk-edited files was verified to round-trip **byte-identically** through a 2-space JSON dump *before* any of them was written. The two that do not round-trip (compact inline objects, 4-space indent) were excluded from that pass and edited by hand.

## Verification

- `check:registers` **PASS — 458 of 458**, exit 0.
- Every touched file still parses as JSON.
- Schema count is **800 before and 800 after**, so nothing was dropped or duplicated.
- Diff is **+930 / −8**, and all 8 deletions are the six boolean lines plus two brace moves from the rich-shape merge.
