### PR TITLE
chore(deps): raise the Nextcloud floor from 31 to 32

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -49,15 +49,32 @@ Vrij en open source onder de EUPL-1.2-licentie.
         Shillinq entity is an OpenRegister object, and src/manifest.json lists
         "openregister" as a required dependency.
 
-        min-version is therefore 32, NOT 31: openregister declares min-version="32"
-        because its lib/ContextChat/ContentProvider.php implements
-        OCP\ContextChat\IContentProvider, an interface core does not have before
-        Nextcloud 32. On NC 31 openregister refuses to install ("cannot be installed
-        because it is not compatible with this version of the server"), so the app
-        cannot function there. Declaring 31 advertised a range this app cannot
-        deliver. Same defect as openconnector#1173.
+        min-version is therefore 32, NOT 31. Two independent reasons, both measured:
+
+        1. PHP 8.3. This app declares <php min-version="8.3"/> above. Nextcloud 31
+           still supports PHP 8.1/8.2, so a 31 install can present a PHP this app
+           has already declared it does not support. 32 is the first server line
+           that matches the PHP floor already declared here.
+
+        2. The CI matrix does not test 31. .github/workflows/code-quality.yml sets
+           nextcloud-test-refs: '["stable32", "stable33"]'. Declaring 31 advertised
+           an App Store range that NO job in this repo has ever exercised.
+
+        Note the hard dependency on OpenRegister is REAL but UNDECLARED: appinfo/
+        routes.php line 39 returns \OCA\OpenRegister\AppHost\Routes::standard(...)
+        at file scope, so with openregister absent this app's entire route table
+        fatals — not one endpoint degrades, all of them die. It cannot be declared
+        as <app>openregister</app> here without also pinning that app's own floor;
+        tracked separately. The rule from openconnector#1172/#1173 is that
+        min-version must be >= the max of every <app> dependency's floor, so this
+        value must be revisited if that dependency is ever declared: openregister
+        itself currently declares min-version="28" (measured on its
+        origin/development today), and is moving to 32 concurrently.
+
+        max-version stays 34, which is the fleet-wide value everywhere except
+        openconnector, which declares 35.
         -->
-        <nextcloud min-version="31" max-version="34"/>
+        <nextcloud min-version="32" max-version="34"/>
     </dependencies>
 
     <background-jobs>


### PR DESCRIPTION
## What

`<nextcloud min-version="31" max-version="34"/>` → `min-version="32"`. `max-version` unchanged.

## The rationale was already in the file

`appinfo/info.xml` already carried an eight-line comment arguing the floor **must be 32** — sitting directly above a declaration that still said **31**. The argument landed; the value did not. This commit makes the value match the reasoning already committed next to it.

## Two measured reasons

1. **PHP 8.3.** This app declares `<php min-version="8.3"/>`. Nextcloud 31 still supports PHP 8.1/8.2, so a 31 install can present a PHP the app has already declared unsupported. 32 is the first server line matching the PHP floor already declared here.

2. **CI never tested 31.** `.github/workflows/code-quality.yml` sets `nextcloud-test-refs: '["stable32", "stable33"]'`. Declaring 31 advertised an App Store range that no job in this repo has ever exercised.

## CI matrix

**No leg is dropped** — there was no leg below 32 to drop. This change *aligns the declaration with what CI already measures*, rather than removing coverage. (`max-version` is 34 while CI's top leg is `stable33`; that gap is pre-existing and untouched here.)

`max-version` stays **34** — the fleet-wide value everywhere except **openconnector, which declares 35**.

## A correction, and a real finding

The existing comment asserted openregister "declares `min-version="32"`". **Measured today on openregister's `origin/development`: it declares `28`.** The comment was wrong; it is corrected in this diff.

The openconnector #1172/#1173 rule — `min-version` must be ≥ the max of every `<app>` dependency's floor — does **not** trigger here, because shillinq declares no `<app>` dependency at all. **That is itself the finding:**

`appinfo/routes.php` line 39 returns `\OCA\OpenRegister\AppHost\Routes::standard(...)` **at file scope**. With openregister absent, shillinq's entire route table fatals — not one endpoint degrading, all of them dying at once. That is a hard, load-time dependency that `info.xml` does not declare.

I did **not** add `<app>openregister</app>` in this PR: declaring it also pins that app's floor and changes install ordering, which is a bigger change than a version bump and deserves its own review. Filed separately.
