### PR TITLE
fix(security): the public booking widget never checked isPublic

### DIFF
--- a/lib/Controller/WidgetApiController.php
+++ b/lib/Controller/WidgetApiController.php
@@ -133,20 +133,95 @@ class WidgetApiController extends Controller
 
         $services = [];
         foreach ($records as $record) {
-            $row        = $this->toArray(object: $record);
-            $services[] = [
+            $row = $this->toArray(object: $record);
+
+            // This endpoint is reachable by any visitor loading an embedded
+            // widget, so only services explicitly flagged isPublic may be
+            // listed. Filtered here rather than in the findAll() query so an
+            // absent or non-boolean value DENIES: a query filter that silently
+            // matched nothing would look identical to "no private services".
+            if ((bool) ($row['isPublic'] ?? false) !== true) {
+                continue;
+            }
+
+            $service = [
                 'serviceId'   => (string) ($row['serviceId'] ?? ''),
                 'name'        => (string) ($row['name'] ?? ''),
                 'duration'    => (int) ($row['duration'] ?? 0),
-                'price'       => ($row['price'] ?? null),
                 'currency'    => (string) ($row['currency'] ?? 'EUR'),
                 'description' => (string) ($row['description'] ?? ''),
             ];
-        }
+
+            // The priceVisible flag is a per-service choice; publishing the
+            // price regardless of it made the setting inert.
+            if ((bool) ($row['priceVisible'] ?? false) === true) {
+                $service['price'] = ($row['basePrice'] ?? $row['price'] ?? null);
+            }
+
+            $services[] = $service;
+        }//end foreach
 
         return new JSONResponse(data: ['services' => $services]);
 
     }//end services()
+
+    /**
+     * Resolve a Service that an anonymous widget visitor is allowed to book.
+     *
+     * Returns null unless the service exists, is active AND is flagged
+     * isPublic. `isPublic` is the boundary between the services a business
+     * offers publicly and its internal catalogue; nothing on the routed widget
+     * path enforced it, so any caller who knew a serviceId could book a
+     * private service through the public endpoint.
+     *
+     * @param string $serviceId Logical service identifier.
+     *
+     * @return array<string,mixed>|null The service row, or null when it may not be booked.
+     *
+     * @spec openspec/specs/bookings-self-service-widget/spec.md
+     */
+    private function resolvePublicService(string $serviceId): ?array
+    {
+        if ($serviceId === '') {
+            return null;
+        }
+
+        try {
+            $objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
+            $records       = $objectService
+                ->setRegister($this->settings->getRegisterSlug())
+                ->setSchema('Service')
+                ->findAll(
+                    [
+                        'filters' => ['serviceId' => $serviceId],
+                        'limit'   => 1,
+                    ]
+                );
+        } catch (\Throwable $e) {
+            // Fail closed: an unavailable catalogue must not permit a booking.
+            $this->logger->error(
+                'Shillinq widget: public-service resolution failed',
+                ['exception' => $e->getMessage(), 'serviceId' => $serviceId]
+            );
+            return null;
+        }
+
+        foreach ($records as $record) {
+            $row = $this->toArray(object: $record);
+            if ((bool) ($row['isPublic'] ?? false) !== true) {
+                return null;
+            }
+
+            if ((string) ($row['status'] ?? '') !== 'active') {
+                return null;
+            }
+
+            return $row;
+        }
+
+        return null;
+
+    }//end resolvePublicService()
 
     /**
      * GET /api/widget/slots — available slots for a service + resource + date.
@@ -265,6 +340,23 @@ class WidgetApiController extends Controller
 
         if ($this->settings->isOpenRegisterAvailable() === false) {
             return $this->serverError(message: 'Booking unavailable.');
+        }
+
+        // Nothing on this path checked isPublic — not guard() (which only
+        // validates the per-business widget key that ships in the embedding
+        // page), not validateAppointmentPayload(), and not
+        // SlotService::getAvailableSlots(). A caller who knew any serviceId
+        // could therefore book a service the business never published.
+        // WidgetService::createAppointment() has always enforced this; it is
+        // simply not the implementation that is routed.
+        if ($this->resolvePublicService(serviceId: $serviceId) === null) {
+            return new JSONResponse(
+                data: [
+                    'error'   => 'service-not-found',
+                    'message' => 'This service is not available for online booking.',
+                ],
+                statusCode: Http::STATUS_NOT_FOUND,
+            );
         }
 
         $date  = substr($startTime, 0, 10);

--- a/lib/Service/WidgetService.php
+++ b/lib/Service/WidgetService.php
@@ -134,8 +134,6 @@ class WidgetService
      * @param string $administrationId The owning administration (tenant scope).
      *
      * @return array<int,array<string,mixed>> The public service list.
-     *
-     * @spec openspec/specs/bookings-self-service-widget/spec.md
      */
     public function listPublicServices(string $administrationId): array
     {
@@ -180,11 +178,7 @@ class WidgetService
             ];
 
             if ((bool) ($service['priceVisible'] ?? false) === true) {
-                // `basePrice` is the Service schema's required price field.
-                // `price` is a legacy spelling that older stored objects may
-                // still carry; read it only as a fallback. Reading `price`
-                // first published 0.00 for every catalogue-seeded service.
-                $public['price']    = (float) ($service['basePrice'] ?? $service['price'] ?? 0);
+                $public['price']    = (float) ($service['price'] ?? 0);
                 $public['currency'] = (string) ($service['currency'] ?? 'EUR');
             }
 

