### PR TITLE
feat(cost): aggregate an hour set for one subject into an employer cost

### DIFF
--- a/lib/Service/SubjectCostAggregator.php
+++ b/lib/Service/SubjectCostAggregator.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * Subject Cost Aggregator
+ *
+ * Aggregates the hours booked against one domain object — a procest case
+ * today, any case/matter object tomorrow — into an employer cost, per hydra
+ * ADR-081. Shillinq does this because Shillinq owns the ledger; the domain app
+ * classifies and displays, it does not sum money.
+ *
+ * The hrmq wage surface is intentionally abstracted, following the same
+ * approach GrotendeelsCriteriumService already takes: the caller supplies an
+ * already-resolved cost rate per person. The live adapter over
+ * `POST /api/employees/cost-rate` (ConductionNL/hrmq#78) wires in here without
+ * touching this policy.
+ *
+ * @category Service
+ * @package  OCA\Shillinq\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://shillinq.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Service;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Sum an hour set for one subject, and cost it when rates are available.
+ *
+ * WHAT THIS REFUSES TO DO, AND WHY IT MATTERS MORE THAN WHAT IT DOES.
+ *
+ * A cost that silently omits someone's hours is worse than no cost at all: it
+ * is plausible, it is lower than the truth, and nothing about it looks wrong.
+ * So this aggregator never returns a total it could not fully compute. If any
+ * person with hours has no resolvable rate, `complete` is false, `costCents`
+ * is null, and the unpriced people are named. Callers render "hours known,
+ * cost unavailable" rather than a number that reads as authoritative.
+ *
+ * Hours are always returned, priced or not — hours are effort, not currency,
+ * and a domain app may show them (ADR-081).
+ *
+ * @spec openspec/specs/subject-cost-aggregation/spec.md
+ */
+class SubjectCostAggregator
+{
+    /**
+     * Wire collaborators.
+     *
+     * @param LoggerInterface $logger PSR logger.
+     *
+     * @return void
+     */
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }//end __construct()
+
+    /**
+     * Aggregate an hour set into hours-per-person and, where possible, a cost.
+     *
+     * `$rates` maps personId => employer cost in CENTS per hour, as resolved
+     * from hrmq. Cents, not euros: money is integer here for the same reason it
+     * is integer in hrmq — a float total over many rows drifts, and a ledger
+     * that drifts is not a ledger.
+     *
+     * @param array<int, array<string, mixed>> $hourRows UrenRegistratie rows for one subject.
+     * @param array<string, int>               $rates    personId => cost cents per hour.
+     *
+     * @return array{
+     *     hours: float, costCents: int|null, complete: bool, currency: string,
+     *     perPerson: array<int, array{personId: string, hours: float, centsPerHour: int|null, costCents: int|null}>,
+     *     unpricedPersonIds: array<int, string>
+     * }
+     *
+     * @spec openspec/specs/subject-cost-aggregation/spec.md#requirement-a-cost-is-published-only-when-every-hour-in-it-could-be-priced
+     */
+    public function aggregate(array $hourRows, array $rates): array
+    {
+        $hoursByPerson = [];
+        foreach ($hourRows as $row) {
+            if (is_array($row) === false) {
+                continue;
+            }
+
+            $hours = $this->toFloat(value: ($row['hours'] ?? null));
+            if ($hours === null) {
+                // A row with no usable hours contributes nothing. Skipping is
+                // right; treating it as 0 silently would be too, but this way
+                // the row never reaches the per-person breakdown and cannot be
+                // mistaken for someone who worked zero hours.
+                continue;
+            }
+
+            $personId = trim((string) ($row['personId'] ?? ''));
+            if ($personId === '') {
+                // Hours nobody owns cannot be priced. They still count toward
+                // effort, under a reserved key, so the total hours stay honest.
+                $personId = '(unattributed)';
+            }
+
+            $hoursByPerson[$personId] = (($hoursByPerson[$personId] ?? 0.0) + $hours);
+        }//end foreach
+
+        $perPerson  = [];
+        $totalHours = 0.0;
+        $totalCents = 0;
+        $unpriced   = [];
+
+        foreach ($hoursByPerson as $personId => $hours) {
+            $totalHours += $hours;
+
+            $centsPerHour = ($rates[$personId] ?? null);
+            if (is_int($centsPerHour) === false || $centsPerHour < 0) {
+                $centsPerHour = null;
+            }
+
+            $costCents = null;
+            if ($centsPerHour === null) {
+                $unpriced[] = (string) $personId;
+            }
+
+            if ($centsPerHour !== null) {
+                // Round once, at the person level, rather than accumulating a
+                // float and rounding at the end — the latter lets sub-cent
+                // error from every row survive into the total.
+                $costCents   = (int) round($hours * $centsPerHour);
+                $totalCents += $costCents;
+            }
+
+            $perPerson[] = [
+                'personId'     => (string) $personId,
+                'hours'        => round(num: $hours, precision: 2),
+                'centsPerHour' => $centsPerHour,
+                'costCents'    => $costCents,
+            ];
+        }//end foreach
+
+        $complete = ($unpriced === [] && $perPerson !== []);
+
+        // A cost is published only when every person with hours could be
+        // priced. See the class docblock: a partial total is plausible, always
+        // too low, and indistinguishable from a correct one.
+        $publishedCost = null;
+        if ($complete === true) {
+            $publishedCost = $totalCents;
+        }
+
+        if ($unpriced !== []) {
+            $this->logger->info(
+                'SubjectCostAggregator: cost withheld — some hours have no resolvable rate',
+                ['unpricedPersonIds' => $unpriced]
+            );
+        }
+
+        return [
+            'hours'             => round(num: $totalHours, precision: 2),
+            'costCents'         => $publishedCost,
+            'complete'          => $complete,
+            'currency'          => 'EUR',
+            'perPerson'         => $perPerson,
+            'unpricedPersonIds' => $unpriced,
+        ];
+    }//end aggregate()
+
+    /**
+     * Coerce an hours value to float, or null when it is not a number.
+     *
+     * OpenRegister returns numeric properties as int, float or numeric string
+     * depending on the storage path, so this accepts all three and rejects
+     * everything else rather than letting PHP cast "" or "n/a" to 0.0.
+     *
+     * @param mixed $value The raw value.
+     *
+     * @return float|null The hours, or null when unusable.
+     *
+     * @spec openspec/specs/subject-cost-aggregation/spec.md#requirement-unusable-hours-are-rejected-rather-than-coerced
+     */
+    private function toFloat(mixed $value): ?float
+    {
+        if (is_int($value) === true || is_float($value) === true) {
+            return (float) $value;
+        }
+
+        if (is_string($value) === true && is_numeric(trim($value)) === true) {
+            return (float) trim($value);
+        }
+
+        return null;
+    }//end toFloat()
+}//end class

