### PR TITLE
refactor(registers): gate-54 140→95, plus 18 schemas the importer never saw (gate-53 slug-resolution 11→0)

### DIFF
--- a/lib/Settings/register.d/50-bookings-deposits.json
+++ b/lib/Settings/register.d/50-bookings-deposits.json
@@ -444,12 +444,26 @@
               "action": "authorize"
             },
             "description": "Confirm to the booking-operator that the deposit was authorized and the invoice was created.",
-            "recipients": {
-              "role": "booking-operator",
-              "scope": "@self.orderId"
-            },
-            "title": "Deposit authorized",
-            "message": "Deposit of @self.amount cents for booking @self.orderId is authorized; invoice @self.arInvoiceId created."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "booking-operator"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Aanbetaling geautoriseerd: {{amount}} cent voor boeking {{orderId}}; factuur {{arInvoiceId}} aangemaakt",
+              "en": "Deposit authorized: {{amount}} cents for booking {{orderId}}; invoice {{arInvoiceId}} created"
+            }
           },
           "onFailed": {
             "trigger": {
@@ -457,12 +471,26 @@
               "action": "fail"
             },
             "description": "Alert the booking-operator that a deposit authorization failed and needs follow-up.",
-            "recipients": {
-              "role": "booking-operator",
-              "scope": "@self.orderId"
-            },
-            "title": "Deposit payment failed",
-            "message": "Deposit for booking @self.orderId failed: @self.lastErrorMessage (@self.lastErrorCode)."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "booking-operator"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Aanbetaling mislukt voor boeking {{orderId}}: {{lastErrorMessage}} ({{lastErrorCode}})",
+              "en": "Deposit payment failed for booking {{orderId}}: {{lastErrorMessage}} ({{lastErrorCode}})"
+            }
           },
           "onVoided": {
             "trigger": {
@@ -473,12 +501,26 @@
               ]
             },
             "description": "Confirm a refund was initiated and a credit note created.",
-            "recipients": {
-              "role": "booking-operator",
-              "scope": "@self.orderId"
-            },
-            "title": "Deposit refunded",
-            "message": "Deposit for booking @self.orderId was voided; credit note @self.creditNoteId created."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "booking-operator"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Aanbetaling teruggeboekt voor boeking {{orderId}}; creditnota {{creditNoteId}} aangemaakt",
+              "en": "Deposit refunded for booking {{orderId}}; credit note {{creditNoteId}} created"
+            }
           }
         },
         "x-openregister-scheduled-workflows": {

--- a/lib/Settings/register.d/add-shillinq-bookkeeping-operations.json
+++ b/lib/Settings/register.d/add-shillinq-bookkeeping-operations.json
@@ -208,12 +208,26 @@
               "action": "submit"
             },
             "description": "Notify the vat-administrator when a return is submitted.",
-            "recipients": {
-              "role": "vat-administrator",
-              "scope": "@self.administrationId"
-            },
-            "title": "BTW-aangifte ingediend",
-            "message": "BTW-aangifte voor @self.periodYear is ingediend via Digipoort."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "vat-administrator"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "BTW-aangifte voor {{periodYear}} is ingediend via Digipoort",
+              "en": "VAT return for {{periodYear}} was submitted through Digipoort"
+            }
           }
         },
         "x-openregister-rbac": {
@@ -1000,12 +1014,26 @@
               "action": "submit"
             },
             "description": "Notify the bcf-administrator when a claim is submitted.",
-            "recipients": {
-              "role": "bcf-administrator",
-              "scope": "@self.administrationId"
-            },
-            "title": "BCF-claim ingediend",
-            "message": "BCF-claim @self.claimNumber is ingediend bij het Compensatiefonds."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "bcf-administrator"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "BCF-claim {{claimNumber}} is ingediend bij het BTW-compensatiefonds",
+              "en": "BCF claim {{claimNumber}} was submitted to the VAT compensation fund"
+            }
           }
         },
         "x-openregister-rbac": {
@@ -1310,14 +1338,35 @@
         },
         "x-openregister-notifications": {
           "onAboveThreshold": {
-            "trigger": "field.aboveThreshold==true",
-            "description": "Alert the treasury-officer when the daily position exceeds the drempelbedrag (REQ-SBK-008).",
-            "recipients": {
-              "role": "treasury-officer",
-              "scope": "@self.administrationId"
+            "trigger": {
+              "type": "updated",
+              "condition": {
+                "field": "aboveThreshold",
+                "operator": "equals",
+                "value": true
+              }
             },
-            "title": "Schatkist-drempel overschreden",
-            "message": "De schatkist-positie van @self.position EUR op @self.businessDate overschrijdt het drempelbedrag."
+            "description": "Alert the treasury-officer when the daily position exceeds the drempelbedrag (REQ-SBK-008).",
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "treasury-officer"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Schatkist-drempel overschreden: positie {{position}} EUR op {{businessDate}}",
+              "en": "Treasury banking threshold exceeded: position {{position}} EUR on {{businessDate}}"
+            }
           }
         },
         "x-openregister-widgets": {

--- a/lib/Settings/register.d/add-shillinq-sbr-xbrl-reporting.json
+++ b/lib/Settings/register.d/add-shillinq-sbr-xbrl-reporting.json
@@ -256,12 +256,26 @@
               "action": "submit"
             },
             "description": "Notify the bookkeeper when a filing is successfully submitted (REQ-SBR-003).",
-            "recipients": {
-              "role": "bookkeeper",
-              "scope": "@self.administrationId"
-            },
-            "title": "SBR/XBRL ingediend",
-            "message": "XBRL-instance @self.instanceNumber (@self.entryPoint) is ingediend bij Digipoort."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "bookkeeper"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "SBR/XBRL ingediend: instance {{instanceNumber}} ({{entryPoint}}) is verstuurd naar Digipoort",
+              "en": "SBR/XBRL submitted: instance {{instanceNumber}} ({{entryPoint}}) was filed with Digipoort"
+            }
           },
           "onRejected": {
             "trigger": {
@@ -269,12 +283,26 @@
               "action": "reject"
             },
             "description": "Notify the bookkeeper when Digipoort rejects a submission (REQ-SBR-003).",
-            "recipients": {
-              "role": "bookkeeper",
-              "scope": "@self.administrationId"
-            },
-            "title": "SBR/XBRL afgewezen",
-            "message": "XBRL-instance @self.instanceNumber (@self.entryPoint) is afgewezen door Digipoort: @self.rejectionReason."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "bookkeeper"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "SBR/XBRL afgewezen: instance {{instanceNumber}} ({{entryPoint}}) is afgewezen door Digipoort — {{rejectionReason}}",
+              "en": "SBR/XBRL rejected: instance {{instanceNumber}} ({{entryPoint}}) was rejected by Digipoort — {{rejectionReason}}"
+            }
           }
         },
         "x-openregister-audit-trail": {

--- a/lib/Settings/register.d/bookings-email-templates.json
+++ b/lib/Settings/register.d/bookings-email-templates.json
@@ -192,7 +192,7 @@
               "email"
             ],
             "template": "@self",
-            "sender": "@self.senderAddress",
+            "sender": "{{senderAddress}}",
             "appliesWhen": {
               "field": "status",
               "in": [
@@ -431,8 +431,8 @@
               "email"
             ],
             "template": "@self",
-            "sender": "@self.senderAddress",
-            "scheduleOffsetHours": "@self.hoursBeforeBooking",
+            "sender": "{{senderAddress}}",
+            "scheduleOffsetHours": "{{hoursBeforeBooking}}",
             "appliesWhen": {
               "field": "status",
               "in": [
@@ -667,7 +667,7 @@
               "email"
             ],
             "template": "@self",
-            "sender": "@self.senderAddress",
+            "sender": "{{senderAddress}}",
             "appliesWhen": {
               "field": "status",
               "in": [

--- a/lib/Settings/register.d/bookings-notification-triggers.json
+++ b/lib/Settings/register.d/bookings-notification-triggers.json
@@ -258,9 +258,9 @@
         },
         "x-openregister-notifications": {
           "onTriggerEventFired": {
-            "trigger": "@self.triggerType",
-            "channels": "@self.channels",
-            "scheduleOffsetHours": "@self.reminderHoursBeforeStart",
+            "trigger": "{{triggerType}}",
+            "channels": "{{channels}}",
+            "scheduleOffsetHours": "{{reminderHoursBeforeStart}}",
             "appliesWhen": {
               "field": "status",
               "in": [
@@ -272,7 +272,7 @@
               "matchBooking": "slug",
               "nullMeansGlobal": true
             },
-            "recipients": "@self.recipients",
+            "recipients": "{{recipients}}",
             "selectTemplate": {
               "byType": {
                 "booking.created": "BookingConfirmationTemplate",
@@ -280,27 +280,27 @@
                 "booking.cancelled": "BookingCancellationTemplate",
                 "booking.reminder": "BookingReminderTemplate"
               },
-              "overrideSlug": "@self.templateOverrideSlug",
+              "overrideSlug": "{{templateOverrideSlug}}",
               "matchLocale": "recipient.languagePreference"
             },
             "skipWhen": {
               "any": [
                 {
-                  "recipientField": "notificationOptOut[@self.triggerType]",
+                  "recipientField": "notificationOptOut[{{triggerType}}]",
                   "equals": true,
-                  "onlyIf": "@self.respectOptOut"
+                  "onlyIf": "{{respectOptOut}}"
                 },
                 {
                   "rateLimit": {
                     "scope": "booking",
-                    "max": "@self.rateLimitPerBookingPerHour",
+                    "max": "{{rateLimitPerBookingPerHour}}",
                     "windowMinutes": 60
                   }
                 },
                 {
                   "rateLimit": {
                     "scope": "organizer",
-                    "max": "@self.rateLimitPerOrganizerPerDay",
+                    "max": "{{rateLimitPerOrganizerPerDay}}",
                     "windowMinutes": 1440
                   }
                 },
@@ -311,7 +311,7 @@
                       "triggerType",
                       "bookingId"
                     ],
-                    "windowMinutes": "@self.deduplicationWindowMinutes"
+                    "windowMinutes": "{{deduplicationWindowMinutes}}"
                   }
                 }
               ]
@@ -325,8 +325,8 @@
                 "queued"
               ],
               "fields": {
-                "triggerName": "@self.name",
-                "triggerType": "@self.triggerType",
+                "triggerName": "{{name}}",
+                "triggerType": "{{triggerType}}",
                 "bookingId": "booking.id",
                 "channel": "channel",
                 "recipient": "recipient.address",
@@ -338,7 +338,7 @@
             },
             "fallback": {
               "mode": "next-channel",
-              "description": "On adapter failure, advance to the next channel in @self.channels. Each attempt is recorded in NotificationDelivery (REQ-BNT-004/005)."
+              "description": "On adapter failure, advance to the next channel in the trigger's own channels list. Each attempt is recorded in NotificationDelivery (REQ-BNT-004/005)."
             },
             "description": "Declarative trigger dispatch consumed from OR's notification engine (ADR-022, REQ-BNT-001/003/004/005/006/009). When the configured booking lifecycle event fires (booking.created / changed / cancelled / reminder), the engine evaluates appliesWhen (status=enabled), scope (appliesToBookingSlug null = global, else match), the recipient rules (each rule's condition expression), the skipWhen gates (opt-out, rate-limit per booking/organizer, dedupe), and dispatches the rendered template through the first available channel. Every attempt is recorded immutably in NotificationDelivery for audit (REQ-BNT-005). Pure-logic gating (rate-limit window, dedupe key, recipient-rule condition parsing, opt-out lookup) is implemented in Shillinq's Notification/ helper namespace for unit-test coverage; live dispatch stays in OR's engine."
           }

--- a/lib/Settings/register.d/bookings-sms-reminder-channel.json
+++ b/lib/Settings/register.d/bookings-sms-reminder-channel.json
@@ -221,9 +221,9 @@
             "channels": [
               "sms"
             ],
-            "connector": "@self.providerConfig.connectorId",
-            "template": "@self.messageTemplate",
-            "sender": "@self.senderId",
+            "connector": "{{providerConfig.connectorId}}",
+            "template": "{{messageTemplate}}",
+            "sender": "{{senderId}}",
             "appliesWhen": {
               "field": "status",
               "in": [
@@ -233,11 +233,11 @@
             "skipWhen": {
               "recipientField": "smsOptOut",
               "equals": true,
-              "onlyIf": "@self.respectOptOut"
+              "onlyIf": "{{respectOptOut}}"
             },
             "retry": {
-              "count": "@self.retryCount",
-              "intervalSeconds": "@self.retryIntervalSeconds"
+              "count": "{{retryCount}}",
+              "intervalSeconds": "{{retryIntervalSeconds}}"
             },
             "description": "Declarative SMS dispatch consumed from OR's notification engine (ADR-022, REQ-SMS-005/008/018/021). When a booking.reminder-due event fires, active channels render their template with booking variables and dispatch via the referenced openconnector connector — unless the recipient has opted out (skipWhen, respected when respectOptOut is true). Retries on transient provider error per retryCount/retryIntervalSeconds; failures are logged with a masked phone number. The pure-logic gating/rendering/normalization is implemented in Shillinq's SmsReminderDispatcher helper (provider-adapter interface), keeping the orchestration unit-tested while live dispatch stays in OR's engine."
           }

--- a/lib/Settings/register.d/bookkeeping-aansluitingen.json
+++ b/lib/Settings/register.d/bookkeeping-aansluitingen.json
@@ -254,6 +254,7 @@
             "type": "string",
             "format": "date-time",
             "nullable": true,
+            "description": "ISO 8601 timestamp at which the explanation was recorded (REQ-AANS-006). Null while the difference is unexplained. An explanation documents why a tie-out difference exists; it does not clear it — resolvedAt does that.",
             "example": null,
             "title": "Explained At"
           },
@@ -280,6 +281,7 @@
           "resolvedBy": {
             "type": "string",
             "nullable": true,
+            "description": "Nextcloud user id of the actor who closed this tie-out difference — i.e. who confirmed the two sources now reconcile, or that the remaining difference has been corrected in the ledger. Null while the difference is still open. Distinct from explainedBy, which only documents the cause.",
             "example": null,
             "title": "Resolved By"
           },
@@ -287,6 +289,7 @@
             "type": "string",
             "format": "date-time",
             "nullable": true,
+            "description": "ISO 8601 timestamp at which the tie-out difference was closed. Null while the difference is still open; a non-null value is what takes this result out of the operator's open-differences worklist.",
             "example": null,
             "title": "Resolved At"
           },

--- a/lib/Settings/register.d/bookkeeping-bado-controleprotocol.json
+++ b/lib/Settings/register.d/bookkeeping-bado-controleprotocol.json
@@ -208,12 +208,26 @@
               "action": "adopt"
             },
             "description": "Notify the concerncontroller when a protocol is adopted.",
-            "recipients": {
-              "role": "concerncontroller",
-              "scope": "@self.organisationId"
-            },
-            "title": "Controleprotocol vastgesteld",
-            "message": "Controleprotocol @self.version voor auditjaar @self.auditYear is vastgesteld."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "concerncontroller"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Controleprotocol {{version}} voor auditjaar {{auditYear}} is vastgesteld",
+              "en": "Audit protocol {{version}} for audit year {{auditYear}} has been adopted"
+            }
           }
         },
         "x-openregister-events": {

--- a/lib/Settings/register.d/bookkeeping-cbs-bestanden-extended.json
+++ b/lib/Settings/register.d/bookkeeping-cbs-bestanden-extended.json
@@ -211,12 +211,26 @@
               "action": "validate"
             },
             "description": "Notify the finance manager when a CBS submission passes validation (REQ-CBS-009).",
