### PR TITLE
chore: raise Nextcloud floor to 32 (PHP 8.3) and drop the impossible stable31 CI leg

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -14,7 +14,16 @@ jobs:
       app-name: shillinq
       php-version: "8.3"
       php-test-versions: '["8.3", "8.4"]'
-      nextcloud-test-refs: '["stable31", "stable32", "stable33"]'
+      # stable31 removed: it tests an IMPOSSIBLE configuration, not a coverage trim.
+      # This app's floor is Nextcloud 32, enforced at INSTALL time, so `occ app:enable`
+      # refuses on NC31. The shared workflow runs app-enable as `|| echo "::warning::..."`,
+      # so that refusal is only a WARNING: the job continues without its data layer and
+      # then dies ~70s later on MISSING SCHEMAS, which reads like an app/migration fault
+      # and sends you to the wrong file entirely.
+      # ORDER matters too: the newman/playwright/journeydoc jobs check out the server at
+      # fromJSON(inputs.nextcloud-test-refs)[0], so a stable31 sitting FIRST put all of them
+      # on the one version this app cannot be enabled on.
+      nextcloud-test-refs: '["stable32", "stable33"]'
       enable-psalm: true
       enable-phpstan: true
       enable-phpmetrics: true

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -48,7 +48,15 @@ Vrij en open source onder de EUPL-1.2-licentie.
     <screenshot>https://raw.githubusercontent.com/ConductionNL/shillinq/main/img/app-store.svg</screenshot>
 
     <dependencies>
-        <nextcloud min-version="28" max-version="34"/>
+        <!--
+            Nextcloud floor is 32 fleet-wide so this app can require PHP 8.3.
+            A min-version is enforced at install time: on an older Nextcloud the
+            app cannot be enabled at all, so advertising a lower floor promises
+            a range the app cannot actually serve. The openregister development
+            line already declares a Nextcloud floor of 32.
+            max-version is deliberately left at its existing value.
+        -->
+        <nextcloud min-version="32" max-version="34"/>
         <php min-version="8.3"/>
     </dependencies>
 


### PR DESCRIPTION
## Why

Product directive from the PO (Ruben): the fleet standardises on Nextcloud 32 so it can require PHP 8.3 — *"we want php 8.3 so going for min version nc 32 fleet wide is a good thing."*

The governing rule (openconnector#1172 / #1173): an app's `min-version` must be `>=` the max of every `<app>` dependency's floor, or the App Store advertises a range the app cannot deliver — the dependency refuses to install and the app is non-functional there. `openregister@development` declares `min-version 32` as of openregister#2384 (merged 2026-08-08T10:45Z); re-measured on this branch with an XML parser and confirmed.

## Shape

**Floor-only PR directly to `main`.** Reason: `main` trails `development` by 188–5206 commits in every repo in this fleet, so a `development` → `main` merge would be a full release, not a floor fix.

## Changes

### 1. `appinfo/info.xml`

| field | before | after |
| --- | --- | --- |
| nextcloud `min-version` | 28 | **32** |
| nextcloud `max-version` | 34 | 34 (**unchanged**, deliberately not normalised) |
| php `min-version` | 8.3 | **8.3** |

A prose comment was added above the `nextcloud` element. It contains **no XML element syntax**: floor guards here count raw regex matches of the nextcloud element across the whole file *including comments*, so a quoted example would read as a second, contradictory declaration and trip the guard. Validated before push: the file parses as XML **and** `<nextcloud\b[^>]*>` matches **exactly once**.

### 2. `.github/workflows/code-quality.yml` — drop the impossible CI leg

`nextcloud-test-refs: '["stable31", "stable32", "stable33"]'` → `'["stable32", "stable33"]'`

**stable31 is removed because it tests an impossible configuration, not to trim coverage.** A floor of 32 is enforced at **install** time, so `occ app:enable` refuses on NC31. The shared workflow runs app-enable as `|| echo "::warning::..."`, so the failure is only a **warning** and the job continues without its data layer, then dies ~70 seconds later on **missing schemas** — which reads like an app/migration fault and sends you to the wrong file entirely.

**Order matters too:** the newman / playwright / journeydoc jobs check out the server at `fromJSON(inputs.nextcloud-test-refs)[0]`, so a `stable31` sitting **first** put all of them on the one version the app cannot be enabled on.

This removes an impossible leg — it does **not** widen the matrix. No new refs are added. Some job names (`PHPUnit (PHP 8.x, NC stable31)`) will legitimately disappear from the check set.

## Measurement notes

All version readings were taken with `xml.etree.ElementTree`, never grep.

- **Measured correction to the brief:** this repo's `main` `appinfo/info.xml` contains **exactly one** `<nextcloud>` occurrence and **no commented-out examples**. The "literal examples inside comments" hazard cited in the rollout brief does not apply to this file — the single-match validation was still run and still passes.
- **`openregister@main` still declares `min-version 28`** (max 34). Only `openregister@development` is at 32. Stated explicitly so no reader infers a claim about `main` that is not true today.
- **This repo declares no `<app>` dependency on either `main` or `development`.** So the dependency-max rule does not *mechanically* bind here; the floor is raised on the fleet directive, and `development` already sits at 32. The install-time argument for dropping stable31 stands on the app's **own** floor of 32 regardless.
- php floor was **already 8.3** on `main` — unchanged by this PR.
- `main`'s latest completed Code Quality run is **fully green**, so the bar for this PR is: no new failures at all.
- **Branch prefix:** this PR was reopened from `hotfix/nc-floor-32-main`. The shared `Branch Protection` workflow requires PRs to `main` to originate from `beta` or `hotfix/*`; the original `chore/*` branch failed that gate legitimately, so the branch was renamed to comply rather than the gate overridden. Content is byte-identical.