### PR TITLE
fix(security): an empty administrationId skipped the IDOR guard entirely

### DIFF
--- a/lib/Controller/BookingDetailController.php
+++ b/lib/Controller/BookingDetailController.php
@@ -145,8 +145,22 @@ class BookingDetailController extends Controller
         // administration; the context service rejects callers without
         // membership. Masked as 404 so the controller does not leak
         // existence to out-of-tenant users.
+        // The `$administrationId !== ''` short-circuit that used to guard this
+        // call DISABLED THE CHECK for exactly the records that need it most.
+        // `?? ''` catches an absent or null administrationId and turns it into
+        // '', and '' then made the whole condition false — so an Appointment
+        // with no owning administration was readable by ANY authenticated user,
+        // cross-tenant, in a bookkeeping app. Records in that state are not
+        // hypothetical here: seed objects that fail their schema's `required`
+        // list are skipped on import, which leaves schemas unpopulated and
+        // partially-formed rows in play (see tests/validate-seeds.js).
+        //
+        // canAccess() already fails closed — AdministrationContextService::
+        // canAccess() returns false for '' on its own line. The service was
+        // right; the caller opted out of it. Calling it unconditionally makes
+        // an unknown administration a 404 instead of a free read.
         $administrationId = (string) ($appointment['administrationId'] ?? '');
-        if ($administrationId !== '' && $this->context->canAccess($administrationId) === false) {
+        if ($this->context->canAccess($administrationId) === false) {
             return new JSONResponse(['error' => 'Booking not found'], Http::STATUS_NOT_FOUND);
         }
 

--- a/tests/Unit/Controller/BookingDetailControllerTest.php
+++ b/tests/Unit/Controller/BookingDetailControllerTest.php
@@ -187,6 +187,23 @@ final class BookingDetailControllerTest extends TestCase
                         'pipelinqContactId' => 'org-kvk-12345678',
                     ],
                     [
+                        // An Appointment with NO owning administration. This is
+                        // the record shape that used to bypass the IDOR guard
+                        // entirely: `?? ''` turned absent/null into '', and the
+                        // caller's `!== ''` short-circuit then skipped canAccess()
+                        // altogether, making the row readable cross-tenant.
+                        'appointmentId'     => 'apt-orphan',
+                        'administrationId'  => '',
+                        'serviceId'         => 'svc-1',
+                        'resourceId'        => 'res-1',
+                        'customerId'        => 'cus-9',
+                        'customerName'      => 'Orphan Record',
+                        'startTime'         => '2026-06-01T12:00:00Z',
+                        'endTime'           => '2026-06-01T12:30:00Z',
+                        'status'            => 'confirmed',
+                        'pipelinqContactId' => null,
+                    ],
+                    [
                         'appointmentId'     => 'apt-unlinked',
                         'administrationId'  => 'adm-1',
                         'serviceId'         => 'svc-1',
@@ -483,6 +500,51 @@ final class BookingDetailControllerTest extends TestCase
         self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
 
     }//end testOutOfTenantCallerIsMaskedAsNotFound()