-            "recipients": {
-              "role": "finance-manager",
-              "scope": "@self.administrationId"
-            },
-            "title": "CBS submission validated",
-            "message": "CBS submission @self.submissionNumber has been validated and is ready for delivery to CBS."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "finance-manager"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "CBS-levering {{submissionNumber}} is gevalideerd en gereed voor verzending naar het CBS",
+              "en": "CBS submission {{submissionNumber}} has been validated and is ready for delivery to CBS"
+            }
           },
           "onRejected": {
             "trigger": {
@@ -224,12 +238,26 @@
               "action": "reject"
             },
             "description": "Notify the finance manager when CBS rejects a submission (REQ-CBS-003).",
-            "recipients": {
-              "role": "finance-manager",
-              "scope": "@self.administrationId"
-            },
-            "title": "CBS submission rejected",
-            "message": "CBS submission @self.submissionNumber was rejected by CBS; a correction submission is required."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "finance-manager"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "CBS-levering {{submissionNumber}} is afgewezen door het CBS; een correctielevering is vereist",
+              "en": "CBS submission {{submissionNumber}} was rejected by CBS; a correction submission is required"
+            }
           }
         },
         "x-openregister-rbac": {

--- a/lib/Settings/register.d/bookkeeping-ccm-rule-engine.json
+++ b/lib/Settings/register.d/bookkeeping-ccm-rule-engine.json
@@ -364,28 +364,64 @@
         },
         "x-openregister-notifications": {
           "onCreate": {
-            "trigger": "onCreate",
-            "description": "Notify the rule owner / assignee when a critical or high-severity finding is created (REQ-CCM-008).",
-            "recipients": {
-              "resolver": "assignee",
-              "fallback": "ruleOwner"
+            "trigger": {
+              "type": "created",
+              "condition": {
+                "field": "severity",
+                "operator": "in",
+                "value": [
+                  "critical",
+                  "high"
+                ]
+              }
             },
+            "description": "Notify the rule owner / assignee when a critical or high-severity finding is created (REQ-CCM-008). The `field` recipient resolves the finding's own assignee and yields nobody while a finding is still unassigned; the `relation` recipient reaches the owner of the CcmRule that fired, which is the fallback the retired imperative dispatcher applied.",
+            "enabled": true,
             "channels": [
-              "in-app"
+              "nc-notification"
             ],
-            "condition": "@self.severity in ['critical','high']",
+            "recipients": [
+              {
+                "kind": "field",
+                "field": "assignee"
+              },
+              {
+                "kind": "relation",
+                "relation": "rule"
+              }
+            ],
+            "subject": {
+              "nl": "CCM-bevinding ({{severity}}) op regel {{ruleCode}}: {{title}}",
+              "en": "CCM finding ({{severity}}) on rule {{ruleCode}}: {{title}}"
+            },
             "template": "ccm-finding-created"
           },
           "onAutoEscalate": {
-            "trigger": "scheduled.autoEscalate",
-            "description": "Auto-escalate critical findings still open after 24h to the CFO (REQ-CCM-008).",
-            "recipients": {
-              "role": "finance-director"
+            "trigger": {
+              "type": "scheduled",
+              "intervalSec": 86400,
+              "filter": {
+                "severity": "critical",
+                "status": "open"
+              }
             },
+            "description": "Auto-escalate critical findings still open after 24h to the CFO (REQ-CCM-008). The 24h re-check cadence is the scheduled trigger's intervalSec; the filter is the escalation condition.",
+            "enabled": true,
             "channels": [
-              "in-app"
+              "nc-notification"
             ],
-            "condition": "@self.severity == 'critical' && @self.status == 'open'",
+            "recipients": [
+              {
+                "kind": "groups",
+                "groups": [
+                  "finance-director"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Escalatie: kritieke CCM-bevinding op regel {{ruleCode}} staat nog open — {{title}}",
+              "en": "Escalation: critical CCM finding on rule {{ruleCode}} is still open — {{title}}"
+            },
             "template": "ccm-finding-escalated"
           }
         },

--- a/lib/Settings/register.d/bookkeeping-credit-control-dunning.json
+++ b/lib/Settings/register.d/bookkeeping-credit-control-dunning.json
@@ -834,25 +834,30 @@
                     "van": {
                       "type": "string",
                       "format": "date",
+                      "description": "First day of this accrual sub-period (inclusive). Equals the parent ingangsdatum for the first sub-period, and the statutory rate-change date for every later one.",
                       "title": "Van"
                     },
                     "tot": {
                       "type": "string",
                       "format": "date",
+                      "description": "Last day of this accrual sub-period (inclusive). Equals the day before the next statutory rate change, or the parent berekendOp for the final sub-period.",
                       "title": "Tot"
                     },
                     "dagen": {
                       "type": "integer",
                       "minimum": 0,
+                      "description": "Whole days accrued in this sub-period (van..tot inclusive). The sub-period dagen sum to the parent dagen.",
                       "title": "Dagen"
                     },
                     "tarief": {
                       "type": "number",
+                      "description": "Annual statutory rate in force during this sub-period, as a decimal (0.1015 = 10,15%). Per art. 6:119a BW for B2B handelsrente or art. 6:119 BW for B2C wettelijke rente.",
                       "title": "Tarief"
                     },
                     "bedrag": {
                       "type": "number",
                       "multipleOf": 0.01,
+                      "description": "Interest accrued in this sub-period in EUR: hoofdsom x tarief x dagen / 365, rounded to cents. The sub-period bedragen sum to the parent bedrag.",
                       "title": "Bedrag"
                     }
                   }

--- a/lib/Settings/register.d/bookkeeping-emu-reporting.json
+++ b/lib/Settings/register.d/bookkeeping-emu-reporting.json
@@ -242,22 +242,53 @@
               "type": "created"
             },
             "description": "Notify the concerncontroller when a quarterly concept-aangifte is generated (REQ-EMU-001).",
-            "recipients": {
-              "role": "emu-concerncontroller",
-              "scope": "@self.administrationId"
-            },
-            "title": "EMU-conceptaangifte gereed",
-            "message": "De EMU-conceptaangifte voor @self.periodeJaar is gegenereerd en wacht op review."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "emu-concerncontroller"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "EMU-conceptaangifte voor {{periodeJaar}} is gegenereerd en wacht op review",
+              "en": "EMU draft return for {{periodeJaar}} has been generated and is awaiting review"
+            }
           },
           "onIngediend": {
-            "trigger": "lifecycle.indienen",
-            "description": "Notify on successful CBS submission (REQ-EMU-006).",
-            "recipients": {
-              "role": "emu-concerncontroller",
-              "scope": "@self.administrationId"
+            "trigger": {
+              "type": "transition",
+              "action": "indienen"
             },
-            "title": "EMU-aangifte ingediend",
-            "message": "EMU-aangifte @self.periodeJaar is ingediend bij het CBS."
+            "description": "Notify on successful CBS submission (REQ-EMU-006).",
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "emu-concerncontroller"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "EMU-aangifte {{periodeJaar}} is ingediend bij het CBS",
+              "en": "EMU return {{periodeJaar}} was submitted to Statistics Netherlands (CBS)"
+            }
           }
         },
         "x-openregister-rbac": {
@@ -673,14 +704,35 @@
         },
         "x-openregister-notifications": {
           "onSchatkistNegatief": {
-            "trigger": "field.instrument=='schatkistbankieren-rekeningcourant'",
-            "description": "Alert the treasury-officer when a negative schatkistbankieren position is recorded as EMU-schuld (REQ-EMU-011).",
-            "recipients": {
-              "role": "treasury-officer",
-              "scope": "@self.reportId"
+            "trigger": {
+              "type": "created",
+              "condition": {
+                "field": "instrument",
+                "operator": "equals",
+                "value": "schatkistbankieren-rekeningcourant"
+              }
             },
-            "title": "Schatkistbankieren rood — EMU-schuld",
-            "message": "Een negatieve schatkistbankieren-positie van @self.uitstaandeSchuld telt mee als EMU-schuld op @self.peildatum."
+            "description": "Alert the treasury-officer when a negative schatkistbankieren position is recorded as EMU-schuld (REQ-EMU-011).",
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "treasury-officer"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Schatkistbankieren rood: negatieve positie van {{uitstaandeSchuld}} telt mee als EMU-schuld op {{peildatum}}",
+              "en": "Treasury banking overdrawn: a negative position of {{uitstaandeSchuld}} counts towards EMU debt on {{peildatum}}"
+            }
           }
         },
         "x-openregister-rbac": {

--- a/lib/Settings/register.d/bookkeeping-rechtmatigheidsverantwoording.json
+++ b/lib/Settings/register.d/bookkeeping-rechtmatigheidsverantwoording.json
@@ -478,18 +478,34 @@
         },
         "x-openregister-notifications": {
           "onBudgetOvershoot": {
-            "trigger": "object.create",
+            "trigger": {
+              "type": "created",
+              "filter": {
+                "criterium": "begroting",
+                "soort": "fout"
+              }
+            },
             "description": "REQ-RV-001: notify the portefeuillehouder of the affected programma when a begroting-fout bevinding is created.",
-            "condition": {
-              "criterium": "begroting",
-              "soort": "fout"
-            },
-            "recipients": {
-              "role": "portefeuillehouder",
-              "scope": "@self.administrationId"
-            },
-            "title": "Begrotingsoverschrijding geconstateerd",
-            "message": "Rechtmatigheidsbevinding @self.bevindingsnummer (programma @self.programma): begrotingsoverschrijding van EUR @self.bedrag_fout."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "portefeuillehouder"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Begrotingsoverschrijding geconstateerd — bevinding {{bevindingsnummer}} (programma {{programma}}): EUR {{bedrag_fout}}",
+              "en": "Budget overrun found — finding {{bevindingsnummer}} (programme {{programma}}): EUR {{bedrag_fout}}"
+            }
           }
         },
         "x-openregister-rbac": {
@@ -692,12 +708,26 @@
               "type": "created"
             },
             "description": "REQ-RV-005: notify college secretaris + auditcommissie that the paragraaf is ready for review.",
-            "recipients": {
-              "role": "auditcommissie",
-              "scope": "@self.administrationId"
-            },
-            "title": "Rechtmatigheidsparagraaf gereed voor beoordeling",
-            "message": "Rechtmatigheidsparagraaf boekjaar @self.boekjaar is geaggregeerd en gereed voor college-beoordeling."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "auditcommissie"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Rechtmatigheidsparagraaf boekjaar {{boekjaar}} is geaggregeerd en gereed voor college-beoordeling",
+              "en": "Lawfulness paragraph for financial year {{boekjaar}} has been aggregated and is ready for board review"
+            }
           }
         },
         "x-openregister-rbac": {

--- a/lib/Settings/register.d/bookkeeping-sbr-xbrl-reporting.json
+++ b/lib/Settings/register.d/bookkeeping-sbr-xbrl-reporting.json
@@ -458,20 +458,102 @@
             "compute": "missing_fields([fiscalYearStart, fiscalYearEnd, taxonomyVersion]) + (applicableEntityTypes is empty ? ['applicableEntityTypes'] : [])"
           }
         },
+        "x-openregister-calculations": {
+          "daysUntilFilingDeadline": {
+            "expression": {
+              "diffDays": [
+                {
+                  "prop": "filingDeadline"
+                },
+                {
+                  "now": []
+                }
+              ]
+            },
+            "type": "integer",
+            "materialise": true,
+            "description": "Whole days remaining until the regulatory filing deadline. Negative once the deadline has passed, and null when filingDeadline is not set — which flows through to deadlineApproaching resolving false rather than guessing a reference date."
+          },
+          "deadlineApproaching": {
+            "expression": {
+              "and": [
+                {
+                  "ne": [
+                    {
+                      "prop": "status"
+                    },
+                    {
+                      "lit": "submitted"
+                    }
+                  ]
+                },
+                {
+                  "ne": [
+                    {
+                      "prop": "status"
+                    },
+                    {
+                      "lit": "approved"
+                    }
+                  ]
+                },
+                {
+                  "ge": [
+                    {
+                      "prop": "daysUntilFilingDeadline"
+                    },
+                    {
+                      "lit": 0
+                    }
+                  ]
+                },
+                {
+                  "le": [
+                    {
+                      "prop": "daysUntilFilingDeadline"
+                    },
+                    {
+                      "lit": 30
+                    }
+                  ]
+                }
+              ]
+            },
+            "type": "boolean",
+            "materialise": true,
+            "description": "True when the filing is still open (not submitted, not approved) and its deadline falls within the next 30 days (REQ-SBR-008). Materialised so the filingDeadlineApproaching scheduled notification can filter on it, and re-evaluated daily without an object write by OpenRegister's temporal calculation sweep (daysUntilFilingDeadline references `now`, which flags this schema as temporal). This is the declarative replacement for the legacy rule's `schedule.fireAt = filingDeadline - P30D` / `skipIf status in [submitted, approved]` pair."
+          }
+        },
         "x-openregister-notifications": {
           "filingDeadlineApproaching": {
-            "trigger": "scheduled",
-            "description": "Notify operators 30 days before the regulatory filing deadline per REQ-SBR-008. Fires once per (administrationId, code) until the filing transitions to submitted or the deadline passes.",
-            "schedule": {
-              "fireAt": "@self.filingDeadline - P30D",
-              "skipIf": "@self.status in ['submitted', 'approved']"
+            "trigger": {
+              "type": "scheduled",
+              "intervalSec": 86400,
+              "filter": {
+                "deadlineApproaching": true
+              }
             },
-            "recipients": {
-              "role": "finance-manager",
-              "scope": "@self.administrationId"
-            },
-            "title": "SBR filing deadline in 30 days",
-            "message": "Filing @self.name (@self.code) for administration @self.administrationId is due on @self.filingDeadline. Open the SBR Documents page to complete the draft."
+            "description": "Notify operators 30 days before the regulatory filing deadline per REQ-SBR-008. The scheduled trigger re-checks daily; the filter is the 30-day window plus the skip condition — a filing already submitted or approved has left the draft status and is therefore no longer matched.",
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "finance-manager"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "SBR-deadline over 30 dagen: {{name}} ({{code}}) moet vóór {{filingDeadline}} zijn ingediend",
+              "en": "SBR filing deadline in 30 days: {{name}} ({{code}}) is due on {{filingDeadline}}"
+            }
           },
           "onRejected": {
             "trigger": {
@@ -479,12 +561,26 @@
               "action": "reject"
             },
             "description": "Notify finance-manager when Belastingdienst rejects a submitted filing (REQ-SBR-005).",
-            "recipients": {
-              "role": "finance-manager",
-              "scope": "@self.administrationId"
-            },
-            "title": "SBR filing rejected by Belastingdienst",
-            "message": "Filing @self.name (@self.code) was rejected: @self.rejectionReason. Remediation required."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "finance-manager"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "SBR-aangifte afgewezen door de Belastingdienst: {{name}} ({{code}}) — {{rejectionReason}}",
+              "en": "SBR filing rejected by the Dutch Tax Administration: {{name}} ({{code}}) — {{rejectionReason}}"
+            }
           }
         },
         "x-openregister-rbac": {

--- a/lib/Settings/register.d/bookkeeping-single-audit-eu-fondsen.json
+++ b/lib/Settings/register.d/bookkeeping-single-audit-eu-fondsen.json
@@ -924,12 +924,26 @@
               "action": "submit"
             },
             "description": "Notify the eu-projectleider when an expenditure is submitted to the MA.",
-            "recipients": {
-              "role": "eu-projectleider",
-              "scope": "@self.administrationId"
-            },
-            "title": "EU-uitgave ingediend bij MA",
-            "message": "EU-uitgave voor @self.declarationPeriod is ingediend bij de managementautoriteit."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "eu-projectleider"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "EU-uitgave voor {{declarationPeriod}} is ingediend bij de managementautoriteit",
+              "en": "EU expenditure for {{declarationPeriod}} was submitted to the managing authority"
+            }
           }
         },
         "x-openregister-rbac": {
@@ -1338,12 +1352,26 @@
               "type": "created"
             },
             "description": "Notify the controller when an irregularity is reported.",
-            "recipients": {
-              "role": "controller",
-              "scope": "@self.administrationId"
-            },
-            "title": "Onregelmatigheid gemeld",
-            "message": "Onregelmatigheid (@self.nature) van @self.amountConcerned EUR gemeld op project @self.euProjectId."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "controller"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Onregelmatigheid gemeld ({{nature}}) van {{amountConcerned}} EUR op project {{euProjectId}}",
+              "en": "Irregularity reported ({{nature}}) of {{amountConcerned}} EUR on project {{euProjectId}}"
+            }
           }
         },
         "x-openregister-rbac": {

--- a/lib/Settings/register.d/bookkeeping-subsidie-verantwoording.json
+++ b/lib/Settings/register.d/bookkeeping-subsidie-verantwoording.json
@@ -284,8 +284,10 @@
               "nc-notification",
               "email"
             ],
-            "subject": "Report Ready for Approval",
-            "message": "Subsidie verantwoording @self.verantwoordingId is submitted for approval."
+            "subject": {
+              "nl": "Subsidieverantwoording {{verantwoordingId}} is ingediend en wacht op goedkeuring",
+              "en": "Grant accountability report {{verantwoordingId}} is submitted and awaiting approval"
+            }
           },
           "onApproved": {
             "trigger": {
@@ -302,8 +304,10 @@
             "channels": [
               "nc-notification"
             ],
-            "subject": "Accountability Report Approved",
-            "message": "Subsidie verantwoording @self.verantwoordingId is approved."
+            "subject": {
+              "nl": "Subsidieverantwoording {{verantwoordingId}} is goedgekeurd",
+              "en": "Grant accountability report {{verantwoordingId}} is approved"
+            }
           },
           "onFinal": {
             "trigger": {
@@ -320,8 +324,10 @@
             "channels": [
               "nc-notification"
             ],
-            "subject": "Accountability Report Finalised",
-            "message": "Subsidie verantwoording @self.verantwoordingId is finalised."
+            "subject": {
+              "nl": "Subsidieverantwoording {{verantwoordingId}} is definitief vastgesteld",
+              "en": "Grant accountability report {{verantwoordingId}} is finalised"
+            }
           },
           "onOverdue": {
             "trigger": {
@@ -341,8 +347,10 @@
             "channels": [
               "nc-notification"
             ],
-            "subject": "Accountability Report Overdue",
-            "message": "Subsidie verantwoording @self.verantwoordingId is overdue for approval (grant @self.grantId)."
+            "subject": {
+              "nl": "Subsidieverantwoording {{verantwoordingId}} is te laat voor goedkeuring (subsidie {{grantId}})",
+              "en": "Grant accountability report {{verantwoordingId}} is overdue for approval (grant {{grantId}})"
+            }
           }
         },
         "x-openregister-relations": {
@@ -592,8 +600,10 @@
             "channels": [
               "nc-notification"
             ],
-            "subject": "Auditor Statement — Under Review",
-            "message": "Auditor statement @self.statementId is now under review."
+            "subject": {
+              "nl": "Accountantsverklaring {{statementId}} is in behandeling genomen door de accountant",
+              "en": "Auditor statement {{statementId}} has been accepted and is now under review"
+            }
           },
           "onApproved": {
             "trigger": {
@@ -611,8 +621,10 @@
               "nc-notification",
               "email"
             ],
-            "subject": "Auditor Statement — Approved",
-            "message": "Auditor statement @self.statementId is approved."
+            "subject": {
+              "nl": "Accountantsverklaring {{statementId}} is goedgekeurd",
+              "en": "Auditor statement {{statementId}} is approved"
+            }
           },
           "onRejected": {
             "trigger": {
@@ -630,8 +642,10 @@
               "nc-notification",
               "email"
             ],
-            "subject": "Auditor Statement — Rejected",
-            "message": "Auditor statement @self.statementId is rejected; grant settlement is blocked."
+            "subject": {
+              "nl": "Accountantsverklaring {{statementId}} is afgekeurd; de subsidievaststelling is geblokkeerd",
+              "en": "Auditor statement {{statementId}} is rejected; grant settlement is blocked"
+            }
           },
           "onConditional": {
             "trigger": {
@@ -649,8 +663,10 @@
               "nc-notification",
               "email"
             ],
-            "subject": "Auditor Statement — Conditional Approval",
-            "message": "Auditor statement @self.statementId is conditionally approved with caveats."
+            "subject": {
+              "nl": "Accountantsverklaring {{statementId}} is met voorbehoud goedgekeurd",
+              "en": "Auditor statement {{statementId}} is conditionally approved, with caveats"
+            }
           }
         },
         "x-openregister-relations": {

--- a/lib/Settings/register.d/bookkeeping-vpb-mkb.json
+++ b/lib/Settings/register.d/bookkeeping-vpb-mkb.json
@@ -294,7 +294,9 @@
           },
           "belastingplichtige": {
             "type": "string",
-            "description": "FK naar de Belastingplichtige.",
+            "format": "uuid",
+            "$ref": "Belastingplichtige",
+            "description": "Reference to the Belastingplichtige (taxable entity) this record belongs to.",
             "example": "belastingplichtige-acme-bv",
             "title": "Belastingplichtige"
           },
@@ -504,43 +506,6 @@
             }
           }
         },
