### PR TITLE
refactor(lifecycle): rename BezwaarTermijnGuard to ObjectionPeriodGuard

### DIFF
--- a/lib/Lifecycle/ObjectionPeriodGuard.php
+++ b/lib/Lifecycle/ObjectionPeriodGuard.php
@@ -8,10 +8,10 @@
  * BezwaarBeroep schema lifecycle transitions reference the methods below for
  * the date-arithmetic preconditions that the declarative DSL cannot yet express:
  *
- *  - canBezwaarMaken():    bezwaar against a DefinitieveAanslag must be lodged
+ *  - canFileObjection():    bezwaar against a DefinitieveAanslag must be lodged
  *                          within 6 weeks of the aanslag dagtekening (REQ-VPB-010,
  *                          Awb art. 6:7).
- *  - canBeroepInstellen(): beroep must be lodged within 6 weeks of the inspecteur
+ *  - canFileAppeal(): beroep must be lodged within 6 weeks of the inspecteur
  *                          uitspraak on the bezwaar (REQ-VPB-010, Awb art. 6:7).
  *
  * ADR-031 exception reason: the date arithmetic spans sibling schemas
@@ -49,18 +49,18 @@ use Psr\Log\LoggerInterface;
  * Statutory termijn guards for the bezwaar/beroep workflow.
  *
  * Referenced from the bookkeeping-vpb-mkb register.d fragment schema lifecycle
- * transitions as OCA\Shillinq\Lifecycle\BezwaarTermijnGuard::<method>.
+ * transitions as OCA\Shillinq\Lifecycle\ObjectionPeriodGuard::<method>.
  *
  * @spec openspec/changes/bookkeeping-vpb-mkb/specs/bookkeeping-vpb-mkb/spec.md
  */
