### PR TITLE
fix(settings): add the canonical settings#update — PUT /api/settings 500s with a ReflectionException

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -30,6 +30,16 @@ use OCP\IRequest;
 
 /**
  * Controller for managing Shillinq application settings.
+ *
+ * Shillinq KEEPS this bespoke controller rather than adopting OpenRegister's
+ * `GenericSettingsController` (fragment-merge `shillinq_register.json` +
+ * `register.d/*.json` config loading — see
+ * `openspec/specs/apphost-adoption/spec.md`). The AppHost only aliases its
+ * generic in when the leaf ships NO class of that name, so this class owes
+ * every method the canonical route table routes to `settings#`:
+ * `index` (GET), `create` (POST, legacy), `update` (PUT) and `load`.
+ *
+ * @spec openspec/specs/app-administration/spec.md
  */
 class SettingsController extends Controller
 {

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -64,14 +64,31 @@ class SettingsController extends Controller
     }//end index()
 
     /**
-     * Update settings with provided data.
+     * Update settings with provided data — the canonical write.
      *
-     * @return JSONResponse
+     * `\OCA\OpenRegister\AppHost\Routes::standard()` ships
+     * `['name' => 'settings#update', 'url' => '/api/settings', 'verb' => 'PUT']`
+     * and shillinq's `appinfo/routes.php` returns that table verbatim, so
+     * `PUT /apps/shillinq/api/settings` is live. Because shillinq KEEPS its own
+     * `SettingsController` (fragment-merge config loading — see
+     * `openspec/specs/apphost-adoption/spec.md`),
+     * `AppHost\Bootstrap::aliasControllerUnlessLeafDefinesIt()` never aliases
+     * OpenRegister's `GenericSettingsController` in, so this app owes every
+     * method the canonical table routes to `settings#`. A missing one is not a
+     * 404 — the router matches, `ControllerMethodReflector` reflects, and the
+     * request dies with a 500.
      *
-     * @spec openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-1
+     * Persists any supplied managed config key via `SettingsService::
+     * updateSettings()` (which filters to `SettingsService::CONFIG_KEYS`) and
+     * returns the refreshed settings. Byte-identical to what the legacy
+     * `create()` POST alias has always written.
+     *
+     * @return JSONResponse Envelope with `success` and the refreshed `config`.
+     *
+     * @spec openspec/specs/app-administration/spec.md
      */
     #[AuthorizedAdminSetting(Application::APP_ID)]
-    public function create(): JSONResponse
+    public function update(): JSONResponse
     {
         $data   = $this->request->getParams();
         $config = $this->settingsService->updateSettings($data);
@@ -82,6 +99,28 @@ class SettingsController extends Controller
                 'config'  => $config,
             ]
         );