-        "x-openregister-relations": {
-          "belastingplichtigeRef": {
-            "localField": "belastingplichtige",
-            "relatedSchema": "Belastingplichtige",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "De belastingplichtige van deze aangifte."
-          },
-          "correcties": {
-            "localField": "id",
-            "relatedSchema": "FiscaleCorrectie",
-            "relatedField": "aangifte",
-            "cardinality": "one-to-many",
-            "description": "Fiscale correcties commercieel → fiscaal (REQ-VPB-002)."
-          },
-          "innovatieboxClaims": {
-            "localField": "id",
-            "relatedSchema": "Innovatiebox",
-            "relatedField": "aangifte",
-            "cardinality": "one-to-many",
-            "description": "Innovatiebox-claims (REQ-VPB-004)."
-          },
-          "investeringsAftrekken": {
-            "localField": "id",
-            "relatedSchema": "InvesteringsAftrek",
-            "relatedField": "aangifte",
-            "cardinality": "one-to-many",
-            "description": "KIA/EIA/MIA/Vamil-claims (REQ-VPB-008)."
-          },
-          "definitieveAanslag": {
-            "localField": "id",
-            "relatedSchema": "DefinitieveAanslag",
-            "relatedField": "aangifte",
-            "cardinality": "one-to-one",
-            "description": "De definitieve aanslag (REQ-VPB-010)."
-          }
-        },
         "x-openregister-rbac": {
           "roles": {
             "fiscalist": {
@@ -597,7 +562,9 @@
           },
           "aangifte": {
             "type": "string",
-            "description": "FK naar de VpbAangifte.",
+            "format": "uuid",
+            "$ref": "VpbAangifte",
+            "description": "Reference to the VpbAangifte (corporate income tax return) this record belongs to.",
             "example": "vpb-aangifte-acme-2026",
             "title": "Aangifte"
           },
@@ -645,15 +612,6 @@
           "correctieBedrag": {
             "description": "Fiscaal bedrag minus commercieel bedrag (REQ-VPB-002).",
             "expr": "(@self.fiscaalBedrag ?? 0) - (@self.commercieelBedrag ?? 0)"
-          }
-        },
-        "x-openregister-relations": {
-          "aangifteRef": {
-            "localField": "aangifte",
-            "relatedSchema": "VpbAangifte",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "De aangifte waartoe deze correctie behoort."
           }
         },
         "x-openregister-rbac": {
@@ -707,7 +665,9 @@
           },
           "aangifte": {
             "type": "string",
-            "description": "FK naar de VpbAangifte.",
+            "format": "uuid",
+            "$ref": "VpbAangifte",
+            "description": "Reference to the VpbAangifte (corporate income tax return) this record belongs to.",
             "example": "vpb-aangifte-acme-2026",
             "title": "Aangifte"
           },
@@ -797,15 +757,6 @@
           },
           "transitions": {}
         },
-        "x-openregister-relations": {
-          "aangifteRef": {
-            "localField": "aangifte",
-            "relatedSchema": "VpbAangifte",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "De aangifte waartoe deze claim behoort."
-          }
-        },
         "x-openregister-rbac": {
           "roles": {
             "fiscalist": {
@@ -857,7 +808,9 @@
           },
           "belastingplichtige": {
             "type": "string",
-            "description": "FK naar de Belastingplichtige (houdstermaatschappij).",
+            "format": "uuid",
+            "$ref": "Belastingplichtige",
+            "description": "Reference to the holding Belastingplichtige (houdstermaatschappij) that owns this participation.",
             "example": "belastingplichtige-acme-bv",
             "title": "Belastingplichtige"
           },
@@ -945,15 +898,6 @@
             "expr": "(@self.aandeelhouderschapPercentage ?? 0) >= 5"
           }
         },
-        "x-openregister-relations": {
-          "belastingplichtigeRef": {
-            "localField": "belastingplichtige",
-            "relatedSchema": "Belastingplichtige",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "De houdster-belastingplichtige."
-          }
-        },
         "x-openregister-rbac": {
           "roles": {
             "fiscalist": {
@@ -1004,7 +948,9 @@
           },
           "moedermaatschappij": {
             "type": "string",
-            "description": "FK naar de Belastingplichtige-moedermaatschappij.",
+            "format": "uuid",
+            "$ref": "Belastingplichtige",
+            "description": "Reference to the parent Belastingplichtige (moedermaatschappij) at the head of this fiscale eenheid.",
             "example": "belastingplichtige-acme-bv",
             "title": "Moedermaatschappij"
           },
@@ -1066,15 +1012,6 @@
             "title": "Voorvoegingsverliezen Per Dochter"
           }
         },
-        "x-openregister-relations": {
-          "moederRef": {
-            "localField": "moedermaatschappij",
-            "relatedSchema": "Belastingplichtige",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "De moedermaatschappij."
-          }
-        },
         "x-openregister-rbac": {
           "roles": {
             "fiscalist": {
@@ -1126,7 +1063,9 @@
           },
           "belastingplichtige": {
             "type": "string",
-            "description": "FK naar de Belastingplichtige.",
+            "format": "uuid",
+            "$ref": "Belastingplichtige",
+            "description": "Reference to the Belastingplichtige (taxable entity) this record belongs to.",
             "example": "belastingplichtige-acme-bv",
             "title": "Belastingplichtige"
           },
@@ -1200,15 +1139,6 @@
             "guard": "OCA\\Shillinq\\Lifecycle\\VpbBerekeningGuard::bepaalVerjaardatum"
           }
         },
-        "x-openregister-relations": {
-          "belastingplichtigeRef": {
-            "localField": "belastingplichtige",
-            "relatedSchema": "Belastingplichtige",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "De belastingplichtige die het verlies droeg."
-          }
-        },
         "x-openregister-rbac": {
           "roles": {
             "fiscalist": {
@@ -1260,7 +1190,9 @@
           },
           "aangifte": {
             "type": "string",
-            "description": "FK naar de VpbAangifte.",
+            "format": "uuid",
+            "$ref": "VpbAangifte",
+            "description": "Reference to the VpbAangifte (corporate income tax return) this record belongs to.",
             "example": "vpb-aangifte-acme-2026",
             "title": "Aangifte"
           },
@@ -1343,15 +1275,6 @@
             "expr": "(@self.type == 'EIA' and contains(@self.gecombineerdMet, 'MIA')) or (@self.type == 'MIA' and contains(@self.gecombineerdMet, 'EIA'))"
           }
         },
-        "x-openregister-relations": {
-          "aangifteRef": {
-            "localField": "aangifte",
-            "relatedSchema": "VpbAangifte",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "De aangifte waartoe deze aftrek behoort."
-          }
-        },
         "x-openregister-rbac": {
           "roles": {
             "fiscalist": {
@@ -1404,7 +1327,9 @@
           },
           "belastingplichtige": {
             "type": "string",
-            "description": "FK naar de Belastingplichtige.",
+            "format": "uuid",
+            "$ref": "Belastingplichtige",
+            "description": "Reference to the Belastingplichtige (taxable entity) this record belongs to.",
             "example": "belastingplichtige-acme-bv",
             "title": "Belastingplichtige"
           },
@@ -1472,15 +1397,6 @@
             "title": "Herzieningsuitslag"
           }
         },
-        "x-openregister-relations": {
-          "belastingplichtigeRef": {
-            "localField": "belastingplichtige",
-            "relatedSchema": "Belastingplichtige",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "De belastingplichtige."
-          }
-        },
         "x-openregister-rbac": {
           "roles": {
             "fiscalist": {
@@ -1532,7 +1448,9 @@
           },
           "aangifte": {
             "type": "string",
-            "description": "FK naar de VpbAangifte.",
+            "format": "uuid",
+            "$ref": "VpbAangifte",
+            "description": "Reference to the VpbAangifte (corporate income tax return) this record belongs to.",
             "example": "vpb-aangifte-acme-2026",
             "title": "Aangifte"
           },
@@ -1648,22 +1566,6 @@
             }
           }
         },
-        "x-openregister-relations": {
-          "aangifteRef": {
-            "localField": "aangifte",
-            "relatedSchema": "VpbAangifte",
-            "relatedField": "id",
-            "cardinality": "one-to-one",
-            "description": "De aangifte waarop deze aanslag ziet."
-          },
-          "bezwaren": {
-            "localField": "id",
-            "relatedSchema": "BezwaarBeroep",
-            "relatedField": "aanslag",
-            "cardinality": "one-to-many",
-            "description": "Bezwaar/beroep-procedures tegen deze aanslag (REQ-VPB-010)."
-          }
-        },
         "x-openregister-rbac": {
           "roles": {
             "fiscalist": {
@@ -1715,7 +1617,9 @@
           },
           "aanslag": {
             "type": "string",
-            "description": "FK naar de DefinitieveAanslag.",
+            "format": "uuid",
+            "$ref": "DefinitieveAanslag",
+            "description": "Reference to the DefinitieveAanslag (final assessment) this objection or appeal contests.",
             "example": "definitieve-aanslag-acme-2026",
             "title": "Aanslag"
           },
@@ -1940,15 +1844,6 @@
               "label": "Afronden (berusten)",
               "description": "Berusten in de uitspraak; procedure afgerond."
             }
-          }
-        },
-        "x-openregister-relations": {
-          "aanslagRef": {
-            "localField": "aanslag",
-            "relatedSchema": "DefinitieveAanslag",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "De bestreden aanslag."
           }
         },
         "x-openregister-rbac": {

--- a/lib/Settings/register.d/btw-suppletie-detection.json
+++ b/lib/Settings/register.d/btw-suppletie-detection.json
@@ -19,16 +19,24 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["collected", "paid", "reverse-charge"]
+                  "enum": ["collected", "paid", "reverse-charge"],
+                  "title": "Rubriek Type",
+                  "description": "Which side of the BTW return this bucket belongs to: collected = verschuldigde omzetbelasting (output VAT), paid = voorbelasting (input VAT), reverse-charge = verlegde BTW."
                 },
                 "taxRate": {
-                  "type": "number"
+                  "type": "number",
+                  "title": "Tax Rate",
+                  "description": "BTW rate of this bucket as a percentage (21, 9 or 0), not a decimal fraction."
                 },
                 "totalVATAmount": {
-                  "type": "number"
+                  "type": "number",
+                  "title": "Total VAT Amount",
+                  "description": "VAT amount filed for this bucket, in EUR."
                 },
                 "totalTaxableAmount": {
-                  "type": "number"
+                  "type": "number",
+                  "title": "Total Taxable Amount",
+                  "description": "Taxable base (omzet excluding VAT) filed for this bucket, in EUR."
                 }
               }
             },
@@ -43,16 +51,24 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["collected", "paid", "reverse-charge"]
+                  "enum": ["collected", "paid", "reverse-charge"],
+                  "title": "Rubriek Type",
+                  "description": "Which side of the BTW return this bucket belongs to: collected = verschuldigde omzetbelasting (output VAT), paid = voorbelasting (input VAT), reverse-charge = verlegde BTW."
                 },
                 "taxRate": {
-                  "type": "number"
+                  "type": "number",
+                  "title": "Tax Rate",
+                  "description": "BTW rate of this bucket as a percentage (21, 9 or 0), not a decimal fraction."
                 },
                 "totalVATAmount": {
-                  "type": "number"
+                  "type": "number",
+                  "title": "Total VAT Amount",
+                  "description": "VAT amount for this bucket as recomputed from the general ledger now, in EUR."
                 },
                 "totalTaxableAmount": {
-                  "type": "number"
+                  "type": "number",
+                  "title": "Total Taxable Amount",
+                  "description": "Taxable base (omzet excluding VAT) for this bucket as recomputed from the general ledger now, in EUR."
                 }
               }
             },
@@ -67,20 +83,29 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["collected", "paid", "reverse-charge"]
+                  "enum": ["collected", "paid", "reverse-charge"],
+                  "title": "Rubriek Type",
+                  "description": "Which side of the BTW return this delta belongs to: collected = verschuldigde omzetbelasting (output VAT), paid = voorbelasting (input VAT), reverse-charge = verlegde BTW."
                 },
                 "taxRate": {
-                  "type": "number"
+                  "type": "number",
+                  "title": "Tax Rate",
+                  "description": "BTW rate of the bucket this delta applies to, as a percentage (21, 9 or 0)."
                 },
                 "deltaVATAmount": {
-                  "type": "number"
+                  "type": "number",
+                  "title": "Delta VAT Amount",
+                  "description": "currentSnapshot minus filedSnapshot for this bucket's VAT amount, in EUR. Positive means additional VAT is owed; negative means a refund is due."
                 },
                 "deltaTaxableAmount": {
-                  "type": "number"
+                  "type": "number",
+                  "title": "Delta Taxable Amount",
+                  "description": "currentSnapshot minus filedSnapshot for this bucket's taxable base, in EUR."
                 },
                 "glAccountNumber": {
                   "type": "string",
                   "nullable": true,
+                  "title": "GL Account Number",
                   "description": "Account the original rubriek posted to; reused for the GL correction line."
                 }
               }

--- a/lib/Settings/register.d/gl-account-suggestion-consume.json
+++ b/lib/Settings/register.d/gl-account-suggestion-consume.json
@@ -24,11 +24,11 @@
             "type": "object",
             "description": "The last-fetched docudesk GL-account suggestion (REQ-GAC-003): {code, label, confidence, rationale, source}. Cached on the draft so the operator's eventual booking choice can be compared against it without a live round-trip. Never auto-applied to glAccount (REQ-GAC-004) — informational only.",
             "properties": {
-              "code": { "type": "string" },
-              "label": { "type": "string", "nullable": true },
-              "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
-              "rationale": { "type": "string" },
-              "source": { "type": "string", "enum": ["history", "keyword-rule", "none"] }
+              "code": { "type": "string", "title": "Account Code", "description": "The suggested grootboekrekening code from the chart of accounts (bookkeeping-chart-of-accounts), e.g. '4300'. Informational only — never written to glAccount without operator confirmation (REQ-GAC-004)." },
+              "label": { "type": "string", "nullable": true, "title": "Account Label", "description": "Human-readable name of the suggested account as docudesk knew it at suggestion time. Cached so the suggestion still reads sensibly if the account is later renamed; null when docudesk returned no name." },
+              "confidence": { "type": "number", "minimum": 0, "maximum": 1, "title": "Confidence", "description": "How strongly docudesk backs this suggestion, from 0 (no confidence) to 1 (certain). A decimal fraction, not a percentage." },
+              "rationale": { "type": "string", "title": "Rationale", "description": "Docudesk's own plain-language explanation of why this account was suggested, shown to the operator so the suggestion can be judged rather than merely accepted." },
+              "source": { "type": "string", "enum": ["history", "keyword-rule", "none"], "title": "Source", "description": "How the suggestion was derived: history = this supplier's past bookings, keyword-rule = a text-matching mapping rule, none = docudesk had no basis to suggest anything." }
             },
             "nullable": true,
             "example": { "code": "4300", "label": "Kantoorkosten", "confidence": 0.8, "rationale": "Booked to 4300 in 8 of the last 10 invoices from this supplier", "source": "history" },
@@ -56,11 +56,11 @@
             "type": "object",
             "description": "The last-fetched docudesk GL-account suggestion (REQ-GAC-003): {code, label, confidence, rationale, source}. Never auto-applied to glAccount (REQ-GAC-004).",
             "properties": {
-              "code": { "type": "string" },
-              "label": { "type": "string", "nullable": true },
-              "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
-              "rationale": { "type": "string" },
-              "source": { "type": "string", "enum": ["history", "keyword-rule", "none"] }
+              "code": { "type": "string", "title": "Account Code", "description": "The suggested grootboekrekening code from the chart of accounts (bookkeeping-chart-of-accounts), e.g. '4400'. Informational only — never written to glAccount without operator confirmation (REQ-GAC-004)." },
+              "label": { "type": "string", "nullable": true, "title": "Account Label", "description": "Human-readable name of the suggested account as docudesk knew it at suggestion time. Cached so the suggestion still reads sensibly if the account is later renamed; null when docudesk returned no name." },
+              "confidence": { "type": "number", "minimum": 0, "maximum": 1, "title": "Confidence", "description": "How strongly docudesk backs this suggestion, from 0 (no confidence) to 1 (certain). A decimal fraction, not a percentage." },
+              "rationale": { "type": "string", "title": "Rationale", "description": "Docudesk's own plain-language explanation of why this account was suggested, shown to the operator so the suggestion can be judged rather than merely accepted." },
+              "source": { "type": "string", "enum": ["history", "keyword-rule", "none"], "title": "Source", "description": "How the suggestion was derived: history = this supplier's past bookings, keyword-rule = a text-matching mapping rule, none = docudesk had no basis to suggest anything." }
             },
             "nullable": true,
             "example": { "code": "4400", "label": "Representatiekosten", "confidence": 0.4, "rationale": "Keyword 'lunch' matched mapping rule → 4400", "source": "keyword-rule" },

--- a/lib/Settings/register.d/recurring-invoicing.json
+++ b/lib/Settings/register.d/recurring-invoicing.json
@@ -136,7 +136,7 @@
                 "minimum": 1,
                 "nullable": true,
                 "title": "Occurrence Count",
-                "description": "The count or quantity of occurrenc."
+                "description": "Total number of invoices this profile generates before it ends. Counted from the first generated period; when it is reached the profile transitions to ended (REQ-RIN-005)."
               }
             },
             "title": "End Condition"
@@ -379,6 +379,16 @@
               "status",
               "nextRunDate"
             ]