--- a/openspec/specs/subject-cost-aggregation/spec.md
+++ b/openspec/specs/subject-cost-aggregation/spec.md
@@ -1,0 +1,75 @@
+# Subject cost aggregation
+
+## Purpose
+
+Turn the hours booked against one domain object — a procest case today, any
+case/matter object tomorrow — into an employer cost.
+
+Per hydra ADR-081 the split is fixed: the domain app **classifies** (it may
+show a sum of hours, because hours are effort rather than currency) and
+Shillinq **aggregates**, because Shillinq owns the general ledger. The wage
+half of an hour's cost is hrmq's and is served by
+`POST /api/employees/cost-rate`; the ledger-derived additions are Shillinq's.
+
+`UrenRegistratie.subjectApp` / `subjectId` are what make an hour attributable
+to a domain object at all.
+
+## Requirements
+
+### Requirement: A cost is published only when every hour in it could be priced
+
+The aggregator SHALL group an hour set by `personId` and cost each person's
+hours at that person's own rate.
+
+Where ANY person with hours has no resolvable rate, it MUST NOT return a
+total. `complete` SHALL be false, the cost SHALL be null, and the unpriced
+people SHALL be named so a caller can say what is missing.
+
+This is the requirement the capability exists to protect. A cost that silently
+omits someone's hours is worse than no cost at all: it is plausible, it is
+**always lower** than the truth, and nothing about it looks wrong on a case
+page. A caller renders "hours known, cost unavailable" rather than a number
+that reads as authoritative.
+
+Hours SHALL be returned whether or not a cost could be computed.
+
+#### Scenario: One unpriced person withholds the whole total
+- **GIVEN** hours booked by two people and a rate for only one of them
+- **WHEN** the subject is aggregated
+- **THEN** the cost is null, `complete` is false, the unpriced person is named,
+  and the total hours still cover both
+- @e2e exclude pure aggregation policy — asserted by PHPUnit
+
+### Requirement: Money is integer and rounded once per person
+
+All monetary values SHALL be integer cents. A float total accumulated over
+many rows drifts, and a ledger that drifts is not a ledger.
+
+Rounding SHALL happen once per PERSON, after their hours are summed — never
+per row. Three rows of one-third hour at €10.00 is 1000 cents when summed per
+person and 999 when each row is rounded first.
+
+#### Scenario: Per-row rounding does not leak into the total
+- **GIVEN** three rows of one-third hour for the same person at 1000 cents/hour
+- **WHEN** the subject is aggregated
+- **THEN** the cost is exactly 1000 cents
+- @e2e exclude arithmetic — asserted by PHPUnit
+
+### Requirement: Unusable hours are rejected rather than coerced
+
+A row whose `hours` is not numeric SHALL be skipped, not cast. PHP coerces
+`''` and `'n/a'` to `0.0` without complaint, which invents a person who
+"worked no hours" — and, having no rate, would flip an otherwise complete cost
+to incomplete.
+
+Hours carrying no `personId` SHALL still count toward total hours, under a
+reserved key, but can never be priced: the effort happened even though nobody
+owns it.
+
+#### Scenario: Junk rows neither count nor invent people
+- **GIVEN** an hour set containing non-numeric hours for people who have no
+  other rows, plus one valid priced row
+- **WHEN** the subject is aggregated
+- **THEN** only the valid row appears in the breakdown, the cost is complete,
+  and no person was invented by coercion
+- @e2e exclude input validation — asserted by PHPUnit

