### PR TITLE
test(e2e): point the spec-coverage routes at the ones the manifest declares

### DIFF
--- a/tests/e2e/spec-coverage/bookkeeping.spec.ts
+++ b/tests/e2e/spec-coverage/bookkeeping.spec.ts
@@ -23,9 +23,12 @@ const PAGES: Array<{ route: string, title: string, titleRe?: RegExp }> = [
 	{ route: '/bookkeeping/bank-reconciliation', title: 'Bank Reconciliation' },
 	{ route: '/bookkeeping/matching-rules', title: 'Matching Rules' },
 	{ route: '/fixed-assets', title: 'Fixed Assets' },
-	{ route: '/bookkeeping/vendors', title: 'Vendors' },
-	{ route: '/bookkeeping/accounts-payable', title: 'Accounts Payable' },
-	{ route: '/bookkeeping/ap-aging', title: 'AP Aging' },
+	// Renamed in the manifest; the routes below are what it actually declares.
+	// 'Vendors' became 'Payees', Accounts Payable moved to /ap-transactions,
+	// and AP Aging to /ap-aging-t2.
+	{ route: '/bookkeeping/payees', title: 'Payees' },
+	{ route: '/bookkeeping/ap-transactions', title: 'Accounts Payable' },
+	{ route: '/bookkeeping/ap-aging-t2', title: 'AP Aging' },
 	{ route: '/bookkeeping/payment-runs', title: 'Payment Runs' },
 	{ route: '/bookkeeping/customers', title: 'Customers' },
 	{ route: '/bookkeeping/accounts-receivable', title: 'Accounts Receivable' },
@@ -45,7 +48,11 @@ const PAGES: Array<{ route: string, title: string, titleRe?: RegExp }> = [
 	{ route: '/financial-statements/trial-balance-lines', title: 'Trial Balance', titleRe: /Trial Balance/i },
 	{ route: '/financial-statements/consolidations', title: 'Consolidations' },
 	{ route: '/financial-statements/consolidated-report', title: 'Consolidated Report' },
-	{ route: '/iv3-reports', title: 'IV3 Reports' },
+	// The manifest route is Dutch (`/iv3-rapportages`) while its title is
+	// already English ("IV3 reports"). Matching the route as declared rather
+	// than renaming it here: a route slug is a bookmarkable URL, so changing
+	// it is a product decision, not a test fix.
+	{ route: '/iv3-rapportages', title: 'IV3 reports' },
 	{ route: '/emu-rapportage', title: 'EMU-rapportage' },
 	{ route: '/bookkeeping/r-d-subsidies', title: 'R&D Subsidies', titleRe: /R&D|R\s*&\s*D|Subsid/i },
 	{ route: '/wbso/tags', title: 'WBSO Tags' },

--- a/tests/e2e/spec-coverage/dashboard-settings.spec.ts
+++ b/tests/e2e/spec-coverage/dashboard-settings.spec.ts
@@ -48,13 +48,15 @@ test.describe('shillinq spec-coverage — Dashboard & Settings', () => {
 
 	test('Features & roadmap — page mounts', async ({ page }) => {
 		const rec = recordShillinqErrors(page)
-		await gotoPage(page, '/FeaturesRoadmap')
+		// The manifest declares this route kebab-cased; '/FeaturesRoadmap' is
+		// the page ID, not its route, and hit the SPA catch-all instead.
+		await gotoPage(page, '/features-roadmap')
 		// Renders a roadmap surface (content text / cards / list).
 		const surfaces = await page.locator(
 			'#content-vue .empty-content, #content-vue [class*="card" i], #content-vue [class*="feature" i], #content-vue li, #content-vue table',
 		).count().catch(() => 0)
 		const hasText = (await page.locator('#content-vue').innerText().catch(() => '')).trim().length > 20
 		expect(surfaces > 0 || hasText, 'features & roadmap should render content').toBeTruthy()
-		assertNoShillinqFailures(rec, '/FeaturesRoadmap')
+		assertNoShillinqFailures(rec, '/features-roadmap')
 	})
 })


### PR DESCRIPTION
Five spec-coverage tests deep-linked routes that no longer exist. The helper names the mechanism exactly:

```
route /X must be declared by the manifest and resolve to itself — a path other than
the requested one means vue-router hit the '/:pathMatch(.*)*' catch-all in
src/main.js and redirected to the Dashboard
```

Each was a rename the spec never followed. Verified against the **assembled** manifest (base + 80 fragments + menu-layout), matched on the page **title** so the mapping is evidence rather than a guess:

| spec route | actual route | evidence |
|---|---|---|
| `/bookkeeping/vendors` | `/bookkeeping/payees` | "Vendors" became "Payees" |
| `/bookkeeping/accounts-payable` | `/bookkeeping/ap-transactions` | title `Accounts Payable` |
| `/bookkeeping/ap-aging` | `/bookkeeping/ap-aging-t2` | title `AP Aging` |
| `/iv3-reports` | `/iv3-rapportages` | title `IV3 reports` |
| `/FeaturesRoadmap` | `/features-roadmap` | page **ID** vs route |

The last is worth calling out: `/FeaturesRoadmap` is the page's **id**, not its route. The two are not interchangeable, and using the id silently hit the catch-all.

## Left alone on purpose

`/iv3-rapportages` keeps its Dutch slug. Its title is already English, so it looks like a translation miss — but a route slug is a **bookmarkable URL**, and renaming it is a product decision, not something to smuggle in through a test fix.

## Not fixed, and deliberately still red

`/inventory/products` and `/inventory/product-attributes` are **not** renames — shillinq declares no product route at all (the inventory cluster has lots, barcodes, reorder-rules, count-templates). The spec asserts pages that were never built, so those two tests are left failing rather than deleted or skipped. That gap is what the spec exists to report, and a green suite that has stopped asking for them is worse than a red one.

## Verified

Every route named in the two touched spec files now resolves in the assembled manifest; the only remaining absences are the two inventory routes above.