--- a/lib/Service/WidgetService.php
+++ b/lib/Service/WidgetService.php
@@ -134,6 +134,8 @@ class WidgetService
      * @param string $administrationId The owning administration (tenant scope).
      *
      * @return array<int,array<string,mixed>> The public service list.
+     *
+     * @spec openspec/specs/bookings-self-service-widget/spec.md
      */
     public function listPublicServices(string $administrationId): array
     {
@@ -178,7 +180,11 @@ class WidgetService
             ];
 
             if ((bool) ($service['priceVisible'] ?? false) === true) {
-                $public['price']    = (float) ($service['price'] ?? 0);
+                // `basePrice` is the Service schema's required price field.
+                // `price` is a legacy spelling that older stored objects may
+                // still carry; read it only as a fallback. Reading `price`
+                // first published 0.00 for every catalogue-seeded service.
+                $public['price']    = (float) ($service['basePrice'] ?? $service['price'] ?? 0);
                 $public['currency'] = (string) ($service['currency'] ?? 'EUR');
             }
 

--- a/tests/Unit/Controller/WidgetApiControllerTest.php
+++ b/tests/Unit/Controller/WidgetApiControllerTest.php
@@ -264,4 +264,195 @@ class WidgetApiControllerTest extends TestCase
 
     }//end testAppointmentsRejectsInvalidTimestamp()
 
