### PR TITLE
feat(cost): resolve real wage rates from hrmq, the last link in the ADR-081 chain

### DIFF
--- a/lib/Service/HrmqCostRateAdapter.php
+++ b/lib/Service/HrmqCostRateAdapter.php
@@ -1,0 +1,283 @@
+<?php
+
+/**
+ * Hrmq cost-rate adapter
+ *
+ * Resolves the employer cost per hour for a set of people from hrmq, so
+ * {@see SubjectCostAggregator} can price an hour set. This is the "adapter
+ * wires here without touching the policy" half that GrotendeelsCriteriumService
+ * anticipates, per hydra ADR-081.
+ *
+ * @category Service
+ * @package  OCA\Shillinq\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://shillinq.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @spec openspec/specs/subject-cost-aggregation/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Service;
+
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Ask hrmq what an hour of each person's time costs the employer.
+ *
+ * IN-PROCESS, NOT OVER HTTP. hrmq exposes POST /api/employees/cost-rate, and
+ * calling it would mean a loopback request that has to carry the user's
+ * session to keep the RBAC it depends on. Resolving hrmq's service through the
+ * container keeps the caller's ambient RBAC without inventing an auth hop, and
+ * hrmq's own Employee / EmploymentContract objects are read through
+ * OpenRegister exactly as any other register is.
+ *
+ * ⚠️ EVERY hrmq REFERENCE IS LAZY AND GUARDED, and that is not defensive
+ * habit — it is a defect this fleet has already paid for. openregister
+ * declared `OCA\OpenRegister\ContextChat\ContentProvider` in a constructor
+ * typehint; `SimpleContainer::resolve()` reflects each parameter type, that
+ * reflection IS the class load, and on a server without the dependency it
+ * threw on every `occ` invocation and every object write. So:
+ *
+ *   - no hrmq type appears in this constructor, or anywhere resolved eagerly;
+ *   - the class name is a plain STRING, never `SomeClass::class`, so nothing
+ *     is resolved at compile time either;
+ *   - absence is a normal state. shillinq does not declare hrmq as a
+ *     dependency, and an instance may legitimately run without it.
+ *
+ * When hrmq is absent this returns an EMPTY map. That is deliberate and it is
+ * safe, because SubjectCostAggregator refuses to publish a total when any
+ * person is unpriced: the case shows "hours known, cost unavailable" rather
+ * than a plausible, too-low number.
+ *
+ * @spec openspec/specs/subject-cost-aggregation/spec.md
+ */
+class HrmqCostRateAdapter
+{
+
+    /**
+     * The hrmq cost-rate service, as a string so nothing resolves at compile time.
+     *
+     * @var string
+     */
+    private const HRMQ_COST_RATE_SERVICE = 'OCA\\Hrmq\\Service\\EmployeeCostRateService';
+
+    /**
+     * The register hrmq stores its Employee / EmploymentContract objects in.
+     *
+     * @var string
+     */
+    private const HRMQ_REGISTER = 'hrmq';
+
+    /**
+     * Wire collaborators.
+     *
+     * @param ContainerInterface $container Container, for the lazy hrmq + ObjectService resolves.
+     * @param LoggerInterface    $logger    PSR logger.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/subject-cost-aggregation/spec.md
+     */
+    public function __construct(
+        private readonly ContainerInterface $container,
+        private readonly LoggerInterface $logger
+    ) {
+    }//end __construct()
+
+    /**
+     * Resolve cost rates for the given people.
+     *
+     * A person hrmq cannot price is OMITTED from the map rather than mapped to
+     * zero. Zero is a number the aggregator would happily multiply, producing
+     * a total that silently excludes that person's cost; an absent key makes
+     * the aggregator withhold the total instead, which is the whole point of
+     * its refusal rule.
+     *
+     * @param array<int, string>               $personIds Person ids to price.
+     * @param string                           $period    Costing period `YYYY-MM`.
+     * @param array<int, array<string, mixed>> $additions Shillinq's ledger-derived additions per ADR-081.
+     *
+     * @return array<string, int> personId => employer cost in cents per hour. Empty when hrmq is unavailable.
+     *
+     * @spec openspec/specs/subject-cost-aggregation/spec.md#requirement-a-cost-is-published-only-when-every-hour-in-it-could-be-priced
+     */
+    public function ratesFor(array $personIds, string $period='', array $additions=[]): array
+    {
+        $service = $this->costRateService();
+        if ($service === null) {
+            return [];
+        }
+
+        $rates = [];
+        foreach (array_unique($personIds) as $personId) {
+            $personId = trim((string) $personId);
+            if ($personId === '') {
+                continue;
+            }
+
+            $employee = $this->hrmqObject(schema: 'Employee', id: $personId);
+            if ($employee === null) {
+                continue;
+            }
+
+            try {
+                $resolved = $service->resolve(
+                    employee: $employee,
+                    contract: $this->activeContract(employeeId: $personId),
+                    period: $period,
+                    extraAdditions: $additions
+                );
+            } catch (Throwable $e) {
+                // An indefensible composition (override with no reason, an
+                // addition with no basis) is hrmq refusing to guess. Omit the
+                // person so the aggregator withholds the total, and say why.
+                $this->logger->warning(
+                    'HrmqCostRateAdapter: hrmq refused a cost rate',
+                    ['personId' => $personId, 'reason' => $e->getMessage()]
+                );
+                continue;
+            }
+
+            $cents = ($resolved['totalCentsPerHour'] ?? null);
+            if (is_int($cents) === true && $cents >= 0) {
+                $rates[$personId] = $cents;
+            }
+        }//end foreach
+
+        return $rates;
+    }//end ratesFor()
+
+    /**
+     * The hrmq cost-rate service, or null when hrmq is not installed.
+     *
+     * `class_exists()` on a plain string asks the autoloader and answers false
+     * rather than dying. See the class docblock for why nothing here may name
+     * an hrmq type directly.
+     *
+     * @return mixed The service, or null.
+     *
+     * @spec openspec/specs/subject-cost-aggregation/spec.md
+     */
+    private function costRateService(): mixed
+    {
+        if (class_exists(class: self::HRMQ_COST_RATE_SERVICE) === false) {
+            $this->logger->debug('HrmqCostRateAdapter: hrmq is not installed — no wage rates available');
+            return null;
+        }
+
+        try {
+            return $this->container->get(id: self::HRMQ_COST_RATE_SERVICE);
+        } catch (Throwable $e) {
+            $this->logger->debug('HrmqCostRateAdapter: hrmq present but unresolvable: '.$e->getMessage());
+            return null;
+        }
+    }//end costRateService()
+
+    /**
+     * Read one object from hrmq's register under the caller's RBAC.
+     *
+     * @param string $schema The hrmq schema slug.
+     * @param string $id     The object id.
+     *
+     * @return array<string, mixed>|null The object, or null when absent/unauthorised.
+     *
+     * @spec openspec/specs/subject-cost-aggregation/spec.md
+     */
+    private function hrmqObject(string $schema, string $id): ?array
+    {
+        try {
+            $row = $this->container->get(id: 'OCA\\OpenRegister\\Service\\ObjectService')
+                ->find(id: $id, register: self::HRMQ_REGISTER, schema: $schema);
+        } catch (Throwable $e) {
+            $this->logger->debug(
+                'HrmqCostRateAdapter: '.$schema.' '.$id.' not readable: '.$e->getMessage()
+            );
+            return null;
+        }
+
+        return $this->toArray(row: $row);
+    }//end hrmqObject()
+
+    /**
+     * The employee's active EmploymentContract, or null.
+     *
+     * Passed to hrmq explicitly rather than left for it to choose: hrmq's own
+     * docblock notes that taking the contract from the caller stops it
+     * silently costing against a different contract than the caller believes
+     * is in force.
+     *
+     * @param string $employeeId The employee id.
+     *
+     * @return array<string, mixed>|null The contract, or null.
+     *
+     * @spec openspec/specs/subject-cost-aggregation/spec.md
+     */
+    private function activeContract(string $employeeId): ?array
+    {
+        try {
+            $rows = $this->container->get(id: 'OCA\\OpenRegister\\Service\\ObjectService')
+                ->findAll(
+                    register: self::HRMQ_REGISTER,
+                    schema: 'EmploymentContract',
+                    filters: ['employee' => $employeeId, 'status' => 'active']
+                );
+        } catch (Throwable $e) {
+            $this->logger->debug('HrmqCostRateAdapter: no active contract for '.$employeeId);
+            return null;
+        }
+
+        foreach (($rows ?? []) as $row) {
+            return $this->toArray(row: $row);
+        }
+
+        return null;
+    }//end activeContract()
+
+    /**
+     * Normalise an ObjectService row to an array.
+     *
+     * ObjectService yields ObjectEntity objects, not arrays — reading them
+     * with array syntax throws "Cannot use object of type ObjectEntity as
+     * array", a defect this repo has hit in VATReturnService and
+     * ComplianceDeadlineCalendarService. House idiom: jsonSerialize(), then
+     * getObject().
+     *
+     * @param mixed $row The row.
+     *
+     * @return array<string, mixed>|null The row as an array, or null.
+     *
+     * @spec openspec/specs/subject-cost-aggregation/spec.md
+     */
+    private function toArray(mixed $row): ?array
+    {
+        if (is_array($row) === true) {
+            return $row;
+        }
+
+        if (is_object($row) === true && method_exists($row, 'jsonSerialize') === true) {
+            $out = $row->jsonSerialize();
+            if (is_array($out) === true) {
+                return $out;
+            }
+        }
+
+        if (is_object($row) === true && method_exists($row, 'getObject') === true) {
+            $out = $row->getObject();
+            if (is_array($out) === true) {
+                return $out;
+            }
+        }
+
+        return null;
+    }//end toArray()
+}//end class