+          },
+          "isEndingSoon": {
+            "description": "True when an active profile is within 30 days of its endCondition.endDate, or has 1 occurrence left of an endCondition.occurrenceCount run (REQ-RIN-005). An open-ended profile (no endCondition) and an already-ended profile both resolve false. Materialised so the onProfileEndingSoon scheduled notification can filter on it.",
+            "expression": "(status == 'active') && (((endCondition.endDate != null) && (endCondition.endDate <= addDays(today(), 30))) || ((endCondition.occurrenceCount != null) && (remainingOccurrences != null) && (remainingOccurrences <= 1)))",
+            "materialise": true,
+            "dependsOn": [
+              "status",
+              "endCondition",
+              "remainingOccurrences"
+            ]
           }
         },
         "x-openregister-scheduled-workflows": {
@@ -399,44 +409,111 @@
           "onDraftGenerated": {
             "trigger": "generation.draft",
             "description": "A recurring draft invoice was generated and is awaiting review.",
-            "recipients": {
-              "role": "bookkeeper",
-              "scope": "@self.administrationId"
-            },
-            "title": "Recurring draft invoice ready for review",
-            "message": "A draft invoice for recurring profile @self.name (@self.lastBillingPeriod) is ready for review."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "bookkeeper"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Conceptfactuur voor terugkerend profiel {{name}} ({{lastBillingPeriod}}) staat klaar voor beoordeling",
+              "en": "Draft invoice for recurring profile {{name}} ({{lastBillingPeriod}}) is ready for review"
+            }
           },
           "onGenerationFailed": {
-            "trigger": "field-change",
-            "field": "lastRunStatus",
-            "condition": "lastRunStatus == 'failed'",
-            "description": "A recurring generation run failed and needs operator attention.",
-            "recipients": {
-              "role": "bookkeeper",
-              "scope": "@self.administrationId"
+            "trigger": {
+              "type": "updated",
+              "condition": {
+                "field": "lastRunStatus",
+                "operator": "equals",
+                "value": "failed"
+              }
             },
-            "title": "Recurring invoice generation failed",
-            "message": "Generation for recurring profile @self.name failed: @self.lastRunError."
+            "description": "A recurring generation run failed and needs operator attention.",
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "bookkeeper"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Generatie van terugkerend profiel {{name}} is mislukt: {{lastRunError}}",
+              "en": "Generation for recurring profile {{name}} failed: {{lastRunError}}"
+            }
           },
           "onProfileEndingSoon": {
-            "trigger": "scheduled",
-            "description": "A recurring profile is approaching its end condition.",
-            "recipients": {
-              "role": "bookkeeper",
-              "scope": "@self.administrationId"
+            "trigger": {
+              "type": "scheduled",
+              "intervalSec": 86400,
+              "filter": {
+                "isEndingSoon": true
+              }
             },
-            "title": "Recurring profile ending soon",
-            "message": "Recurring profile @self.name is approaching its end condition."
+            "description": "A recurring profile is approaching its end condition. The scheduled trigger re-checks daily and matches on the materialised isEndingSoon calculation, so an open-ended or already-ended profile never fires.",
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "bookkeeper"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Terugkerend profiel {{name}} nadert zijn einddatum of laatste termijn",
+              "en": "Recurring profile {{name}} is approaching its end condition"
+            }
           },
           "onIndexationApplied": {
             "trigger": "generation.indexation",
             "description": "Annual price indexation was applied to a recurring profile.",
-            "recipients": {
-              "role": "bookkeeper",
-              "scope": "@self.administrationId"
-            },
-            "title": "Recurring profile indexation applied",
-            "message": "Indexation of @self.indexationPercent% was applied to recurring profile @self.name."
+            "enabled": true,
+            "channels": [
+              "nc-notification"
+            ],
+            "recipients": [
+              {
+                "kind": "object-acl",
+                "permission": "manage"
+              },
+              {
+                "kind": "groups",
+                "groups": [
+                  "bookkeeper"
+                ]
+              }
+            ],
+            "subject": {
+              "nl": "Indexering van {{indexationPercent}}% toegepast op terugkerend profiel {{name}}",
+              "en": "Indexation of {{indexationPercent}}% was applied to recurring profile {{name}}"
+            }
           }
         },
         "x-openregister-relations": {

--- a/lib/Settings/register.d/zz-order-primitive.json
+++ b/lib/Settings/register.d/zz-order-primitive.json
@@ -153,6 +153,7 @@
           "subsidie": {
             "type": "object",
             "nullable": true,
+            "title": "Subsidie Details",
             "description": "Populated only when orderType=subsidie. The full field set of the retired Subsidie schema (per Awb afdeling 4.2 + VNG ASV-model 2022) — no regulatory field dropped (REQ-ORD-002/003).",
             "properties": {
               "subsidieNumber": {
@@ -334,6 +335,7 @@
           "purchase": {
             "type": "object",
             "nullable": true,
+            "title": "Purchase Order Details",
             "description": "Populated only when orderType=purchase. The full field set of PurchaseOrder — amounts stay in integer EURO CENTS per ADR-022 (REQ-ORD-002/003).",
             "properties": {
               "poNumber": {
@@ -461,6 +463,7 @@
           "engagement": {
             "type": "object",
             "nullable": true,
+            "title": "Engagement Details",
             "description": "Populated only when orderType=engagement. The full field set of DBAOpdracht — Wet DBA compliance engagement (modelovereenkomst + risicoklasse), per REQ-ORD-002/003.",
             "properties": {
               "ondernemingId": {
@@ -609,6 +612,7 @@
           "migratedFrom": {
             "type": "object",
             "nullable": true,
+            "title": "Migrated From",
             "description": "Idempotency + provenance marker stamped by the FoldIntoOrder repair step. Never set by users.",
             "properties": {
               "schema": {

--- a/lib/Settings/shillinq_register.json
+++ b/lib/Settings/shillinq_register.json
@@ -327,7 +327,9 @@
         "properties": {
           "bankConnectionId": {
             "type": "string",
-            "description": "FK to the BankConnection that sourced this statement.",
+            "format": "uuid",
+            "$ref": "BankConnection",
+            "description": "Reference to the PSD2 BankConnection that generated this statement.",
             "example": "bank-conn-uuid-1",
             "title": "Bank Connection ID"
           },
@@ -383,15 +385,6 @@
             ],
             "template": "bank-statement-available",
             "description": "Notify the configured bank-connection operator when a new statement is available. Declarative fan-out per ADR-031; no BankNotificationService."
-          }
-        },
-        "x-openregister-relations": {
-          "bankConnection": {
-            "localField": "bankConnectionId",
-            "relatedSchema": "BankConnection",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "The PSD2 bank connection that generated this statement."
           }
         },
         "x-openregister-rbac": {
@@ -563,15 +556,6 @@
               "label": "Reverse transaction",
               "description": "Mark this transaction as reversed. A compensating GLTransaction referencing this one via reversesTransactionId must exist."
             }
-          }
-        },
-        "x-openregister-relations": {
-          "lines": {
-            "localField": "id",
-            "relatedSchema": "GLLine",
-            "relatedField": "transactionId",
-            "cardinality": "one-to-many",
-            "description": "All GLLine rows belonging to this transaction."
           }
         },
         "x-openregister-rbac": {
@@ -815,7 +799,7 @@
           },
           "accountNumber": {
             "type": "string",
-            "description": "FK to Account.accountNumber.",
+            "description": "FK to Account.accountNumber (bookkeeping-chart-of-accounts). A business key, not an object identifier — the referenced Account must be in lifecycleState active for the post transition to succeed.",
             "example": "4100",
             "title": "Account Number"
           },
@@ -897,17 +881,17 @@
           },
           "costCenterCode": {
             "type": "string",
-            "description": "FK to CostCenter.code for analytical cost-center reporting. Backwards-compatible with the existing costCenter field per REQ-CC-003.",
+            "description": "FK to AnalyticalDimension.code (dimensionType=cost-center) for dimension-tagged analytical reporting per REQ-CC-003 + REQ-ADIM-101. A business key, not an object identifier. Field name and stored values are unchanged; only the target was re-pointed from the retired CostCenter schema to the unified AnalyticalDimension, so this stays backwards-compatible with the existing costCenter field.",
             "nullable": true,
             "example": "KC-100",
             "title": "Cost Center Code"
           },
           "kostenDragerCode": {
             "type": "string",
-            "description": "FK to KostenDrager.code for cost-unit analytical reporting per REQ-CC-003.",
+            "description": "FK to AnalyticalDimension.code (dimensionType=cost-object) for cost-unit analytical reporting per REQ-CC-003 + REQ-ADIM-101. A business key, not an object identifier. Field name and stored values are unchanged; only the target was re-pointed from the retired KostenDrager schema to the unified AnalyticalDimension.",
             "nullable": true,
             "example": "KD-001",
-            "title": "Cost Center Code"
+            "title": "Kosten Drager Code"
           },
           "projectCode": {
             "type": "string",
@@ -946,43 +930,6 @@
               "eigenaars-woning"
             ],
             "title": "OZB Category"
-          }
-        },
-        "x-openregister-relations": {
-          "parentTransaction": {
-            "localField": "transactionId",
-            "relatedSchema": "GLTransaction",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "The parent GLTransaction that owns this line."
-          },
-          "account": {
-            "localField": "accountNumber",
-            "relatedSchema": "Account",
-            "relatedField": "accountNumber",
-            "cardinality": "many-to-one",
-            "description": "FK to Account.accountNumber (bookkeeping-chart-of-accounts). Requires Account.lifecycleState = active on the post transition."
-          },
-          "costCenterRelation": {
-            "localField": "costCenterCode",
-            "relatedSchema": "AnalyticalDimension",
-            "relatedField": "code",
-            "cardinality": "many-to-one",
-            "description": "FK to AnalyticalDimension.code (dimensionType=cost-center) for dimension-tagged analytical reporting per REQ-CC-003 + REQ-ADIM-101. Field name and stored values unchanged; register re-targeted from the retired CostCenter to the unified AnalyticalDimension."
-          },
-          "kostenDragerRelation": {
-            "localField": "kostenDragerCode",
-            "relatedSchema": "AnalyticalDimension",
-            "relatedField": "code",
-            "cardinality": "many-to-one",
-            "description": "FK to AnalyticalDimension.code (dimensionType=cost-object) for cost-unit analytical reporting per REQ-CC-003 + REQ-ADIM-101. Field name and stored values unchanged; register re-targeted from the retired KostenDrager to the unified AnalyticalDimension."
-          },
-          "projectRelation": {
-            "localField": "projectCode",
-            "relatedSchema": "Project",
-            "relatedField": "code",
-            "cardinality": "many-to-one",
-            "description": "FK to Project.code for project accounting and WBSO time-per-project per REQ-CC-003 + REQ-CC-007."
           }
         },
         "x-openregister-aggregations": {
@@ -1571,15 +1518,6 @@
               "description": "Move to historical archive from blocked state. Requires zero open balance.",
               "requires": "OCA\\Shillinq\\Guard\\AccountBalanceGuard::requireZeroBalance"
             }
-          }
-        },
-        "x-openregister-relations": {
-          "parentAccount": {
-            "localField": "parentAccountNumber",
-            "relatedSchema": "Account",
-            "relatedField": "accountNumber",
-            "cardinality": "many-to-one",
-            "description": "Self-relation enabling hierarchical chart-of-accounts navigation."
           }
         },
         "x-openregister-rbac": {
@@ -3368,15 +3306,6 @@
               }
             }
           }
-        },
-        "x-openregister-relations": {
-          "parentProgramma": {
-            "localField": "parentCode",
-            "relatedSchema": "BBVProgramma",
-            "relatedField": "code",
-            "cardinality": "many-to-one",
-            "description": "Self-relation for hierarchical programma navigation (hoofdprogramma → sub-programma)."
-          }
         }
       },
       "WaterschapHeffingPosting": {
@@ -3770,7 +3699,9 @@
           },
           "administrationId": {
             "type": "string",
-            "description": "FK to the Administration owning this asset. Scopes uniqueness of assetNumber.",
+            "format": "uuid",
+            "$ref": "Administration",
+            "description": "Reference to the Administration owning this asset. Scopes uniqueness of assetNumber.",
             "example": "adm-1",
             "title": "Administration ID"
           }
@@ -4146,36 +4077,6 @@
               "label": "Reject proposal",
               "description": "Reject the asset proposal without capitalising it."
             }
-          }
-        },
-        "x-openregister-relations": {
-          "administration": {
-            "localField": "administrationId",
-            "relatedSchema": "Administration",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "Administration that owns this asset."
-          },
-          "assetAccount": {
-            "localField": "assetAccountNumber",
-            "relatedSchema": "Account",
-            "relatedField": "accountNumber",
-            "cardinality": "many-to-one",
-            "description": "Balance-sheet account carrying the asset's gross value."
-          },
-          "accumulatedDepAccount": {
-            "localField": "accumulatedDepAccountNumber",
-            "relatedSchema": "Account",
-            "relatedField": "accountNumber",
-            "cardinality": "many-to-one",
-            "description": "Contra account for accumulated depreciation."
-          },
-          "depreciationExpenseAccount": {
-            "localField": "depreciationExpenseAccountNumber",
-            "relatedSchema": "Account",
-            "relatedField": "accountNumber",
-            "cardinality": "many-to-one",
-            "description": "P&L account for the periodic depreciation expense charge."
           }
         },
         "x-openregister-rbac": {
@@ -5599,15 +5500,6 @@
             "description": "Financial records — 7 years per Selectielijst 5.1.2 (REQ-CPA-014)."
           }
         },
-        "x-openregister-relations": {
-          "parentProject": {
-            "localField": "parentCode",
-            "relatedSchema": "Project",
-            "relatedField": "code",
-            "cardinality": "many-to-one",
-            "description": "Self-relation enabling hierarchical project navigation per REQ-CC-002."
-          }
-        },
         "x-openregister-aggregations": {
           "segmentPnl": {
             "description": "Segment P&L for this project: sum of GLLine amounts whose projectCode equals this record's code per REQ-CC-005. Shape is sufficient for WBSO time-per-project join per REQ-CC-007.",
@@ -5876,7 +5768,12 @@
           },
           "projectId": {
             "type": "string",
-            "description": "FK to the analytical dimension (AnalyticalDimension with dimensionType=project) for this budget allocation per REQ-CPA-103. Formerly CostProject.id — retargeted to AnalyticalDimension by retire-cost-project.",
+            "format": "uuid",
+            "$ref": "AnalyticalDimension",
+            "x-relation-filter": {
+              "dimensionType": "project"
+            },
+            "description": "Reference to the parent analytical dimension (an AnalyticalDimension with dimensionType=project) for this budget allocation per REQ-CPA-103. Formerly CostProject.id — retargeted to AnalyticalDimension by retire-cost-project.",
             "example": "cp-1",
             "title": "Project ID"
           },
@@ -5946,15 +5843,6 @@
             "rule": "selectielijst:5.1.2",
             "years": 7,
             "description": "Financial records — 7 years per Selectielijst 5.1.2 (REQ-CPA-115)."
-          }
-        },
-        "x-openregister-relations": {
-          "analyticalDimension": {
-            "localField": "projectId",
-            "relatedSchema": "AnalyticalDimension",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "Parent AnalyticalDimension (dimensionType=project) for this allocation per REQ-CPA-103. Formerly CostProject; retargeted to AnalyticalDimension by retire-cost-project."
           }
         },
         "x-openregister-rbac": {
@@ -8545,7 +8433,9 @@
           },
           "fiscalYearId": {
             "type": "string",
-            "description": "FK to the FiscalYear this closing entry belongs to. Per REQ-YEC-001.",
+            "format": "uuid",
+            "$ref": "FiscalYear",
+            "description": "Reference to the FiscalYear this closing entry belongs to. Per REQ-YEC-001.",
             "example": "fy-2026-nl",
             "title": "Fiscal Year ID"
           },
@@ -8603,8 +8493,10 @@
           },
           "glTransactionId": {
             "type": "string",
+            "format": "uuid",
+            "$ref": "GLTransaction",
             "nullable": true,
-            "description": "FK to the GLTransaction that materialised this closing entry when posted. Set by the lifecycle action on transition:post per REQ-YEC-009.",
+            "description": "Reference to the GLTransaction that materialised this closing entry when posted. Set by the lifecycle action on transition:post per REQ-YEC-009.",
             "example": "gl-txn-2026-close-revenue",
             "title": "GL Transaction ID"
           },
@@ -8720,27 +8612,6 @@
             }
           }
         },
-        "x-openregister-relations": {
-          "fiscalYear": {
-            "localField": "fiscalYearId",
-            "relatedSchema": "FiscalYear",
-            "cardinality": "many-to-one",
-            "description": "The fiscal year this closing entry belongs to."
-          },
-          "template": {
-            "localField": "automationTemplate",
-            "relatedSchema": "ClosingEntryTemplate",
-            "relatedField": "templateId",
-            "cardinality": "many-to-one",
-            "description": "The closing-entry template that generated this entry (when generated automatically)."
-          },
-          "glTransaction": {
-            "localField": "glTransactionId",
-            "relatedSchema": "GLTransaction",
-            "cardinality": "one-to-one",
-            "description": "The materialised GL transaction (set when the entry is posted)."
-          }
-        },
         "x-openregister-rbac": {
           "roles": {
             "bookkeeper": {
@@ -8825,7 +8696,9 @@
           },
           "fiscalYearId": {
             "type": "string",
-            "description": "FK to the FiscalYear this record covers. One RetainedEarnings record per (fiscalYearId, administrationId). Per REQ-YEC-002.",
+            "format": "uuid",
+            "$ref": "FiscalYear",
+            "description": "Reference to the FiscalYear this record covers. One RetainedEarnings record per (fiscalYearId, administrationId). Per REQ-YEC-002.",
             "example": "fy-2026-nl",
             "title": "Fiscal Year ID"
           },
@@ -8866,8 +8739,10 @@
           },
           "closingEntryId": {
             "type": "string",
+            "format": "uuid",
+            "$ref": "ClosingEntry",
             "nullable": true,
-            "description": "FK to the ClosingEntry that materialised the retained-earnings transfer for this FY. Set when the FY close lifecycle posts the entry per REQ-YEC-002 / REQ-YEC-009.",
+            "description": "Reference to the ClosingEntry that materialised the retained-earnings transfer for this FY. Set when the FY close lifecycle posts the entry per REQ-YEC-002 / REQ-YEC-009.",
             "example": "ce-2026-retained-earnings",
             "title": "Closing Entry ID"
           },
@@ -8876,20 +8751,6 @@
             "description": "FK to the Administration that owns this retained-earnings record. Composite uniqueness with fiscalYearId per D5.",
             "example": "adm-consultancy-nl",
             "title": "Administration ID"
-          }
-        },
-        "x-openregister-relations": {
-          "fiscalYear": {
-            "localField": "fiscalYearId",
-            "relatedSchema": "FiscalYear",
-            "cardinality": "many-to-one",
-            "description": "The fiscal year this retained-earnings record covers."
-          },
-          "closingEntry": {
-            "localField": "closingEntryId",
-            "relatedSchema": "ClosingEntry",
-            "cardinality": "one-to-one",
-            "description": "The closing entry that materialised the retained-earnings rollforward."
           }
         },
         "x-openregister-aggregations": {
@@ -8994,15 +8855,6 @@
             "description": "Optional start date if the administration rotates closing accounts across fiscal years (e.g. switching from 9900 to 9990). When null, this ClosingAccount applies indefinitely. Per REQ-YEC-003.",
             "example": "2026-01-01",
             "title": "Effective From"
-          }
-        },
-        "x-openregister-relations": {
-          "account": {
-            "localField": "accountNumber",
-            "relatedSchema": "Account",
-            "relatedField": "accountNumber",
-            "cardinality": "many-to-one",
-            "description": "The GL account designated as the closing / income-summary account."
           }
         },
         "x-openregister-rbac": {
@@ -9184,15 +9036,6 @@
             }
           }
         },
-        "x-openregister-relations": {
-          "closingAccount": {
-            "localField": "closingAccountNumber",
-            "relatedSchema": "Account",
-            "relatedField": "accountNumber",
-            "cardinality": "many-to-one",
-            "description": "The GL account these closing entries flow through."
-          }
-        },
         "x-openregister-rbac": {
           "roles": {
             "bookkeeper": {
@@ -9329,7 +9172,9 @@
           },
           "claimId": {
             "type": "string",
-            "description": "FK to parent ExpenseClaimEntry.id; null until the receipt is added to a claim.",
+            "format": "uuid",
+            "$ref": "ExpenseClaimEntry",
+            "description": "Reference to the parent ExpenseClaimEntry; null until the receipt is added to a claim.",
             "nullable": true,
             "example": "exp-claim-2026-0001",
             "title": "Claim ID"
@@ -9417,15 +9262,6 @@
               "value": "@self.receiptDate"
             },
             "nullable": true
-          }
-        },
-        "x-openregister-relations": {
-          "claim": {
-            "localField": "claimId",
-            "relatedSchema": "ExpenseClaimEntry",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "Parent expense claim this receipt belongs to."
           }
         },
         "x-openregister-rbac": {
@@ -9543,7 +9379,9 @@
           },
           "claimId": {
             "type": "string",
-            "description": "FK to parent ExpenseClaimEntry.id; null until added to a claim.",
+            "format": "uuid",
+            "$ref": "ExpenseClaimEntry",
+            "description": "Reference to the parent ExpenseClaimEntry; null until added to a claim.",
             "nullable": true,
             "example": "exp-claim-2026-0001",
             "title": "Claim ID"
@@ -9612,15 +9450,6 @@
               "prop": "@ref.rate.ratePerKm"
             },
             "targetField": "ratePerKm"