--- a/tests/Unit/Service/SubjectCostAggregatorTest.php
+++ b/tests/Unit/Service/SubjectCostAggregatorTest.php
@@ -1,0 +1,240 @@
+<?php
+
+/**
+ * SubjectCostAggregator Unit Tests
+ *
+ * @category Tests
+ * @package  OCA\Shillinq\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://shillinq.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Service;
+
+use OCA\Shillinq\Service\SubjectCostAggregator;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * The aggregator must never publish a total it could not fully compute.
+ *
+ * That is the property most of these tests exist for. A cost that silently
+ * omits one person's hours is worse than no cost: it is plausible, it is
+ * always LOWER than the truth, and nothing about it looks wrong on a case
+ * detail page. So a partial rate set must yield `complete: false` and a null
+ * cost, not a smaller number.
+ *
+ * @covers \OCA\Shillinq\Service\SubjectCostAggregator
+ */
+class SubjectCostAggregatorTest extends TestCase
+{
+
+    /**
+     * Subject under test.
+     *
+     * @var SubjectCostAggregator
+     */
+    private SubjectCostAggregator $aggregator;
+
+    /**
+     * Build the aggregator.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->aggregator = new SubjectCostAggregator(new NullLogger());
+    }
+
+    /**
+     * Hours are summed per person and costed at that person's rate.
+     *
+     * @return void
+     */
+    public function testCostsEachPersonAtTheirOwnRate(): void
+    {
+        $result = $this->aggregator->aggregate(
+            [
+                ['personId' => 'alice', 'hours' => 2.0],
+                ['personId' => 'alice', 'hours' => 1.5],
+                ['personId' => 'bob', 'hours' => 4.0],
+            ],
+            ['alice' => 6000, 'bob' => 5000]
+        );
+
+        self::assertSame(7.5, $result['hours']);
+        self::assertTrue($result['complete']);
+        // alice 3.5h @ 60.00 = 210.00, bob 4h @ 50.00 = 200.00
+        self::assertSame((21000 + 20000), $result['costCents']);
+        self::assertSame('EUR', $result['currency']);
+    }
+
+    /**
+     * One unpriced person withholds the WHOLE total, not just their share.
+     *
+     * This is the assertion that matters. Returning bob's cost alone would be
+     * a plausible, too-low number on a case page with no indication that
+     * anything is missing.
+     *
+     * @return void
+     */
+    public function testAnyUnpricedPersonWithholdsTheEntireCost(): void
+    {
+        $result = $this->aggregator->aggregate(
+            [
+                ['personId' => 'alice', 'hours' => 3.0],
+                ['personId' => 'bob', 'hours' => 4.0],
+            ],
+            ['bob' => 5000]
+        );
+
+        self::assertNull($result['costCents'], 'a partial cost must never be published');
+        self::assertFalse($result['complete']);
+        self::assertSame(['alice'], $result['unpricedPersonIds']);
+        self::assertSame(7.0, $result['hours'], 'hours stay complete even when the cost cannot');
+    }
+
+    /**
+     * Hours are reported even when no rate is available at all.
+     *
+     * Hours are effort, not currency — ADR-081 lets a domain app show them.
+     *
+     * @return void
+     */
+    public function testHoursSurviveWithNoRatesAtAll(): void
+    {
+        $result = $this->aggregator->aggregate(
+            [['personId' => 'alice', 'hours' => 2.25]],
+            []
+        );
+
+        self::assertSame(2.25, $result['hours']);
+        self::assertNull($result['costCents']);
+        self::assertFalse($result['complete']);
+    }
+
+    /**
+     * An empty hour set is not a zero cost.
+     *
+     * Zero hours costing zero is arguably true, but `complete: true` with a 0
+     * total would render "€0.00" on a case nobody has booked time to — which
+     * reads as "this was free" rather than "nothing recorded yet".
+     *
+     * @return void
+     */
+    public function testNoHoursIsNotAZeroCost(): void
+    {
+        $result = $this->aggregator->aggregate([], ['alice' => 6000]);
+
+        self::assertSame(0.0, $result['hours']);
+        self::assertFalse($result['complete']);
+        self::assertNull($result['costCents']);
+        self::assertSame([], $result['perPerson']);
+    }
+
+    /**
+     * Hours with no person are counted but never priced.
+     *
+     * @return void
+     */
+    public function testUnattributedHoursCountButCannotBePriced(): void
+    {
+        $result = $this->aggregator->aggregate(
+            [
+                ['personId' => '', 'hours' => 1.0],
+                ['personId' => 'alice', 'hours' => 2.0],
+            ],
+            ['alice' => 6000]
+        );
+
+        self::assertSame(3.0, $result['hours'], 'unowned hours still happened');
+        self::assertFalse($result['complete']);
+        self::assertContains('(unattributed)', $result['unpricedPersonIds']);
+    }
+
+    /**
+     * Non-numeric hours are rejected rather than cast to zero.
+     *
+     * PHP would turn '' and 'n/a' into 0.0 without complaint, which quietly
+     * drops a row into the breakdown as a person who worked no hours.
+     *
+     * @return void
+     */
+    public function testNonNumericHoursAreRejectedNotCastToZero(): void
+    {
+        // The junk rows belong to DIFFERENT people on purpose. An earlier
+        // version of this test put all three rows on alice, and a mutation
+        // replacing the numeric check with a blanket `(float) $value` PASSED
+        // it: 'n/a' and '' both cast to 0.0, alice's total was still 2.5, and
+        // the breakdown still had exactly one entry. Nothing observable moved.
+        //
+        // With the junk on carol and dave, a 0.0 cast invents two people who
+        // "worked no hours", neither of whom has a rate — so the breakdown
+        // grows and `complete` flips to false. That is the difference the
+        // assertion is supposed to detect.
+        $result = $this->aggregator->aggregate(
+            [
+                ['personId' => 'carol', 'hours' => 'n/a'],
+                ['personId' => 'dave', 'hours' => ''],
+                ['personId' => 'alice', 'hours' => '2.5'],
+            ],
+            ['alice' => 4000]
+        );
+
+        self::assertSame(2.5, $result['hours'], 'only the numeric row counts');
+        self::assertCount(1, $result['perPerson'], 'a rejected row must not invent a person');
+        self::assertSame(['alice'], array_column($result['perPerson'], 'personId'));
+        self::assertTrue($result['complete'], 'the one real row is fully priced');
+        self::assertSame(10000, $result['costCents']);
+    }
+
+    /**
+     * Rounding happens once per person, not once at the end.
+     *
+     * Three rows of 1/3 hour at 1000 cents is 1000 cents exactly when summed
+     * per person. Rounding each ROW instead would give 333+333+333 = 999.
+     *
+     * @return void
+     */
+    public function testRoundingIsPerPersonNotPerRow(): void
+    {
+        $third  = (1 / 3);
+        $result = $this->aggregator->aggregate(
+            [
+                ['personId' => 'alice', 'hours' => $third],
+                ['personId' => 'alice', 'hours' => $third],
+                ['personId' => 'alice', 'hours' => $third],
+            ],
+            ['alice' => 1000]
+        );
+
+        self::assertSame(1000, $result['costCents']);
+    }
+
+    /**
+     * A negative or non-integer rate is treated as no rate.
+     *
+     * @return void
+     */
+    public function testAMalformedRateIsTreatedAsAbsent(): void
+    {
+        $result = $this->aggregator->aggregate(
+            [['personId' => 'alice', 'hours' => 1.0]],
+            ['alice' => -500]
+        );
+
+        self::assertFalse($result['complete']);
+        self::assertNull($result['costCents']);
+        self::assertSame(['alice'], $result['unpricedPersonIds']);
+    }
+}


