### PR TITLE
fix(manifest): six pages rendered nothing — customComponent is not a key the renderer reads

### DIFF
--- a/src/manifest.d/bookings-confirm-flow.json
+++ b/src/manifest.d/bookings-confirm-flow.json
@@ -6,14 +6,15 @@
 			"type": "custom",
 			"component": "BookingsConfirmationPortal",
 			"title": "Confirm your appointment",
-			"public": true
+			"_note": "Anonymous, token-scoped confirm/decline surface. Every standard page type assumes an authenticated Nextcloud shell and an OpenRegister object the viewer is allowed to read; this page has neither. It resolves one appointment from a single-use token against the #[PublicPage] endpoints in appinfo/routes.php (confirmationApi#lookupByToken / validate-confirmation-token) and offers only confirm or decline. The page's public reachability comes from those #[PublicPage] attributes, NOT from the manifest — the `public: true` key that used to sit here was read by nothing (it appears nowhere in the shipped nc-vue dist, nor in src/main.js or src/registry.js) and has been removed."
 		},
 		{
 			"id": "BookingsPendingConfirmations",
 			"route": "/verkoop/openstaande-bevestigingen",
 			"type": "custom",
 			"component": "BookingsConfirmationPortal",
-			"title": "Pending confirmations"
+			"title": "Pending confirmations",
+			"_note": "Operator-side view of the same BookingsConfirmationPortal component, listing appointments still awaiting a customer response. It renders the identical token-driven confirm/decline widget rather than an OpenRegister object list, so it shares the reason above: no standard page type can express it."
 		}
 	],
 	"menu": [

--- a/src/manifest.d/bookings-confirm-flow.json
+++ b/src/manifest.d/bookings-confirm-flow.json
@@ -4,7 +4,7 @@
 			"id": "BookingsConfirmationPortal",
 			"route": "/confirm/:appointmentId",
 			"type": "custom",
-			"customComponent": "BookingsConfirmationPortal",
+			"component": "BookingsConfirmationPortal",
 			"title": "Confirm your appointment",
 			"public": true
 		},
@@ -12,7 +12,7 @@
 			"id": "BookingsPendingConfirmations",
 			"route": "/verkoop/openstaande-bevestigingen",
 			"type": "custom",
-			"customComponent": "BookingsConfirmationPortal",
+			"component": "BookingsConfirmationPortal",
 			"title": "Pending confirmations"
 		}
 	],

--- a/src/manifest.d/bookkeeping-period-close.json
+++ b/src/manifest.d/bookkeeping-period-close.json
@@ -76,6 +76,7 @@
 			"route": "/bookkeeping/period-close/:id",
 			"type": "custom",
 			"component": "PeriodCloseDetail",
+			"_note": "Period-close cockpit, not a record view. Beyond the FiscalPeriod fields it drives a four-step close workflow through /api/period-close/:id/{start-close,close,reopen,lock-audit} with per-transition role gates (period-closer, auditor) and a reopen reason prompt, and renders the close checklist and assistant flags. `type: detail` renders declared fields plus lifecycle transitions on the OBJECT; it cannot host the endpoint-driven checklist and audit-lock cockpit this page is. Its config is retained so the field/lifecycle/link declarations stay manifest-owned.",
 			"title": "Period Close",
 			"config": {
 				"register": "shillinq",

--- a/src/manifest.d/bookkeeping-period-close.json
+++ b/src/manifest.d/bookkeeping-period-close.json
@@ -75,7 +75,7 @@
 			"id": "PeriodCloseDetail",
 			"route": "/bookkeeping/period-close/:id",
 			"type": "custom",
-			"customComponent": "PeriodCloseDetail",
+			"component": "PeriodCloseDetail",
 			"title": "Period Close",
 			"config": {
 				"register": "shillinq",

--- a/src/manifest.d/bookkeeping-wbso-sno-administratie.json
+++ b/src/manifest.d/bookkeeping-wbso-sno-administratie.json
@@ -36,21 +36,21 @@
 			"id": "WbsoChartOfAccounts",
 			"route": "/bookkeeping/chart-of-accounts",
 			"type": "custom",
-			"customComponent": "WbsoChartOfAccountsView",
+			"component": "WbsoChartOfAccountsView",
 			"title": "Chart of Accounts"
 		},
 		{
 			"id": "WbsoTransactions",
 			"route": "/bookkeeping/transactions",
 			"type": "custom",
-			"customComponent": "WbsoTransactionsView",
+			"component": "WbsoTransactionsView",
 			"title": "Transactions"
 		},
 		{
 			"id": "WbsoDocuments",
 			"route": "/bookkeeping/documents",
 			"type": "custom",
-			"customComponent": "WbsoDocumentsView",
+			"component": "WbsoDocumentsView",
 			"title": "Documents"
 		}
 	]