+    /**
+     * Authenticate a widget caller so the isPublic tests reach the catalogue.
+     *
+     * @return void
+     */
+    private function authoriseWidgetCaller(): void
+    {
+        $this->request->method('getParam')->willReturnMap([['businessId', '', 'salon-001']]);
+        $this->request->method('getHeader')->willReturnMap(
+            [
+                ['Authorization', 'Bearer bk_live_valid'],
+                ['If-None-Match', ''],
+            ]
+        );
+        $this->auth->method('validateApiKey')->willReturn(
+            [
+                'valid' => true,
+                'key'   => ['rateLimit' => 100],
+            ]
+        );
+        $this->auth->method('consumeRateLimit')->willReturn(
+            [
+                'allowed'   => true,
+                'remaining' => 99,
+            ]
+        );
+        $this->settings->method('isOpenRegisterAvailable')->willReturn(true);
+        $this->settings->method('getRegisterSlug')->willReturn('shillinq');
+
+    }//end authoriseWidgetCaller()
+
+    /**
+     * Build an ObjectService stub returning a fixed Service catalogue.
+     *
+     * @param array<int,array<string,mixed>> $rows Service rows to return from findAll().
+     *
+     * @return object
+     */
+    private function catalogueStub(array $rows): object
+    {
+        // phpcs:disable
+        return new class($rows) {
+            private array $rows;
+            public function __construct(array $rows) { $this->rows = $rows; }
+            public function setRegister(string $r): static { return $this; }
+            public function setSchema(string $s): static { return $this; }
+            public function findAll(array $c=[]): array
+            {
+                $sid = (string) ($c['filters']['serviceId'] ?? '');
+                if ($sid === '') {
+                    return $this->rows;
+                }
+                return array_values(array_filter(
+                    $this->rows,
+                    static fn (array $r): bool => ((string) ($r['serviceId'] ?? '')) === $sid
+                ));
+            }
+        };
+        // phpcs:enable
+    }//end catalogueStub()
+
+    /**
+     * A service that is active but NOT flagged isPublic must never be listed
+     * by the public widget catalogue.
+     *
+     * @return void
+     */
+    public function testServicesOmitsServicesThatAreNotPublic(): void
+    {
+        $this->authoriseWidgetCaller();
+        $this->container->method('get')->willReturn(
+            $this->catalogueStub(
+                [
+                    [
+                        'serviceId' => 'svc-public',
+                        'name'      => 'Haircut',
+                        'status'    => 'active',
+                        'isPublic'  => true,
+                    ],
+                    [
+                        'serviceId' => 'svc-internal',
+                        'name'      => 'Internal staff slot',
+                        'status'    => 'active',
+                        'isPublic'  => false,
+                    ],
+                    [
+                        'serviceId' => 'svc-unflagged',
+                        'name'      => 'Legacy service with no isPublic key',
+                        'status'    => 'active',
+                    ],
+                ]
+            )
+        );
+
+        $ids = array_column($this->makeController()->services()->getData()['services'], 'serviceId');
+
+        self::assertSame(['svc-public'], $ids, 'only isPublic services may be listed');
+
+    }//end testServicesOmitsServicesThatAreNotPublic()
+
+    /**
+     * priceVisible is a per-service choice; a service that hides its price
+     * must not have one published.
+     *
+     * @return void
+     */
+    public function testServicesOmitsPriceWhenPriceVisibleIsFalse(): void
+    {
+        $this->authoriseWidgetCaller();
+        $this->container->method('get')->willReturn(
+            $this->catalogueStub(
+                [
+                    [
+                        'serviceId'    => 'svc-hidden-price',
+                        'name'         => 'Consult',
+                        'status'       => 'active',
+                        'isPublic'     => true,
+                        'basePrice'    => 150,
+                        'priceVisible' => false,
+                    ],
+                ]
+            )
+        );
+
+        $service = $this->makeController()->services()->getData()['services'][0];
+
+        self::assertArrayNotHasKey('price', $service);
+
+    }//end testServicesOmitsPriceWhenPriceVisibleIsFalse()
+
+    /**
+     * The booking endpoint must refuse a serviceId that is not public, even
+     * though the caller holds a valid widget API key. Without this the widget
+     * key — which ships in the embedding page — was enough to book any
+     * service whose id could be guessed or read from another surface.
+     *
+     * @return void
+     */
+    public function testAppointmentsRefusesAServiceThatIsNotPublic(): void
+    {
+        $this->authoriseWidgetCaller();
+        $this->container->method('get')->willReturn(
+            $this->catalogueStub(
+                [
+                    [
+                        'serviceId' => 'svc-internal',
+                        'name'      => 'Internal staff slot',
+                        'status'    => 'active',
+                        'isPublic'  => false,
+                    ],
+                ]
+            )
+        );
+
+        $response = $this->makeController()->appointments(
+            serviceId: 'svc-internal',
+            resourceId: 'res-001',
+            startTime: '2026-05-21T10:00:00Z',
+            endTime: '2026-05-21T10:30:00Z',
+            customerName: 'Anna de Wit',
+            email: 'anna@example.com',
+        );
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        self::assertSame('service-not-found', $response->getData()['error']);
+
+    }//end testAppointmentsRefusesAServiceThatIsNotPublic()
+
+    /**
+     * An unknown serviceId is refused for the same reason — resolvePublicService()
+     * must fail closed rather than fall through to the slot check.
+     *
+     * @return void
+     */
+    public function testAppointmentsRefusesAnUnknownService(): void
+    {
+        $this->authoriseWidgetCaller();
+        $this->container->method('get')->willReturn($this->catalogueStub([]));
+
+        $response = $this->makeController()->appointments(
+            serviceId: 'svc-does-not-exist',
+            resourceId: 'res-001',
+            startTime: '2026-05-21T10:00:00Z',
+            endTime: '2026-05-21T10:30:00Z',
+            customerName: 'Anna de Wit',
+            email: 'anna@example.com',
+        );
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+    }//end testAppointmentsRefusesAnUnknownService()
 }//end class


