### PR TITLE
fix(period-close): name the reopen action's handler by FQCN, not by an id nothing registers

### DIFF
--- a/lib/Settings/register.d/bookkeeping-period-close.json
+++ b/lib/Settings/register.d/bookkeeping-period-close.json
@@ -318,7 +318,7 @@
               "actions": [
                 {
                   "trigger": "x-openregister-lifecycle-action",
-                  "action": "append-reopen-history",
+                  "action": "OCA\\Shillinq\\Lifecycle\\Action\\AppendReopenHistoryAction",
                   "description": "Append {closedAt, closedBy, reopenedAt, reopenedBy, closeReason} to reopenedHistory and clear closedAt/closedBy (REQ-PC-006).",
                   "actionParameters": {
                     "target": "reopenedHistory"


### PR DESCRIPTION
## What

`FiscalPeriod.reopen` declared its lifecycle action as `"append-reopen-history"`. Nothing resolves that name, so every otherwise-valid reopen answered HTTP 500.

OpenRegister's `LifecycleActionRegistry::resolve()` (`lib/Service/Lifecycle/LifecycleActionRegistry.php`) accepts a declared action name in exactly two forms:

- `set-fields` / `set-field` — its only two `BUILTINS`;
- otherwise the string is used **verbatim as a container id** (`$lookup = $actionName`).

`append-reopen-history` is neither. shillinq registers no service under that id — `lib/AppInfo/Application.php` has no lifecycle-action registration at all, and no class in this app implements `LifecycleActionInterface`. The registry is deliberately fail-loud, so resolution threw.

Naming the handler by its FQCN is the path that works without a registration: the container autowires a concrete, autoloadable class.

## Landing order — this change is NOT self-sufficient

The handler class `OCA\Shillinq\Lifecycle\Action\AppendReopenHistoryAction` is added by a **different branch** (`fix/newman-remaining`); it does not exist on `development` yet.

Until that lands, reopen still fails — with "class not found" instead of "no handler registered". That is the same user-visible 500 as today, so this is not a regression, but it only becomes a *fix* once the class is on `development`. **Merge that branch first, or accept that this commit is inert until it does.**

## Verified the parsed value, not the source text

A single-backslash version parses to a *different string* and fails with an identical-looking error, so the source text is not the evidence — the parsed value is:

```
$ jq -r '.. | objects | select(.trigger=="x-openregister-lifecycle-action") | .action' \
    lib/Settings/register.d/bookkeeping-period-close.json
set-fields
OCA\Shillinq\Lifecycle\Action\AppendReopenHistoryAction
set-fields
```

which matches the class's own declaration exactly:

```
namespace OCA\Shillinq\Lifecycle\Action;
class AppendReopenHistoryAction implements LifecycleActionInterface
```

`check:registers` and `check:seeds` both pass.