+
+
+    /**
+     * An Appointment with an EMPTY administrationId must still be guarded.
+     *
+     * This is the regression this test exists for. The guard used to read
+     * `if ($administrationId !== '' && $this->context->canAccess(...) === false)`.
+     * Because `?? ''` normalises an absent or null administrationId to '',
+     * the `!== ''` term made the whole condition false and canAccess() was
+     * NEVER CALLED — so a record with no owning administration was readable
+     * by any authenticated user, across tenants, in a bookkeeping app.
+     *
+     * The assertion that matters is `expects($this->once())` on canAccess:
+     * asserting only on the 404 status would also pass if the controller
+     * happened to 404 for some unrelated reason. What is being pinned is
+     * that the guard RUNS, with the empty value, and is allowed to refuse.
+     *
+     * @return void
+     */
+    public function testAppointmentWithEmptyAdministrationIdIsMaskedAsNotFound(): void
+    {
+        $context = $this->createMock(AdministrationContextService::class);
+        $context->method('currentUserId')->willReturn('alice');
+
+        // The real AdministrationContextService::canAccess() returns false for
+        // '' on its own first line — it already fails closed. The bug was that
+        // the caller never invoked it. Pin the invocation, with the empty value.
+        $context->expects($this->once())
+            ->method('canAccess')
+            ->with('')
+            ->willReturn(false);
+
+        $controller = new BookingDetailController(
+            $this->request,
+            $this->container,
+            $this->settings,
+            $context,
+            $this->pipelinq,
+            $this->createMock(LoggerInterface::class),
+        );
+
+        $response = $controller->show(id: 'apt-orphan');
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+    }//end testAppointmentWithEmptyAdministrationIdIsMaskedAsNotFound()
 
 
     /**


### PR DESCRIPTION
## An empty `administrationId` skipped the IDOR guard entirely

`BookingDetailController::show()` is `#[NoAdminRequired]`. Its ADR-005 guard read:

```php
$administrationId = (string) ($appointment['administrationId'] ?? '');
if ($administrationId !== '' && $this->context->canAccess($administrationId) === false) {
    return new JSONResponse(['error' => 'Booking not found'], Http::STATUS_NOT_FOUND);
}
```

`?? ''` normalises an **absent or null** `administrationId` to the empty string. `$administrationId !== ''` then makes the whole condition **false**, so `canAccess()` was **never called**.

**Result: an Appointment with no owning administration was readable by any authenticated user, across tenants, in a bookkeeping app.**

## The service was never wrong — the caller opted out of it

`AdministrationContextService::canAccess()` already fails closed:

```php
public function canAccess(string $administrationId): bool
{
    if ($administrationId === '') {
        return false;
    }
    ...
```

It returns `false` for `''` on its own first line. The fix is simply to **invoke it unconditionally**, which turns an unknown administration into a 404 instead of a free read. One line.

## Why this is live here, not theoretical

Records with a missing `administrationId` are exactly what this repo produces. Seed objects that fail their schema's `required` list are **skipped on import** — 74 of them today (`tests/validate-seeds.js`) — which leaves schemas unpopulated and partially-formed rows in play. **The seed defect and this defect share a trigger.**

## Same shape as two other repos

opencatalogi#828 and portaliq#65. The tell is identical in all three:

> `?? 'default'` catches **absent and null but NOT the empty string**, and a guard conditioned on `!== ''` **silently disables itself** for precisely the rows that most need guarding.

## Can-fail proof

Restored the `!== '' &&` short-circuit with the test unchanged:

```
Failed asserting that 200 is identical to 404.
FAILURES! Tests: 11, Assertions: 44, Failures: 1.
```

**That failure is the leak** — the orphan record served **200** to a caller with no access. Restored → `OK (11 tests, 45 assertions)`.

The new test asserts `canAccess()` is **invoked once, with `''`** — not merely that the response is a 404. A status-only assertion would also pass if the controller 404'd for an unrelated reason; what is pinned is that the guard **runs** and is allowed to refuse.

**None of the 10 pre-existing tests changed.** Unlike opencatalogi#828, where six tests had to be rewritten because they pinned the vulnerability as correct, no test here was asserting the broken behaviour.

## Not fixed here — a second, wider instance (filed separately)

The same shape appears in `lib/Reporting/Generator/ReportDataTrait::lineFilters()`, which is shared by at least 7 report generators (BalanceSheet, ProfitLoss, BbvJaarstukken, ManagementLetter, Saft, XafAuditfile, …):

```php
$administrationId = $this->contextString($context, 'administrationId');
if ($administrationId !== '') {
    $filters['administrationId'] = $administrationId;
}
...
if ($filters === []) {
    return [];
}
```

An empty `administrationId` adds **no** administration filter; if `period` is also empty the method returns an **empty filter set** — a general-ledger read across every administration. `contextString()` returns `''` for null, absent *and* non-string input, so the `''` path is reachable three ways. That has a much wider blast radius than this one-line controller fix and deserves its own review rather than riding along here.
