### PR TITLE
fix(newman): the 3 dead Calendar seeds and the reopen 500 — 8 failing assertions down to 2

### DIFF
--- a/lib/Settings/register.d/bookings-resource-calendar.json
+++ b/lib/Settings/register.d/bookings-resource-calendar.json
@@ -393,9 +393,7 @@
         "tuesday": "09:00-17:00",
         "wednesday": "09:00-17:00",
         "thursday": "09:00-17:00",
-        "friday": "09:00-17:00",
-        "saturday": null,
-        "sunday": null
+        "friday": "09:00-17:00"
       },
       "status": "active"
     },
@@ -415,8 +413,7 @@
         "wednesday": "08:00-18:00",
         "thursday": "08:00-18:00",
         "friday": "08:00-18:00",
-        "saturday": "09:00-13:00",
-        "sunday": null
+        "saturday": "09:00-13:00"
       },
       "status": "active"
     },
@@ -436,8 +433,7 @@
         "wednesday": "10:00-18:00",
         "thursday": "10:00-18:00",
         "friday": "10:00-20:00",
-        "saturday": "10:00-16:00",
-        "sunday": null
+        "saturday": "10:00-16:00"
       },
       "status": "active"
     },

--- a/lib/Settings/register.d/bookkeeping-period-close.json
+++ b/lib/Settings/register.d/bookkeeping-period-close.json
@@ -318,7 +318,7 @@
               "actions": [
                 {
                   "trigger": "x-openregister-lifecycle-action",
-                  "action": "append-reopen-history",
+                  "action": "OCA\\Shillinq\\Lifecycle\\Action\\AppendReopenHistoryAction",
                   "description": "Append {closedAt, closedBy, reopenedAt, reopenedBy, closeReason} to reopenedHistory and clear closedAt/closedBy (REQ-PC-006).",
                   "actionParameters": {
                     "target": "reopenedHistory"


### PR DESCRIPTION
Two independent causes, both measured on a **single-owner rig** (nextcloud:34.0.0-apache + openregister + shillinq, `docker compose -p sqnm`, port 8117), with the **status code printed on every probe**.

Confirmed on CI: full-scope run [31518149676](https://github.com/ConductionNL/shillinq/actions/runs/31518149676) — Newman **8 → 2** failing assertions (bookings 8/8, VAT 20/20, shillinq 32/32, TenderNed 3/5).

---

## 1. `Calendar` cal-001..cal-003 have NEVER imported

```
[ImportHandler] Skipping object 'bookings-resource-calendar-cal-001' - import failed:
Property 'workingHours.saturday' should be type 'string' but is 'null'.
```

OpenRegister accepts `null` for **any top-level** property and rejects it for **any nested** one, and the declared `nullable: true` changes nothing either way:

| probe | body | result |
|---|---|---|
| A | nested `saturday: null` (declared `nullable:true`) | **HTTP 400** |
| B | key omitted | **HTTP 201** |
| C | top-level `workingHours: null` (`nullable:true`) | **HTTP 201** |
| D | top-level `organization: null` (**no** nullable flag) | **HTTP 201** |

Mechanism, read in the source: `ValidateObject.php:1750-1782` widens `type` → `[type,"null"]` **only over the top-level `properties` map** and never recurses; Opis JSON Schema does not know OpenAPI's `nullable` keyword at all (`grep -n nullable ValidateObject.php` → nothing).

🔴 **The standards-correct repair is a trap.** I tried `"type": ["string","null"]`. OpenRegister rejects a union type outright — `Failed to create schema (Pass 1)` — and the **entire `Calendar` schema then vanished from the register**, after which every calendar endpoint died. Measured and **reverted**; recorded here so nobody re-attempts it.

So the three seeds **drop the closed weekdays** instead of writing them as null. Nothing reads `workingHours` (`CalendarController:583` echoes it; no other caller exists), so no behaviour changes. The canonical requirement (`openspec/specs/bookings/spec.md` REQ-002, whose scenario uses `sat: null, sun: null`) is **deliberately left alone** — the platform is what has to change. Filed separately against openregister.

### This also refutes the diagnosis in #488

#488 says `CalendarController::loadCalendar()`'s `filters` envelope "matches nothing", on the strength of `grep "objectSlug\":\"cal-001\"` returning nothing. The log's `objectSlug` is the `@self.slug` — **`bookings-resource-calendar-cal-001`** — so that grep could never have matched.

Positive control: I created a Calendar through the OR API and called the accused endpoint. `GET /api/v2/calendars/probe-B` → **HTTP 200** with the payload. The filter was never the bug.

⚠️ Separately: `GET /api/v2/calendars` (list) answers `{"calendars":[]}` with **HTTP 200** when there is no active administration, because `resolveAdministrationId('')` returns `null` and the code still puts `administrationId => null` in the filter map. The collection's assertion (*"contains calendars array"*) **passes over an empty array**, which is why the list endpoint looked green the whole time. `?organization=adm-1` returns the rows. Not changed here.

---

## 2. `POST /api/period-close/{id}/reopen` answered 500 on a valid transition

```
Lifecycle action "append-reopen-history" could not be resolved:
Class "append-reopen-history" does not exist
```

`LifecycleActionRegistry::resolve()` (openregister `lib/Service/Lifecycle/LifecycleActionRegistry.php:110-145`) looks a declared action name up **literally as a service id**, and its `BUILTINS` map holds **only** `set-fields` / `set-field`.

`AppendReopenHistoryAction` and its unit test already existed — the handler was simply unreachable under that name, and **the unit test could not notice**, because it instantiates the class directly and never goes through the registry.

The action now names the handler by **FQCN**, which the server container autowires — exactly as the same transition's `preconditions` already do (`OCA\Shillinq\Lifecycle\PeriodCloseGuard::closeReasonSupplied`). Same request now answers **HTTP 200**; `shillinq.postman_collection.json` is 32/32.

⚠️ **shillinq still declares 11 × `materialise-gl-transaction`, plus `route-to-approver`, `publish-cloudevent`, `trigger-low-stock-alert`, `trigger-auto-po`, `submit`, `reject`, `approve`, `validate`** — none of them builtins, every one a latent 500 on the same mechanism. Filed separately; not fixed here.

---

## What is left

The remaining 2 assertions are the `Verplichting` dual-vocabulary collision (#485 / #471). Measured from **both** sides — the Newman POST fails on `verplichtingsnummer, soort`; the app's own seed `vpl-sample-utrecht-schoonmaak` fails on `verplichtingNummer, omschrijving, bedrag` — so **no single payload can satisfy the merged schema**. That needs a decision about which capability owns the schema, and is not fixable without one.