--- a/tests/Unit/Service/HrmqCostRateAdapterTest.php
+++ b/tests/Unit/Service/HrmqCostRateAdapterTest.php
@@ -1,0 +1,256 @@
+<?php
+
+/**
+ * HrmqCostRateAdapter Unit Tests
+ *
+ * @category Tests
+ * @package  OCA\Shillinq\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://shillinq.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Service;
+
+use OCA\Shillinq\Service\HrmqCostRateAdapter;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\NullLogger;
+use ReflectionClass;
+use RuntimeException;
+
+// shillinq's CI does not install hrmq, so the class the adapter probes for
+// with class_exists() is genuinely absent here. Two of the tests below need it
+// PRESENT to exercise the resolved path at all — without this they skip, and a
+// test that always skips is a test that never protects anything.
+//
+// Aliasing a stub into hrmq's namespace makes class_exists() answer true while
+// keeping the real dependency absent, which is exactly the shape the adapter
+// has to cope with. Guarded so that an environment where hrmq IS installed
+// uses the real class instead of colliding with it.
+if (class_exists('OCA\\Hrmq\\Service\\EmployeeCostRateService') === false) {
+    class_alias(HrmqCostRateServiceStub::class, 'OCA\\Hrmq\\Service\\EmployeeCostRateService');
+}
+
+/**
+ * Stand-in for hrmq's cost-rate service. Never used directly — the container
+ * stub returns the per-test double; this exists only so class_exists() passes.
+ */
+class HrmqCostRateServiceStub
+{
+    /**
+     * @return array<string, mixed> An empty resolution.
+     */
+    public function resolve(...$args): array
+    {
+        return [];
+    }
+}
+
+/**
+ * The adapter must degrade to "no rates", never to "zero".
+ *
+ * The distinction is the whole safety property. An absent key makes
+ * SubjectCostAggregator withhold the total; a zero would be multiplied
+ * happily, producing a cost that silently excludes that person.
+ *
+ * The hrmq-absent case is also the one this fleet has been bitten by: naming a
+ * missing app's type anywhere the container resolves eagerly is fatal, so the
+ * structural test below pins that no hrmq type appears in the constructor.
+ *
+ * @covers \OCA\Shillinq\Service\HrmqCostRateAdapter
+ */
+class HrmqCostRateAdapterTest extends TestCase
+{
+
+    /**
+     * Build an adapter over a stub container.
+     *
+     * @param mixed                $costRateService The hrmq service double, or null to omit it.
+     * @param array<string, mixed> $objects         Object id => row returned by find().
+     * @param array<int, mixed>    $contracts       Rows returned by findAll().
+     *
+     * @return HrmqCostRateAdapter The adapter.
+     */
+    private function adapter(mixed $costRateService, array $objects=[], array $contracts=[]): HrmqCostRateAdapter
+    {
+        $objectService = new class($objects, $contracts) {
+            /**
+             * @param array<string, mixed> $objects   Rows by id.
+             * @param array<int, mixed>    $contracts Contract rows.
+             */
+            public function __construct(private array $objects, private array $contracts)
+            {
+            }
+
+            /**
+             * @return mixed The stubbed row.
+             */
+            public function find(string $id, string $register, string $schema): mixed
+            {
+                if (array_key_exists($id, $this->objects) === false) {
+                    throw new RuntimeException('not found');
+                }
+
+                return $this->objects[$id];
+            }
+
+            /**
+             * @return array<int, mixed> The stubbed contracts.
+             */
+            public function findAll(string $register, string $schema, array $filters=[]): array
+            {
+                return $this->contracts;
+            }
+        };
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnCallback(
+            function (string $id) use ($objectService, $costRateService) {
+                if (str_contains($id, 'ObjectService') === true) {
+                    return $objectService;
+                }
+
+                if ($costRateService === null) {
+                    throw new RuntimeException('hrmq absent');
+                }
+
+                return $costRateService;
+            }
+        );
+
+        return new HrmqCostRateAdapter($container, new NullLogger());
+    }
+
+    /**
+     * A resolvable person is priced from hrmq's total.
+     *
+     * @return void
+     */
+    public function testPricesAPersonFromHrmqsTotal(): void
+    {
+        $service = new class {
+            /**
+             * @return array<string, mixed> The resolved rate.
+             */
+            public function resolve(...$args): array
+            {
+                return ['totalCentsPerHour' => 6250];
+            }
+        };
+
+        $rates = $this->adapter($service, ['alice' => ['id' => 'alice']])->ratesFor(['alice']);
+
+        self::assertSame(['alice' => 6250], $rates);
+    }
+
+    /**
+     * With hrmq absent the map is EMPTY — never zeros.
+     *
+     * An empty map makes the aggregator withhold the cost. A map of zeros
+     * would be multiplied into a confident €0.00.
+     *
+     * @return void
+     */
+    public function testAbsentHrmqYieldsNoRatesRatherThanZeroes(): void
+    {
+        $rates = $this->adapter(null, ['alice' => ['id' => 'alice']])->ratesFor(['alice', 'bob']);
+
+        self::assertSame([], $rates);
+        self::assertNotContains(0, $rates, 'a zero rate would be silently multiplied into a wrong total');
+    }
+
+    /**
+     * No hrmq type may appear in the constructor.
+     *
+     * This is the structural guard, and it exists because the fleet has
+     * already paid for the alternative: openregister named a ContextChat type
+     * in a constructor, `SimpleContainer::resolve()` reflected it, and that
+     * reflection loaded a class that does not exist on servers without the
+     * dependency — throwing on every occ invocation and every object write.
+     *
+     * @return void
+     */
+    public function testNoHrmqTypeIsNamedInTheConstructor(): void
+    {
+        $constructor = (new ReflectionClass(HrmqCostRateAdapter::class))->getConstructor();
+        self::assertNotNull(actual: $constructor);
+
+        foreach ($constructor->getParameters() as $parameter) {
+            $type = $parameter->getType();
+            if ($type === null || $type->isBuiltin() === true) {
+                continue;
+            }
+
+            self::assertStringNotContainsString(
+                needle: 'Hrmq',
+                haystack: $type->getName(),
+                message: sprintf(
+                    '%s is typed to %s. shillinq does not depend on hrmq, so the container '
+                    .'resolving this class would fatal wherever hrmq is absent. Resolve it '
+                    .'lazily behind class_exists() instead.',
+                    $parameter->getName(),
+                    $type->getName()
+                )
+            );
+        }
+    }
+
+    /**
+     * The hrmq class is referenced as a STRING, never `::class`.
+     *
+     * `Foo::class` on an imported name is compile-time and safe, but on an
+     * IMPORTED symbol it also requires the `use` statement — and a `use` of a
+     * missing class is itself harmless while being an invitation to typehint
+     * it later. Keeping the name a string keeps the boundary obvious.
+     *
+     * @return void
+     */
+    public function testTheHrmqClassNameStaysAString(): void
+    {
+        $source = (string) file_get_contents(
+            __DIR__.'/../../../lib/Service/HrmqCostRateAdapter.php'
+        );
+
+        self::assertStringNotContainsString(
+            needle: 'use OCA\\Hrmq\\',
+            haystack: $source,
+            message: 'importing an hrmq symbol makes it one edit away from a fatal constructor typehint'
+        );
+        self::assertStringContainsString(
+            needle: "class_exists(class: self::HRMQ_COST_RATE_SERVICE)",
+            haystack: $source,
+            message: 'the hrmq service must be probed before it is resolved'
+        );
+    }
+
+    /**
+     * A person hrmq refuses is OMITTED, not defaulted.
+     *
+     * @return void
+     */
+    public function testARefusedPersonIsOmittedFromTheMap(): void
+    {
+        $service = new class {
+            /**
+             * @return array<string, mixed> Never returned — always throws.
+             */
+            public function resolve(...$args): array
+            {
+                throw new RuntimeException('addition "overhead" has no basis');
+            }
+        };
+
+        $rates = $this->adapter($service, ['alice' => ['id' => 'alice']])->ratesFor(['alice']);
+
+        self::assertArrayNotHasKey('alice', $rates);
+    }
+}