-          }
-        },
-        "x-openregister-relations": {
-          "claim": {
-            "localField": "claimId",
-            "relatedSchema": "ExpenseClaimEntry",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "Parent expense claim this mileage entry belongs to."
           }
         },
         "x-openregister-rbac": {
@@ -9727,7 +9556,9 @@
           },
           "claimId": {
             "type": "string",
-            "description": "FK to parent ExpenseClaimEntry.id; null until added to a claim.",
+            "format": "uuid",
+            "$ref": "ExpenseClaimEntry",
+            "description": "Reference to the parent ExpenseClaimEntry; null until added to a claim.",
             "nullable": true,
             "example": "exp-claim-2026-0001",
             "title": "Claim ID"
@@ -9831,15 +9662,6 @@
               "value": "@self.travelStartDate"
             },
             "nullable": true
-          }
-        },
-        "x-openregister-relations": {
-          "claim": {
-            "localField": "claimId",
-            "relatedSchema": "ExpenseClaimEntry",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "Parent expense claim this per-diem record belongs to."
           }
         },
         "x-openregister-rbac": {
@@ -9949,9 +9771,11 @@
           "receiptIds": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid",
+              "$ref": "Receipt"
             },
-            "description": "FKs to linked Receipt records.",
+            "description": "References to the Receipt records linked to this claim.",
             "nullable": true,
             "example": [
               "REC-2026-0001",
@@ -9962,9 +9786,11 @@
           "mileageIds": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid",
+              "$ref": "MileageEntry"
             },
-            "description": "FKs to linked MileageEntry records.",
+            "description": "References to the MileageEntry records linked to this claim.",
             "nullable": true,
             "example": [
               "MLG-2026-0001"
@@ -9974,9 +9800,11 @@
           "perDiemIds": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid",
+              "$ref": "PerDiem"
             },
-            "description": "FKs to linked PerDiem records.",
+            "description": "References to the PerDiem records linked to this claim.",
             "nullable": true,
             "example": [
               "PDM-2026-0001"
@@ -10249,29 +10077,6 @@
             ],
             "operation": "sum",
             "targetField": "totalAmount"
-          }
-        },
-        "x-openregister-relations": {
-          "receipts": {
-            "localField": "receiptIds",
-            "relatedSchema": "Receipt",
-            "relatedField": "id",
-            "cardinality": "one-to-many",
-            "description": "All Receipt records linked to this claim."
-          },
-          "mileageEntries": {
-            "localField": "mileageIds",
-            "relatedSchema": "MileageEntry",
-            "relatedField": "id",
-            "cardinality": "one-to-many",
-            "description": "All MileageEntry records linked to this claim."
-          },
-          "perDiemEntries": {
-            "localField": "perDiemIds",
-            "relatedSchema": "PerDiem",
-            "relatedField": "id",
-            "cardinality": "one-to-many",
-            "description": "All PerDiem records linked to this claim."
           }
         },
         "x-openregister-rbac": {
@@ -13181,7 +12986,9 @@
           },
           "assetRef": {
             "type": "string",
-            "description": "FK to FixedAsset UUID (OpenRegister relation).",
+            "format": "uuid",
+            "$ref": "FixedAsset",
+            "description": "Reference to the FixedAsset this depreciation schedule belongs to.",
             "example": "fa-uuid-0001",
             "title": "Asset Ref"
           },
@@ -13405,15 +13212,6 @@
                 "operation": "sum"
               }
             }
-          }
-        },
-        "x-openregister-relations": {
-          "fixedAsset": {
-            "localField": "assetRef",
-            "relatedSchema": "FixedAsset",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "The fixed asset this depreciation schedule belongs to."
           }
         },
         "x-openregister-audit-trail": {
@@ -14593,15 +14391,6 @@
               }
             }
           }
-        },
-        "x-openregister-relations": {
-          "linkedAccount": {
-            "localField": "linkedAccountNumber",
-            "relatedSchema": "Account",
-            "relatedField": "accountNumber",
-            "cardinality": "many-to-one",
-            "description": "FK to Chart-of-Accounts entry for GL classification per T1 bookkeeping-chart-of-accounts."
-          }
         }
       },
       "SBRDocumentType": {
@@ -14931,7 +14720,9 @@
         "properties": {
           "sourceAccountId": {
             "type": "string",
-            "description": "FK to Account.id — the Shillinq chart-of-accounts entry being mapped.",
+            "format": "uuid",
+            "$ref": "Account",
+            "description": "Reference to the Shillinq chart-of-accounts Account being mapped to an XBRL GL concept.",
             "example": "account-uuid-1000",
             "title": "Source Account ID"
           },
@@ -14971,22 +14762,6 @@
             "nullable": true,
             "example": "Direct mapping per RGS 3.5 MKB classification.",
             "title": "Notes"
-          }
-        },
-        "x-openregister-relations": {
-          "account": {
-            "localField": "sourceAccountId",
-            "relatedSchema": "Account",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "The Shillinq Account being mapped to an XBRL GL concept."
-          },
-          "taxonomy": {
-            "localField": "taxonomyVersion",
-            "relatedSchema": "XBRLTaxonomy",
-            "relatedField": "taxonomyVersion",
-            "cardinality": "many-to-one",
-            "description": "The XBRLTaxonomy version this mapping applies to."
           }
         },
         "x-openregister-rbac": {
@@ -15591,15 +15366,6 @@
             }
           }
         },
-        "x-openregister-relations": {
-          "repaymentInstallments": {
-            "localField": "id",
-            "relatedSchema": "RepaymentInstallment",
-            "relatedField": "subsidieId",
-            "cardinality": "one-to-many",
-            "description": "Child RepaymentInstallment records for the terugvordering afbetalingsregeling per REQ-SUB-007. NOT a parallel state machine per ADR-022."
-          }
-        },
         "x-openregister-rbac": {
           "roles": {
             "subsidie-coordinator": {
@@ -15650,7 +15416,9 @@
         "properties": {
           "subsidieId": {
             "type": "string",
-            "description": "FK to the Subsidie.id that this instalment belongs to.",
+            "format": "uuid",
+            "$ref": "Subsidie",
+            "description": "Reference to the Subsidie this instalment belongs to, as part of its terugvordering afbetalingsregeling per REQ-SUB-007.",
             "example": "sub-terugvordering-uuid",
             "title": "Subsidy ID"
           },
@@ -15837,15 +15605,6 @@
             "description": "Notify subsidie-coordinator when a repayment instalment becomes overdue per REQ-SUB-007 + REQ-SUB-010."
           }
         },
-        "x-openregister-relations": {
-          "subsidie": {
-            "localField": "subsidieId",
-            "relatedSchema": "Subsidie",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "The Subsidie record for which this instalment is part of the afbetalingsregeling per REQ-SUB-007."
-          }
-        },
         "x-openregister-rbac": {
           "roles": {
             "subsidie-coordinator": {
@@ -15990,22 +15749,6 @@
             "administrationId",
             "accountNumber"
           ]
-        },
-        "x-openregister-relations": {
-          "account": {
-            "localField": "accountNumber",
-            "relatedSchema": "Account",
-            "relatedField": "accountNumber",
-            "cardinality": "many-to-one",
-            "description": "FK to the T1 Account schema (chart of accounts)."
-          },
-          "bbvTaakveld": {
-            "localField": "taakveld",
-            "relatedSchema": "BbvTaakveld",
-            "relatedField": "taakveldCode",
-            "cardinality": "many-to-one",
-            "description": "FK to the BbvTaakveld catalogue entry."
-          }
         },
         "x-openregister-rbac": {
           "roles": {
@@ -16177,7 +15920,9 @@
         "properties": {
           "statementId": {
             "type": "string",
-            "description": "FK to the parent BankStatement.",
+            "format": "uuid",
+            "$ref": "BankStatement",
+            "description": "Reference to the parent BankStatement this line was imported from.",
             "example": "bs-uuid-1",
             "title": "Statement ID"
           },
@@ -16299,15 +16044,6 @@
               "trigger": "operator-action",
               "description": "Operator marks line as \"unmatched final\". Lifecycle materialises a GLTransaction to the designated suspense account per REQ-BR-007. Declarative per ADR-031."
             }
-          }
-        },
-        "x-openregister-relations": {
-          "statement": {
-            "localField": "statementId",
-            "relatedSchema": "BankStatement",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "The parent bank statement."
           }
         },
         "x-openregister-rbac": {
@@ -16632,7 +16368,9 @@
           },
           "matchingRuleId": {
             "type": "string",
-            "description": "FK to the MatchingRule that produced this candidate.",
+            "format": "uuid",
+            "$ref": "MatchingRule",
+            "description": "Reference to the MatchingRule that produced this candidate match.",
             "nullable": true,
             "example": "rule-uuid-1",
             "title": "Matching Rule ID"
@@ -16713,15 +16451,6 @@
             "confidenceField": "confidenceScore",
             "emitSchema": "ReconciliationMatch",
             "deduplication": "first-match-wins"
-          }
-        },
-        "x-openregister-relations": {
-          "matchingRule": {
-            "localField": "matchingRuleId",
-            "relatedSchema": "MatchingRule",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "The matching rule that produced this candidate."
           }
         },
         "x-openregister-rbac": {
@@ -16993,15 +16722,6 @@
             "description": "FK to the Administration that owns this IP asset.",
             "example": "adm-1",
             "title": "Administration ID"
-          }
-        },
-        "x-openregister-relations": {
-          "winstToerekeningen": {
-            "localField": "id",
-            "relatedSchema": "WinstToerekening",
-            "relatedField": "ipAssetId",
-            "cardinality": "one-to-many",
-            "description": "All WinstToerekening records attributed to this IP asset."
           }
         },
         "x-openregister-audit-trail": {
@@ -17414,9 +17134,11 @@
         "properties": {
           "ipAssetId": {
             "type": "string",
-            "description": "FK to IPAssetValuation.id this toerekening applies to.",
+            "format": "uuid",
+            "$ref": "IPAssetValuation",
+            "description": "Reference to the IPAssetValuation this profit attribution applies to.",
             "example": "ip-asset-uuid-1",
-            "title": "Ip Asset ID"
+            "title": "IP Asset ID"
           },
           "periodId": {
             "type": "string",
@@ -17552,15 +17274,6 @@
             "type": "number",
             "description": "Computed verdeelsleutel ratio for omzet-aandeel and r-en-d-uren methods. Null for custom-formula. JSON-AST nested if over verdeelsleutel with division.",
             "example": 0.3
-          }
-        },
-        "x-openregister-relations": {
-          "ipAsset": {
-            "localField": "ipAssetId",
-            "relatedSchema": "IPAssetValuation",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "The IP asset this profit attribution belongs to."
           }
         },
         "x-openregister-rbac": {
@@ -18507,15 +18220,6 @@
             }
           }
         },
-        "x-openregister-relations": {
-          "currencyBalances": {
-            "localField": "id",
-            "relatedSchema": "CurrencyBalance",
-            "relatedField": "accountId",
-            "cardinality": "one-to-many",
-            "description": "All CurrencyBalance snapshot records for this bank account across currencies."
-          }
-        },
         "x-openregister-aggregations": {
           "balanceByCurrency": {
             "description": "Latest balance per currency for this bank account. Aggregates CurrencyBalance records grouped by currency. Used for T3 cash-position dashboards per REQ-MC-004.",
@@ -18556,7 +18260,9 @@
           },
           "accountId": {
             "type": "string",
-            "description": "FK to BankAccount.id. Identifies which bank account this balance belongs to.",
+            "format": "uuid",
+            "$ref": "BankAccount",
+            "description": "Reference to the BankAccount this balance snapshot belongs to. Enables account metadata lookup on the detail page.",
             "example": "bank-eur-op",
             "title": "Account ID"
           },
@@ -18588,15 +18294,6 @@
             "description": "Timestamp of the most recent balance update. Used to determine snapshot freshness for reconciliation and cash-position reports.",
             "example": "2026-05-21T09:00:00Z",
             "title": "Last Updated"
-          }
-        },
-        "x-openregister-relations": {
-          "bankAccount": {
-            "localField": "accountId",
-            "relatedSchema": "BankAccount",
-            "relatedField": "id",
-            "cardinality": "many-to-one",
-            "description": "The bank account this balance snapshot belongs to. FK enabling account metadata lookup on the detail page."
           }
         },
         "x-openregister-filters": {
@@ -19684,15 +19381,6 @@
             "default": false,
             "description": "Whether this categorie is mandatory in the Iv3-aanlevering per informatievoorschrift.",
             "title": "Iv3 Mandatory"
-          }
-        },
-        "x-openregister-relations": {
-          "parent": {
-            "localField": "parentCode",
-            "relatedSchema": "EconomischeCategorie",
-            "relatedField": "code",
-            "cardinality": "many-to-one",
-            "description": "Self-relation for the economische-categorie hierarchy."
           }
         },
         "x-openregister-rbac": {
@@ -21084,15 +20772,6 @@
           "adminScope": {
             "field": "administrationId",
             "enforce": true
-          }
-        },
-        "x-openregister-relations": {
-          "order": {
-            "localField": "orderId",
-            "relatedSchema": "SalesOrder",
-            "relatedField": "orderId",
-            "cardinality": "many-to-one",
-            "description": "The parent SalesOrder this line belongs to."
           }
         }
       }
@@ -22799,7 +22478,9 @@
         },
         "writeOffGlTransactionId": {
           "type": "string",
-          "description": "Back-reference to the compensating GLTransaction emitted on write-off (debit bad-debt expense, credit AR control) per REQ-AR-007.",
+          "format": "uuid",
+          "$ref": "GLTransaction",
+          "description": "Reference to the compensating GLTransaction emitted on write-off (debit bad-debt expense, credit AR control) per REQ-AR-007.",
           "nullable": true,
           "example": "gl-txn-2026-wo-0001"
         },
@@ -23205,36 +22886,6 @@
           ]
         }
       },
-      "x-openregister-relations": {
-        "customer": {
-          "localField": "customerId",
-          "relatedSchema": "CustomerMaster",
-          "relatedField": "id",
-          "cardinality": "many-to-one",
-          "description": "FK to the CustomerMaster record this invoice bills."
-        },
-        "glTransaction": {
-          "localField": "glTransactionId",
-          "relatedSchema": "GLTransaction",
-          "relatedField": "id",
-          "cardinality": "many-to-one",
-          "description": "Back-reference to the materialised issue GLTransaction."
-        },
-        "writeOffGlTransaction": {
-          "localField": "writeOffGlTransactionId",
-          "relatedSchema": "GLTransaction",
-          "relatedField": "id",
-          "cardinality": "many-to-one",
-          "description": "Back-reference to the compensating write-off GLTransaction per REQ-AR-007."
-        },
-        "dunningRecords": {
-          "localField": "id",
-          "relatedSchema": "DunningRecord",
-          "relatedField": "invoiceRef",
-          "cardinality": "one-to-many",
-          "description": "Dunning timeline rows for this invoice per REQ-AR-005."
-        }
-      },
       "x-openregister-rbac": {
         "roles": {
           "bookkeeper": {
@@ -23399,7 +23050,9 @@
       "properties": {
         "invoiceRef": {
           "type": "string",
-          "description": "FK to ARInvoice UUID.",
+          "format": "uuid",
+          "$ref": "ARInvoice",
+          "description": "Reference to the parent ARInvoice this dunning record belongs to.",
           "example": "arinv-2026-0001"
         },
         "reminderLevel": {
@@ -23475,15 +23128,6 @@
           "type": "string",
           "description": "FK to the administration owning this dunning record.",
           "example": "adm-1"
-        }
-      },
-      "x-openregister-relations": {
-        "invoice": {
-          "localField": "invoiceRef",
-          "relatedSchema": "ARInvoice",
-          "relatedField": "id",
-          "cardinality": "many-to-one",
-          "description": "FK to the parent ARInvoice this dunning record belongs to."
         }
       },
       "x-openregister-rbac": {
@@ -23621,7 +23265,9 @@
         },
         "overrideId": {
           "type": "string",
-          "description": "Optional FK to ServiceCategoryOverride if this line's vatRate / serviceCategory combination was authorised under an exception per REQ-VAT-002bis.",
+          "format": "uuid",
+          "$ref": "ServiceCategoryOverride",
+          "description": "Optional reference to the ServiceCategoryOverride consulted at issue time, when this line's vatRate / serviceCategory combination was authorised under an exception per REQ-VAT-002bis.",
           "nullable": true,
           "example": "sco-2026-0001"
         },
@@ -23629,29 +23275,6 @@
           "type": "string",
           "description": "FK to the administration owning this audit record.",
           "example": "adm-1"
-        }
-      },
-      "x-openregister-relations": {
-        "invoice": {
-          "localField": "invoiceNumber",
-          "relatedSchema": "ARInvoice",
-          "relatedField": "invoiceNumber",
-          "cardinality": "many-to-one",
-          "description": "FK to the ARInvoice the audit record belongs to. The number is a stable business key; immutable once issued."
-        },
-        "fiscalPeriod": {
-          "localField": "settlementPeriod",
-          "relatedSchema": "FiscalPeriod",
-          "relatedField": "periodId",
-          "cardinality": "many-to-one",
-          "description": "FK to the FiscalPeriod bound at issue time per REQ-VAT-005."
-        },
-        "override": {
-          "localField": "overrideId",
-          "relatedSchema": "ServiceCategoryOverride",
-          "relatedField": "id",
-          "cardinality": "many-to-one",
-          "description": "Optional link to the ServiceCategoryOverride consulted at issue time per REQ-VAT-002bis."
         }
       },
       "x-openregister-aggregations": {
@@ -25302,7 +24925,9 @@
       "properties": {
         "subsidieId": {
           "type": "string",
-          "description": "FK to the parent Subsidie record of subtype specifieke-uitkering. Per ADR-022, no parallel SiSa subsidie register — indicator attaches to the existing T3 subsidie register.",
+          "format": "uuid",
+          "$ref": "Subsidie",
+          "description": "Reference to the parent Subsidie record of subtype specifieke-uitkering. Per ADR-022, no parallel SiSa subsidie register — the indicator attaches to the existing T3 subsidie register.",
           "example": "subsidie-uuid-d8-2026"
         },
         "regelingCode": {
@@ -25426,15 +25051,6 @@
           ],
           "template": "sisa-submission-confirmation",
           "description": "Notify the financial officer when a SiSa bijlage is submitted to BZK. Declarative; no SisaSubmissionService per ADR-031."
-        }
-      },
-      "x-openregister-relations": {
-        "subsidie": {
-          "localField": "subsidieId",
-          "relatedSchema": "Subsidie",
-          "relatedField": "id",
-          "cardinality": "many-to-one",
-          "description": "FK to the parent Subsidie record of subtype specifieke-uitkering. Declared per ADR-022 child-register pattern; no parallel SiSa subsidie register."
         }
       },
       "x-openregister-audit": {
@@ -25579,15 +25195,6 @@
               "VpbAangifte.Resultaat": "totalResultaat"
             }
           }
