### PR TITLE
chore(deps): pin @conduction/nextcloud-vue to 2.2.0-vue3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.1",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@conduction/nextcloud-vue": "2.2.0-vue3.2",
+        "@conduction/nextcloud-vue": "2.2.0-vue3.6",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "~2.5.2",
         "@nextcloud/capabilities": "^1.2.1",
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.2.0-vue3.2",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.2.tgz",
-      "integrity": "sha512-U/3pRbbumvM3rek/x821KoeplbfH4Qtod3quF+6bFt1Vn8TzjMKtdN/lSQgLGP9BZF7mA6yNbU6UyWHW0pMjkg==",
+      "version": "2.2.0-vue3.6",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.6.tgz",
+      "integrity": "sha512-OutxBnIIxlgEkkGkxy/kUQcJ4EtxEX3lQ27N1aUGW5sEYmvi8JaboqVnKfWcmmaoyqsJzy1IS4Jo3sEYe07K4w==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.1",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@conduction/nextcloud-vue": "2.2.0-vue3.6",
+        "@conduction/nextcloud-vue": "2.2.0-vue3.7",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "~2.5.2",
         "@nextcloud/capabilities": "^1.2.1",
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.2.0-vue3.6",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.6.tgz",
-      "integrity": "sha512-OutxBnIIxlgEkkGkxy/kUQcJ4EtxEX3lQ27N1aUGW5sEYmvi8JaboqVnKfWcmmaoyqsJzy1IS4Jo3sEYe07K4w==",
+      "version": "2.2.0-vue3.7",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.7.tgz",
+      "integrity": "sha512-x0aj0ACfLUDIak3/A51jVyxCPWPIFYfhv7FG2WIQA5+WKfxfJ2rzt8mIl65AmW646PZxsOz4iPo1pCm3EUeuIQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.1",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@conduction/nextcloud-vue": "2.2.0-vue3.7",
+        "@conduction/nextcloud-vue": "2.2.0-vue3.9",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "~2.5.2",
         "@nextcloud/capabilities": "^1.2.1",
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.2.0-vue3.7",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.7.tgz",
-      "integrity": "sha512-x0aj0ACfLUDIak3/A51jVyxCPWPIFYfhv7FG2WIQA5+WKfxfJ2rzt8mIl65AmW646PZxsOz4iPo1pCm3EUeuIQ==",
+      "version": "2.2.0-vue3.9",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.9.tgz",
+      "integrity": "sha512-9HC1dhYfCqw7JeZ3mn4Zr260iBCWlWa/1slrPTdmIbODvbWlf82guAZEnMq17XvWmDJRcAVNBzYtIT2kWwZutA==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "dependencies": {
-    "@conduction/nextcloud-vue": "2.2.0-vue3.7",
+    "@conduction/nextcloud-vue": "2.2.0-vue3.9",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "~2.5.2",
     "@nextcloud/capabilities": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "dependencies": {
-    "@conduction/nextcloud-vue": "2.2.0-vue3.6",
+    "@conduction/nextcloud-vue": "2.2.0-vue3.7",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "~2.5.2",
     "@nextcloud/capabilities": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "dependencies": {
-    "@conduction/nextcloud-vue": "2.2.0-vue3.2",
+    "@conduction/nextcloud-vue": "2.2.0-vue3.6",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "~2.5.2",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
## What

Hard-pins `@conduction/nextcloud-vue` to exactly **`2.2.0-vue3.9`** (development is on `2.2.0-vue3.2`).

This PR started at `2.2.0-vue3.6`. The `vue3` dist-tag moved **3.7 (07:37) → 3.8 (08:51) → 3.9 (09:18)** while it was in flight, because every merge to `feat/vue-3` cuts a publish. It is now pinned to **3.9 and frozen there** — a fleet consistent on one version beats a fleet split across three.

`^2.2.0` does **not** match `2.2.0-vue3.9` (caret ranges do not cross prerelease boundaries) and `latest`/`beta` are the **retired Vue 2 lineage**. Positive controls: `2.2.0-vue3.9` resolves; `3.0.0-*` returns **E404**.

## Lockfile control

Regenerating the lockfile with the pin **unchanged** is a **0-line diff** in this repo, so the whole `+5/-5` is the version move. The lockfile was regenerated by npm, never hand-edited.

## Verified

`2.2.0-vue3.9` was not pre-verified against our apps, so this run is the verification:

| | before | after |
|---|---|---|
| installed version (off disk, after real `npm ci`) | `2.2.0-vue3.6` | **`2.2.0-vue3.9`** — one copy, peer `vue ^3.5.0` |
| unit tests (`npm run test:unit`) | 171 passed / 15 files | 171 passed / 15 files |
| `test:l10n` | exit 0 | exit 0, output identical |
| webpack build | 3 warnings, 0 errors | 3 warnings, 0 errors |
| bundle total | 70,917,574 B | 70,950,671 B (**+33,097 B, +0.05%**) |

No regression on 3.9. Branch is up to date with `development`; none of the other open PRs (#493, #484, #440) were touched.

## Re-confirmed for #493 against the 3.9 dist

3.8/3.9 touch `CnIndexPage` slots and param handling, so #493's evidence — originally read off the `2.2.0-vue3.2` dist — was re-checked against **3.9**. **It still holds:**

- The renderer resolves a `type: "custom"` page via **`page.component`** (`page.component || page.slots?.main`), looked up against the **`customComponents`** registry as `ctx.customComponents[name]`.
- **`customComponent` (singular) is still not a key the renderer reads.**
- `CnIndexPage` in 3.9 warns explicitly on unresolvable lookups, e.g. `cardComponent "…" not found in customComponents registry. Falling back to CnObjectCard.` — so a wrong key now surfaces as a console warning rather than a silent blank.

That last point is new in 3.8/3.9 and is worth knowing before #493 lands: some of the "six blank pages" should now announce themselves.