+    }//end update()
+
+    /**
+     * Legacy alias for {@see update()} — the POST spelling of the same write.
+     *
+     * The canonical AppHost route table still ships `settings#create`
+     * (POST /api/settings) for the pre-ADR-066 `index/create/load` dialect, and
+     * shillinq's admin UI still POSTs to it, so it stays reachable (ADR-029)
+     * and keeps writing exactly what it wrote before.
+     *
+     * The attribute is repeated deliberately: Nextcloud's SecurityMiddleware
+     * evaluates auth attributes on the DISPATCHED method only, so delegating to
+     * an `#[AuthorizedAdminSetting]` method does not inherit its posture.
+     *
+     * @return JSONResponse Envelope with `success` and the refreshed `config`.
+     *
+     * @spec openspec/specs/app-administration/spec.md
+     */
+    #[AuthorizedAdminSetting(Application::APP_ID)]
+    public function create(): JSONResponse
+    {
+        return $this->update();
     }//end create()
 
     /**

--- a/openspec/specs/app-administration/spec.md
+++ b/openspec/specs/app-administration/spec.md
@@ -28,9 +28,18 @@ Shillinq MUST provide an authenticated settings surface backed by
 managed config keys (`register`, `rgs_template`, `administration_id`)
 plus the derived metadata fields `openregisters` (whether OpenRegister
 is installed) and `isAdmin` (whether the current user is a Nextcloud
-admin). `POST /apps/shillinq/api/settings` persists any supplied managed
-key via `IAppConfig` and returns the refreshed settings. Keys not in the
-managed set are ignored.
+admin). `PUT /apps/shillinq/api/settings` (route `settings#update`, the
+canonical AppHost write) persists any supplied managed key via
+`IAppConfig` and returns the refreshed settings; `POST
+/apps/shillinq/api/settings` (route `settings#create`) is the legacy
+alias for the same write and MUST remain byte-identical in behaviour.
+Keys not in the managed set are ignored.
+
+Because shillinq KEEPS its own `SettingsController` rather than adopting
+the AppHost generic, no generic controller is aliased in to cover the
+canonical route names — every method the canonical table routes to
+`settings#` MUST exist on shillinq's own class, otherwise the request
+fails with a 500 (`ReflectionException`) rather than a 404.
 
 #### Scenario: Operator reads current settings
 
@@ -50,6 +59,19 @@ managed set are ignored.
 - **WHEN** the request is processed
 - **THEN** the `register` app-config value MUST be stored as a string and
   the response MUST report `success: true` with the refreshed `config`.
+
+#### Scenario: Canonical PUT write reaches the kept controller
+
+@e2e exclude REST API contract: covered by PHPUnit SettingsControllerWriteTest — not browser-observable
+
+- **GIVEN** the canonical AppHost route table routes
+  `PUT /apps/shillinq/api/settings` to `settings#update` and shillinq ships
+  its own `SettingsController`, so no generic is aliased in
+- **WHEN** an admin sends `PUT /apps/shillinq/api/settings` with
+  `{ "register": "shillinq" }`
+- **THEN** `SettingsController::update()` MUST exist and be dispatchable, the
+  value MUST be persisted, and the response MUST report `success: true` with
+  the refreshed `config` — identical to the `POST` alias.
 
 ### Requirement: REQ-Admin-002 The system SHALL support forced re-import of the register configuration
 

--- a/tests/Unit/AppInfo/CanonicalRouteMethodContractTest.php
+++ b/tests/Unit/AppInfo/CanonicalRouteMethodContractTest.php
@@ -1,0 +1,288 @@
+<?php
+
+/**
+ * Tests for the canonical AppHost route table's method contract.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\AppInfo
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/app-administration/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\AppInfo;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * The canonical AppHost route table routes a fixed set of names into THIS
+ * app's controller namespace, and OpenRegister only substitutes its generic
+ * controller when this app does not ship a class of that name.
+ *
+ * `OCA\OpenRegister\AppHost\Bootstrap::aliasControllerUnlessLeafDefinesIt()`
+ * registers the DI alias `OCA\Shillinq\Controller\XController` ->
+ * `OCA\OpenRegister\AppHost\Controller\GenericXController` ONLY when the leaf
+ * class does not exist. So the seam has two sides, and they fail differently:
+ *
+ *   - Leaf does NOT ship the class  -> the alias binds, the generic serves
+ *     every canonical method. Nothing is owed. (This is why the absence of
+ *     DashboardController / HealthController / MetricsController on disk is
+ *     correct per `openspec/specs/apphost-adoption/spec.md` and must not be
+ *     "fixed" by creating them.)
+ *   - Leaf DOES ship the class      -> the alias is skipped and the generic is
+ *     never constructed, so the leaf owes EVERY method the canonical table
+ *     routes to that controller. A missing one is not a 404: the router
+ *     matches the URL, `ControllerMethodReflector` reflects the method, and the
+ *     request dies with a 500 `ReflectionException`.
+ *
+ * Measured live on the dev instance 2026-08-08: shillinq shipped its own
+ * `SettingsController` with `index/create/load` but no `update()`, while the
+ * canonical table routes `PUT /api/settings` to `settings#update`.
+ * `GET /apps/shillinq/api/settings` returned 200 and
+ * `PUT /apps/shillinq/api/settings` returned 500 with
+ * "Method OCA\Shillinq\Controller\SettingsController::update() does not exist".
+ *
+ * This test asserts the ITEM (each individual method), never the container
+ * (the controller class merely existing).
+ */
+final class CanonicalRouteMethodContractTest extends TestCase
+{
+
+    /**
+     * The canonical route names supplied by
+     * `\OCA\OpenRegister\AppHost\Routes::standard()`.
+     *
+     * Keyed `controllerPrefix => [method, ...]`. This list is a local mirror:
+     * shillinq's `appinfo/routes.php` delegates to `Routes::standard()`
+     * unconditionally and ships NO local fallback copy, so the literal strings
+     * `settings#update` etc. do not appear anywhere in this repository. A test
+     * that grepped `appinfo/routes.php` for them would find nothing and could
+     * only pass vacuously or fail wrongly — see
+     * `testRouteTableStillDelegatesToTheCanonicalAppHostTable()` for the
+     * assertion that IS meaningful here, and
+     * `testCanonicalListMatchesOpenRegistersOwnTableWhenReachable()` for the
+     * best-effort cross-check against the real source.
+     *
+     * @var array<string, array<int, string>>
+     */
+    private const CANONICAL_ROUTES = [
+        'Dashboard'   => ['page', 'catchAll'],
+        'Settings'    => ['index', 'create', 'update', 'load'],
+        'Preferences' => ['getPreference', 'setPreference'],
+        'Metrics'     => ['index'],
+        'Health'      => ['index'],
+    ];
+
+
+    /**
+     * Absolute path to this app's repository root.
+     *
+     * @return string The repository root path.
+     */
+    private function repoRoot(): string
+    {
+        return dirname(__DIR__, 3);
+
+    }//end repoRoot()
+
+
+    /**
+     * The route table must still delegate to the canonical AppHost table.
+     *
+     * This is the positive control for the method contract below: the leaf-owed
+     * method list only binds while `appinfo/routes.php` actually returns
+     * `Routes::standard(...)`. If shillinq ever stopped delegating (inlining
+     * its own table instead), the canonical list would be stale and a green
+     * from the next test would mean nothing. Read that green only together
+     * with a green here.
+     *
+     * @return void
+     */
+    public function testRouteTableStillDelegatesToTheCanonicalAppHostTable(): void
+    {
+        $routesFile = $this->repoRoot().'/appinfo/routes.php';
+        $this->assertFileExists($routesFile, 'appinfo/routes.php must exist');
+
+        $routesSource = file_get_contents($routesFile);
+        $this->assertIsString($routesSource, 'appinfo/routes.php must be readable');
+
+        $this->assertStringContainsString(
+            'OCA\\OpenRegister\\AppHost\\Routes::standard',
+            $routesSource,
+            'appinfo/routes.php no longer delegates to the canonical AppHost route '
+            .'table. The leaf-owed method list in this test is derived from that '
+            .'table, so it is now stale — re-derive it from whatever routes.php '
+            .'actually declares before trusting the method contract test.'
+        );
+
+    }//end testRouteTableStillDelegatesToTheCanonicalAppHostTable()
+
+
+    /**
+     * Cross-check the local mirror against OpenRegister's real route table.
+     *
+     * OpenRegister is a runtime app dependency, not a composer dependency, so
+     * its source is not present in this repository's `vendor/` and is normally
+     * unreachable from a CI checkout. This half therefore SKIPS in CI and
+     * provides no signal there — it only fires for a developer running the
+     * suite from a workspace that also holds an openregister checkout. It is
+     * kept because when it does run it is the only thing that can catch the
+     * local mirror drifting from the real table.
+     *
+     * @return void
+     */
+    public function testCanonicalListMatchesOpenRegistersOwnTableWhenReachable(): void
+    {
+        $candidates = [
+            $this->repoRoot().'/../openregister/lib/AppHost/Routes.php',
+            $this->repoRoot().'/../../openregister/lib/AppHost/Routes.php',
+            '/var/www/html/custom_apps/openregister/lib/AppHost/Routes.php',
+        ];
+
+        $source = null;
+        foreach ($candidates as $candidate) {
+            if (file_exists($candidate) === true) {
+                $source = file_get_contents($candidate);
+                break;
+            }
+        }
+
+        if (is_string($source) === false) {
+            $this->markTestSkipped(
+                'OpenRegister\'s AppHost/Routes.php is not reachable from this checkout, '
+                .'so the canonical route list cannot be cross-checked here. This is the '
+                .'expected state in CI — treat the mirror in self::CANONICAL_ROUTES as '
+                .'unverified by this run.'
+            );
+        }
+
+        foreach (self::CANONICAL_ROUTES as $prefix => $methods) {
+            foreach ($methods as $method) {
+                $routeName = lcfirst($prefix).'#'.$method;
+                $this->assertStringContainsString(
+                    "'".$routeName."'",
+                    $source,
+                    sprintf(
+                        'OpenRegister\'s AppHost route table no longer declares "%s". '
+                        .'The mirror in this test is stale.',
+                        $routeName
+                    )
+                );
+            }
+        }
+
+    }//end testCanonicalListMatchesOpenRegistersOwnTableWhenReachable()
+
+
+    /**
+     * A controller this app ships itself must implement every canonical
+     * method routed to it — the AppHost generic will not fill the gap.
+     *
+     * @return void
+     */
+    public function testLeafOwnedControllersImplementEveryCanonicalMethodRoutedToThem(): void
+    {
+        $inspected = 0;
+        $missing   = [];
+
+        foreach (self::CANONICAL_ROUTES as $prefix => $methods) {
+            $class = 'OCA\\Shillinq\\Controller\\'.$prefix.'Controller';
+
+            // The class file existing on disk is what makes the AppHost skip
+            // the alias. `class_exists()` alone would also be satisfied by the
+            // DI alias target in a booted container, which is precisely the
+            // case this test must NOT treat as leaf-owned.
+            $file = $this->repoRoot().'/lib/Controller/'.$prefix.'Controller.php';
+            if (file_exists($file) === false) {
+                continue;
+            }
+
+            $this->assertTrue(
+                class_exists($class),
+                sprintf('%s exists on disk but does not autoload as %s', $file, $class)
+            );
+
+            $reflection = new ReflectionClass($class);
+
+            foreach ($methods as $method) {
+                $inspected++;
+                if ($reflection->hasMethod($method) === false) {
+                    $missing[] = $prefix.'Controller::'.$method.'()';
+                    continue;
+                }
+
+                $this->assertTrue(
+                    $reflection->getMethod($method)->isPublic(),
+                    sprintf('%s::%s() must be public to be dispatchable', $class, $method)
+                );
+            }
+        }//end foreach
+
+        // Positive control: an empty $missing ("nothing is missing") is only
+        // meaningful if something was actually inspected. Zero inspections
+        // would mean the lib/Controller path probe silently matched nothing.
+        $this->assertGreaterThan(
+            0,
+            $inspected,
+            'No leaf-owned canonical controller was inspected — the lib/Controller '
+            .'path probe is broken, so the empty finding list means nothing.'
+        );
+
+        $this->assertSame(
+            [],
+            $missing,
+            sprintf(
+                "The canonical AppHost route table routes to these method(s), but this "
+                ."app ships the controller itself so no generic is aliased in. Each of "
+                ."these is a 500, not a 404.\n  - %s",
+                implode("\n  - ", $missing)
+            )
+        );
+
+    }//end testLeafOwnedControllersImplementEveryCanonicalMethodRoutedToThem()
+
+
+    /**
+     * The settings write must be reachable under BOTH canonical verbs.
+     *
+     * Named explicitly (rather than only via the loop above) so a regression
+     * reports the actual defect by name instead of a generic list entry.
+     *
+     * @return void
+     */
+    public function testSettingsControllerExposesBothCanonicalWriteMethods(): void
+    {
+        $reflection = new ReflectionClass(\OCA\Shillinq\Controller\SettingsController::class);
+
+        foreach (['update', 'create'] as $method) {
+            $this->assertTrue(
+                $reflection->hasMethod($method),
+                sprintf(
+                    'SettingsController::%s() does not exist. The canonical AppHost table '
+                    .'routes PUT /api/settings to settings#update and POST /api/settings '
+                    .'to settings#create; a missing method is a 500, not a 404.',
+                    $method
+                )
+            );
+
+            $this->assertTrue(
+                $reflection->getMethod($method)->isPublic(),
+                sprintf('SettingsController::%s() must be public to be dispatchable', $method)
+            );
+        }
+
+    }//end testSettingsControllerExposesBothCanonicalWriteMethods()
+
+
+}//end class