-        }
-      },
-      "x-openregister-relations": {
-        "costCenter": {
-          "localField": "costCenterId",
-          "relatedSchema": "AnalyticalDimension",
-          "relatedField": "code",
-          "cardinality": "many-to-one",
-          "description": "FK to the ondernemingsactiviteit cost-center dimension. AnalyticalDimension.dimensionType MUST be cost-center AND AnalyticalDimension.ondernemingsActiviteit MUST be true per REQ-VPB-002 + REQ-ADIM-102. Re-targeted from the retired CostCenter to the unified AnalyticalDimension; stored costCenterId values unchanged."
         }
       },
       "x-openregister-rbac": {

--- a/lib/Settings/shillinq_register.json
+++ b/lib/Settings/shillinq_register.json
@@ -20774,890 +20774,13 @@
             "enforce": true
           }
         }
-      }
-    },
-    "SisaReport": {
-      "slug": "SisaReport",
-      "icon": "FileDocumentCheckOutline",
-      "version": "0.1.0",
-      "title": "SiSa Report",
-      "description": "Single Information Single Audit (SiSa) compliance report per fiscal year per REQ-SISA-001. Aggregates transaction counts, on-time settlement %, audit findings, and overall audit opinion for Dutch government grant compliance (WBSO, BBV).",
-      "x-schema-org": "schema:Report",
-      "type": "object",
-      "required": [
-        "reportNumber",
-        "fiscalYear",
-        "administrationId",
-        "reportDate",
-        "currency",
-        "auditOpinion",
-        "complianceStatus",
-        "lifecycleState"
-      ],
-      "properties": {
-        "reportNumber": {
-          "type": "string",
-          "description": "Unique report identifier per administration (e.g., SISA-2026-ADM001).",
-          "example": "SISA-2026-ADM001"
-        },
-        "fiscalYear": {
-          "type": "integer",
-          "minimum": 2000,
-          "maximum": 2100,
-          "description": "Fiscal year covered by this SiSa report (e.g., 2026).",
-          "example": 2026
-        },
-        "administrationId": {
-          "type": "string",
-          "description": "FK to the Administration this report belongs to.",
-          "example": "adm-gem-amsterdam"
-        },
-        "reportDate": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Date the report was generated or finalised.",
-          "example": "2026-12-31T00:00:00Z"
-        },
-        "totalTransactionCount": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Total number of financial transactions in the fiscal period.",
-          "nullable": true,
-          "example": 1250
-        },
-        "onTimeSettlementPercent": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 100,
-          "description": "Percentage of obligations settled by their due date (0–100). Computed via x-openregister-aggregations.onTimeSettlement.",
-          "nullable": true,
-          "example": 95.4
-        },
-        "totalAmount": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Total financial value of all transactions in the fiscal period (EUR).",
-          "nullable": true,
-          "example": 4250000.0
-        },
-        "currency": {
-          "type": "string",
-          "minLength": 3,
-          "maxLength": 3,
-          "description": "ISO 4217 currency code for all monetary amounts in this report.",
-          "default": "EUR",
-          "example": "EUR"
-        },
-        "criticalFindingsCount": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Count of critical-severity audit findings from ComplianceAuditTrail.",
-          "nullable": true,
-          "example": 0
-        },
-        "majorFindingsCount": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Count of major-severity audit findings.",
-          "nullable": true,
-          "example": 1
-        },
-        "minorFindingsCount": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Count of minor-severity audit findings.",
-          "nullable": true,
-          "example": 3
-        },
-        "observationsCount": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Count of governance observations from ComplianceAuditTrail.",
-          "nullable": true,
-          "example": 2
-        },
-        "remediationOverdueCount": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Count of remediation actions that are overdue (remediationDueDate < today AND remediationStatus != completed).",
-          "nullable": true,
-          "example": 0
-        },
-        "auditOpinion": {
-          "type": "string",
-          "enum": [
-            "unqualified",
-            "qualified",
-            "adverse",
-            "disclaimer"
-          ],
-          "description": "Overall audit opinion per REQ-SISA-009: unqualified (0 findings), qualified (1-2 major), adverse (3+ major or any critical), disclaimer (any overdue remediation).",
-          "example": "unqualified"
-        },
-        "managementLetterId": {
-          "type": "string",
-          "description": "FK to the ManagementLetter record associated with this report.",
-          "nullable": true,
-          "example": "mgmt-letter-2026-001"
-        },
-        "complianceStatus": {
-          "type": "string",
-          "enum": [
-            "compliant",
-            "non-compliant",
-            "under-review"
-          ],
-          "description": "Overall compliance status of the administration for this fiscal year.",
-          "example": "compliant"
-        },
-        "lifecycleState": {
-          "type": "string",
-          "enum": [
-            "draft",
-            "finalized",
-            "submitted",
-            "archived"
-          ],
-          "description": "Lifecycle state of this SiSa report.",
-          "default": "draft",
-          "example": "draft"
-        },
-        "submissionDate": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Date this report was submitted to the relevant authority.",
-          "nullable": true,
-          "example": "2027-03-01T09:00:00Z"
-        }
       },