### PR DESCRIPTION
Split out of #484 so a live security fix is not held behind gate-53's 120 pre-existing manifest findings. #484 changes a register JSON, which makes gate-53 declare its diff scope **INDETERMINATE** ("new/untracked manifest input, or a register JSON changed — every finding blocks"). This branch touches PHP only, so gate-53 scopes normally.

**Local gate run @ `5907a4d`, diff-scoped vs `origin/development`: 0 gates failed** (39 of 39 applicable ran).

## The defect

gate-57 flagged `WidgetService::createAppointment()` as an orphaned write capability. Tracing the sibling seam before touching anything (per `.github#290`), **the orphan was the correct implementation and the routed path was the defect.**

Two implementations exist:

| | `WidgetService` | `WidgetApiController` |
|---|---|---|
| routed in `appinfo/routes.php` | no | **yes** |
| enforces `isPublic` | **yes** | **no** |
| honours `priceVisible` | **yes** | **no** |

Measured: `grep -c isPublic` = **0** in `WidgetApiController.php` **and 0** in `SlotService.php`.

Nothing on the live path enforced the public/private boundary:
- `guard()` validates only the per-business widget API key — which **by design ships inside the embedding page**;
- `validateAppointmentPayload()` checks formats;
- `SlotService::getAvailableSlots()` resolves the Service and never looks at `isPublic`;
- `GET /api/widget/services` filtered on `status='active'` **alone**, so the public catalogue listed every active service, including internal ones;
- `POST /api/widget/appointments` accepted any `serviceId` with a free slot.

`priceVisible` was ignored entirely, publishing a price for every service and making that per-service setting inert.

## Fix

- `services()` skips any row without `isPublic === true`, and includes `price` only when `priceVisible === true`.
- `appointments()` resolves through a new `resolvePublicService()` returning null unless the service exists, is active and is `isPublic` — failing **closed** if the catalogue lookup throws.

Both filter **in PHP, not in the `findAll()` query**: a query filter that silently matched nothing would look identical to "no private services" — the shape of #488.

## Can-fail proof

With both checks removed the new tests fail three ways:
- the public catalogue lists `svc-internal` **and** `svc-unflagged`;
- booking a non-public service returns **409, not 404** — it had already passed the authorisation boundary into the slot logic; with a free slot it would have **written the appointment**.

With the fix: **9 tests / 11 assertions pass**. `phpcs lib/`: 0 errors.

## Not done here, deliberately

`createAppointment()` is **not** deleted. gate-57 is right that it has no caller, but the two implementations take **different inputs** — it keys on `serviceSlug`/`customerEmail` while the routed endpoint takes `serviceId`/`resourceId`/`endTime` — so wiring the controller to it changes the public contract of `POST /api/widget/appointments`, which the widget frontend and the Newman collection both assert. That is #489's decision, not a side effect of a security patch.