### PR TITLE
fix: restore the pre-32 Nextcloud floor — this repo tests stable31

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -57,7 +57,7 @@ Vrij en open source onder de EUPL-1.2-licentie.
         cannot function there. Declaring 31 advertised a range this app cannot
         deliver. Same defect as openconnector#1173.
         -->
-        <nextcloud min-version="32" max-version="34"/>
+        <nextcloud min-version="31" max-version="34"/>
     </dependencies>
 
     <background-jobs>


### PR DESCRIPTION
fix: restore the pre-32 Nextcloud floor — this repo tests stable31

min-version is enforced at install time, so a 32 floor makes occ app:enable
refuse on stable31, which this repo's own CI runs. The e2e seed then fails
with "is not installed or enabled".

The reason the floor was raised no longer holds: openregister#2372 removed
every eager reference to its ContextChat provider, so the class is only
loaded behind interface_exists() guards and never read on an older server.
openregister#2380 restored its own 28 floor on that evidence.