--- a/tests/Unit/Controller/SettingsControllerWriteTest.php
+++ b/tests/Unit/Controller/SettingsControllerWriteTest.php
@@ -1,0 +1,244 @@
+<?php
+
+/**
+ * SettingsController write-path unit tests.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/app-administration/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Controller\SettingsController;
+use OCA\Shillinq\Service\SettingsService;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * The canonical AppHost route table routes BOTH `PUT /api/settings`
+ * (`settings#update`) and `POST /api/settings` (`settings#create`) into this
+ * controller, and because shillinq ships the class itself no generic is
+ * aliased in to cover either.
+ *
+ * These tests assert the ITEM — that the write actually reaches
+ * `SettingsService::updateSettings()` with the request's own parameters, and
+ * that the returned payload carries the service's result. A test that only
+ * checked for a 200, or only that the response was a JSONResponse, would pass
+ * against a controller that silently wrote nothing.
+ */
+final class SettingsControllerWriteTest extends TestCase
+{
+
+    /**
+     * The mocked request.
+     *
+     * @var IRequest&MockObject
+     */
+    private IRequest&MockObject $request;
+
+    /**
+     * The mocked settings service.
+     *
+     * @var SettingsService&MockObject
+     */
+    private SettingsService&MockObject $settingsService;
+
+    /**
+     * Controller under test.
+     *
+     * @var SettingsController
+     */
+    private SettingsController $controller;
+
+
+    /**
+     * Set up the mocks shared by every test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request         = $this->createMock(IRequest::class);
+        $this->settingsService = $this->createMock(SettingsService::class);
+
+        $this->controller = new SettingsController(
+            request: $this->request,
+            settingsService: $this->settingsService
+        );
+
+    }//end setUp()
+
+
+    /**
+     * PUT /api/settings must persist the request parameters and return them.
+     *
+     * @return void
+     */
+    public function testUpdatePersistsTheRequestParametersAndReturnsTheStoredConfig(): void
+    {
+        $submitted = ['register' => 'shillinq'];
+        $stored    = [
+            'register'          => 'shillinq',
+            'rgs_template'      => 'bbv',
+            'administration_id' => 'ADM-001',
+            'openregisters'     => true,
+            'isAdmin'           => true,
+        ];
+
+        $this->request->method('getParams')->willReturn($submitted);
+
+        // The ITEM: the write reaches the service, with the submitted params.
+        $this->settingsService->expects($this->once())
+            ->method('updateSettings')
+            ->with($submitted)
+            ->willReturn($stored);
+
+        $response = $this->controller->update();
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(
+            [
+                'success' => true,
+                'config'  => $stored,
+            ],
+            $response->getData(),
+            'update() must return the config the service actually stored, not the submission'
+        );
+
+    }//end testUpdatePersistsTheRequestParametersAndReturnsTheStoredConfig()
+
+
+    /**
+     * POST /api/settings is the legacy alias and must write identically.
+     *
+     * The alias staying a real write — not an empty success — is load-bearing:
+     * shillinq's admin settings UI still POSTs to this route.
+     *
+     * @return void
+     */
+    public function testCreateDelegatesToUpdateAndStillWrites(): void
+    {
+        $submitted = ['rgs_template' => 'bbv'];
+        $stored    = ['rgs_template' => 'bbv'];
+
+        $this->request->method('getParams')->willReturn($submitted);
+
+        $this->settingsService->expects($this->once())
+            ->method('updateSettings')
+            ->with($submitted)
+            ->willReturn($stored);
+
+        $response = $this->controller->create();
+
+        $this->assertInstanceOf(JSONResponse::class, $response);
+        $this->assertSame(
+            [
+                'success' => true,
+                'config'  => $stored,
+            ],
+            $response->getData(),
+            'create() must produce the same written result as update()'
+        );
+
+    }//end testCreateDelegatesToUpdateAndStillWrites()
+
+
+    /**
+     * The write must not be skipped when the submission is empty.
+     *
+     * An early return on an empty payload would look identical to a
+     * successful no-op write from the caller's side.
+     *
+     * @return void
+     */
+    public function testEmptySubmissionStillReachesTheService(): void
+    {
+        $this->request->method('getParams')->willReturn([]);
+
+        $this->settingsService->expects($this->once())
+            ->method('updateSettings')
+            ->with([])
+            ->willReturn(['unchanged' => true]);
+
+        $response = $this->controller->update();
+
+        $this->assertSame(
+            [
+                'success' => true,
+                'config'  => ['unchanged' => true],
+            ],
+            $response->getData()
+        );
+
+    }//end testEmptySubmissionStillReachesTheService()
+
+
+    /**
+     * Both write verbs must carry the app's admin posture.
+     *
+     * Nextcloud's SecurityMiddleware evaluates auth attributes on the
+     * DISPATCHED method only, so `create()` delegating to `update()` does NOT
+     * inherit `update()`'s posture — each needs its own attribute. Equally, a
+     * write must never pick up the posture of a sibling READ method.
+     *
+     * @return void
+     */
+    public function testBothWriteVerbsAreAdminGuardedIndependently(): void
+    {
+        $inspected = 0;
+
+        foreach (['update', 'create'] as $method) {
+            $attributes = (new ReflectionMethod(SettingsController::class, $method))
+                ->getAttributes(AuthorizedAdminSetting::class);
+
+            $this->assertCount(
+                1,
+                $attributes,
+                sprintf(
+                    'SettingsController::%s() is a WRITE and must declare its own '
+                    .'#[AuthorizedAdminSetting] — the middleware only reads attributes '
+                    .'on the dispatched method, so delegation does not inherit posture.',
+                    $method
+                )
+            );
+
+            $this->assertSame(
+                [Application::APP_ID],
+                $attributes[0]->getArguments(),
+                sprintf(
+                    'SettingsController::%s() must be bound to this app\'s admin setting, '
+                    .'matching the posture of the existing settings write.',
+                    $method
+                )
+            );
+
+            $inspected++;
+        }//end foreach
+
+        // Positive control: the loop above asserts nothing if it never ran.
+        $this->assertSame(2, $inspected, 'Both write verbs must have been inspected');
+
+    }//end testBothWriteVerbsAreAdminGuardedIndependently()
+
+
+}//end class


