### PR TITLE
feat(uren): let an hour entry name the domain object it was worked on

### DIFF
--- a/lib/Settings/register.d/uren-domain-subject-link.json
+++ b/lib/Settings/register.d/uren-domain-subject-link.json
@@ -1,0 +1,32 @@
+{
+  "_meta": {
+    "spdx-license": "EUPL-1.2",
+    "spdx-copyright": "2026 Conduction B.V.",
+    "change": "uren-domain-subject-link",
+    "adr": "ADR-037 modular register fragment — never edit shillinq_register.json",
+    "description": "Lets an hour entry name the DOMAIN OBJECT it was worked on — a procest case today, any case/matter object tomorrow. Before this, UrenRegistratie could only be scoped inside Shillinq's own world (projectId, costProjectId, taskId, projectAssignmentId), so hours booked against a case in a domain app had nowhere to record that fact and no case could show what it had cost. Per hydra ADR-081, the domain app CLASSIFIES and Shillinq AGGREGATES: procest may show a sum of hours for its case, but the money side stays here, in the app that owns the ledger. Both fields are optional and nullable — every existing hour entry stays valid, and an entry with no subject is simply not attributable to a domain object.",
+    "adr-081": "hydra/openspec/architecture/adr-081-money-and-effort-ownership.md"
+  },
+  "components": {
+    "schemas": {
+      "UrenRegistratie": {
+        "properties": {
+          "subjectApp": {
+            "type": "string",
+            "description": "App id owning the domain object these hours were worked on, e.g. 'procest'. Deliberately a free string rather than an enum: ADR-081 names procest as the first consumer and 'any case/matter app tomorrow' as the next, and an enum here would make every new domain app a change to Shillinq's register. MUST be set together with subjectId — one without the other is an unresolvable reference.",
+            "nullable": true,
+            "example": "procest",
+            "title": "Subject App"
+          },
+          "subjectId": {
+            "type": "string",
+            "description": "Id of the domain object in subjectApp — a procest case uuid, for example. Optional: an hour entry that is purely project- or task-scoped inside Shillinq has no domain subject and leaves both fields unset. This is a WEAK reference by design, not a relatedSchema: the target lives in another app's register, so Shillinq cannot resolve or cascade it, and an hour entry MUST survive the domain object being archived.",
+            "nullable": true,
+            "example": "0b3f7c1e-6b1a-4f39-9d2c-2f0c9b7a51ee",
+            "title": "Subject Id"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/Unit/Settings/UrenDomainSubjectLinkTest.php
+++ b/tests/Unit/Settings/UrenDomainSubjectLinkTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * UrenRegistratie domain-subject link.
+ *
+ * @category Tests
+ * @package  OCA\Shillinq\Tests\Unit\Settings
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://shillinq.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Settings;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * An hour entry can name the domain object it was worked on.
+ *
+ * WHY THIS MATTERS AND WHY IT IS TESTED HERE.
+ *
+ * Before this fragment, `UrenRegistratie` could only be scoped inside
+ * Shillinq's own world — projectId, costProjectId, taskId,
+ * projectAssignmentId. Hours worked on a procest case had nowhere to record
+ * that, so no case could report what it had cost. `subjectApp` + `subjectId`
+ * close that, and hydra ADR-081 fixes the division of labour: the domain app
+ * CLASSIFIES (procest may show a sum of HOURS on its case) and Shillinq
+ * AGGREGATES (the money stays in the app that owns the ledger).
+ *
+ * The assertions below are about the CONTRACT, not the storage:
+ *
+ *  1. Both fields must be DECLARED. OpenRegister's MagicMapper discards
+ *     properties a schema does not declare — it logs and continues — so an
+ *     hour entry POSTed with a subject against an undeclared schema would be
+ *     accepted, stored without it, and silently unattributable. That failure
+ *     has no runtime symptom, which is why it is pinned.
+ *  2. Both must be NULLABLE. Every hour entry that exists today has no
+ *     subject; making either required would invalidate the entire historical
+ *     ledger on the next validation pass.
+ *  3. Neither may be a `relatedSchema`. The target lives in ANOTHER app's
+ *     register, so Shillinq cannot resolve or cascade it — and an hour entry
+ *     must survive the domain object being archived. A relatedSchema here
+ *     would invite exactly the cascade that must not happen.
+ *
+ * @coversNothing
+ */
+class UrenDomainSubjectLinkTest extends TestCase
+{
+
+    /**
+     * The merged UrenRegistratie properties, assembled the way the loader does.
+     *
+     * @return array<string, array<string, mixed>> Property name => definition.
+     */
+    private function mergedProperties(): array
+    {
+        $settings = __DIR__.'/../../../lib/Settings';
+
+        $sources = [$settings.'/shillinq_register.json'];
+        foreach ((array) glob($settings.'/register.d/*.json') as $fragment) {
+            $sources[] = $fragment;
+        }
+
+        $props = [];
+        foreach ($sources as $source) {
+            $doc = json_decode((string) file_get_contents($source), associative: true);
+            if (is_array($doc) === false) {
+                continue;
+            }
+
+            $schema = ($doc['components']['schemas']['UrenRegistratie'] ?? null);
+            if (is_array($schema) === true && is_array(($schema['properties'] ?? null)) === true) {
+                $props = array_merge($props, $schema['properties']);
+            }
+        }
+
+        return $props;
+    }
+
+    /**
+     * Both subject fields are declared, so MagicMapper will not discard them.
+     *
+     * @return void
+     */
+    public function testTheSubjectFieldsAreDeclared(): void
+    {
+        $props = $this->mergedProperties();
+
+        foreach (['subjectApp', 'subjectId'] as $field) {
+            self::assertArrayHasKey(
+                $field,
+                $props,
+                sprintf(
+                    'UrenRegistratie does not declare "%s". OpenRegister\'s MagicMapper DISCARDS '
+                    .'undeclared properties — an hour entry POSTed with a subject would be accepted, '
+                    .'stored without it, and silently unattributable to any case.',
+                    $field
+                )
+            );
+        }
+    }
+
+    /**
+     * Both are optional, so the existing ledger stays valid.
+     *
+     * @return void
+     */
+    public function testTheSubjectFieldsAreOptionalAndNullable(): void
+    {
+        $settings = __DIR__.'/../../../lib/Settings';
+
+        $required = [];
+        $sources  = [$settings.'/shillinq_register.json'];
+        foreach ((array) glob($settings.'/register.d/*.json') as $fragment) {
+            $sources[] = $fragment;
+        }
+
+        foreach ($sources as $source) {
+            $doc    = json_decode((string) file_get_contents($source), associative: true);
+            $schema = ($doc['components']['schemas']['UrenRegistratie'] ?? null);
+            if (is_array($schema) === true) {
+                $required = array_merge($required, (array) ($schema['required'] ?? []));
+            }
+        }
+
+        $props = $this->mergedProperties();
+
+        foreach (['subjectApp', 'subjectId'] as $field) {
+            self::assertNotContains(
+                $field,
+                $required,
+                $field.' must not be required — every hour entry recorded before this change has no '
+                .'subject, and requiring it would invalidate the whole historical ledger.'
+            );
+            self::assertTrue(
+                ($props[$field]['nullable'] ?? false),
+                $field.' must be nullable for the same reason.'
+            );
+        }
+    }
+
+    /**
+     * The link is weak: not a relatedSchema, because the target is another app's.
+     *
+     * @return void
+     */
+    public function testTheSubjectLinkIsWeakRatherThanARelation(): void
+    {
+        $props = $this->mergedProperties();
+
+        foreach (['subjectApp', 'subjectId'] as $field) {
+            self::assertArrayNotHasKey(
+                'relatedSchema',
+                $props[$field],
+                $field.' must not declare relatedSchema: the target lives in another app\'s register, '
+                .'so Shillinq cannot resolve or cascade it, and an hour entry must survive the domain '
+                .'object being archived.'
+            );
+        }
+    }
+}


### PR DESCRIPTION
You cannot put an hours or cost widget on a procest case today, and this is why: `UrenRegistratie` can only be scoped inside Shillinq's own world — `projectId`, `costProjectId`, `taskId`, `projectAssignmentId`. An hour worked on a case has nowhere to say so, so **no case can report what it consumed**.

`subjectApp` + `subjectId` close that. Per hydra **ADR-081** the division of labour is fixed: the domain app **classifies** (procest may show a sum of *hours* — hours are not money) and Shillinq **aggregates** (the money side stays in the app that owns the ledger).

## Three deliberate choices, each pinned by a test

| choice | why |
|---|---|
| a **generic subject**, not a `caseId` | ADR-081 names procest as the first consumer and *"any case/matter app tomorrow"* as the next. A `caseId` would make the second consumer a schema change here. Free string rather than an enum for the same reason. |
| **optional and nullable** | every hour entry recorded before today has no subject; requiring either field would invalidate the entire historical ledger on the next validation pass |
| a **weak reference**, not a `relatedSchema` | the target lives in another app's register, so Shillinq can neither resolve nor cascade it — and an hour entry must survive the domain object being archived |

Declared in a `register.d` fragment, never in `shillinq_register.json` (ADR-037).

## Tests — mutation-verified in three arms

| mutation | result |
|---|---|
| undeclare `subjectId` | **2 failures + 1 error** |
| make `subjectApp` required | **1 failure** |
| add `relatedSchema` to `subjectId` | **1 failure** |
| restored | OK (3 tests, 8 assertions) |

The first arm is the one with **no runtime symptom**: MagicMapper *discards* undeclared properties — it logs and continues — so an hour POSTed with a subject against an undeclared schema is accepted, stored without it, and silently unattributable to any case.

`check:registers` PASS (458/458) and `check:markers` OK are unchanged by this.

## Still missing — named so it is not mistaken for done

Nothing **writes** these fields yet, and the cost half needs a Shillinq endpoint that aggregates an hour set into a figure, because procest must not sum money itself. This PR makes the attribution *expressible*; it does not yet make it happen.
Pairs with ConductionNL/hrmq#78, which exposes the wage half of `hourlyCost = wageCost + Σ additions`.

**Decision worth a second opinion:** I chose a generic `subjectApp`/`subjectId` pair over (a) a procest-specific `caseId` or (b) routing hours through a Shillinq `Project` mapped to each case. (b) needs no new field but forces a Project onto every case, which looked like the bigger product assumption. Happy to switch if you prefer either.
