### PR TITLE
fix(registers): Kostenpost's if/then allOf aborted the ENTIRE register import — Newman 19 → 36

### DIFF
--- a/lib/Settings/shillinq_register.json
+++ b/lib/Settings/shillinq_register.json
@@ -21605,7 +21605,7 @@
       "icon": "ReceiptTextOutline",
       "version": "0.1.0",
       "title": "Kostenpost",
-      "description": "Individual expense line item within a subsidie dossier. Linked to parent Subsidie via subsidieId. The allowed kostencategorie values are constrained per-regeling via JSON Schema allOf/if-then blocks (REQ-RDS-002). MIT: personnel/materials/external-services/equipment-depreciation/other-direct. SBIR: personnel/materials/equipment-depreciation/other-direct. EU Horizon: personnel/subcontracting/other-direct/indirect-25-percent. EFRO: personnel/external-services/materials/equipment/other/indirect-flat-rate. REACT-EU: EFRO + green-recovery. No PHP category validator per ADR-031.",
+      "description": "Individual expense line item within a subsidie dossier. Linked to parent Subsidie via subsidieId. kostencategorie is constrained to the full enum on the property itself. The per-regeling NARROWING (REQ-RDS-002) is NOT ENFORCED: it was declared as a top-level JSON Schema allOf/if-then block, which OpenRegister's importer cannot read — SchemaMapper::resolveSchemaExtension() treats every allOf entry as a parent-schema identifier and throws on a subschema, aborting the import of the WHOLE register (openregister#2419). The block never ran: this schema sat above components.schemas until #511 and was never imported at all. The intended narrowing, for whoever restores it: MIT: personnel/materials/external-services/equipment-depreciation/other-direct. SBIR: personnel/materials/equipment-depreciation/other-direct. EU Horizon: personnel/subcontracting/other-direct/indirect-25-percent. EFRO: personnel/external-services/materials/equipment/other/indirect-flat-rate. REACT-EU: EFRO + green-recovery. No PHP category validator per ADR-031.",
       "x-schema-org": "schema:MonetaryAmount",
       "type": "object",
       "required": [
@@ -21699,134 +21699,6 @@
           "example": "adm-1"
         }
       },
-      "allOf": [
-        {
-          "if": {
-            "properties": {
-              "subsidieRegeling": {
-                "const": "mit"
-              }
-            },
-            "required": [
-              "subsidieRegeling"
-            ]
-          },
-          "then": {
-            "properties": {
-              "kostencategorie": {
-                "enum": [
-                  "personnel",
-                  "materials",
-                  "external-services",
-                  "equipment-depreciation",
-                  "other-direct"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "subsidieRegeling": {
-                "const": "sbir"
-              }
-            },
-            "required": [
-              "subsidieRegeling"
-            ]
-          },
-          "then": {
-            "properties": {
-              "kostencategorie": {
-                "enum": [
-                  "personnel",
-                  "materials",
-                  "equipment-depreciation",
-                  "other-direct"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "subsidieRegeling": {
-                "const": "eu-horizon"
-              }
-            },
-            "required": [
-              "subsidieRegeling"
-            ]
-          },
-          "then": {
-            "properties": {
-              "kostencategorie": {
-                "enum": [
-                  "personnel",
-                  "subcontracting",
-                  "other-direct",
-                  "indirect-25-percent"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "subsidieRegeling": {
-                "const": "efro"
-              }
-            },
-            "required": [
-              "subsidieRegeling"
-            ]
-          },
-          "then": {
-            "properties": {
-              "kostencategorie": {
-                "enum": [
-                  "personnel",
-                  "external-services",
-                  "materials",
-                  "equipment",
-                  "other",
-                  "indirect-flat-rate"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "subsidieRegeling": {
-                "const": "react-eu"
-              }
-            },
-            "required": [
-              "subsidieRegeling"
-            ]
-          },
-          "then": {
-            "properties": {
-              "kostencategorie": {
-                "enum": [
-                  "personnel",
-                  "external-services",
-                  "materials",
-                  "equipment",
-                  "other",
-                  "indirect-flat-rate",
-                  "green-recovery"
-                ]
-              }
-            }
-          }
-        }
-      ],
       "x-openregister-lifecycle": {
         "states": {
           "entered": "Ingevoerd, wacht op goedkeuring.",


### PR DESCRIPTION
Regression I introduced in #511, measured and owned.

## Measurement

Newman failed assertions, read from the development runs themselves:

| development head | collections | total failed |
|---|---|---|
| `371671ee` (pre-#511) | 3 + 4 + 5 + 7 | **19** |
| `b17a0c9f` (post-#511) | 3 + 18 + 8 + 7 | **36** |

## Cause

#511 moved 13 schemas from `components.<Name>` — one level above the only key the importer reads — into `components.schemas`. That was correct, and it is also what exposed this. `Kostenpost` was one of the 13, and carries a **top-level `allOf` of standard JSON Schema conditionals** (`if`/`then` narrowing `kostencategorie` per subsidy scheme).

OpenRegister's `SchemaMapper::resolveSchemaExtension()` treats every `allOf` entry as a **parent schema identifier** and passes it to `loadSchema(string|int $identifier)`. An object throws, and the exception propagates out of the import:

```
occ app:enable → "Shillinq: configuration import failed"
SchemaMapper::loadSchema(): Argument #1 ($identifier) must be of type
string|int, array given  (SchemaMapper.php:3670)
```

**The blast radius is not the one schema.** The import aborts, so no register is created for any of the ~506 schemas, and every OpenRegister-backed endpoint answers `Did expect one result but found none ... FROM oc_openregister_registers` — 26 such log lines in the Newman job, across calendars, period-close and e-invoicing.

Filed upstream: ConductionNL/openregister#2419.

## Why remove rather than wait

It costs nothing to remove and everything to keep. The schema was never imported before #511, so this narrowing **has never been enforced on a single object**. The base `kostencategorie` enum is untouched and still constrains the property to the full value set; only the per-regeling narrowing is absent — exactly as it has always been in practice.

The intended narrowing is written into the schema's own `description`, naming openregister#2419, so it is recoverable rather than silently dropped.

Swept the whole effective config (monolith + all 154 register.d fragments): **0** schemas now carry a top-level `allOf`, so this was the only instance and there is no second landmine behind it.

`check:registers` PASS 469/469, 506 schemas.

## What to check on this PR

The Newman job. If the diagnosis is right, the register imports and the count drops back toward 19 — the first three collections in particular should return to 3 / 4 / 5.