### PR DESCRIPTION
`SubjectCostAggregator` (#466) takes a `personId => centsPerHour` map and refuses to publish a total when anyone is unpriced. **This is what fills that map** — the last link in the ADR-081 chain.

## In-process, not over HTTP

hrmq exposes `POST /api/employees/cost-rate` (ConductionNL/hrmq#78), but calling it from here means a loopback request that has to carry the user's session to keep the RBAC that endpoint depends on. Resolving hrmq's service through the container keeps the caller's ambient RBAC **without inventing an auth hop**, and hrmq's `Employee` / `EmploymentContract` objects are read through OpenRegister exactly as any other register is.

## Every hrmq reference is lazy and guarded

Not defensive habit — a defect this fleet paid for three days ago. openregister named `ContentProvider` in a constructor typehint; `SimpleContainer::resolve()` reflects each parameter type, **that reflection is the class load**, and on a server without the dependency it threw on every `occ` invocation and every object write (openregister#2372). So here:

- no hrmq type appears in the constructor, or anywhere resolved eagerly;
- the class name is a plain **string** — never `::class`, never imported — so nothing resolves at compile time either;
- absence is a **normal** state: shillinq does not declare hrmq as a dependency and an instance may legitimately run without it.

## Absence yields an empty map, never zeroes

That distinction is the whole safety property. An absent key makes the aggregator **withhold** the cost; a zero would be multiplied happily into a confident, wrong, always-too-low total. Same per person: someone hrmq *refuses* to price (an override with no reason, an addition with no basis) is omitted with a logged reason rather than defaulted.

## Tests — mutation-verified in three arms

| mutation | result |
|---|---|
| default an unpriceable person to `0` instead of omitting | **1 failure** |
| name an hrmq type in the constructor (the fatal shape) | **2 failures** |
| swallow hrmq's refusal and price the person anyway | **1 failure** |
| restored | OK (5 tests) |

**Two of those tests originally skipped**, because shillinq's CI does not install hrmq so the probed class is genuinely absent — and a test that always skips protects nothing. They now alias a stub into hrmq's namespace so `class_exists()` answers true while the real dependency stays absent, which is exactly the shape the adapter must cope with. Guarded so an environment that *does* have hrmq uses the real class rather than colliding.

13 tests green across the aggregator and the adapter. phpcs, phpmd and phpstan clean.