--- a/src/manifest.d/bookkeeping-wbso-sno-administratie.json
+++ b/src/manifest.d/bookkeeping-wbso-sno-administratie.json
@@ -37,6 +37,7 @@
 			"route": "/bookkeeping/chart-of-accounts",
 			"type": "custom",
 			"component": "WbsoChartOfAccountsView",
+			"_note": "Hierarchical RGS chart-of-accounts TREE with expand/collapse (REQ-WBSO-006), read from /api/wbso-sno/accounts/hierarchy via WbsoAccountApiController. `type: index` is register/schema-driven through config.register + config.schema and renders a flat object table; it cannot express a nested hierarchy served by a bespoke REST endpoint that is not an OpenRegister schema at all.",
 			"title": "Chart of Accounts"
 		},
 		{
@@ -44,6 +45,7 @@
 			"route": "/bookkeeping/transactions",
 			"type": "custom",
 			"component": "WbsoTransactionsView",
+			"_note": "WBSO/SNO transaction list (REQ-WBSO-002 / REQ-WBSO-008) read from the bespoke /api/v1/transactions endpoint, not from an OpenRegister register/schema, so `type: index` — which resolves its rows through config.register + config.schema — has no data source to point at. The view already renders through the shared nc-vue CnDataTable, so the deviation is the data source, not the presentation.",
 			"title": "Transactions"
 		},
 		{
@@ -51,6 +53,7 @@
 			"route": "/bookkeeping/documents",
 			"type": "custom",
 			"component": "WbsoDocumentsView",
+			"_note": "WBSO/SNO document list with upload (REQ-WBSO-003 / REQ-WBSO-007 / REQ-WBSO-009) read from the bespoke /api/v1/documents endpoint rather than an OpenRegister register/schema, so `type: index` has no config.register/config.schema to resolve. Like the transactions view it already renders through the shared nc-vue CnDataTable; the data source is what makes it custom.",
 			"title": "Documents"
 		}
 	]


### PR DESCRIPTION
Found while clearing gate-53 for #484. Six pages have been shipping as blank empty-states, including a **public** one.

## The rule

The shipped renderer resolves a custom page's body as:

```js
const name = page.component || page.slots?.main
```
`node_modules/@conduction/nextcloud-vue/dist/esm/components/CnPageRenderer/CnPageRenderer.vue2.js:530`

Singular **`customComponent` appears zero times** in the shipped renderer. Six pages declared it and nothing else, so each resolved to no component and rendered the ADR-041 empty state instead of its view:

| page | route |
|---|---|
| `BookingsConfirmationPortal` | **`/confirm/:appointmentId`** — public |
| `BookingsPendingConfirmations` | `/verkoop/openstaande-bevestigingen` |
| `WbsoChartOfAccounts` | `/bookkeeping/chart-of-accounts` |
| `WbsoTransactions` | `/bookkeeping/transactions` |
| `WbsoDocuments` | `/bookkeeping/documents` |
| `PeriodCloseDetail` | `/bookkeeping/period-close/:id` |

All five referenced components **are** registered in `src/registry.js` — these pages were one word away from working. `/confirm/:appointmentId` is the public appointment-confirmation portal, so this was a dead public surface.

## Verification

Rebuilt the assembled manifest (base + 80 fragments + menu-layout): **6/6 now resolve** under the shipped rule, and **zero** singular `customComponent` keys remain anywhere in `src/manifest*`. `validate-manifest`: PASS (0 issues) on both the structural lint and the consistency check.

## ⚠️ Measured against the shipped package, not a source checkout

My first trace read `apps-extra/nextcloud-vue`, which is parked on branch `wip/cnindexpage-export-action` at **`1.0.0-beta.184` — the Vue 2 line** — while shillinq installs **`2.2.0-vue3.2`** (`package.json` pin; lockfile resolves to the published tarball). Different major lines, so that reading proved nothing about what shillinq actually runs. Everything above is re-verified in `node_modules`, against the code that ships.

(For the record, the pin is healthy: `2.2.0-vue3.2` is real and published. The `vue3` dist-tag has since moved to `2.2.0-vue3.6`, so shillinq is 4 patches behind on that line — not a phantom `3.x` pin.)

## Still open from the same trace

`Orders` and `OrderDetail` in `src/manifest.d/order-workspace.json` declare `register` / `schema` / `columns` / `filters` / `aggregations` / `relatedSchemas` / `auditTrail` / `sidebarProps` **at page level**, where nothing reads them — the shipped components read `config.register`, and `page.register` / `page.schema` appear nowhere in the dist. Both therefore mount with **no register and no schema** and fetch nothing. That restructure is a larger edit and is left for a follow-up so this one-word fix can land on its own.