### PR DESCRIPTION
## The defect

`\OCA\OpenRegister\AppHost\Routes::standard()` ships the canonical route
`['name' => 'settings#update', 'url' => '/api/settings', 'verb' => 'PUT']`, and
shillinq's `appinfo/routes.php` is literally
`return \OCA\OpenRegister\AppHost\Routes::standard([...])` — so that route is
live in production.

`AppHost\Bootstrap::aliasControllerUnlessLeafDefinesIt()` only substitutes
OpenRegister's `GenericSettingsController` when the leaf ships **no** class of
that name. shillinq ships `lib/Controller/SettingsController.php`, so the alias
is skipped and shillinq owes **every** method the canonical table routes to
`settings#`. It had `index` / `create` / `load` but no `update()`.

A missing method here is **not a 404**: the router matches the URL, the
dispatcher reflects the method, and the request dies with a 500.

### Pre-fix evidence (measured live, 2026-08-08, dev instance NC 34.0.0.12)

```
curl -u admin:admin -H 'OCS-APIRequest: true' -X GET  http://localhost:8080/apps/shillinq/api/settings
  -> 200  {"register":"","rgs_template":"bbv","administration_id":"ADM-001","legal_region":"gemeente","openregisters":true,"isAdmin":true}
  (positive control: route + auth + controller all resolve)

curl -u admin:admin -H 'OCS-APIRequest: true' -X POST http://localhost:8080/apps/shillinq/api/settings
  -> 200  {"success":true,"config":{...}}

curl -u admin:admin -H 'OCS-APIRequest: true' -X PUT  http://localhost:8080/apps/shillinq/api/settings
  -> 500
```

