### PR TITLE
fix(routes): route the accountant portal — both endpoints were unrouted, the page 404'd for every user

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -708,5 +708,24 @@ return \OCA\OpenRegister\AppHost\Routes::standard(
             // URLs declared before the SPA catch-all per ADR-016.
             ['name' => 'deadlineCalendarSettings#index', 'url' => '/api/deadline-calendar/settings', 'verb' => 'GET'],
             ['name' => 'deadlineCalendarSettings#update', 'url' => '/api/deadline-calendar/settings', 'verb' => 'POST'],
+
+            // Accountant portal (accountant-portal, REQ-ACP-001/002/004).
+            // These two were MISSING from this table entirely while every other
+            // piece of the feature shipped: the page is registered by
+            // src/manifest.d/accountant-portal.json, rendered by
+            // src/views/AccountantPortalDashboard.vue, and called by
+            // src/api/accountantApi.js — which requested
+            // `/apps/shillinq/api/accountant/dashboard` and
+            // `/apps/shillinq/api/accountant/administrations/{id}/handover-pack`
+            // against a router that had no entry for either, so the portal
+            // 404'd on open for every user. AccountantPortalController::dashboard()
+            // and ::handoverPack() existed and were correct; only the wiring was
+            // absent. Both are #[NoAdminRequired] and scoped server-side to the
+            // caller's AdministrationMembership records (a non-granted
+            // administration is masked as 404, never 403). The static
+            // /dashboard URL and the static /handover-pack suffix are declared
+            // before the SPA catch-all per ADR-016.
+            ['name' => 'accountantPortal#dashboard', 'url' => '/api/accountant/dashboard', 'verb' => 'GET'],
+            ['name' => 'accountantPortal#handoverPack', 'url' => '/api/accountant/administrations/{id}/handover-pack', 'verb' => 'GET'],
         ]
         );

