### PR TITLE
fix(widget): the first API key for a business could never be minted (gate-57)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -537,6 +537,10 @@ return \OCA\OpenRegister\AppHost\Routes::standard(
 
             // Widget API-key admin (bookings-self-service-widget, REQ-WSW-009).
             // #[AuthorizedAdminSetting]-gated lifecycle of per-business widget keys.
+            // `create` mints the FIRST key for a businessId; `rotate` replaces an
+            // existing one and refuses when there is none, so without `create` no
+            // business could ever be issued a key at all.
+            ['name' => 'widgetSettings#create', 'url' => '/api/widget/admin/keys/create', 'verb' => 'POST'],
             ['name' => 'widgetSettings#rotate', 'url' => '/api/widget/admin/keys/rotate', 'verb' => 'POST'],
             ['name' => 'widgetSettings#revoke', 'url' => '/api/widget/admin/keys/revoke', 'verb' => 'POST'],
 

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -2110,6 +2110,7 @@
         "Add adjustment": "Add adjustment",
         "Adjustment direction": "Adjustment direction",
         "Adjustment type": "Adjustment type",
+        "Administration ID": "Administration ID",
         "Administration id": "Administration id",
         "Against": "Against",
         "All administrations": "All administrations",

--- a/lib/Controller/WidgetSettingsController.php
+++ b/lib/Controller/WidgetSettingsController.php
@@ -76,11 +76,63 @@ class WidgetSettingsController extends Controller
     }//end actor()
 
     /**
-     * Generate or rotate the API key for a business (REQ-WSW-009).
+     * Mint the FIRST API key for a business (REQ-WSW-009 §1, "Generate API keys").
+     *
+     * This is the missing half of the key lifecycle. {@see rotate()} REPLACES an
+     * existing key and returns `No active key found for businessId.` when there
+     * is none, so before this endpoint existed a business could never be issued
+     * its first key through the app — the admin view's "Generate key" button hit
+     * `rotate` and always failed on a fresh businessId, leaving the public widget
+     * unbootstrappable.
+     *
+     * Unlike rotate(), this needs `administrationId`: the tenant boundary is read
+     * off the predecessor record when rotating, and there is no predecessor here.
+     *
+     * Returns the plaintext key once; only its bcrypt hash is persisted.
+     *
+     * @return JSONResponse HTTP 200 with the one-time plaintext key, or 400.
+     *
+     * @spec openspec/specs/bookings-self-service-widget/spec.md
+     */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
+    public function create(): JSONResponse
+    {
+        $businessId       = trim((string) $this->request->getParam('businessId', ''));
+        $administrationId = trim((string) $this->request->getParam('administrationId', ''));
+
+        if ($businessId === '' || $administrationId === '') {
+            return new JSONResponse(
+                ['success' => false, 'message' => 'businessId and administrationId are required.'],
+                Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        $result = $this->authService->createApiKey(
+            administrationId: $administrationId,
+            businessId: $businessId,
+            actor: $this->actor()
+        );
+        $status = Http::STATUS_BAD_REQUEST;
+        if ($result['success'] === true) {
+            $status = Http::STATUS_OK;
+        }
+
+        return new JSONResponse($result, $status);
+
+    }//end create()
+
+    /**
+     * Rotate the API key for a business (REQ-WSW-009 §3).
+     *
+     * Replaces the active key and puts the predecessor into the 7-day grace
+     * window. Refuses when the business has no active key — minting the first
+     * one is {@see create()}, not this.
      *
      * Returns the plaintext key once; only its hash is persisted.
      *
      * @return JSONResponse HTTP 200 with the one-time plaintext key, or 400.
+     *
+     * @spec openspec/specs/bookings-self-service-widget/spec.md
      */
     #[AuthorizedAdminSetting(Application::APP_ID)]
     public function rotate(): JSONResponse
@@ -105,9 +157,11 @@ class WidgetSettingsController extends Controller
     }//end rotate()
 
     /**
-     * Revoke the API key for a business immediately (REQ-WSW-009).
+     * Revoke the API key for a business immediately (REQ-WSW-009 §5).
      *
      * @return JSONResponse HTTP 200 on success, or 400.
+     *
+     * @spec openspec/specs/bookings-self-service-widget/spec.md
      */
     #[AuthorizedAdminSetting(Application::APP_ID)]
     public function revoke(): JSONResponse

--- a/src/views/BookingWidgetKeys.vue
+++ b/src/views/BookingWidgetKeys.vue
@@ -12,9 +12,21 @@
 				class="shillinq-widget-keys__input">
 		</div>
 
+		<div class="shillinq-widget-keys__field">
+			<label for="wsw-administration-id">{{ t('shillinq', 'Administration ID') }}</label>
+			<input
+				id="wsw-administration-id"
+				v-model.trim="administrationId"
+				type="text"
+				class="shillinq-widget-keys__input">
+		</div>
+
 		<div class="shillinq-widget-keys__actions">
-			<NcButton variant="primary" :disabled="!businessId || busy" @click="rotate">
-				{{ t('shillinq', 'Generate key') }} / {{ t('shillinq', 'Rotate key') }}
+			<NcButton variant="primary" :disabled="!businessId || !administrationId || busy" @click="generate">
+				{{ t('shillinq', 'Generate key') }}
+			</NcButton>
+			<NcButton variant="secondary" :disabled="!businessId || busy" @click="rotate">
+				{{ t('shillinq', 'Rotate key') }}
 			</NcButton>
 			<NcButton variant="error" :disabled="!businessId || busy" @click="revoke">
 				{{ t('shillinq', 'Revoke key') }}
@@ -46,6 +58,7 @@ export default {
 	data() {
 		return {
 			businessId: '',
+			administrationId: '',
 			plaintextKey: '',
 			message: '',
 			busy: false,
@@ -72,11 +85,31 @@ export default {
 				this.busy = false
 			}
 		},
+		/**
+		 * Mint the FIRST key for a businessId (REQ-WSW-009 §1).
+		 *
+		 * This used to post to `keys/rotate`, which refuses with "No active key
+		 * found for businessId." whenever the business has no key yet — so the
+		 * button labelled "Generate key" could never generate one. It also sent
+		 * `administrationId: this.businessId`, a field `rotate` never reads;
+		 * `create` genuinely needs the tenant boundary, so it is its own input.
+		 */
+		async generate() {
+			this.plaintextKey = ''
+			const result = await this.post('widget/admin/keys/create', {
+				businessId: this.businessId,
+				administrationId: this.administrationId,
+			})
+			if (result.success && result.apiKey) {
+				this.plaintextKey = result.apiKey
+			}
+			this.message = result.message || ''
+		},
+		/** Replace an existing key; the predecessor keeps working for 7 days. */
 		async rotate() {
 			this.plaintextKey = ''
 			const result = await this.post('widget/admin/keys/rotate', {
 				businessId: this.businessId,
-				administrationId: this.businessId,
 			})
 			if (result.success && result.apiKey) {
 				this.plaintextKey = result.apiKey

--- a/src/views/BookingWidgetKeys.vue
+++ b/src/views/BookingWidgetKeys.vue
@@ -93,6 +93,9 @@ export default {
 		 * button labelled "Generate key" could never generate one. It also sent
 		 * `administrationId: this.businessId`, a field `rotate` never reads;
 		 * `create` genuinely needs the tenant boundary, so it is its own input.
+		 *
+		 * @return {Promise<void>}
+		 * @spec openspec/specs/bookings-self-service-widget/spec.md
 		 */
 		async generate() {
 			this.plaintextKey = ''
@@ -105,7 +108,12 @@ export default {
 			}
 			this.message = result.message || ''
 		},
-		/** Replace an existing key; the predecessor keeps working for 7 days. */
+		/**
+		 * Replace an existing key; the predecessor keeps working for 7 days.
+		 *
+		 * @return {Promise<void>}
+		 * @spec openspec/specs/bookings-self-service-widget/spec.md
+		 */
 		async rotate() {
 			this.plaintextKey = ''
 			const result = await this.post('widget/admin/keys/rotate', {

--- a/tests/Unit/Controller/WidgetSettingsControllerTest.php
+++ b/tests/Unit/Controller/WidgetSettingsControllerTest.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * Unit tests for WidgetSettingsController's key lifecycle (REQ-WSW-009).
+ *
+ * The point of these tests is the seam that was MISSING, not the one that
+ * worked: `WidgetAuthService::createApiKey()` was fully implemented (mint,
+ * bcrypt hash, prefix, persist, audit) and had no route, no controller method
+ * and no caller anywhere in the app. The admin view's "Generate key" button
+ * posted to `widget/admin/keys/rotate`, and `rotateApiKey()` returns
+ * `No active key found for businessId.` when the business has no key yet — so
+ * the FIRST key for any business was unobtainable and the public booking widget
+ * could not be bootstrapped at all.
+ *
+ * Covered here:
+ *   - create() reaches createApiKey() with BOTH ids and returns the one-time
+ *     plaintext key;
+ *   - create() refuses (400) without administrationId and never reaches the
+ *     service — rotate() derives the tenant boundary from the predecessor
+ *     record, create() has no predecessor to derive it from;
+ *   - rotate() still refuses on a business with no active key, which is the
+ *     behaviour that made this gap invisible, and MUST NOT be "fixed" by
+ *     letting rotate mint;
+ *   - revoke() is unchanged.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/bookings-self-service-widget/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\WidgetSettingsController;
+use OCA\Shillinq\Service\WidgetAuthService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for WidgetSettingsController.
+ */
+class WidgetSettingsControllerTest extends TestCase
+{
+
+    /**
+     * IRequest stub.
+     *
+     * @var IRequest&MockObject
+     */
+    private IRequest&MockObject $request;
+
+    /**
+     * Auth service stub.
+     *
+     * @var WidgetAuthService&MockObject
+     */
+    private WidgetAuthService&MockObject $auth;
+
+    /**
+     * User session stub.
+     *
+     * @var IUserSession&MockObject
+     */
+    private IUserSession&MockObject $session;
+
+    /**
+     * Build the collaborator doubles and a signed-in admin.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->request = $this->createMock(IRequest::class);
+        $this->auth    = $this->createMock(WidgetAuthService::class);
+        $this->session = $this->createMock(IUserSession::class);
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('admin');
+        $this->session->method('getUser')->willReturn($user);
+
+    }//end setUp()
+
+    /**
+     * Build the controller under test.
+     *
+     * @return WidgetSettingsController The controller.
+     */
+    private function controller(): WidgetSettingsController
+    {
+        return new WidgetSettingsController($this->request, $this->auth, $this->session);
+
+    }//end controller()
+
+    /**
+     * Stub the request parameters the controller reads.
+     *
+     * @param array<string,string> $params Parameter name => value.
+     *
+     * @return void
+     */
+    private function params(array $params): void
+    {
+        $this->request->method('getParam')->willReturnCallback(
+            static function (string $key, $default=null) use ($params) {
+                return ($params[$key] ?? $default);
+            }
+        );
+
+    }//end params()
+
+    /**
+     * create() mints the first key and returns the one-time plaintext.
+     *
+     * @return void
+     */
+    public function testCreateMintsTheFirstKeyForABusiness(): void
+    {
+        $this->params(['businessId' => 'biz-1', 'administrationId' => 'adm-1']);
+
+        $this->auth->expects($this->once())
+            ->method('createApiKey')
+            ->with('adm-1', 'biz-1', 'admin')
+            ->willReturn(
+                [
+                    'success'    => true,
+                    'businessId' => 'biz-1',
+                    'apiKey'     => 'plaintext-shown-once',
+                ]
+            );
+
+        $response = $this->controller()->create();
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+        $this->assertSame('plaintext-shown-once', $response->getData()['apiKey']);
+
+    }//end testCreateMintsTheFirstKeyForABusiness()
+
+    /**
+     * create() refuses without administrationId and never reaches the service.
+     *
+     * The old admin view sent `administrationId: this.businessId` — a field the
+     * rotate endpoint never read. Minting genuinely needs the tenant boundary,
+     * so it is required rather than silently defaulted to the businessId.
+     *
+     * @return void
+     */
+    public function testCreateRefusesWithoutAdministrationId(): void
+    {
+        $this->params(['businessId' => 'biz-1']);
+
+        $this->auth->expects($this->never())->method('createApiKey');
+
+        $response = $this->controller()->create();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        $this->assertFalse($response->getData()['success']);
+
+    }//end testCreateRefusesWithoutAdministrationId()
+
+    /**
+     * rotate() still refuses a business with no active key.
+     *
+     * This is the behaviour that hid the missing capability: the "Generate key"
+     * button hit this path and always failed on a fresh businessId. The fix is
+     * a create endpoint, NOT letting rotate mint — rotate must keep failing
+     * here, or the 7-day predecessor grace contract loses its meaning.
+     *
+     * @return void
+     */
+    public function testRotateStillRefusesWhenThereIsNoActiveKey(): void
+    {
+        $this->params(['businessId' => 'biz-fresh']);
+
+        $this->auth->expects($this->never())->method('createApiKey');
+        $this->auth->expects($this->once())
+            ->method('rotateApiKey')
+            ->with('biz-fresh', 'admin')
+            ->willReturn(['success' => false, 'message' => 'No active key found for businessId.']);
+
+        $response = $this->controller()->rotate();
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+
+    }//end testRotateStillRefusesWhenThereIsNoActiveKey()
+
+    /**
+     * revoke() delegates unchanged.
+     *
+     * @return void
+     */
+    public function testRevokeDelegatesToTheService(): void
+    {
+        $this->params(['businessId' => 'biz-1']);
+
+        $this->auth->expects($this->once())
+            ->method('revokeApiKey')
+            ->with('biz-1', 'admin')
+            ->willReturn(['success' => true]);
+
+        $response = $this->controller()->revoke();
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+
+    }//end testRevokeDelegatesToTheService()
+}//end class


### PR DESCRIPTION
## What gate 57 found

Gate 57 (orphaned-write-capability) named `WidgetAuthService::createApiKey()` — zero non-test production callers.

It is **not a stub**. It generates the key, bcrypt-hashes it, stores the prefix, persists the `WidgetAccessKey` record and writes the audit entry. It simply had no route, no controller method, and no caller anywhere in the app.

## What that cost

`appinfo/routes.php` registered only `widgetSettings#rotate` and `#revoke`. The admin view's primary button read **"Generate key / Rotate key"** and posted to `widget/admin/keys/rotate`. `WidgetAuthService::rotateApiKey()` opens with:

```php
$existing = $this->findActiveKeyByBusinessId(businessId: $businessId);
if ($existing === null) {
    return ['success' => false, 'message' => 'No active key found for businessId.'];
}
```

So on a `businessId` that has no key yet — i.e. **every new partner** — the button labelled "Generate key" always failed. There is no seed, repair step or background job that writes a `WidgetAccessKey` either, so the public booking widget could not be bootstrapped for any business without hand-creating the OpenRegister object.

REQ-WSW-009 §1 requires exactly this: *"Generate API keys — upon partner signup"*.

The view also sent `administrationId: this.businessId`, a field `rotate` never reads. Minting genuinely needs the tenant boundary — `rotate` derives it from the predecessor record and `create` has no predecessor — so it is now its own input, and **required** rather than silently defaulted to the businessId.

## Changes

- route `widgetSettings#create` → `POST /api/widget/admin/keys/create`;
- `WidgetSettingsController::create()`, `#[AuthorizedAdminSetting]`-gated like its siblings;
- the admin view splits into three buttons — Generate / Rotate / Revoke — mapping 1:1 to the three service methods and the three audit actions (`created`, `rotated`, `revoked`);
- `tests/Unit/Controller/WidgetSettingsControllerTest.php` (new — the controller had **no test at all**).

`rotate()` deliberately **still refuses** a business with no active key. That is the behaviour that hid this gap, but letting rotate mint would destroy the 7-day predecessor grace contract. The fix is a create endpoint, not a laxer rotate; a test pins that.

## Verified both directions

Disposable `nextcloud:32-apache` container (PHP 8.3), this worktree bind-mounted at `custom_apps/shillinq`. No shared dev instance touched.

| | result |
|---|---|
| gate 57 on `WidgetAuthService` before | 1 finding — `createApiKey` |
| gate 57 after | **0 findings** |
| new + adjacent widget tests | **15/15 pass** |
| `create()` rewired to `rotateApiKey` (the **pre-fix wiring**, mutant) | **1 FAIL** |

The mutant is the positive control, and it doubles as proof the run tests **this** tree rather than a deployed copy: editing this worktree's `lib/` changed the result.

`php -l` clean. `phpcs`: **0 errors** on the changed controller.

## ⚠️ Heads-up for whoever owns `fix/newman-integration-failures`

Commit `39f55472` on that branch accidentally absorbed an **incomplete, mid-flight** copy of this change from a shared worktree: it carries the `appinfo/routes.php` `widgetSettings#create` line, part of `WidgetSettingsController`, and the **template half** of `src/views/BookingWidgetKeys.vue` — including `@click="generate"` — while the file contains **zero** `async generate` definitions. As committed there, clicking "Generate key" is a Vue runtime error.

Those hunks should be dropped from `fix/newman-integration-failures`; the complete, tested change is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)