`nextcloud.log` for that exact request:

```
"method":"PUT","url":"/apps/shillinq/api/settings","user":"admin","version":"34.0.0.12",
"Exception":"ReflectionException",
"Message":"Method OCA\\Shillinq\\Controller\\SettingsController::update() does not exist"
  at lib/private/AppFramework/Utility/ControllerMethodReflector.php:40
  <- lib/private/AppFramework/Http/Dispatcher.php:68
```

## What `update()` writes, and why it matches shillinq's settings surface

The existing `create()` body moves **verbatim** into `update()`:

```php
$data   = $this->request->getParams();
$config = $this->settingsService->updateSettings($data);
return new JSONResponse(['success' => true, 'config' => $config]);
```

`SettingsService::updateSettings()` filters the submission to the app's managed
`CONFIG_KEYS` (`register`, `rgs_template`, `administration_id`, …), writes each
present key through `IAppConfig::setValueString()`, and returns the refreshed
`getSettings()` map (managed keys plus the derived `openregisters` / `isAdmin`
flags). That is exactly the write documented by
`openspec/specs/app-administration/spec.md` REQ-Admin-001 — so `PUT` and the
legacy `POST` are literally the same write, and `create()` is now a one-line
`return $this->update();` delegate. Behaviour for existing POST callers is
byte-identical.