### PR DESCRIPTION
The last link in ADR-081's chain. hrmq owns the wage half and now serves it (ConductionNL/hrmq#78); `UrenRegistratie` can name the domain object an hour was worked on (#463); procest shows the hours (ConductionNL/procest#758). Missing was the piece that turns hours into **money** — and per ADR-081 that belongs **here**, because Shillinq owns the ledger. A domain app classifies and displays; it does not sum money.

## The central rule is a refusal

This **never returns a total it could not fully compute.** If any person with hours has no resolvable rate, `complete` is false, `costCents` is null, and the unpriced people are named.

A cost that silently omits someone's hours is worse than no cost: it is plausible, it is **always lower** than the truth, and nothing about it looks wrong on a case page. Hours are still returned either way — hours are effort, not currency.

## Four more decisions worth stating

| decision | why |
|---|---|
| **cents, never floats** | a float total over many rows drifts, and a ledger that drifts is not a ledger |
| **round once per person** | rounding per row loses a cent every time — three rows of ⅓ hour at €10 is 1000 cents summed per person, **999** rounded per row. Pinned by test. |
| **reject non-numeric hours** | PHP turns `''` and `'n/a'` into `0.0` without complaint, inventing a person who "worked no hours" who — having no rate — flips a complete cost to incomplete |
| **count unattributed hours, never price them** | total hours stay honest while the cost correctly refuses |

## Why the rates are injected

The hrmq rate surface arrives as a resolved `personId => centsPerHour` map rather than being called directly — the approach `GrotendeelsCriteriumService` already takes in this repo: *"the hrmq loondienst-hours surface is intentionally abstracted… the adapter wires here without touching the policy"*. The live adapter over `POST /api/employees/cost-rate` is the next commit, not this one.

## Tests — mutation-verified in four arms

| mutation | result |
|---|---|
| publish a partial cost instead of withholding it | **4 failures** |
| round per row instead of per person | **1 failure** |
| drop unattributed hours from the total | **1 failure** |
| cast non-numeric hours to `0.0` | **1 failure** |
| restored | OK (8 tests, 27 assertions) |

**The fourth arm initially survived.** The test had put all three junk rows on the *same* person, so a `0.0` cast changed nothing observable — same total, same single breakdown entry. Moving the junk onto different people makes the cast invent two unpriced people, which is the difference the assertion was supposed to detect. That reasoning is recorded in the test so the next reader does not undo it.

phpcs, phpmd and phpstan clean.