--- a/tests/vitest/accountantPortalRouting.spec.js
+++ b/tests/vitest/accountantPortalRouting.spec.js
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: EUPL-1.2
+ * Copyright (C) 2026 Conduction B.V.
+ *
+ * Contract test for the accountant-portal wiring (accountant-portal,
+ * REQ-ACP-001 / REQ-ACP-002 / REQ-ACP-004).
+ *
+ * WHY THIS EXISTS. Every other piece of the accountant portal shipped —
+ * the manifest page (src/manifest.d/accountant-portal.json), the view
+ * (src/views/AccountantPortalDashboard.vue), the API client
+ * (src/api/accountantApi.js) and the controller
+ * (lib/Controller/AccountantPortalController.php) — while
+ * `appinfo/routes.php` contained no entry for either endpoint. The portal
+ * therefore 404'd on open for every user, and nothing caught it: the
+ * controller's unit tests call the methods directly, so they never touch
+ * the router.
+ *
+ * This test asserts the two files AGREE. It reads the URLs the client
+ * actually requests out of src/api/accountantApi.js and requires each one
+ * to have a matching declaration in appinfo/routes.php. It deliberately
+ * does NOT hardcode the URL list on one side only: a test that merely
+ * restated routes.php back to itself would pass even if the client asked
+ * for something else entirely.
+ *
+ * @spec openspec/specs/accountant-portal/spec.md
+ */
+
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+
+const repoRoot = path.resolve(__dirname, '..', '..')
+const routesSource = fs.readFileSync(path.join(repoRoot, 'appinfo', 'routes.php'), 'utf8')
+const clientSource = fs.readFileSync(path.join(repoRoot, 'src', 'api', 'accountantApi.js'), 'utf8')
+
+/**
+ * Extract every declared route as {name, url, verb} from appinfo/routes.php.
+ *
+ * Matches the two literal styles used in that file — the one-line
+ * `['name' => 'x#y', 'url' => '/…', 'verb' => 'GET']` form and the
+ * multi-line form — by keying off the quoted values rather than layout,
+ * so reformatting the file does not silently empty this list.
+ *
+ * @return {Array<{name: string, url: string, verb: string}>} Declared routes.
+ */
+function parseDeclaredRoutes() {
+	const routes = []
+	const re = /'name'\s*=>\s*'([^']+)'\s*,\s*'url'\s*=>\s*'([^']+)'\s*,\s*'verb'\s*=>\s*'([^']+)'/g
+	let m
+	while ((m = re.exec(routesSource)) !== null) {
+		routes.push({ name: m[1], url: m[2], verb: m[3] })
+	}
+	return routes
+}
+
+/**
+ * Extract the shillinq API paths that accountantApi.js requests, normalising
+ * any `${...}` template placeholder to the Nextcloud `{id}` route wildcard.
+ *
+ * @return {Array<string>} Requested API paths, e.g. `/api/accountant/dashboard`.
+ */
+function parseClientPaths() {
+	const paths = []
+	const re = /\/apps\/shillinq(\/api\/[^'"`]*)/g
+	let m
+	while ((m = re.exec(clientSource)) !== null) {
+		paths.push(m[1].replace(/\$\{[^}]*\}/g, '{id}'))
+	}
+	return paths
+}
+
+describe('accountant portal routing contract', () => {
+	// Guard against the whole suite passing because a regex silently matched
+	// nothing. A zero-length input would make every assertion below vacuous.
+	it('parses a non-empty route table and a non-empty client URL list', () => {
+		expect(parseDeclaredRoutes().length).toBeGreaterThan(50)
+		expect(parseClientPaths().length).toBeGreaterThan(0)
+	})
+
+	it('declares a route for every URL src/api/accountantApi.js requests', () => {
+		const declaredUrls = parseDeclaredRoutes().map((r) => r.url)
+		for (const requested of parseClientPaths()) {
+			expect(declaredUrls, `no route declared for ${requested}`).toContain(requested)
+		}
+	})
+
+	it('routes accountantPortal#dashboard at GET /api/accountant/dashboard', () => {
+		expect(parseDeclaredRoutes()).toContainEqual({
+			name: 'accountantPortal#dashboard',
+			url: '/api/accountant/dashboard',
+			verb: 'GET',
+		})
+	})
+
+	it('routes accountantPortal#handoverPack at GET the handover-pack URL', () => {
+		expect(parseDeclaredRoutes()).toContainEqual({
+			name: 'accountantPortal#handoverPack',
+			url: '/api/accountant/administrations/{id}/handover-pack',
+			verb: 'GET',
+		})
+	})
+})


### PR DESCRIPTION
## The accountant portal was never routed

`AccountantPortalController::dashboard()` and `::handoverPack()` had **no entry in `appinfo/routes.php`**. Every other part of the feature shipped:

| piece | file | state |
|---|---|---|
| menu/page registration | `src/manifest.d/accountant-portal.json` | present |
| view | `src/views/AccountantPortalDashboard.vue` | present |
| API client | `src/api/accountantApi.js` | present |
| controller | `lib/Controller/AccountantPortalController.php` | present, correct |
| **route** | `appinfo/routes.php` | **absent** |

`src/api/accountantApi.js:23` requests `/apps/shillinq/api/accountant/dashboard` and `:39` requests `/apps/shillinq/api/accountant/administrations/{id}/handover-pack`. Neither resolved. **Opening the accountant portal 404'd for every user.**

This is the same shape as #460 (the unobtainable first API key): a complete-looking feature with one missing wiring link.

## Why nothing caught it

Two independent blind spots:

1. The controller's own tests call the methods **directly**, so they never touch the router.
2. **gate-14 (route-reachability) cannot read this route table.** shillinq registers routes by returning `\OCA\OpenRegister\AppHost\Routes::standard(...)`; gate-14 only parses literal route arrays.

gate-14 *did* flag these two — inside a set of 7 where the other **5 are false positives**. `settings#index|create|load` and `preferences#getPreference|setPreference` are registered by `Routes::standard()` itself, at `openregister/lib/AppHost/Routes.php` lines **115–122**. Those five must NOT be "fixed": adding literal duplicates would collide. Only the 2 accountant routes were real.

## The test, and proof it can fail

`tests/vitest/accountantPortalRouting.spec.js` asserts the two files **agree** — it reads the URLs the client actually requests out of `src/api/accountantApi.js` and requires a matching declaration in `appinfo/routes.php`. It deliberately does not restate `routes.php` back to itself, which would pass even if the client asked for something else.

Both arms measured:

- **with the fix** — 4/4 pass.
- **without the fix** (routes.php reverted, test unchanged) — **3 of 4 fail**, naming the cause: `no route declared for /api/accountant/dashboard`.

The first test is a non-vacuity guard: it asserts the parse produced a non-empty route table. It **passes in both arms** (216 routes parsed), which proves the 3 failures are the missing route and not a regex that silently matched nothing.

## Scope

`appinfo/routes.php` +2 route entries, +1 test file. No controller, service or frontend code changed. Both routes are static-prefixed and declared before the SPA catch-all per ADR-016.