-      "x-openregister-lifecycle": {
-        "field": "lifecycleState",
-        "initialState": "draft",
-        "states": {
-          "draft": {
-            "label": "Draft",
-            "description": "Report is being compiled. Aggregation data may be incomplete."
-          },
-          "finalized": {
-            "label": "Finalized",
-            "description": "Audit opinion computed; report is ready for authority submission."
-          },
-          "submitted": {
-            "label": "Submitted",
-            "description": "Report submitted to the relevant government authority."
-          },
-          "archived": {
-            "label": "Archived",
-            "description": "Historical archive state; retained per audit-retention rules."
-          }
-        },
-        "transitions": {
-          "finalize": {
-            "from": "draft",
-            "to": "finalized",
-            "label": "Finalize report",
-            "description": "Lock aggregation data and compute audit opinion. Calls SisaReportingService::calculateAuditOpinion() per ADR-031 exception if OR conditional aggregations are not stable.",
-            "requires": "OCA\\Shillinq\\Service\\SisaReportingService::canBeFinalized"
-          },
-          "submit": {
-            "from": "finalized",
-            "to": "submitted",
-            "label": "Submit to authority",
-            "description": "Mark report as submitted to the government authority."
-          },
-          "archive": {
-            "from": "submitted",
-            "to": "archived",
-            "label": "Archive report",
-            "description": "Move to historical archive after authority acknowledgement."
-          },
-          "reopen": {
-            "from": "finalized",
-            "to": "draft",
-            "label": "Reopen for correction",
-            "description": "Return finalized report to draft for correction (before submission only)."
-          }
-        }
-      },
-      "x-openregister-aggregations": {
-        "onTimeSettlement": {
-          "description": "On-time settlement compliance per REQ-SISA-007: COUNT(obligations settled by dueDate) / COUNT(all non-draft, non-voided obligations) * 100. Source: Obligation and Payment registers from T1 bookkeeping-general-ledger. Filters to isSISAEligible grants only.",
-          "sourceSchema": "Obligation",
-          "sourceRegister": "shillinq",
-          "filter": {
-            "administrationId": "@self.administrationId",
-            "fiscalYear": "@self.fiscalYear",
-            "grantIsSISAEligible": true,
-            "status": {
-              "not_in": [
-                "draft",
-                "voided",
-                "written-off"
-              ]
-            }
-          },
-          "operations": {
-            "totalObligations": {
-              "field": "id",
-              "operation": "count"
-            },
-            "onTimeObligations": {
-              "field": "id",
-              "operation": "count",
-              "condition": "settledDate <= dueDate"
-            }
-          },
-          "output": "onTimeSettlementPercent",
-          "outputFormula": "onTimeObligations / totalObligations * 100"
-        },
-        "findingCounts": {
-          "description": "Aggregate audit finding counts per REQ-SISA-008 from ComplianceAuditTrail. Groups by severity and counts overdue remediations.",
-          "sourceSchema": "ComplianceAuditTrail",
-          "sourceRegister": "shillinq",
-          "filter": {
-            "administrationId": "@self.administrationId",
-            "fiscalYear": "@self.fiscalYear"
-          },
-          "operations": {
-            "criticalFindingsCount": {
-              "field": "id",
-              "operation": "count",
-              "condition": "findingSeverity = 'critical'"
-            },
-            "majorFindingsCount": {
-              "field": "id",
-              "operation": "count",
-              "condition": "findingSeverity = 'major'"
-            },
-            "minorFindingsCount": {
-              "field": "id",
-              "operation": "count",
-              "condition": "findingSeverity = 'minor'"
-            },
-            "observationsCount": {
-              "field": "id",
-              "operation": "count",
-              "condition": "observationNumber IS NOT NULL"
-            },
-            "remediationOverdueCount": {
-              "field": "id",
-              "operation": "count",
-              "condition": "remediationStatus = 'overdue'"
-            }
-          }
-        }
-      },
-      "x-openregister-calculations": {
-        "auditOpinion": {
-          "materialise": true,
-          "targetField": "auditOpinion",
-          "type": "string",
-          "description": "Declarative audit opinion rule per REQ-SISA-009. JSON-AST: nested if — disclaimer if remediationOverdueCount>0; adverse if criticalFindingsCount>0 or majorFindingsCount>=3; qualified if majorFindingsCount>=1; else unqualified.",
-          "expression": {
-            "if": [
-              {
-                "gt": [
-                  {
-                    "prop": "remediationOverdueCount"
-                  },
-                  {
-                    "lit": 0
-                  }
-                ]
-              },
-              {
-                "lit": "disclaimer"
-              },
-              {
-                "if": [
-                  {
-                    "or": [
-                      {
-                        "gt": [
-                          {
-                            "prop": "criticalFindingsCount"
-                          },
-                          {
-                            "lit": 0
-                          }
-                        ]
-                      },
-                      {
-                        "gte": [
-                          {
-                            "prop": "majorFindingsCount"
-                          },
-                          {
-                            "lit": 3
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "lit": "adverse"
-                  },
-                  {
-                    "if": [
-                      {
-                        "gte": [
-                          {
-                            "prop": "majorFindingsCount"
-                          },
-                          {
-                            "lit": 1
-                          }
-                        ]
-                      },
-                      {
-                        "lit": "qualified"
-                      },
-                      {
-                        "lit": "unqualified"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      },
-      "x-openregister-rbac": {
-        "roles": {
-          "sisa-controller": {
-            "permissions": [
-              "create",
-              "read",
-              "update"
-            ]
-          },
-          "auditor": {
-            "permissions": [
-              "read"
-            ]
-          }
-        }
-      }
-    },
-    "AuditDocument": {
-      "slug": "AuditDocument",
-      "icon": "FileSign",
-      "version": "0.1.0",
-      "title": "Audit Document",
-      "description": "A financial document participating in SiSa audit (invoice, purchase order, journal entry, payment). Every state transition triggers an immutable audit-trail event via OR's audit service per REQ-SISA-001 and REQ-SISA-003.",
-      "x-schema-org": "schema:DigitalDocument",
-      "type": "object",
-      "required": [
-        "documentNumber",
-        "documentType",
-        "glTransactionId",
-        "administrationId",
-        "signingUser",
-        "signingTimestamp",
-        "state",
-        "lifecycleState",
-        "currency"
-      ],
-      "properties": {
-        "documentNumber": {
-          "type": "string",
-          "description": "Unique document identifier per administration.",
-          "example": "DOC-2026-00001"
-        },
-        "documentType": {
-          "type": "string",
-          "enum": [
-            "invoice",
-            "purchase-order",
-            "journal-entry",
-            "payment"
-          ],
-          "description": "Type of financial document participating in SiSa audit.",
-          "example": "invoice"
-        },
-        "glTransactionId": {
-          "type": "string",
-          "description": "FK to the related GLTransaction (T1 general-ledger).",
-          "example": "glt-2026-00123"
-        },
-        "administrationId": {
-          "type": "string",
-          "description": "FK to the Administration owning this document.",
-          "example": "adm-gem-amsterdam"
-        },
-        "signingUser": {
-          "type": "string",
-          "description": "Nextcloud user ID who signed or issued the document. Captured by OR audit service on the issued/signed transition.",
-          "example": "alice@gemeente-amsterdam.nl"
-        },
-        "signingTimestamp": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Timestamp when the document was signed. Captured by OR audit service.",
-          "example": "2026-06-15T10:30:00Z"
-        },
-        "signingReason": {
-          "type": "string",
-          "description": "Optional reason or comment on signing (e.g., 'approved per committee decision 2026-06-14').",
-          "nullable": true,
-          "example": "Approved per procurement committee decision 2026-06-14"
-        },
-        "state": {
-          "type": "string",
-          "enum": [
-            "draft",
-            "issued",
-            "signed",
-            "voided"
-          ],
-          "description": "Document signing state per REQ-SISA-004 lifecycle.",
-          "default": "draft",
-          "example": "draft"
-        },
-        "lifecycleState": {
-          "type": "string",
-          "enum": [
-            "active",
-            "archived"
-          ],
-          "description": "Archival lifecycle state.",
-          "default": "active",
-          "example": "active"
-        },
-        "relatedTransactionAmount": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Amount of the related GL transaction for context display.",
-          "nullable": true,
-          "example": 12500.0
-        },
-        "currency": {
-          "type": "string",
-          "minLength": 3,
-          "maxLength": 3,
-          "description": "ISO 4217 currency code for relatedTransactionAmount.",
-          "default": "EUR",
-          "example": "EUR"
-        }
-      },
-      "x-openregister-audit-trail": {
-        "enabled": true,
-        "description": "OR audit service captures every state transition automatically (actor, timestamp, action, before/after state). No app-local event table per ADR-022 D2."
-      },
-      "x-openregister-lifecycle": {
-        "field": "state",
-        "initialState": "draft",
-        "states": {
-          "draft": {
-            "label": "Draft",
-            "description": "Document is being prepared. Not yet legally effective."
-          },
-          "issued": {
-            "label": "Issued",
-            "description": "Document issued and legally effective. Awaiting authorised signature."
-          },
-          "signed": {
-            "label": "Signed",
-            "description": "Document signed by authorised user. Immutable; captured in OR audit trail."
-          },
-          "voided": {
-            "label": "Voided",
-            "description": "Document voided. Compensating GL posting required per T1 REQ-GL-004."
-          }
-        },
-        "transitions": {
-          "issue": {
-            "from": "draft",
-            "to": "issued",
-            "label": "Issue document",
-            "description": "Operator issues the document after validating format against the linked GL transaction."
-          },
-          "sign": {
-            "from": "issued",
-            "to": "signed",
-            "label": "Sign document",
-            "description": "Authorised user signs the document. Signature authority verified per T2 authorization-mandate-management (deferred to T3 if not yet stable)."
-          },
-          "voidFromDraft": {
-            "from": "draft",
-            "to": "voided",
-            "label": "Void draft",
-            "description": "Operator cancels the document before issuance."
-          },
-          "voidFromSigned": {
-            "from": "signed",
-            "to": "voided",
-            "label": "Void signed document",
-            "description": "Operator reverses a signed document. Requires compensating GL posting created per T1 REQ-GL-004."
-          }
-        }
-      },
-      "x-openregister-rbac": {
-        "roles": {
-          "bookkeeper": {
-            "permissions": [
-              "create",
-              "read",
-              "update"
-            ]
-          },
-          "sisa-controller": {
-            "permissions": [
-              "create",
-              "read",
-              "update"
-            ]
-          },
-          "auditor": {
-            "permissions": [
-              "read"
-            ]
-          }
-        }
-      }
-    },
-    "ComplianceAuditTrail": {
-      "slug": "ComplianceAuditTrail",
-      "icon": "ClipboardCheckOutline",
-      "version": "0.1.0",
-      "title": "Compliance Audit Trail",
-      "description": "Auditor working log per administration tracking audit findings (critical/major/minor), governance observations, and remediation status per REQ-SISA-005. Referenced by SisaReport aggregation to compute finding counts and overall opinion.",
-      "x-schema-org": "schema:Event",
-      "type": "object",
-      "required": [
-        "trailNumber",
-        "administrationId",
-        "fiscalYear",
-        "auditDate",
-        "status"
-      ],
-      "properties": {
-        "trailNumber": {
-          "type": "string",
-          "description": "Unique compliance audit trail identifier.",
-          "example": "CAT-2026-ADM001-001"
-        },
-        "administrationId": {
-          "type": "string",
-          "description": "FK to the Administration under audit.",
-          "example": "adm-gem-amsterdam"
-        },
-        "fiscalYear": {
-          "type": "integer",
-          "minimum": 2000,
-          "maximum": 2100,
-          "description": "Fiscal year under audit.",
-          "example": 2026
-        },
-        "findingNumber": {
-          "type": "string",
-          "description": "Reference number of an individual audit finding.",
-          "nullable": true,
-          "example": "FIND-2026-001"
-        },
-        "findingSeverity": {
-          "type": "string",
-          "enum": [
-            "critical",
-            "major",
-            "minor"
-          ],
-          "description": "Severity classification of the finding.",
-          "nullable": true,
-          "example": "major"
-        },
-        "findingDescription": {
-          "type": "string",
-          "description": "Detailed description of the audit finding.",
-          "nullable": true,
-          "example": "BTW-afdracht over Q3 2026 niet tijdig ingediend; €18.500 achterstalling."
-        },
-        "observationNumber": {
-          "type": "string",
-          "description": "Reference number of an individual governance observation.",
-          "nullable": true,
-          "example": "OBS-2026-001"
-        },
-        "observationDescription": {
-          "type": "string",
-          "description": "Governance improvement observation (non-finding, informational).",
-          "nullable": true,
-          "example": "Inkoopproces mist formele budgethouder-goedkeuring voor orders boven €10.000."
-        },
-        "remediationDueDate": {
-          "type": "string",
-          "format": "date",
-          "description": "Target date for remediation completion.",
-          "nullable": true,
-          "example": "2027-03-31"
-        },
-        "remediationStatus": {
-          "type": "string",
-          "enum": [
-            "pending",
-            "in-progress",
-            "completed",
-            "overdue"
-          ],
-          "description": "Current remediation status.",
-          "nullable": true,
-          "example": "pending"
-        },
-        "remediationCompletionDate": {
-          "type": "string",
-          "format": "date",
-          "description": "Date remediation was completed.",
-          "nullable": true,
-          "example": null
-        },
-        "auditorName": {
-          "type": "string",
-          "description": "Auditor or audit firm name responsible for this trail entry.",
-          "nullable": true,
-          "example": "Ernst & Young Accountants LLP"
-        },
-        "auditDate": {
-          "type": "string",
-          "format": "date",
-          "description": "Date of the audit fieldwork or finding issuance.",
-          "example": "2026-11-15"
-        },
-        "status": {
-          "type": "string",
-          "enum": [
-            "draft",
-            "submitted",
-            "closed"
-          ],
-          "description": "Status of this audit trail record.",
-          "default": "draft",
-          "example": "submitted"
-        }
-      },
-      "x-openregister-lifecycle": {
-        "field": "status",
-        "initialState": "draft",
-        "states": {
-          "draft": {
-            "label": "Draft",
-            "description": "Trail entry being compiled by auditor."
-          },
-          "submitted": {
-            "label": "Submitted",
-            "description": "Trail entry submitted to management for acknowledgement."
-          },
-          "closed": {
-            "label": "Closed",
-            "description": "Finding remediated or observation acknowledged; trail closed."
-          }
-        },
-        "transitions": {
-          "submit": {
-            "from": "draft",
-            "to": "submitted",
-            "label": "Submit to management",
-            "description": "Auditor submits the finding or observation to management."
-          },
-          "close": {
-            "from": "submitted",
-            "to": "closed",
-            "label": "Close trail",
-            "description": "Management acknowledges finding or remediation is complete."
-          }
-        }
-      }
-    },
-    "ManagementLetter": {
-      "slug": "ManagementLetter",
-      "icon": "EmailOutline",
-      "version": "0.1.0",
-      "title": "Management Letter",
-      "description": "Formal auditor-to-management communication documenting SiSa findings, observations, and remediation recommendations per REQ-SISA-006. T2 provides the data structure; T4 attaches external auditor signature and authority submission. Note: a ManagementLetter entity also exists in compliance-audit spec; reconciliation during T2/T4 implementing cycle will merge or disambiguate.",
-      "x-schema-org": "schema:DigitalDocument",
-      "type": "object",
-      "required": [
-        "letterNumber",
-        "sisaReportId",
-        "auditorName",
-        "issuedDate",
-        "status"
-      ],
-      "properties": {
-        "letterNumber": {
-          "type": "string",
-          "description": "Unique management letter identifier.",
-          "example": "ML-2026-ADM001-001"
-        },
-        "sisaReportId": {
-          "type": "string",
-          "description": "FK to the SisaReport this letter belongs to.",
-          "example": "sisa-report-uuid-001"
-        },
-        "auditorName": {
-          "type": "string",
-          "description": "Auditor or audit firm name who issued this letter.",
-          "example": "Deloitte Accountants B.V."
-        },
-        "issuedDate": {
-          "type": "string",
-          "format": "date",
-          "description": "Date this management letter was issued.",
-          "example": "2027-01-15"
-        },
-        "dueResponseDate": {
-          "type": "string",
-          "format": "date",
-          "description": "Deadline for management to respond to the letter.",
-          "nullable": true,
-          "example": "2027-02-15"
-        },
-        "findingsSummary": {
-          "type": "string",
-          "description": "Summary of audit findings included in this letter.",
-          "nullable": true,
-          "example": "1 major bevinding (BTW-afdracht) en 3 mineure bevindingen aangetroffen in FY2026."
-        },
-        "observationsSummary": {
-          "type": "string",
-          "description": "Summary of governance improvement observations.",
-          "nullable": true,
-          "example": "Aanbeveling: versterking van het inkoopproces voor orders boven €10.000."
-        },
-        "remediationRecommendations": {
-          "type": "string",
-          "description": "Recommended corrective actions for identified findings.",
-          "nullable": true,
-          "example": "Herstel BTW-aangifte Q3 2026 vóór 31 maart 2027. Implementeer budgethouder-goedkeuring."
-        },
-        "auditOpinion": {
-          "type": "string",
-          "description": "Auditor's audit opinion as stated in this letter (pre-computed from SisaReport.auditOpinion).",
-          "nullable": true,
-          "example": "qualified"
-        },
-        "status": {
-          "type": "string",
-          "enum": [
-            "draft",
-            "issued",
-            "acknowledged",
-            "archived"
-          ],
-          "description": "Status of this management letter.",
-          "default": "draft",
-          "example": "issued"
-        }
-      },
-      "x-openregister-lifecycle": {
-        "field": "status",
-        "initialState": "draft",
-        "states": {
-          "draft": {
-            "label": "Draft",
-            "description": "Letter is being composed."
-          },
-          "issued": {
-            "label": "Issued",
-            "description": "Letter formally issued to management."
-          },
-          "acknowledged": {
-            "label": "Acknowledged",
-            "description": "Management has acknowledged receipt and committed to remediation."
-          },
-          "archived": {
-            "label": "Archived",
-            "description": "Letter archived after remediation cycle completion."
-          }
-        },
-        "transitions": {
-          "issue": {
-            "from": "draft",
-            "to": "issued",
-            "label": "Issue letter",
-            "description": "Auditor formally issues the management letter."
-          },
-          "acknowledge": {
-            "from": "issued",
-            "to": "acknowledged",
-            "label": "Acknowledge",
-            "description": "Management acknowledges the letter and commits to action."
-          },
-          "archive": {
-            "from": "acknowledged",
-            "to": "archived",
-            "label": "Archive",
-            "description": "Archive letter after remediation cycle is complete."
-          }
-        }
-      }
-    },
-    "Grant": {
-      "slug": "Grant",
-      "icon": "HandCoinOutline",
-      "version": "0.1.0",
-      "title": "Grant",
-      "description": "A financial grant or subsidy awarded to an organization under a subsidy scheme (WBSO, BBV, NSO, Tozo). Includes isSISAEligible flag per REQ-SISA-010 to control SiSa report aggregation filtering. Full grant lifecycle (application, disbursement, compliance) is declared by add-shillinq-grant-subsidy-management; this stub adds the SiSa eligibility field.",
-      "x-schema-org": "schema:Grant",
-      "type": "object",
-      "required": [
-        "grantId",
-        "name",
-        "awardedAmount",
-        "awardDate",
-        "status"
-      ],
-      "properties": {
-        "grantId": {
-          "type": "string",
-          "description": "Unique grant identifier.",
-          "example": "WBSO-2026-AMS-001"
-        },
-        "name": {
-          "type": "string",
-          "description": "Grant name or description.",
-          "example": "WBSO Subsidie 2026 — R&D innovatie"
-        },
-        "awardedAmount": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Total amount awarded in EUR.",
-          "example": 125000.0
-        },
-        "awardDate": {
-          "type": "string",
-          "format": "date-time",
-          "description": "Date the grant was formally awarded.",
-          "example": "2026-01-01T00:00:00Z"
-        },
-        "status": {
-          "type": "string",
-          "enum": [
-            "active",
-            "completed",
-            "suspended",
-            "revoked"
-          ],
-          "description": "Current grant status.",
-          "default": "active",
-          "example": "active"
-        },
-        "accountingStandard": {
-          "type": "string",
-          "description": "Governmental accounting standard applied (e.g., BBV, RJ290).",
-          "nullable": true,
-          "example": "BBV"
-        },
-        "isSISAEligible": {
-          "type": "boolean",
-          "description": "Whether this grant requires Single Information Single Audit compliance per REQ-SISA-010. WBSO and BBV grants are eligible; Tozo and NSO grants are not.",
-          "default": false,
-          "example": true
-        }
-      }
-    },
     "APInvoice": {
       "slug": "APInvoice",
+      "x-openregister-audit-trail": {
+        "enabled": true,
+        "description": "Every create, update and lifecycle transition of an AP invoice is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001). The approval and posting transitions are the evidence chain for the materialised GLTransaction."
+      },
       "icon": "ReceiptTextOutline",
       "version": "0.1.0",
       "title": "AP Invoice",
@@ -22094,13 +21217,6 @@
       },
       "x-schema-org": "schema:Organization",
       "type": "object",
-      "required": [
-        "customerNumber",
-        "name",
-        "paymentTermDays",
-        "administrationId",
-        "lifecycleState"
-      ],
       "properties": {
         "customerNumber": {
           "type": "string",
@@ -22298,17 +21414,6 @@
       },
       "x-schema-org": "schema:Invoice",
       "type": "object",
-      "required": [
-        "invoiceNumber",
-        "customerId",
-        "invoiceDate",
-        "dueDate",
-        "currency",
-        "totalAmount",
-        "lines",
-        "state",
-        "administrationId"
-      ],
       "properties": {
         "invoiceNumber": {
           "type": "string",
@@ -23040,13 +22145,6 @@
       },
       "x-schema-org": "schema:Action",
       "type": "object",
-      "required": [
-        "invoiceRef",
-        "reminderLevel",
-        "dispatchedAt",
-        "dispatchedBy",
-        "administrationId"
-      ],
       "properties": {
         "invoiceRef": {
           "type": "string",
@@ -23521,6 +22619,10 @@
     },
     "Kostenpost": {
       "slug": "Kostenpost",
+      "x-openregister-audit-trail": {
+        "enabled": true,
+        "description": "Every create, update and delete of a subsidie cost line is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001). Grant-funded expenditure must be reconstructable per regeling for the subsidievaststelling."
+      },
       "icon": "ReceiptTextOutline",
       "version": "0.1.0",
       "title": "Kostenpost",
@@ -24280,12 +23382,6 @@
       "description": "Stock level per SKU at a specific bin Location per REQ-LOC-009 and inventory-stock-tracking spec. Always recorded at bin level (most-granular); warehouse/zone aggregation via Location.stockRollup. locationId FK references bin-type Location only.",
       "x-schema-org": "schema:Thing",
       "type": "object",
-      "required": [
-        "sku",
-        "locationId",
-        "quantity",
-        "administrationId"
-      ],
       "properties": {
         "sku": {
           "type": "string",
@@ -24362,6 +23458,10 @@
     },
     "WBSOTag": {
       "slug": "WBSOTag",
+      "x-openregister-audit-trail": {
+        "enabled": true,
+        "description": "Every create, update and delete of a WBSO project code is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001). The code set is administration-configurable, so a change to it retroactively reclassifies tagged hours and must be attributable."
+      },
       "icon": "TagCheckOutline",
       "version": "0.1.0",
       "title": "WBSO Tag",
@@ -24480,6 +23580,10 @@
     },
     "WBSOActivityCode": {
       "slug": "WBSOActivityCode",
+      "x-openregister-audit-trail": {
+        "enabled": true,
+        "description": "Every create, update and delete of a WBSO activity code is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001). A- versus B-code classification decides which hours are eligible for the afdrachtvermindering, so a change to it must be attributable."
+      },
       "icon": "ClipboardListOutline",
       "version": "0.1.0",
       "title": "WBSO Activity Code",
@@ -24610,6 +23714,10 @@
     },
     "WBSOExportLog": {
       "slug": "WBSOExportLog",
+      "x-openregister-audit-trail": {
+        "enabled": true,
+        "description": "Every create, update and lifecycle transition of a WBSO export is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001). The export log is the record of what was submitted to RvO and when."
+      },
       "icon": "FileExportOutline",
       "version": "0.1.0",
       "title": "WBSO Export Log",
@@ -24905,6 +24013,10 @@
     },
     "SisaRegelingIndicator": {
       "slug": "SisaRegelingIndicator",
+      "x-openregister-audit-trail": {
+        "enabled": true,
+        "description": "Every create, update and delete of a SiSa regeling indicator is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001). The indicator is filed as part of the jaarrekening bijlage and must be reconstructable for the accountant."
+      },
       "icon": "FileCheckOutline",
       "version": "0.1.0",
       "title": "SiSa Regeling Indicator",
@@ -25216,6 +24328,10 @@
     },
     "SoProject": {
       "slug": "SoProject",
+      "x-openregister-audit-trail": {
+        "enabled": true,
+        "description": "Every create, update and delete of an S&O project is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001). The RvO project link underpins the WBSO afdrachtvermindering and must be reconstructable on inspection."
+      },
       "icon": "FlaskOutline",
       "version": "0.1.0",
       "title": "S&O-project",
@@ -25305,6 +24421,10 @@
     },
     "SoUrenStaat": {
       "slug": "SoUrenStaat",
+      "x-openregister-audit-trail": {
+        "enabled": true,
+        "description": "Every create, update and lifecycle transition of an S&O timesheet is written to OpenRegister's immutable audit trail with actor and timestamp (REQ-AT-001). Approved hours feed the quarterly RvO mededeling, so the approval trail is the WBSO evidence chain."
+      },
       "icon": "ClockCheckOutline",
       "version": "0.1.0",
       "title": "S&O-uren-staat",
@@ -25494,6 +24614,7 @@
           }
         }
       }
+    }
     }
   },
   "mappings": {

--- a/lib/Settings/shillinq_register.json
+++ b/lib/Settings/shillinq_register.json
@@ -20804,29 +20804,34 @@
         "invoiceNumber": {
           "type": "string",
           "description": "Shillinq-side reference (auto-generated per administration).",
-          "example": "INV-V-2026-0001"
+          "example": "INV-V-2026-0001",
+          "title": "Invoice Number"
         },
         "vendorInvoiceRef": {
           "type": "string",
           "description": "The vendor's own invoice number as it appears on the paper/PDF invoice.",
-          "example": "ACME-2026-00123"
+          "example": "ACME-2026-00123",
+          "title": "Vendor's Invoice Number"
         },
         "vendorId": {
           "type": "string",
           "description": "FK to VendorMaster UUID.",
-          "example": "vendor-acme-1"
+          "example": "vendor-acme-1",
+          "title": "Vendor"
         },
         "invoiceDate": {
           "type": "string",
           "format": "date",
           "description": "Date on the vendor's invoice.",
-          "example": "2026-01-15"
+          "example": "2026-01-15",
+          "title": "Invoice Date"
         },
         "dueDate": {
           "type": "string",
           "format": "date",
           "description": "Auto-calculated from invoiceDate + vendor.paymentTermDays; overrideable by operator.",
-          "example": "2026-02-14"
+          "example": "2026-02-14",
+          "title": "Payment Due"
         },
         "currency": {
           "type": "string",
@@ -20834,25 +20839,29 @@
           "maxLength": 3,
           "description": "ISO 4217 currency code. T2: base currency only; T5 adds multi-currency.",
           "default": "EUR",
-          "example": "EUR"
+          "example": "EUR",
+          "title": "Currency"
         },
         "totalAmount": {
           "type": "number",
           "minimum": 0,
           "description": "Total amount including tax. Credit notes are separate journal types, not negative totals.",
-          "example": 1250.0
+          "example": 1250.0,
+          "title": "Total Incl. VAT"
         },
         "taxAmount": {
           "type": "number",
           "minimum": 0,
           "description": "VAT/BTW amount. T3 adds automated VAT posting; T2 carries the field for reporting.",
           "nullable": true,
-          "example": 217.98
+          "example": 217.98,
+          "title": "VAT Amount"
         },
         "lines": {
           "type": "array",
           "minItems": 1,
           "description": "Invoice line breakdown. Each line maps to one GL expense account.",
+          "title": "Invoice Lines",
           "items": {
             "type": "object",
             "required": [
@@ -20863,31 +20872,37 @@
             "properties": {
               "description": {
                 "type": "string",
-                "description": "Line description."
+                "description": "Line description.",
+                "title": "Description"
               },
               "accountNumber": {
                 "type": "string",
-                "description": "FK to Account.accountNumber (expense account)."
+                "description": "FK to Account.accountNumber (expense account).",
+                "title": "Expense Account"
               },
               "amount": {
                 "type": "number",
                 "minimum": 0,
-                "description": "Line amount (non-negative; see REQ-AP-003)."
+                "description": "Line amount (non-negative; see REQ-AP-003).",
+                "title": "Line Amount"
               },
               "taxCode": {
                 "type": "string",
                 "description": "Tax code for this line (e.g. BTW21, BTW9, BTW0).",
-                "nullable": true
+                "nullable": true,
+                "title": "Tax Code"
               },
               "quantity": {
                 "type": "number",
                 "description": "Quantity ordered/received (required for 3-way match when PO/GR present).",
-                "nullable": true
+                "nullable": true,
+                "title": "Quantity"
               },
               "unitPrice": {
                 "type": "number",
                 "description": "Unit price (required for 3-way match quantity parity check).",
-                "nullable": true
+                "nullable": true,
+                "title": "Unit Price"
               }
             }
           }
@@ -20896,17 +20911,20 @@
           "type": "string",
           "description": "docudesk FK URI per bookkeeping-document-attachment-integration. Points to the scanned vendor invoice PDF.",
           "nullable": true,
-          "example": "docudesk://files/shillinq/invoices/acme-2026-00123.pdf"
+          "example": "docudesk://files/shillinq/invoices/acme-2026-00123.pdf",
+          "title": "Scanned Invoice"
         },
         "purchaseOrderRef": {
           "type": "string",
           "description": "FK to PO register UUID (future T4 procurement; nullable in T2). Declared so T4 attaches additively per REQ-AP-006.",
-          "nullable": true
+          "nullable": true,
+          "title": "Purchase Order"
         },
         "goodsReceiptRef": {
           "type": "string",
           "description": "FK to Goods Receipt register UUID (future T4; nullable in T2). Declared so T4 attaches additively per REQ-AP-006.",
-          "nullable": true
+          "nullable": true,
+          "title": "Goods Receipt"
         },
         "approvalState": {
           "type": "string",
@@ -20917,7 +20935,8 @@
             "rejected"
           ],
           "description": "OR approval-workflow state mirror per REQ-AP-005. Tracks the approval routing status.",
-          "example": "pending"
+          "example": "pending",
+          "title": "Approval Status"
         },
         "state": {
           "type": "string",
@@ -20932,29 +20951,34 @@
           ],
           "description": "AP invoice lifecycle state per REQ-AP-004.",
           "default": "draft",
-          "example": "draft"
+          "example": "draft",
+          "title": "Status"
         },
         "glTransactionId": {
           "type": "string",
           "description": "Back-reference to the materialised GLTransaction once the invoice is posted.",
           "nullable": true,
-          "example": "gl-txn-2026-ap-0001"
+          "example": "gl-txn-2026-ap-0001",
+          "title": "Posted GL Transaction"
         },
         "idealLink": {
           "type": "string",
           "description": "Per-invoice iDEAL payment link (x-openregister-calculations output per REQ-AP-007). Populated when paymentMethod=ideal.",
-          "nullable": true
+          "nullable": true,
+          "title": "iDEAL Payment Link"
         },
         "periodId": {
           "type": "string",
           "description": "FK to the FiscalPeriod for GL posting (resolved on post transition per REQ-AP-004).",
           "nullable": true,
-          "example": "2026-Q1"
+          "example": "2026-Q1",
+          "title": "Fiscal Period"
         },
         "administrationId": {
           "type": "string",
           "description": "FK to the administration owning this AP invoice.",
-          "example": "adm-1"
+          "example": "adm-1",
+          "title": "Administration"
         }
       },
       "x-openregister-notifications": {
@@ -23478,29 +23502,34 @@
         "wbsoCode": {
           "type": "string",
           "description": "Official WBSO project code (SO, TWO, SMART) or custom code per WBSO legislation. Not an enum — operators may add custom codes per subsidy agreement (REQ-WBSO-002).",
-          "example": "SO"
+          "example": "SO",
+          "title": "WBSO Code"
         },
         "displayName": {
           "type": "string",
           "description": "Dutch display name of the WBSO code shown in UI and exports (REQ-WBSO-002).",
-          "example": "Stand-alone Project"
+          "example": "Stand-alone Project",
+          "title": "Display Name"
         },
         "description": {
           "type": "string",
           "nullable": true,
           "description": "RVO alignment notes and subsidy conditions for this code.",
-          "example": "Solo R&D project funded by WBSO subsidy — no collaborative partner required."
+          "example": "Solo R&D project funded by WBSO subsidy — no collaborative partner required.",
+          "title": "Description"
         },
         "rvoCertificationUrl": {
           "type": "string",
           "nullable": true,
           "description": "Link to the official RVO directive or legislation reference for this code.",
-          "example": "https://www.rvo.nl/subsidies-financiering/wbso"
+          "example": "https://www.rvo.nl/subsidies-financiering/wbso",
+          "title": "RVO Certification URL"
         },
         "administrationId": {
           "type": "string",
           "description": "FK to the Administration owning this WBSO code entry.",
-          "example": "adm-1"
+          "example": "adm-1",
+          "title": "Administration ID"
         },
         "lifecycleState": {
           "type": "string",
@@ -23511,7 +23540,8 @@
             "deprecated"
           ],
           "default": "active",
-          "example": "active"
+          "example": "active",
+          "title": "Lifecycle State"
         }
       },
       "x-openregister-lifecycle": {
@@ -24209,7 +24239,8 @@
         "costCenterId": {
           "type": "string",
           "description": "FK to AnalyticalDimension.code (dimensionType=cost-center) with ondernemingsActiviteit: true. The ondernemingsactiviteit whose Vpb-pligtige accounts this link declares. Re-targeted from the retired CostCenter to the unified AnalyticalDimension per REQ-ADIM-102; stored values unchanged.",
-          "example": "KC-OA-001"
+          "example": "KC-OA-001",
+          "title": "Cost Center ID"
         },
         "accountNumbers": {
           "type": "array",
@@ -24224,24 +24255,28 @@
             "4300",
             "8000",
             "8100"
-          ]
+          ],
+          "title": "Account Numbers"
         },
         "vpbPligtigVanaf": {
           "type": "string",
           "format": "date",
           "description": "Start date of Vpb-pligtigheid for this ondernemingsactiviteit cluster per Wet modernisering Vpb-plicht (2016). Postings before this date are excluded from the Vpb-balans.",
-          "example": "2016-01-01"
+          "example": "2016-01-01",
+          "title": "Vpb-pligtig Vanaf"
         },
         "administrationId": {
           "type": "string",
           "description": "FK to the Administration owning this link. Scopes the link to one bookkeeping administration.",
-          "example": "adm-1"
+          "example": "adm-1",
+          "title": "Administration ID"
         },
         "description": {
           "type": "string",
           "description": "Operator-authored description of the ondernemingsactiviteit Vpb cluster.",
           "nullable": true,
-          "example": "Zwembad exploitatie — ondernemingsactiviteit per Vpb-plicht 2016"
+          "example": "Zwembad exploitatie — ondernemingsactiviteit per Vpb-plicht 2016",
+          "title": "Description"
         }
       },
       "x-openregister-aggregations": {


### PR DESCRIPTION
> **Partial by design, and stated up front: gate-54 goes 140 → 95, not to 0.** Two of the 43 register files are fully converted; 41 remain. gate-18 and gate-51 were split onto **#502** so 39→0 and 35→0 are not held behind 134 hand-edited relation blocks. This branch is stacked on #502 — merge that first and this PR's diff is gate-54 only.

## The rule, checked against ADR-062 itself

Confirmed against `hydra/openspec/architecture/adr-062-detail-page-grid-discipline.md` rule 7 directly, not only against in-repo exemplars — **ADR-062 and the exemplars agree, there is no disagreement to report.** Rule 7 verbatim: a relation is a schema **property** carrying `type: "string"` (or array `items`), `"format": "uuid"` and `"$ref": "<schemaKey>"` in the same register set, with `x-relation-filter` riding on the same property; per-schema `x-openregister-relations` blocks are **explicitly banned**, retired 2026-07-08 because nothing consumes them.

Two boundaries from rule 7 that the gate helper does **not** enforce and that shaped the conversion:

- **Nextcloud user ids are not relations.** Only a `*Ref` field gets a `$ref` (ADR-046 pattern).
- **`$ref` may be a string slug OR a numeric schema id** — the live schema API rewrites slugs to ids.

## How each relation was decided — not blanket-converted

The discriminator is `relatedField`:

| `relatedField` | meaning | action |
|---|---|---|
| `"id"` | the property holds the **target object's identity** | canonical `format: uuid` + `$ref` |
| a natural key (`accountNumber`, `code`, `invoiceNumber`, `taxonomyVersion`, …) | the property holds a **business key** | fold the block's meaning into the property description, **no `$ref`** |
| `localField` names a property that does not exist | the block described **nothing** | remove, and list it |

Inventing a `$ref` for a business key would change what OpenRegister does with the data and create a relation resolving to nothing. **Every `$ref` added was checked to resolve** against a schema key or slug in the register set — a dangling `$ref` is itself a gate-54 finding (checks d/f), so an unchecked conversion turns 140 findings into a different 140. The gate reports none from this branch.

## What the numbers actually are — and the part that matters most

On `development` @ `aa8ff276`: **134 blocks, 214 relation declarations**.

**53 of those 214 described nothing at all.** They were not wrong, they were **inert** — someone intended a relation there and it never existed:

- **40** name a `localField` that is **not a property of the schema** (mostly `"id"`, i.e. inverse-side declarations of a relation the child owns; several have no `localField` key at all);
- **22** name a `relatedSchema` that resolves to **no schema key or slug** in the register set (9 overlap with the above).

These must not vanish into a green, so **the ones already removed are listed by schema + field in their commit messages**, and every one still outstanding is listed below.

### Done — `lib/Settings/shillinq_register.json` (35 → 0) and `bookkeeping-vpb-mkb.json` (10 → 0)

45 blocks, 59 declarations, split four ways:

| outcome | n | notes |
|---|---|---|
| real relation, converted to property-level `$ref` | 34 | incl. 3 **array** relations (`$ref` on `items`), and `ProjectBudget.projectId` which also carries the block's narrowing as an `x-relation-filter` on the same property |
| **business key**, description folded, no `$ref` | 22 | two stale descriptions corrected in passing — `GLLine.costCenterCode` / `kostenDragerCode` still named the retired `CostCenter` / `KostenDrager`, while the block already recorded the re-target to `AnalyticalDimension` |
| **inert, removed** | 10 | listed below |
| duplicate of a property that already had the canonical `$ref` | 3 | `GLLine.parentTransaction`, `ARInvoice.customerId`, `ARInvoice.glTransactionId` |

**Inert declarations removed (10) — every one had `localField: "id"`, and in every case the child-side property now carries the canonical `$ref`, so the relation itself survives and only the dead half is gone:**

```
GLTransaction.lines                  -> GLLine.transactionId
Subsidie.repaymentInstallments       -> RepaymentInstallment.subsidieId
IPAssetValuation.winstToerekeningen  -> WinstToerekening.ipAssetId
BankAccount.currencyBalances         -> CurrencyBalance.accountId
ARInvoice.dunningRecords             -> DunningRecord.invoiceRef
VpbAangifte.correcties               -> FiscaleCorrectie.aangifte
VpbAangifte.innovatieboxClaims       -> Innovatiebox.aangifte
VpbAangifte.investeringsAftrekken    -> InvesteringsAftrek.aangifte
VpbAangifte.definitieveAanslag       -> DefinitieveAanslag.aangifte
DefinitieveAanslag.bezwaren          -> BezwaarBeroep.aanslag
```

`bookkeeping-vpb-mkb.json`'s property descriptions were Dutch prose ("FK naar de Belastingplichtige") and are now English, **keeping the standardised Dutch tax terms exactly as they are** — `Belastingplichtige`, `VpbAangifte`, `DefinitieveAanslag`, `moedermaatschappij`, `houdstermaatschappij`, `fiscale eenheid`.

### Remaining — 94 blocks / 155 declarations across 41 fragments, of which 44 are inert

**Still-outstanding inert declarations, listed so they can be re-created deliberately rather than silently lost:**

`localField` absent or not a property of the schema (31):
```
bookkeeping-bank-reconciliation.json      BankReconciliation.matches            id -> BankReconciliationMatch
bookkeeping-cbs-bestanden-extended.json   CBSSubmission.administration          (no localField)
bookkeeping-cbs-bestanden-extended.json   CBSLine.cbsSubmission                 (no localField)
bookkeeping-cost-centers-dimensions.json  AnalyticalDimension.referenceTarget   (no localField) -> '@self.referenceSchema'
bookkeeping-detachering-payroll-…json     Employee.payrolls                     id -> Payroll
bookkeeping-detachering-payroll-…json     Payroll.deductions                    id -> Deduction
bookkeeping-detachering-payroll-…json     Payroll.determinationLetters          id -> DeterminationLetter
bookkeeping-market-government-…json       CommercialActivity.integralCostPrices id -> IntegralCostPrice
bookkeeping-market-government-…json       CommercialActivity.activityCostAllocations id -> ActivityCostAllocation
bookkeeping-market-government-…json       CommercialActivity.alerts             id -> AlertLog
bookkeeping-market-government-…json       CommercialActivity.benchmarks         id -> MarketBenchmark
bookkeeping-period-close.json             GLLine.periodRelation                 periodId -> FiscalPeriod  (GLLine is not declared in this fragment)
bookkeeping-reconciliation-reports.json   BankReconciliation.matches            id -> ReconciliationMatch
bookkeeping-reconciliation-reports.json   BankReconciliation.report             id -> ReconciliationReport
bookkeeping-sbr-xbrl-reporting.json       XBRLTaxonomy.mappings / SBRDocumentType.administration / SBRDocumentType.taxonomy / XBRLMapping.sourceAccount / XBRLMapping.taxonomy   (all: no localField)
bookkeeping-titel-9-jaarrekening.json     AnnualReport.balanceSheet / .incomeStatement / .cashFlowStatement / .notes / .directorReport / .reviewWorkflow   (all: localField id)
bookkeeping-vpb-corporate-tax-balans.json VpbBalansLink.costCenter              (no localField)
dba-compliance-marker.json                DBAOpdracht.intake / .flags           localField '@self.id'
inventory-lot-batch-expiry.json           InventoryLot.stockMovements / .expiryAlerts   (no localField)
recurring-invoicing.json                  RecurringInvoiceProfile.generatedInvoices     id -> ARInvoice
```

`relatedSchema` resolves to nothing (22) — **and they fall into three distinct causes, which matters because the fix differs**:

1. **Cross-app references (6)** — `pipelinq:Product`, on `Barcode.product`, `InventoryCycleCountLine.product`, `InventoryLot.product`, `StockMove.product`, `InventoryStock.product`, `InventoryValuation.product`. OpenRegister resolves `$ref` within **one** register set, so a schema owned by another app is **not expressible as a relation at all**. These need `x-external-register: pipelinq` + a bare identifier, **not** a `$ref` — the helper has an explicit exemption for exactly this shape.
2. **Targets that exist but are declared in the wrong place (see below) (≈5)** — `Location` on `InventoryCycleCount`, `InventoryCycleCountLine`, `StockMove` ×2, `InventoryStock`.
3. **Targets that do not exist at all (≈11)** — `Person` (`InventoryCycleCount.initiator`, `ExpiryAlert.recipient`) — a contact is a **Nextcloud entity**, not a schema, so these are not relations; `OverheadDistributionRule`; `@self.referenceSchema` used as a schema name; and 7 with no `relatedSchema` key whatsoever.

## Found while doing this, not fixed here

**23 schemas in `lib/Settings/shillinq_register.json` are declared under `components.<Name>` instead of `components.schemas.<Name>`** — including `ARInvoice`, `APInvoice`, `CustomerMaster`, `DunningRecord`, `Location`, `InventoryStock`. OpenRegister imports `components.schemas`, so **that section is very likely never imported at all**. It also explains cause (2) above, and why the gate helpers cannot see those schemas: they resolve `components.schemas`, which is why an `x-relation-filter` placed on one of their properties gets reported as "placed off a property". Same family of silent-absence defect as the duplicate-`required` finding in #498, and it needs its own change.

## Both directions proven

Planted one true positive: re-introduced a single `x-openregister-relations` block on the (now canonical) `BezwaarBeroep.aanslag` property in `bookkeeping-vpb-mkb.json`.

```
before plant   gate-54 = 95
after  plant   gate-54 = 96   ← + exactly one finding:
   bookkeeping-vpb-mkb.json: banned dialect — 'x-openregister-relations' block
   at /components/schemas/BezwaarBeroep/properties/aanslag (…ADR-062 rule 7)
after revert   gate-54 = 95
```

## Measurements

Helpers run directly over all **155** tracked register files (full-tree scope, `HYDRA_GATE_BASE_REF` unset), reproducing the full-run numbers exactly:

| gate | `development` @ `aa8ff276` | this branch |
|---|---|---|
| gate-54 relation-dialect | **140** | **95** |
| gate-18 notification-dialect | 39 | 0 *(via #502)* |
| gate-51 schema-property-titles | 35 | 0 *(via #502)* |

The single non-`banned dialect` gate-54 finding, `Contract.decisions — $ref 'Decision' does not resolve`, is **untouched and still present**: it lives in `contract-lifecycle-management.json`, whose blocks are not yet converted, and fixing it in isolation would be a guess about whether a `Decision` schema is meant to exist.

`npm run check:registers`, `npm run check:seeds` (74, at baseline) and `npm run check:manifest` (Ajv 0 errors, 0 consistency issues) are green after every batch. No baselines added, no suppressions, no `exclude` waivers, no gate helper edited, no register file deleted, and no scripted rewrite of any JSON — every edit was made by hand.

---

**Do not merge without review** — the lead agent merges.

---

## Added after review — the `components.<Name>` fix, and what it costs

### 18 schemas were declared where the importer never looks

`lib/Settings/shillinq_register.json` declared 23 schemas under `components.<Name>` instead of `components.schemas.<Name>`. OpenRegister imports `components.schemas`, so **18 schemas — including `ARInvoice`, `APInvoice`, `CustomerMaster`, `DunningRecord` — existed only at a level nothing reads**, and 5 more were stale shadow copies. Nothing reported it: the JSON is valid and `occ app:enable` exits 0. What it produced was a **404 at runtime**, reaching a user as `Request failed with status code 404`.

**The 5 shadows were diffed before either side was deleted, and the result decided which side went.** Each misplaced twin is a **strict subset** of its `components.schemas` sibling — every key and value at the wrong level present and identical in the live copy, **nothing existing only at the wrong level**. They differ in one direction: the live copy carries `title` on all 60 properties and, on 4 of 5, an `x-openregister-audit-trail`. The shadows are stale copies that missed later edits, so deleting them stranded nothing.

| | before | after |
|---|---|---|
| `components.schemas` in that file | 101 | **119** |
| `validate-registers` total schemas | 493 | **506** |
| seeds naming an undeclared schema | 14 | **1** |
| seeds that cannot satisfy their schema | 74 | 74 (baseline) |
| **gate-53 crossref `slug-resolution`** | **11** | **0** |
| gate-53 `removals-invariant` | 150 | 150 (untouched) |
| gate-53 `registry-crossref` | 6 | 6 (untouched) |

All 11 `slug-resolution` errors were on 6 schemas — `Kostenpost`, `VATAuditRecord`, `VATGLAccounts`, `WBSOTag`, `WBSOActivityCode`, `WBSOExportLog` — **6 of 6 in the misplaced set, nothing left over**.

**Both directions, isolated to one variable:** reverting *only* the two-line `components.schemas` boundary, leaving every other edit in place, reproduces 493 / 14 / 11 exactly; re-applying returns 506 / 1 / 0.

**Two defect classes surfaced the instant the schemas became visible, and both are fixed here rather than absorbed:** 8 statutory schemas had no `x-openregister-audit-trail` (`check:registers` went red); and 4 became **new** duplicate-`required` conflicts (`check:seeds` went 74 → 83), resolved by the single-owner rule with the effective `required` **byte-identical to before** — conflicting keys stay at 47, the development figure.

### The cost: gate-51 0 → 214, of which 179 remain

Making 18 schemas visible makes them inspectable. **206 missing `title`, 8 missing `title` + `description`**, confined entirely to these 18 and no others. Three schemas are now done (APInvoice 24, WBSOTag 6, VpbBalansLink 5) — **full-tree 214 → 179, diff-scoped vs `development` 19 → 0.**

Remaining, by schema: `ARInvoice` 26 · `CustomerMaster` 22 · `WBSOExportLog` 15 · `VATAuditRecord` 14 · `SisaRegelingIndicator` 13 · `DunningRecord` 13 · `Location` 12 · `InventoryStockTransfer` 11 · `Kostenpost` 10 · `SoUrenStaat` 8 · `SoProject` 8 · `WBSOActivityCode` 7 · `VATGLAccounts` 7 · `InventoryStock` 7 · `ServiceCategoryOverride` 6.

**Titles are form labels, not documentation** — `fieldsFromSchema` does `label: tr(prop.title || key)` (nextcloud-vue `src/utils/schema.js:81`, `:520`), so `title` renders next to the input and the meaning belongs in `description`, which 206 of the 214 already carry. Within that constraint the label still says what the field is *for* rather than re-casing the identifier: `dueDate` → "Payment Due", `sourceDocumentUri` → "Scanned Invoice", `glTransactionId` → "Posted GL Transaction", `lines[].accountNumber` → "Expense Account".

### ⚠️ A green gate-53 is NOT clearance for this stack to land

The gate-53 diff-scoper (`manifest_diff_scope.py:194-197`) forces scope `ALL` when any changed file matches `lib/**register**.json`. This branch changes **22** register JSONs, so gate-53 — **and gate-51 and gate-54** — run unscoped and every finding blocks. **No register-touching PR can merge until all three are at zero across the whole stack.**

### Method for the "53 inert declarations" figure

214 relation declarations across the 134 blocks on `development` @ `aa8ff276`: **40** name a `localField` that is not a property (or omit it), **22** name an unresolvable `relatedSchema`, and **9 are in both sets** — union = 40 + 22 − 9 = **53**. An earlier relay of **62** added the two counts without subtracting the overlap; **53 is the correct figure**.
