### PR TITLE
refactor(shillinq): DBAFactuurMonitorListener → DbaInvoiceMonitorListener

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -47,8 +47,8 @@ use OCA\Shillinq\Listener\LeaseActivationListener;
 use OCA\Shillinq\Listener\BookingCreatedTimelinePublishListener;
 use OCA\Shillinq\Listener\BookingLifecycleTransitionListener;
 use OCA\Shillinq\Listener\CommitmentMaterialisationListener;
-use OCA\Shillinq\Listener\DBAFactuurMonitorListener;
 use OCA\Shillinq\Listener\ContractObligationTaskListener;
+use OCA\Shillinq\Listener\DbaInvoiceMonitorListener;
 use OCA\Shillinq\Listener\DeepLinkRegistrationListener;
 use OCA\Shillinq\Listener\DeliveryDispatchListener;
 use OCA\Shillinq\Listener\ExtractionCompletedListener;
@@ -655,7 +655,7 @@ class Application extends App implements IBootstrap
         // narrow behaviour on an assumption the code does not state.
         $context->registerEventListener(
             event: ObjectCreatedEvent::class,
-            listener: DBAFactuurMonitorListener::class
+            listener: DbaInvoiceMonitorListener::class
         );
 
         // Bookkeeping-tenderned-integratie Tasks 5.1 / 5.2 / 5.3 — react to

--- a/lib/Listener/DbaInvoiceMonitorListener.php
+++ b/lib/Listener/DbaInvoiceMonitorListener.php
@@ -48,7 +48,7 @@ use Throwable;
  *
  * @spec openspec/specs/dba-compliance-marker/spec.md
  */
-class DBAFactuurMonitorListener implements IEventListener
+class DbaInvoiceMonitorListener implements IEventListener
 {
     /**
      * Constructor.
@@ -111,7 +111,7 @@ class DBAFactuurMonitorListener implements IEventListener
             // Non-blocking: log and continue. The AP/AR factuur commit MUST NOT
             // be undone by a DBA monitoring hiccup.
             $this->logger->warning(
-                'DBAFactuurMonitorListener: VBAR assess/emit failed (non-blocking).',
+                'DbaInvoiceMonitorListener: VBAR assess/emit failed (non-blocking).',
                 ['opdrachtId' => $opdrachtId, 'factuurId' => $factuurId, 'exception' => $e->getMessage()]
             );
         }//end try
@@ -163,7 +163,7 @@ class DBAFactuurMonitorListener implements IEventListener
                 }
             }
         } catch (Throwable $e) {
-            $this->logger->debug('DBAFactuurMonitorListener: extract failed', ['exception' => $e->getMessage()]);
+            $this->logger->debug('DbaInvoiceMonitorListener: extract failed', ['exception' => $e->getMessage()]);
         }//end try
 
         return null;


### PR DESCRIPTION
A **code-only** slice of `openspec/changes/english-vocabulary`, and the first shillinq slice deliberately.

`factuur` = invoice. `DBA` is the statute's own abbreviation (Wet DBA) and stays, normalised to `Dba` to match PSR naming.

## Why this listener first

It is the **one listener not wired by class name from a register fragment**. It's registered via `::class` in `lib/AppInfo/Application.php`, so a missed reference is a compile-time error, not a silently unwired listener.

shillinq's guards — `BezwaarTermijnGuard`, `RechtmatigheidGuard`, `ProgrammabegrotingGuard` and the rest — are each **named as strings in `lib/Settings` JSON**. Renaming one of those without its fragment entry produces a guard that simply stops being invoked, with nothing raised. Those are a separate slice that moves class and fragment together.

## Two small things worth noting

The rename pushed the `use` statement out of alphabetical order, which phpcs enforces and No syntax errors detected in Standard input code doesn't care about — re-sorted.

I scoped this **inside the worktree** rather than the shared checkout. Scoping against a different revision is exactly what made the docudesk pass miss seven files, one of which held a real typed dependency.

## Verification
`php -l` clean; class name matches file name; no residual reference anywhere, including the phpmd / phpstan / psalm baselines (checked — hrmq's baseline keys suppressions by file path, so that check is not optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)