-class BezwaarTermijnGuard
+class ObjectionPeriodGuard
 {
     /**
-     * The statutory termijn length for bezwaar and beroep (Awb art. 6:7).
+     * The statutory period for objection and appeal (Awb art. 6:7).
      *
      * @var string
      */
-    private const TERMIJN = '6 weeks';
+    private const STATUTORY_PERIOD = '6 weeks';
 
     /**
      * Construct the guard with DI dependencies.
@@ -85,35 +85,38 @@ class BezwaarTermijnGuard
      * Fail-closed: returns false on any exception, a missing aanslag, or a
      * dagtekening that cannot be parsed.
      *
-     * @param string                   $aangifteId The VpbAangifte id (call-signature parity).
-     * @param array<string,mixed>|null $object     The aangifte being transitioned.
+     * @param string                   $taxReturnId The VpbAangifte id (call-signature parity).
+     * @param array<string,mixed>|null $object      The tax return being transitioned.
      *
-     * @return bool True when the bezwaartermijn has not yet expired.
+     * @return bool True when the objection period has not yet expired.
      *
      * @spec openspec/changes/bookkeeping-vpb-mkb/specs/bookkeeping-vpb-mkb/spec.md
      */
-    public function canBezwaarMaken(string $aangifteId, ?array $object=null): bool
+    public function canFileObjection(string $taxReturnId, ?array $object=null): bool
     {
         try {
-            $resolvedId = $aangifteId;
+            $resolvedId = $taxReturnId;
             if ($object !== null && (string) ($object['id'] ?? '') !== '') {
                 $resolvedId = (string) $object['id'];
             }
 
-            $aanslag = $this->resolveAanslagForAangifte(aangifteId: $resolvedId);
-            if ($aanslag === null) {
+            $assessment = $this->resolveAssessmentForTaxReturn(taxReturnId: $resolvedId);
+            if ($assessment === null) {
                 return false;
             }
 
-            return $this->withinTermijn(startDate: (string) ($aanslag['dagtekening'] ?? ''));
+            // 'dagtekening' is a SCHEMA PROPERTY KEY, not an identifier: it names a
+            // column on the DefinitieveAanslag shard table. It moves when that
+            // schema is renamed, together with its data migration — not here.
+            return $this->withinPeriod(startDate: (string) ($assessment['dagtekening'] ?? ''));
         } catch (\Throwable $e) {
             $this->logger->error(
-                'BezwaarTermijnGuard: canBezwaarMaken check failed — denying transition (fail-closed)',
-                ['aangifteId' => $aangifteId, 'exception' => $e->getMessage()]
+                'ObjectionPeriodGuard: canFileObjection check failed — denying transition (fail-closed)',
+                ['taxReturnId' => $taxReturnId, 'exception' => $e->getMessage()]
             );
             return false;
         }//end try
-    }//end canBezwaarMaken()
+    }//end canFileObjection()
 
     /**
      * Returns true iff beroep may still be lodged after the inspecteur uitspraak.
@@ -121,48 +124,51 @@ class BezwaarTermijnGuard
      * REQ-VPB-010: beroep is admissible within 6 weeks of the uitspraakDatum on
      * the bezwaar. Fail-closed on any exception or an unparseable uitspraakDatum.
      *
-     * @param string                   $bezwaarId The BezwaarBeroep id (call-signature parity).
-     * @param array<string,mixed>|null $object    The bezwaar record being transitioned.
+     * @param string                   $objectionId The BezwaarBeroep id (call-signature parity).
+     * @param array<string,mixed>|null $object      The objection record being transitioned.
      *
-     * @return bool True when the beroepstermijn has not yet expired.
+     * @return bool True when the appeal period has not yet expired.
      *
      * @spec openspec/changes/bookkeeping-vpb-mkb/specs/bookkeeping-vpb-mkb/spec.md
      */
-    public function canBeroepInstellen(string $bezwaarId, ?array $object=null): bool
+    public function canFileAppeal(string $objectionId, ?array $object=null): bool
     {
         try {
-            $bezwaar = $object;
-            if ($bezwaar === null || isset($bezwaar['uitspraakDatum']) === false) {
-                $bezwaar = $this->resolveObject(schema: 'BezwaarBeroep', id: $bezwaarId);
+            // 'BezwaarBeroep' and 'uitspraakDatum' are the SCHEMA NAME and a
+            // SCHEMA PROPERTY KEY — the data contract, renamed with their
+            // migration, not with this class.
+            $objection = $object;
+            if ($objection === null || isset($objection['uitspraakDatum']) === false) {
+                $objection = $this->resolveObject(schema: 'BezwaarBeroep', id: $objectionId);
             }
 
-            if ($bezwaar === null) {
+            if ($objection === null) {
                 return false;
             }
 
-            $uitspraakDatum = (string) ($bezwaar['uitspraakDatum'] ?? '');
-            if ($uitspraakDatum === '') {
+            $rulingDate = (string) ($objection['uitspraakDatum'] ?? '');
+            if ($rulingDate === '') {
                 return false;
             }
 
-            return $this->withinTermijn(startDate: $uitspraakDatum);
+            return $this->withinPeriod(startDate: $rulingDate);
         } catch (\Throwable $e) {
             $this->logger->error(
-                'BezwaarTermijnGuard: canBeroepInstellen check failed — denying transition (fail-closed)',
-                ['bezwaarId' => $bezwaarId, 'exception' => $e->getMessage()]
+                'ObjectionPeriodGuard: canFileAppeal check failed — denying transition (fail-closed)',
+                ['objectionId' => $objectionId, 'exception' => $e->getMessage()]
             );
             return false;
         }//end try
-    }//end canBeroepInstellen()
+    }//end canFileAppeal()
 
     /**
-     * Returns true iff today is on or before startDate + the statutory termijn.
+     * Returns true iff today is on or before startDate + the statutory period.
      *
-     * @param string $startDate The termijn start date (YYYY-MM-DD).
+     * @param string $startDate The period start date (YYYY-MM-DD).
      *
-     * @return bool True when within the termijn; false on an empty/invalid date.
+     * @return bool True when within the period; false on an empty/invalid date.
      */
-    private function withinTermijn(string $startDate): bool
+    private function withinPeriod(string $startDate): bool
     {
         if ($startDate === '') {
             return false;
@@ -174,41 +180,44 @@ class BezwaarTermijnGuard
             return false;
         }
 
-        $deadline = $start->modify('+'.self::TERMIJN);
+        $deadline = $start->modify('+'.self::STATUTORY_PERIOD);
         $today    = new DateTimeImmutable('today');
 
         return $today <= $deadline;
-    }//end withinTermijn()
+    }//end withinPeriod()
 
     /**
-     * Resolve the DefinitieveAanslag linked to a given aangifte.
+     * Resolve the DefinitieveAanslag linked to a given tax return.
      *
-     * @param string $aangifteId The VpbAangifte id.
+     * @param string $taxReturnId The VpbAangifte id.
      *
-     * @return array<string,mixed>|null The aanslag, or null when not found.
+     * @return array<string,mixed>|null The assessment, or null when not found.
      */
-    private function resolveAanslagForAangifte(string $aangifteId): ?array
+    private function resolveAssessmentForTaxReturn(string $taxReturnId): ?array
     {
-        if ($aangifteId === '') {
+        if ($taxReturnId === '') {
             return null;
         }
 
         $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
         $register      = $this->resolveRegister();
 
-        $aanslagen = $objectService
+        // 'DefinitieveAanslag' and the 'aangifte' filter key are the data
+        // contract — the registered schema title and one of its property
+        // columns. Both move with the schema rename and its migration.
+        $assessments = $objectService
             ->setRegister($register)
             ->setSchema('DefinitieveAanslag')
-            ->findAll(['filters' => ['aangifte' => $aangifteId]]);
+            ->findAll(['filters' => ['aangifte' => $taxReturnId]]);
 
-        foreach ($aanslagen as $aanslag) {
-            if (is_array($aanslag) === true) {
-                return $aanslag;
+        foreach ($assessments as $assessment) {
+            if (is_array($assessment) === true) {
+                return $assessment;
             }
         }
 
         return null;
-    }//end resolveAanslagForAangifte()
+    }//end resolveAssessmentForTaxReturn()
 
     /**
      * Resolve an object of the given schema by id via ObjectService.

--- a/lib/Settings/register.d/bookkeeping-vpb-mkb.json
+++ b/lib/Settings/register.d/bookkeeping-vpb-mkb.json
@@ -4,7 +4,7 @@
     "spdx-copyright": "2026 Conduction B.V.",
     "change": "bookkeeping-vpb-mkb",
     "spec": "openspec/changes/bookkeeping-vpb-mkb/specs/bookkeeping-vpb-mkb/spec.md",
-    "description": "ADR-037 register fragment declaring the reguliere Vennootschapsbelasting (Vpb) aangifte data model for BV/NV (T3, regulatory + compliance): Belastingplichtige, VpbAangifte, FiscaleCorrectie, Innovatiebox, Deelneming, FiscaleEenheid, Voorvoegingsverlies, InvesteringsAftrek, VoorlopigeAanslag, DefinitieveAanslag, BezwaarBeroep plus the VpbTariefcatalogus parameterisation table. Per ADR-031 all fiscal logic is declarative metadata: x-openregister-lifecycle state machines, x-openregister-calculations formulas (schijftarief, voorvoegingsverlies-verjaring, facility eligibility), x-openregister-unique constraints, x-openregister-relations and x-openregister-rbac. Cross-schema preconditions that the declarative DSL cannot yet express are delegated to OCA\\Shillinq\\Lifecycle\\VpbAangifteGuard and OCA\\Shillinq\\Lifecycle\\BezwaarTermijnGuard (ADR-031 exception path). No PHP tax-calculation service is authored (ADR-022/ADR-031). Schijftarieven and facility percentages are stored as data (VpbTariefcatalogus) so wetswijzigingen are reproducible per belastingjaar.",
+    "description": "ADR-037 register fragment declaring the reguliere Vennootschapsbelasting (Vpb) aangifte data model for BV/NV (T3, regulatory + compliance): Belastingplichtige, VpbAangifte, FiscaleCorrectie, Innovatiebox, Deelneming, FiscaleEenheid, Voorvoegingsverlies, InvesteringsAftrek, VoorlopigeAanslag, DefinitieveAanslag, BezwaarBeroep plus the VpbTariefcatalogus parameterisation table. Per ADR-031 all fiscal logic is declarative metadata: x-openregister-lifecycle state machines, x-openregister-calculations formulas (schijftarief, voorvoegingsverlies-verjaring, facility eligibility), x-openregister-unique constraints, x-openregister-relations and x-openregister-rbac. Cross-schema preconditions that the declarative DSL cannot yet express are delegated to OCA\\Shillinq\\Lifecycle\\VpbAangifteGuard and OCA\\Shillinq\\Lifecycle\\ObjectionPeriodGuard (ADR-031 exception path). No PHP tax-calculation service is authored (ADR-022/ADR-031). Schijftarieven and facility percentages are stored as data (VpbTariefcatalogus) so wetswijzigingen are reproducible per belastingjaar.",
     "imported": "2026-06-05T00:00:00Z"
   },
   "components": {
@@ -483,8 +483,8 @@
               "from": "aanslag-ontvangen",
               "to": "bezwaar",
               "label": "Bezwaar maken",
-              "description": "Bezwaar mag alleen binnen de wettelijke termijn van 6 weken na de dagtekening van de aanslag (REQ-VPB-010). Cross-schema termijn-check: BezwaarTermijnGuard::canBezwaarMaken.",
-              "requires": "OCA\\Shillinq\\Lifecycle\\BezwaarTermijnGuard::canBezwaarMaken"
+              "description": "Bezwaar mag alleen binnen de wettelijke termijn van 6 weken na de dagtekening van de aanslag (REQ-VPB-010). Cross-schema termijn-check: ObjectionPeriodGuard::canFileObjection.",
+              "requires": "OCA\\Shillinq\\Lifecycle\\ObjectionPeriodGuard::canFileObjection"
             },
             "beroepInstellen": {
               "from": "bezwaar",
@@ -1799,8 +1799,8 @@
               "from": "uitspraak-inspecteur-ontvangen",
               "to": "beroep-pending",
               "label": "Beroep instellen",
-              "description": "Beroep bij de rechtbank binnen 6 weken na uitspraak (REQ-VPB-010). Termijn-check: BezwaarTermijnGuard::canBeroepInstellen.",
-              "requires": "OCA\\Shillinq\\Lifecycle\\BezwaarTermijnGuard::canBeroepInstellen"
+              "description": "Beroep bij de rechtbank binnen 6 weken na uitspraak (REQ-VPB-010). Termijn-check: ObjectionPeriodGuard::canFileAppeal.",
+              "requires": "OCA\\Shillinq\\Lifecycle\\ObjectionPeriodGuard::canFileAppeal"
             },
             "beroepUitspraak": {
               "from": "beroep-pending",

--- a/tests/Unit/Lifecycle/ObjectionPeriodGuardTest.php
+++ b/tests/Unit/Lifecycle/ObjectionPeriodGuardTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Unit tests for BezwaarTermijnGuard.
+ * Unit tests for ObjectionPeriodGuard.
  *
  * @category Test
  * @package  OCA\Shillinq\Tests\Unit\Lifecycle
@@ -22,7 +22,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\Shillinq\Lifecycle\BezwaarTermijnGuard;
+use OCA\Shillinq\Lifecycle\ObjectionPeriodGuard;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -30,12 +30,12 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
- * Tests for BezwaarTermijnGuard.
+ * Tests for ObjectionPeriodGuard.
  *
  * Covers REQ-VPB-010 — bezwaar within 6 weeks of the aanslag dagtekening and
  * beroep within 6 weeks of the inspecteur uitspraak.
  */
-class BezwaarTermijnGuardTest extends TestCase
+class ObjectionPeriodGuardTest extends TestCase
 {
 
     /**
@@ -62,9 +62,9 @@ class BezwaarTermijnGuardTest extends TestCase
     /**
      * The guard under test.
      *
-     * @var BezwaarTermijnGuard
+     * @var ObjectionPeriodGuard
      */
-    private BezwaarTermijnGuard $guard;
+    private ObjectionPeriodGuard $guard;
 
     /**
      * Set up test fixtures.
@@ -83,7 +83,7 @@ class BezwaarTermijnGuardTest extends TestCase
 
         $this->appConfig->method('getValueString')->willReturn('shillinq');
 
-        $this->guard = new BezwaarTermijnGuard(
+        $this->guard = new ObjectionPeriodGuard(
             container: $this->container,
             appConfig: $this->appConfig,
             logger: $this->logger,
@@ -104,7 +104,7 @@ class BezwaarTermijnGuardTest extends TestCase
         );
 
         // phpcs:ignore CustomSniffs.Functions.NamedParameters
-        self::assertTrue($this->guard->canBezwaarMaken(aangifteId: 'aangifte-1', object: ['id' => 'aangifte-1']));
+        self::assertTrue($this->guard->canFileObjection(taxReturnId:'aangifte-1', object: ['id' => 'aangifte-1']));
 
     }//end testCanBezwaarMakenWithinTermijn()
 
@@ -121,7 +121,7 @@ class BezwaarTermijnGuardTest extends TestCase
         );
 
         // phpcs:ignore CustomSniffs.Functions.NamedParameters
-        self::assertFalse($this->guard->canBezwaarMaken(aangifteId: 'aangifte-2', object: ['id' => 'aangifte-2']));
+        self::assertFalse($this->guard->canFileObjection(taxReturnId:'aangifte-2', object: ['id' => 'aangifte-2']));
 
     }//end testCannotBezwaarMakenAfterTermijn()
 
@@ -135,7 +135,7 @@ class BezwaarTermijnGuardTest extends TestCase
         $this->container->method('get')->willReturn($this->buildSchemaStub(recordsBySchema: ['DefinitieveAanslag' => []]));
 
         // phpcs:ignore CustomSniffs.Functions.NamedParameters
-        self::assertFalse($this->guard->canBezwaarMaken(aangifteId: 'aangifte-3', object: ['id' => 'aangifte-3']));
+        self::assertFalse($this->guard->canFileObjection(taxReturnId:'aangifte-3', object: ['id' => 'aangifte-3']));
 
     }//end testCannotBezwaarMakenWithoutAanslag()
 
@@ -150,7 +150,7 @@ class BezwaarTermijnGuardTest extends TestCase
 
         // phpcs:ignore CustomSniffs.Functions.NamedParameters
         self::assertTrue(
-            $this->guard->canBeroepInstellen(bezwaarId: 'bezwaar-1', object: ['uitspraakDatum' => $uitspraak])
+            $this->guard->canFileAppeal(objectionId:'bezwaar-1', object: ['uitspraakDatum' => $uitspraak])
         );
 
     }//end testCanBeroepInstellenWithinTermijn()
@@ -166,7 +166,7 @@ class BezwaarTermijnGuardTest extends TestCase
 
         // phpcs:ignore CustomSniffs.Functions.NamedParameters
         self::assertFalse(
-            $this->guard->canBeroepInstellen(bezwaarId: 'bezwaar-2', object: ['uitspraakDatum' => $uitspraak])
+            $this->guard->canFileAppeal(objectionId:'bezwaar-2', object: ['uitspraakDatum' => $uitspraak])
         );
 
     }//end testCannotBeroepInstellenAfterTermijn()
@@ -180,7 +180,7 @@ class BezwaarTermijnGuardTest extends TestCase
     {
         // phpcs:ignore CustomSniffs.Functions.NamedParameters
         self::assertFalse(
-            $this->guard->canBeroepInstellen(bezwaarId: 'bezwaar-3', object: ['uitspraakDatum' => ''])
+            $this->guard->canFileAppeal(objectionId:'bezwaar-3', object: ['uitspraakDatum' => ''])
         );
 
     }//end testCannotBeroepInstellenWithoutUitspraak()
@@ -196,7 +196,7 @@ class BezwaarTermijnGuardTest extends TestCase
         $this->logger->expects($this->once())->method('error');
 
         // phpcs:ignore CustomSniffs.Functions.NamedParameters
-        self::assertFalse($this->guard->canBezwaarMaken(aangifteId: 'aangifte-x', object: ['id' => 'aangifte-x']));
+        self::assertFalse($this->guard->canFileObjection(taxReturnId:'aangifte-x', object: ['id' => 'aangifte-x']));
 
     }//end testBezwaarExceptionFailsClosed()
 

--- a/tests/Unit/Service/VpbMkbFragmentTest.php
+++ b/tests/Unit/Service/VpbMkbFragmentTest.php
@@ -208,25 +208,25 @@ final class VpbMkbFragmentTest extends TestCase
     }//end testVoorvoegingsverliesCalculations()
 
     /**
-     * The bezwaar/beroep lifecycle references the BezwaarTermijnGuard (REQ-VPB-010).
+     * The bezwaar/beroep lifecycle references the ObjectionPeriodGuard (REQ-VPB-010).
      *
      * @return void
      */
-    public function testBezwaarTermijnGuardReferenced(): void
+    public function testObjectionPeriodGuardReferenced(): void
     {
         $aangifte = $this->fragment()['components']['schemas']['VpbAangifte'];
         self::assertSame(
-            'OCA\\Shillinq\\Lifecycle\\BezwaarTermijnGuard::canBezwaarMaken',
+            'OCA\\Shillinq\\Lifecycle\\ObjectionPeriodGuard::canFileObjection',
             $aangifte['x-openregister-lifecycle']['transitions']['bezwaarMaken']['requires']
         );
 
         $bezwaar = $this->fragment()['components']['schemas']['BezwaarBeroep'];
         self::assertSame(
-            'OCA\\Shillinq\\Lifecycle\\BezwaarTermijnGuard::canBeroepInstellen',
+            'OCA\\Shillinq\\Lifecycle\\ObjectionPeriodGuard::canFileAppeal',
             $bezwaar['x-openregister-lifecycle']['transitions']['beroepInstellen']['requires']
         );
 
-    }//end testBezwaarTermijnGuardReferenced()
+    }//end testObjectionPeriodGuardReferenced()
 
     /**
      * Every guard class referenced by the fragment exists as a PHP file.
@@ -238,9 +238,9 @@ final class VpbMkbFragmentTest extends TestCase
         $json = (string) file_get_contents($this->fragmentPath);
 
         $guards = [
-            'OCA\\Shillinq\\Lifecycle\\VpbAangifteGuard'    => __DIR__.'/../../../lib/Lifecycle/VpbAangifteGuard.php',
-            'OCA\\Shillinq\\Lifecycle\\BezwaarTermijnGuard' => __DIR__.'/../../../lib/Lifecycle/BezwaarTermijnGuard.php',
-            'OCA\\Shillinq\\Lifecycle\\VpbBerekeningGuard'  => __DIR__.'/../../../lib/Lifecycle/VpbBerekeningGuard.php',
+            'OCA\\Shillinq\\Lifecycle\\VpbAangifteGuard'     => __DIR__.'/../../../lib/Lifecycle/VpbAangifteGuard.php',
+            'OCA\\Shillinq\\Lifecycle\\ObjectionPeriodGuard' => __DIR__.'/../../../lib/Lifecycle/ObjectionPeriodGuard.php',
+            'OCA\\Shillinq\\Lifecycle\\VpbBerekeningGuard'   => __DIR__.'/../../../lib/Lifecycle/VpbBerekeningGuard.php',
         ];
 
         foreach ($guards as $fqcn => $path) {


### PR DESCRIPTION
## What

Renames `BezwaarTermijnGuard` to `ObjectionPeriodGuard`, together with its two guard methods, its private helpers, its statutory-period constant, and every local variable — the second slice of the fleet English-vocabulary programme in shillinq.

| before | after |
|---|---|
| `BezwaarTermijnGuard` | `ObjectionPeriodGuard` |
| `canBezwaarMaken` | `canFileObjection` |
| `canBeroepInstellen` | `canFileAppeal` |
| `withinTermijn` | `withinPeriod` |
| `resolveAanslagForAangifte` | `resolveAssessmentForTaxReturn` |
| `TERMIJN` | `STATUTORY_PERIOD` |

## Why this one is not a plain class rename

The guard is **wired by string, not by import**. `bookkeeping-vpb-mkb.json` declares each transition guard as

```json
"requires": "OCA\\Shillinq\\Lifecycle\\BezwaarTermijnGuard::canBezwaarMaken"
```

resolved reflectively at runtime. Moving only the PHP file would leave two transitions pointing at a class that no longer exists — and because these guards are **fail-closed**, that does not surface as an error. It surfaces as a bezwaar or beroep transition that quietly stops being permitted. Both `requires` strings and the three prose descriptions naming the class move in this PR.

## What is deliberately left in Dutch

Four strings are the **data contract**, not identifiers:

- `'DefinitieveAanslag'`, `'BezwaarBeroep'` — registered schema titles
- `'dagtekening'`, `'uitspraakDatum'`, and the `'aangifte'` filter key — schema properties, which OpenRegister stores as real snake_cased **columns**

Renaming any of these here without also renaming the schema property and shipping the `ALTER TABLE … RENAME COLUMN` would make the read return **null rather than fail**. They move with the VpbAangifte/BezwaarBeroep schema slice and its migration. Each is annotated in place so the next reader doesn't "finish the job" and break it.

## Named arguments

The unit test calls both guards with named arguments (`aangifteId:`, `bezwaarId:`), and `resolveAanslagForAangifte` was itself called with one. PHP resolves those at call time, so a parameter rename that misses a call site is a **runtime fatal that `php -l` reports as clean** — the defect this programme already hit in pipelinq. All four call sites move here, and the argument names were diffed against the declared parameters.

## Verification

- `php -l` clean on all four files; the fragment still parses as JSON
- **17 tests, 210 assertions green** across both affected test files
- Residual grep over `lib/`, `tests/`, `docs/`, `openspec/` — no live reference to the old names

**Positive control.** `testReferencedGuardClassesExist` asserts only *inside* `if (str_contains($json, $fqcn))`, so it passes vacuously when the class is absent from the fragment — it would have gone green on a half-done rename. Moving the guard file away turned it red at 2 assertions; restoring it returned 3. The branch is genuinely reached, which is what proves the **fragment wiring** was updated and not merely the file.

The archived June change under `openspec/changes/archive/` still names the old class. That is a historical record and is left as written.