shillinq's separate `PipelinqSettingsController` (integration endpoint + token)
is a different surface and is deliberately **not** folded in here.

## Auth-posture decision

Both write verbs keep `#[AuthorizedAdminSetting(Application::APP_ID)]`.

- `update()` **is** the app's existing write, reached by a different verb. It
  gets the same posture `create()` has always carried. Copying
  `#[NoAdminRequired]` from the sibling *read* (`index()`) would have opened the
  app-config write path to any authenticated user.
- `create()` **keeps its own attribute** even though it now only delegates.
  Nextcloud's `SecurityMiddleware` evaluates auth attributes on the
  **dispatched** method only — a delegate does not inherit the callee's posture,
  so dropping the attribute would have silently unguarded `POST /api/settings`.

This is asserted, not just intended:
`SettingsControllerWriteTest::testBothWriteVerbsAreAdminGuardedIndependently()`
reflects both methods and requires exactly one `AuthorizedAdminSetting`
attribute bound to `Application::APP_ID` on each.

## Tests

`tests/Unit/Controller/SettingsControllerWriteTest.php`
- `update()` reaches `SettingsService::updateSettings()` **with the request's
  own params** and returns the config the service actually stored.
- `create()` delegates and still performs the identical write.
- An empty submission still reaches the service (an early return would look
  identical to a successful no-op from the caller's side).
- Both verbs are admin-guarded independently (positive control: asserts both
  were inspected).

`tests/Unit/AppInfo/CanonicalRouteMethodContractTest.php`
- Asserts the **ITEM**: each individual canonical method exists **and is
  public/dispatchable** on every controller shillinq ships itself — never merely
  that the class exists.
- Positive control `assertGreaterThan(0, $inspected)`: an empty "nothing
  missing" result is only readable if something was actually inspected.
- Named assertion for `SettingsController::update|create` so a regression
  reports the defect by name.

**On the route-table half.** shillinq's `routes.php` delegates to
`Routes::standard()` unconditionally and ships **no local copy** of the table,
so the literal string `settings#update` appears **nowhere** in this repository.
A grep-the-route-file test would have found nothing and passed vacuously.
Instead this PR asserts the delegation itself (`Routes::standard` is still
called — the positive control that makes the leaf-owed method list binding) and
cross-checks the local mirror against OpenRegister's real `AppHost/Routes.php`
only when that source is reachable on disk. OpenRegister is a runtime app
dependency, not a composer one, so **that cross-check skips in CI and provides
no signal there** — stated explicitly in the test's skip message rather than
hidden.

## Can-fail proof

`update()` removed with the editor (not `git stash` / `git checkout --`), same
command, same config:

```
$ docker run --rm -v "$PWD":/app -w /app php:8.4-cli php vendor/bin/phpunit -c phpunit-unit.xml --no-coverage \
    --filter 'CanonicalRouteMethodContractTest|SettingsControllerWriteTest'
SFF.EEEE                                                            8 / 8 (100%)

1) …\SettingsControllerWriteTest::testCreateDelegatesToUpdateAndStillWrites
Error: Call to undefined method OCA\Shillinq\Controller\SettingsController::update()
3) …\SettingsControllerWriteTest::testBothWriteVerbsAreAdminGuardedIndependently
ReflectionException: Method OCA\Shillinq\Controller\SettingsController::update() does not exist
4) …\SettingsControllerWriteTest::testUpdatePersistsTheRequestParametersAndReturnsTheStoredConfig
Error: Call to undefined method OCA\Shillinq\Controller\SettingsController::update()

1) …\CanonicalRouteMethodContractTest::testSettingsControllerExposesBothCanonicalWriteMethods
SettingsController::update() does not exist. The canonical AppHost table routes PUT /api/settings
to settings#update …

2) …\CanonicalRouteMethodContractTest::testLeafOwnedControllersImplementEveryCanonicalMethodRoutedToThem
  - SettingsController::update()

Tests: 8, Assertions: 13, Errors: 4, Failures: 2, Skipped: 1.   EXIT=2
```

Restored:

```
......S.                                                            8 / 8 (100%)
OK, but some tests were skipped!
Tests: 8, Assertions: 30, Skipped: 1.                            EXIT=0
```

RED names `SettingsController::update()` — the same symbol the live 500 named.
The single skip is the documented OpenRegister cross-check.

## Full unit suite

`4015 tests, 42628 assertions`. The only 14 errors are `Class "ZipArchive" not
found` in `AuditExportService` / `SepaAuditService` / `ENSIAVerklaringGenerator`
/ `IcpFilingService` tests — the bare `php:8.4-cli` container used locally has
no `ext-zip`. Environment-only, untouched by this PR; CI's image ships zip.

## Coverage

Every new statement is executed by the new tests: `update()`'s 3 statements by
three tests, `create()`'s single delegate statement by one. The moved `create()`
body previously had **no** unit coverage at all (shillinq had no
`SettingsControllerTest`), so this is a net coverage increase, not a waiver.

## Mechanical gates

Run from a fresh extract of `ConductionNL/.github@origin/main` (`846baed`) —
**not** the local `.github` checkout, which measured 77 commits behind. Verdicts
read from stdout, not the exit byte.

Diff-scoped (`--scope-to-diff --base origin/development`, `SCOPE-FILE-COUNT: 4`):

```
58 GATE(S) GREEN — 0 failed
gate-1 spdx-headers PASS · gate-5 route-auth PASS · gate-9 semantic-auth PASS
gate-14 route-reachability PASS · gate-16 spec-coverage PASS
gate-19 e2e-coverage PASS · gate-46 spec-anchor-existence PASS
gate-47 security-change-has-tests PASS · gate-49 controller-exception-translation PASS
gate-64 apphost-autoload-prelude PASS
```

Two applicable gates **did not run** and are therefore unverified by this run,
stated rather than counted as green: `gate-62 store-plane` and
`gate-63 settings-surface` — both are manifest-scoped and this diff touches no
manifest or menu-layout.

A full-repo run (not diff-scoped) shows 16 failing gates, all pre-existing
legacy debt untouched here (e2e-coverage 279 scenarios, spec-anchor-existence
124 findings, relation-dialect 140, several a11y gates, and two
`src/manifest.json` ADR-079 settings-placement findings). None of those findings
name any file in this diff.

Also clean on the changed files: `phpcs --standard=phpcs.xml` (0 errors,
0 warnings), `phpmd`, `phpstan analyse` (`[OK] No errors`).

## Drive-by

`phpcs` flagged `SettingsController`'s class docblock as missing its `@spec`
tag **on `origin/development` already** (verified by running phpcs against
`git show origin/development:lib/Controller/SettingsController.php`). Fixed in a
separate commit rather than left behind.

The write path's `@spec` tags pointed at
`openspec/changes/retrofit-2026-05-25-app-administration/tasks.md#task-1` — a
change directory that was **archived on 2026-05-31 and no longer exists**, so
the anchor was dangling. They now target the canonical spec home,
`openspec/specs/app-administration/spec.md`, which is extended to document the
`PUT` verb and the leaf-owns-every-canonical-method invariant.

## Where the canonical shape did not fit

- OpenRegister's `GenericSettingsControllerBase` binds
  `#[AuthorizedAdminSetting(settings: GenericAdminSettings::class)]` and returns
  the bare settings map. shillinq binds the attribute to `Application::APP_ID`
  and returns a `{success, config}` envelope. shillinq's own conventions were
  matched in both cases — changing either would have broken its live POST
  callers.
- The base class wraps calls in `HandlesExceptionsTrait`. shillinq does not use
  that trait in this controller; adding it would change the error contract of
  the existing `index`/`create`/`load` too, which is out of scope for a
  route-reachability fix. `gate-49 controller-exception-translation` passes
  as-is.
