### PR TITLE
fix(security): call canAccess() in the 14 controllers that skip it — 23 IDORs incl. statutory VAT filing (#518)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2599,16 +2599,16 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
                 "shasum": ""
             },
             "require": {
@@ -2688,7 +2688,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-12-08T14:27:58+00:00"
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/lib/Controller/BadoControleprotocolController.php
+++ b/lib/Controller/BadoControleprotocolController.php
@@ -9,9 +9,17 @@
  * mechanically-derived proposed opinion for one Controleprotocol, used by the
  * Audit Verklaringen view to render the aggregation table + proposed opinion
  * before the auditor signs. The endpoint is available to any authenticated user
- * (#[NoAdminRequired]); the protocol id is validated and reads are delegated to
+ * (#[NoAdminRequired]); the protocol id is validated AND the caller is authorised
+ * for the protocol's owning organisation here
+ * (AdministrationContextService::canAccess(), ADR-005 / REQ-MA-001).
+ *
+ * ⚠️ This paragraph used to say the id "is validated and reads are delegated to
  * OpenRegister's ObjectService, which enforces multitenancy / RBAC, so no
- * cross-organisation audit data leaks. The aggregation + opinion are read-only
+ * cross-organisation audit data leaks". Validation was a character-class regex,
+ * no organisation term reached OpenRegister, and a schema with no
+ * `authorization` block grants everything — so the seven-schema audit bundle,
+ * including the proposed audit opinion, was readable for any protocol id.
+ * The aggregation + opinion are read-only
  * (computed) — the protocol/finding/verklaring lifecycle is driven by the
  * OpenRegister object lifecycle, not by this controller.
  *
@@ -36,6 +44,7 @@ namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Service\AccountantsdossierExportService;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\BadoControleprotocolService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -60,6 +69,7 @@ class BadoControleprotocolController extends Controller
      * @param LoggerInterface                 $logger      Logger for diagnostics (no stack traces to client).
      * @param IUserSession                    $userSession The user session for authentication guard.
      * @param AccountantsdossierExportService $exporter    The accountantsdossier PDF/A exporter (Task 16).
+     * @param AdministrationContextService    $context     RBAC guard — resolves the user's administration memberships.
      *
      * @return void
      */
@@ -69,6 +79,7 @@ class BadoControleprotocolController extends Controller
         private readonly LoggerInterface $logger,
         private readonly IUserSession $userSession,
         private readonly AccountantsdossierExportService $exporter,
+        private readonly AdministrationContextService $context,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -111,6 +122,15 @@ class BadoControleprotocolController extends Controller
                 ['error' => 'protocol_id must be a valid protocol identifier'],
                 Http::STATUS_BAD_REQUEST
             );
+        }
+
+        // ADR-005 / REQ-MA-001. The regex above validates the id's SHAPE; this
+        // authorises the caller for the tenant that owns it. The protocol's
+        // organisationId is the only tenant field in the bundle — the six child
+        // schemas carry none and hang off the protocol's FK.
+        $error = $this->requireAccessibleProtocol(protocolId: $protocolId);
+        if ($error !== null) {
+            return $error;
         }
 
         try {
@@ -175,6 +195,15 @@ class BadoControleprotocolController extends Controller
             );
         }
 
+        // ADR-005 / REQ-MA-001. The regex above validates the id's SHAPE; this
+        // authorises the caller for the tenant that owns it. The protocol's
+        // organisationId is the only tenant field in the bundle — the six child
+        // schemas carry none and hang off the protocol's FK.
+        $error = $this->requireAccessibleProtocol(protocolId: $protocolId);
+        if ($error !== null) {
+            return $error;
+        }
+
         try {
             $envelope = $this->exporter->exportDossier(protocolId: $protocolId);
         } catch (\RuntimeException $e) {
@@ -201,4 +230,39 @@ class BadoControleprotocolController extends Controller
 
         return new JSONResponse($envelope, Http::STATUS_OK);
     }//end exportAccountantsdossier()
+
+    /**
+     * Authorise the caller for the tenant that owns a Controleprotocol (ADR-005).
+     *
+     * A protocol that does not exist and a protocol belonging to an organisation
+     * the caller has no membership for are deliberately indistinguishable: both
+     * answer 404, so the endpoint never confirms the protocol exists.
+     *
+     * @param string $protocolId The Controleprotocol.id.
+     *
+     * @return JSONResponse|null A 404 response when refused, null when allowed.
+     *
+     * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-12
+     */
+    private function requireAccessibleProtocol(string $protocolId): ?JSONResponse
+    {
+        try {
+            $organisationId = $this->service->organisationIdFor(protocolId: $protocolId);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'BadoControleprotocolController: failed to resolve protocol tenant',
+                ['protocolId' => $protocolId, 'exception' => $e->getMessage()]
+            );
+
+            return new JSONResponse(['error' => 'Controleprotocol not found'], Http::STATUS_NOT_FOUND);
+        }
+
+        // canAccess() already fails closed on '' (AdministrationContextService:220).
+        if ($organisationId === null || $this->context->canAccess(administrationId: $organisationId) === false) {
+            return new JSONResponse(['error' => 'Controleprotocol not found'], Http::STATUS_NOT_FOUND);
+        }
+
+        return null;
+
+    }//end requireAccessibleProtocol()
 }//end class

--- a/lib/Controller/BadoControleprotocolController.php
+++ b/lib/Controller/BadoControleprotocolController.php
@@ -257,7 +257,8 @@ class BadoControleprotocolController extends Controller
             return new JSONResponse(['error' => 'Controleprotocol not found'], Http::STATUS_NOT_FOUND);
         }
 
-        // canAccess() already fails closed on '' (AdministrationContextService:220).
+        // A protocol with no organisationId is refused: canAccess() already
+        // fails closed on '' (AdministrationContextService:220).
         if ($organisationId === null || $this->context->canAccess(administrationId: $organisationId) === false) {
             return new JSONResponse(['error' => 'Controleprotocol not found'], Http::STATUS_NOT_FOUND);
         }

--- a/lib/Controller/InventoryScanController.php
+++ b/lib/Controller/InventoryScanController.php
@@ -17,8 +17,16 @@
  * (@NoAdminRequired — normal warehouse staff, not admins). The POST endpoint
  * additionally re-checks the acting user's role per operation type against
  * Nextcloud group membership; admins implicitly hold all roles. The asserted
- * client-side role is never trusted. IDOR-safe: the acting user id is taken from
- * the session, never from the request body.
+ * client-side role is never trusted. The acting user id is taken from the
+ * session, never from the request body, AND the administration named on the
+ * request is checked against the caller's memberships
+ * (AdministrationContextService::canAccess(), ADR-005 / REQ-MA-001).
+ *
+ * ⚠️ This paragraph used to end "IDOR-safe: the acting user id is taken from the
+ * session, never from the request body." True and irrelevant: the ADMINISTRATION
+ * id was a request parameter with the hardcoded default `'adm-1'`, so a request
+ * that simply omitted it read (and wrote) tenant `adm-1`. The default is gone;
+ * an absent or non-member administration is now a 400/404.
  *
  * @category Controller
  * @package  OCA\Shillinq\Controller
@@ -40,6 +48,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\InventoryScanService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -79,17 +88,19 @@ class InventoryScanController extends Controller
     /**
      * Constructor.
      *
-     * @param IRequest             $request      The request.
-     * @param IUserSession         $userSession  The user session (acting user / IDOR scope).
-     * @param IGroupManager        $groupManager Group membership for role checks.
-     * @param InventoryScanService $scanService  Server-authoritative scan logic.
-     * @param LoggerInterface      $logger       Logger.
+     * @param IRequest                     $request      The request.
+     * @param IUserSession                 $userSession  The user session (acting user identity).
+     * @param IGroupManager                $groupManager Group membership for role checks.
+     * @param InventoryScanService         $scanService  Server-authoritative scan logic.
+     * @param AdministrationContextService $context      RBAC guard — resolves the user's administration memberships.
+     * @param LoggerInterface              $logger       Logger.
      */
     public function __construct(
         IRequest $request,
         private readonly IUserSession $userSession,
         private readonly IGroupManager $groupManager,
         private readonly InventoryScanService $scanService,
+        private readonly AdministrationContextService $context,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
@@ -109,7 +120,7 @@ class InventoryScanController extends Controller
      * @NoAdminRequired
      */
     #[NoAdminRequired]
-    public function resolve(string $barcode='', string $administrationId='adm-1'): JSONResponse
+    public function resolve(string $barcode='', string $administrationId=''): JSONResponse
     {
         $user = $this->userSession->getUser();
         if ($user === null) {
@@ -121,7 +132,13 @@ class InventoryScanController extends Controller
             return new JSONResponse(data: ['message' => 'A barcode or SKU is required.'], statusCode: Http::STATUS_BAD_REQUEST);
         }
 
-        $item = $this->scanService->resolveBarcode(barcode: $barcode, administrationId: trim($administrationId));
+        $administrationId = trim($administrationId);
+        $error            = $this->requireAccessibleAdministration(administrationId: $administrationId);
+        if ($error !== null) {
+            return $error;
+        }
+
+        $item = $this->scanService->resolveBarcode(barcode: $barcode, administrationId: $administrationId);
         if ($item === null) {
             return new JSONResponse(data: ['found' => false]);
         }
@@ -143,7 +160,7 @@ class InventoryScanController extends Controller
      * @NoAdminRequired
      */
     #[NoAdminRequired]
-    public function sync(string $since='', string $administrationId='adm-1'): JSONResponse
+    public function sync(string $since='', string $administrationId=''): JSONResponse
     {
         $user = $this->userSession->getUser();
         if ($user === null) {
@@ -155,7 +172,13 @@ class InventoryScanController extends Controller
             $sinceArg = null;
         }
 
-        $stock = $this->scanService->getStockDelta(since: $sinceArg, administrationId: trim($administrationId));
+        $administrationId = trim($administrationId);
+        $error            = $this->requireAccessibleAdministration(administrationId: $administrationId);
+        if ($error !== null) {
+            return $error;
+        }
+
+        $stock = $this->scanService->getStockDelta(since: $sinceArg, administrationId: $administrationId);
 
         return new JSONResponse(
             data: [
@@ -171,8 +194,10 @@ class InventoryScanController extends Controller
      *
      * Each operation is role-gated (REQ-PERM-001), deduplicated on its
      * transactionId (REQ-SYNC-001), and applied to the stock ledger. The acting
-     * user id is taken from the session (IDOR-safe). Returns one ACK per
-     * operation, keyed by transactionId.
+     * user id is taken from the session, and the administration is checked
+     * against the caller's memberships before any operation is applied
+     * (ADR-005 / REQ-MA-001). Returns one ACK per operation, keyed by
+     * transactionId.
      *
      * @param array<int, array<string, mixed>> $operations       The operation batch.
      * @param string                           $administrationId Administration scope.
@@ -184,7 +209,7 @@ class InventoryScanController extends Controller
      * @NoAdminRequired
      */
     #[NoAdminRequired]
-    public function scan(array $operations=[], string $administrationId='adm-1'): JSONResponse
+    public function scan(array $operations=[], string $administrationId=''): JSONResponse
     {
         $user = $this->userSession->getUser();
         if ($user === null) {
@@ -202,8 +227,13 @@ class InventoryScanController extends Controller
             );
         }
 
+        $admin = trim($administrationId);
+        $error = $this->requireAccessibleAdministration(administrationId: $admin);
+        if ($error !== null) {
+            return $error;
+        }
+
         $userId  = $user->getUID();
-        $admin   = trim($administrationId);
         $results = [];
 
         foreach ($operations as $operation) {
@@ -213,6 +243,40 @@ class InventoryScanController extends Controller
         return new JSONResponse(data: ['results' => $results]);
 
     }//end scan()
+
+    /**
+     * Require the caller to be a member of the named administration (ADR-005).
+     *
+     * The administration is a request parameter on every endpoint of this
+     * controller. It used to default to the literal `'adm-1'`, so omitting it
+     * silently selected a real tenant; the default is now empty and an empty
+     * value is refused.
+     *
+     * @param string $administrationId The already-trimmed administration id.
+     *
+     * @return JSONResponse|null A 400/404 response when refused, null when allowed.
+     *
+     * @spec openspec/changes/inventory-mobile-scanner/tasks.md#T1.3
+     */
+    private function requireAccessibleAdministration(string $administrationId): ?JSONResponse
+    {
+        if ($administrationId === '') {
+            return new JSONResponse(
+                data: ['message' => 'An administrationId is required.'],
+                statusCode: Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        if ($this->context->canAccess(administrationId: $administrationId) === false) {
+            return new JSONResponse(
+                data: ['message' => 'Administration not found'],
+                statusCode: Http::STATUS_NOT_FOUND
+            );
+        }
+
+        return null;
+
+    }//end requireAccessibleAdministration()
 
     /**
      * Validate, authorise and apply a single operation, returning its ACK.

--- a/lib/Controller/NotificationController.php
+++ b/lib/Controller/NotificationController.php
@@ -50,6 +50,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\SettingsService;
 use RuntimeException;
 use OCP\AppFramework\Controller;
@@ -77,17 +78,19 @@ class NotificationController extends Controller
     /**
      * Constructor.
      *
-     * @param IRequest           $request     Request object.
-     * @param ContainerInterface $container   DI container for lazy ObjectService resolution.
-     * @param SettingsService    $settings    Register slug + OR availability.
-     * @param IUserSession       $userSession Logged-in user for the per-booking authorization gate.
-     * @param LoggerInterface    $logger      Logger for failure paths.
+     * @param IRequest                     $request     Request object.
+     * @param ContainerInterface           $container   DI container for lazy ObjectService resolution.
+     * @param SettingsService              $settings    Register slug + OR availability.
+     * @param IUserSession                 $userSession Logged-in user — the 401 anonymous-rejection guard only.
+     * @param AdministrationContextService $context     RBAC guard — the per-booking authorization gate (ADR-005).
+     * @param LoggerInterface              $logger      Logger for failure paths.
      */
     public function __construct(
         IRequest $request,
         private readonly ContainerInterface $container,
         private readonly SettingsService $settings,
         private readonly IUserSession $userSession,
+        private readonly AdministrationContextService $context,
         private readonly LoggerInterface $logger
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
@@ -114,6 +117,11 @@ class NotificationController extends Controller
     {
         if ($this->userSession->getUser() === null) {
             return new JSONResponse(data: ['message' => 'Not logged in'], statusCode: Http::STATUS_UNAUTHORIZED);
+        }
+
+        $error = $this->requireAccessibleBooking(bookingId: $id);
+        if ($error !== null) {
+            return $error;
         }
 
         try {
@@ -171,6 +179,11 @@ class NotificationController extends Controller
     {
         if ($this->userSession->getUser() === null) {
             return new JSONResponse(data: ['message' => 'Not logged in'], statusCode: Http::STATUS_UNAUTHORIZED);
+        }
+
+        $error = $this->requireAccessibleBooking(bookingId: $id);
+        if ($error !== null) {
+            return $error;
         }
 
         $params  = $this->request->getParams();
@@ -465,4 +478,58 @@ class NotificationController extends Controller
 
         return null;
     }//end findTriggerBySlug()
+
+    /**
+     * Require the caller to be a member of the administration owning a booking (ADR-005).
+     *
+     * `BookingNotificationTrigger` carries no tenant field at all — its only
+     * scoping is `appliesToBookingSlug` — so the administration has to come from
+     * the `Booking` the route names. Both endpoints previously fetched the
+     * triggers instance-wide and used the booking id only to WIDEN the filter
+     * (a trigger with an empty `appliesToBookingSlug` matches every booking), so
+     * quoting any booking id returned the instance's trigger configuration.
+     *
+     * A booking that does not exist and a booking in another administration both
+     * answer 404 (REQ-MA-001: mask, never confirm).
+     *
+     * @param string $bookingId The booking slug / uuid from the route.
+     *
+     * @return JSONResponse|null A 404 response when refused, null when allowed.
+     *
+     * @spec openspec/changes/bookings-notification-triggers/tasks.md#task-8
+     */
+    private function requireAccessibleBooking(string $bookingId): ?JSONResponse
+    {
+        try {
+            $service = $this->resolveObjectService();
+            $rows    = $service
+                ->setRegister($this->settings->getRegisterSlug())
+                ->setSchema('Booking')
+                ->findAll(['filters' => ['id' => $bookingId]]);
+        } catch (Throwable $e) {
+            $this->logger->warning('shillinq.notification.booking.unavailable', ['error' => $e->getMessage()]);
+            return new JSONResponse(data: ['message' => 'Booking unavailable'], statusCode: Http::STATUS_SERVICE_UNAVAILABLE);
+        }
+
+        foreach ((array) $rows as $row) {
+            if (is_array($row) === false) {
+                $row = (array) json_decode((string) json_encode($row), true);
+            }
+
+            $rowId = (string) ($row['id'] ?? ($row['@self']['id'] ?? ''));
+            if ($rowId !== $bookingId && (string) ($row['bookingId'] ?? '') !== $bookingId) {
+                continue;
+            }
+
+            // canAccess() fails closed on '' (AdministrationContextService:220).
+            if ($this->context->canAccess(administrationId: (string) ($row['administrationId'] ?? '')) === true) {
+                return null;
+            }
+
+            break;
+        }
+
+        return new JSONResponse(data: ['message' => 'Booking not found'], statusCode: Http::STATUS_NOT_FOUND);
+
+    }//end requireAccessibleBooking()
 }//end class

--- a/lib/Controller/NotificationController.php
+++ b/lib/Controller/NotificationController.php
@@ -521,7 +521,8 @@ class NotificationController extends Controller
                 continue;
             }
 
-            // canAccess() fails closed on '' (AdministrationContextService:220).
+            // A booking with no administrationId is refused: canAccess() fails
+            // closed on '' (AdministrationContextService:220).
             if ($this->context->canAccess(administrationId: (string) ($row['administrationId'] ?? '')) === true) {
                 return null;
             }

--- a/lib/Controller/NotificationController.php
+++ b/lib/Controller/NotificationController.php
@@ -110,6 +110,8 @@ class NotificationController extends Controller
      *
      * @return JSONResponse `{triggers: [{slug, name, triggerType, channels, status, appliesToBookingSlug}]}`.
      *
+     * @spec openspec/specs/bookings-notification-triggers/spec.md
+     *
      * @NoAdminRequired
      */
     #[NoAdminRequired]
@@ -171,6 +173,8 @@ class NotificationController extends Controller
      * @param string $id Booking slug / uuid.
      *
      * @return JSONResponse `{triggers: […]}` or error envelope.
+     *
+     * @spec openspec/specs/bookings-notification-triggers/spec.md
      *
      * @NoAdminRequired
      */

--- a/lib/Controller/OssController.php
+++ b/lib/Controller/OssController.php
@@ -4,13 +4,19 @@
  * OSS (One-Stop-Shop) Controller
  *
  * Tier-2 read API for the Union One-Stop-Shop pipeline. Exposes two GET
- * endpoints, both available to any authenticated user (#[NoAdminRequired]) and both
- * scoped to a server-validated administration so no cross-administration data
- * leaks (REQ-OSS-002, REQ-OSS-004): destination-country VAT-rate resolution
- * (REQ-OSS-001) and quarterly draft-return generation (REQ-OSS-004). Threshold
+ * endpoints, both available to any authenticated user (#[NoAdminRequired]):
+ * destination-country VAT-rate resolution (REQ-OSS-001, no administration
+ * parameter) and quarterly draft-return generation (REQ-OSS-004), which is
+ * authorised against the caller's administration memberships here
+ * (AdministrationContextService::canAccess(), ADR-005 / REQ-MA-001). Threshold
  * evaluation (REQ-OSS-002) is enforced server-side at invoice-save time through
- * OssThresholdGuard, not as a client endpoint. Reads are delegated to
- * OpenRegister's ObjectService, which enforces multitenancy / RBAC. No mutation
+ * OssThresholdGuard, not as a client endpoint.
+ *
+ * ⚠️ This paragraph used to say both endpoints were "scoped to a server-validated
+ * administration so no cross-administration data leaks" and that reads were
+ * "delegated to OpenRegister's ObjectService, which enforces multitenancy /
+ * RBAC". The "server validation" was `preg_match(self::ID_PATTERN, …)`, and
+ * OpenRegister received no administration term. No mutation
  * routes — OSS records are created/transitioned through the OpenRegister lifecycle.
  * No stack traces are returned to the client.
  *
@@ -34,6 +40,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\OssRateResolver;
 use OCA\Shillinq\Service\OssReturnGenerator;
 use OCP\AppFramework\Controller;
@@ -61,11 +68,12 @@ class OssController extends Controller
     /**
      * Constructor.
      *
-     * @param IRequest           $request         The request object.
-     * @param OssRateResolver    $rateResolver    Destination-country VAT-rate resolver.
-     * @param OssReturnGenerator $returnGenerator Quarterly return draft generator.
-     * @param LoggerInterface    $logger          Logger (no stack traces to client).
-     * @param IUserSession       $userSession     The user session.
+     * @param IRequest                     $request         The request object.
+     * @param OssRateResolver              $rateResolver    Destination-country VAT-rate resolver.
+     * @param OssReturnGenerator           $returnGenerator Quarterly return draft generator.
+     * @param LoggerInterface              $logger          Logger (no stack traces to client).
+     * @param IUserSession                 $userSession     The user session.
+     * @param AdministrationContextService $context         RBAC guard — resolves the user's administration memberships.
      *
      * @return void
      */
@@ -75,6 +83,7 @@ class OssController extends Controller
         private readonly OssReturnGenerator $returnGenerator,
         private readonly LoggerInterface $logger,
         private readonly IUserSession $userSession,
+        private readonly AdministrationContextService $context,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
     }//end __construct()
@@ -167,6 +176,14 @@ class OssController extends Controller
 
         if (preg_match(self::ID_PATTERN, $registrationId) !== 1) {
             return new JSONResponse(['error' => 'registration_id is required'], Http::STATUS_BAD_REQUEST);
+        }
+
+        // ⚠️ `preg_match(self::ID_PATTERN, ...)` is a character-class test, not a
+        // "server-validated administration". This draft exposes cross-border EU
+        // OSS turnover per member state, so the membership check belongs here
+        // (ADR-005 / REQ-MA-001).
+        if ($this->context->canAccess(administrationId: $administrationId) === false) {
+            return new JSONResponse(['error' => 'Administration not found'], Http::STATUS_NOT_FOUND);
         }
 
         try {

--- a/lib/Controller/RecognitionController.php
+++ b/lib/Controller/RecognitionController.php
@@ -13,10 +13,16 @@
  *
  * The endpoint is available to any authenticated user (#[NoAdminRequired]); it
  * rejects unauthenticated callers (401), validates administrationId + from/to before
- * the data layer (400), and delegates reads to OpenRegister's ObjectService, which
- * enforces per-administration multitenancy — so an authenticated user cannot read
- * another administration's orders (ADR-005 Rule 3 / no-admin-idor). This mirrors the
- * in-repo RevenueController precedent.
+ * the data layer (400), and authorises the administration against the caller's
+ * memberships here (AdministrationContextService::canAccess(), ADR-005 Rule 3 /
+ * no-admin-idor, REQ-MA-001).
+ *
+ * ⚠️ This paragraph used to end "delegates reads to OpenRegister's ObjectService,
+ * which enforces per-administration multitenancy — so an authenticated user cannot
+ * read another administration's orders". That was false: no administration term was
+ * passed into OpenRegister, and a schema with no `authorization` block grants every
+ * action to every authenticated user. Any authenticated user COULD read another
+ * administration's orders, and the sentence is why nobody looked.
  *
  * @category Controller
  * @package  OCA\Shillinq\Controller
@@ -39,6 +45,7 @@ namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Recognition\RevenueRecognitionService;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -57,10 +64,11 @@ class RecognitionController extends Controller
     /**
      * Constructor for the RecognitionController.
      *
-     * @param IRequest                  $request            The request object.
-     * @param RevenueRecognitionService $recognitionService The recognition computation service.
-     * @param IUserSession              $userSession        Session for the auth body-guard.
-     * @param LoggerInterface           $logger             Logger for diagnostics (no stack traces to client).
+     * @param IRequest                     $request            The request object.
+     * @param RevenueRecognitionService    $recognitionService The recognition computation service.
+     * @param IUserSession                 $userSession        Session for the auth body-guard.
+     * @param AdministrationContextService $context            RBAC guard — resolves the user's administration memberships.
+     * @param LoggerInterface              $logger             Logger for diagnostics (no stack traces to client).
      *
      * @return void
      */
@@ -68,6 +76,7 @@ class RecognitionController extends Controller
         IRequest $request,
         private readonly RevenueRecognitionService $recognitionService,
         private readonly IUserSession $userSession,
+        private readonly AdministrationContextService $context,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
@@ -115,6 +124,14 @@ class RecognitionController extends Controller
                 ['error' => 'administrationId must be a valid administration identifier'],
                 Http::STATUS_BAD_REQUEST
             );
+        }
+
+        // ⚠️ The regex above is INPUT VALIDATION, not authorisation — it was the
+        // only thing standing between any authenticated user and another
+        // tenant's recurring-revenue book. The membership check is what the
+        // docblock's "ADR-005 IDOR-safety" always claimed (REQ-MA-001).
+        if ($this->context->canAccess(administrationId: $administrationId) === false) {
+            return new JSONResponse(['error' => 'Administration not found'], Http::STATUS_NOT_FOUND);
         }
 
         if (preg_match('/^\\d{4}-\\d{2}-\\d{2}$/', $from) !== 1) {

--- a/lib/Controller/ReportingController.php
+++ b/lib/Controller/ReportingController.php
@@ -32,7 +32,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`
@@ -68,7 +73,12 @@ use OCP\IUserSession;
 /**
  * HTTP surface for Reporting & Compliance: catalogue, generation, listing, download.
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`
@@ -150,6 +160,8 @@ class ReportingController extends Controller
      * + downloadPath). A service-level `{ error: ... }` envelope is surfaced as 422.
      *
      * @return JSONResponse The GeneratedReport record, or an error envelope.
+     *
+     * @spec exclude No canonical requirement exists for the reporting capability — see #525.
      */
     #[NoAdminRequired]
     public function generate(): JSONResponse
@@ -200,6 +212,8 @@ class ReportingController extends Controller
      * included, which then fed `download/{id}`.
      *
      * @return JSONResponse `{ reports: [...] }`.
+     *
+     * @spec exclude No canonical requirement exists for the reporting capability — see #525.
      */
     #[NoAdminRequired]
     public function generated(): JSONResponse
@@ -253,6 +267,8 @@ class ReportingController extends Controller
      * @param string $id The GeneratedReport id.
      *
      * @return DataDownloadResponse|JSONResponse The streamed file, or a 404 JSON envelope.
+     *
+     * @spec exclude No canonical requirement exists for the reporting capability — see #525.
      */
     #[NoAdminRequired]
     public function download(string $id): DataDownloadResponse|JSONResponse

--- a/lib/Controller/ReportingController.php
+++ b/lib/Controller/ReportingController.php
@@ -11,9 +11,17 @@
  * the browser for download.
  *
  * Every endpoint is `#[NoAdminRequired]` — finance officers and controllers, not
- * only admins, work with reports. The download endpoint resolves the GeneratedReport
- * record and its stored Nextcloud file through the service, which scopes file access
- * to the current user's Files home.
+ * only admins, work with reports — and every endpoint that names an
+ * administration or a stored report is authorised here against the caller's
+ * memberships (AdministrationContextService, ADR-005 / REQ-MA-001).
+ *
+ * ⚠️ This paragraph previously stated that the service "scopes file access to
+ * the current user's Files home". It did not: `resolveFile()` used
+ * `IRootFolder::getById()` and `IRootFolder::get($path)`, both of which resolve
+ * across EVERY user's storage, and `generated()` treated `administrationId` as
+ * an OPTIONAL filter, so omitting it listed every tenant's reports together
+ * with the ids that feed `download/{id}`. Both are fixed; the sentence is
+ * retained as a warning because it is the reason nobody looked.
  *
  * @category Controller
  * @package  OCA\Shillinq\Controller
@@ -48,6 +56,7 @@ namespace OCA\Shillinq\Controller;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Reporting\ReportCatalogue;
 use OCA\Shillinq\Reporting\ReportGenerationService;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -77,9 +86,10 @@ class ReportingController extends Controller
     /**
      * Constructor.
      *
-     * @param IRequest                $request     The current request.
-     * @param IUserSession            $userSession Anonymous-rejection guard (ADR-005).
-     * @param ReportGenerationService $service     The generation/orchestration service.
+     * @param IRequest                     $request     The current request.
+     * @param IUserSession                 $userSession Anonymous-rejection guard (ADR-005).
+     * @param ReportGenerationService      $service     The generation/orchestration service.
+     * @param AdministrationContextService $context     RBAC guard — resolves the user's administration memberships.
      *
      * @return void
      */
@@ -87,6 +97,7 @@ class ReportingController extends Controller
         IRequest $request,
         private readonly IUserSession $userSession,
         private readonly ReportGenerationService $service,
+        private readonly AdministrationContextService $context,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -156,6 +167,13 @@ class ReportingController extends Controller
             return new JSONResponse(['error' => 'missing-report-type'], Http::STATUS_BAD_REQUEST);
         }
 
+        // ADR-005 / REQ-MA-001 — generating a report against another tenant's
+        // ledger. An empty administrationId means "no administration scope" and
+        // is left to the service; a NAMED administration must be one of ours.
+        if ($administrationId !== '' && $this->context->canAccess(administrationId: $administrationId) === false) {
+            return new JSONResponse(['error' => 'not-found'], Http::STATUS_NOT_FOUND);
+        }
+
         $result = $this->service->generate(
             reportType: $reportType,
             period: $period,
@@ -174,7 +192,12 @@ class ReportingController extends Controller
     /**
      * GET /api/reporting/generated — list previously generated reports.
      *
-     * Optional query filters: reportType, period, administrationId, category.
+     * Optional query filters: reportType, period, category. `administrationId`
+     * is NOT optional in effect: the listing is always scoped to the caller's
+     * administration memberships (ADR-005 / REQ-MA-001), and an explicit
+     * administrationId may only narrow that scope, never widen it. It used to be
+     * an optional filter, so omitting it returned every tenant's reports — ids
+     * included, which then fed `download/{id}`.
      *
      * @return JSONResponse `{ reports: [...] }`.
      */
@@ -185,23 +208,47 @@ class ReportingController extends Controller
             return new JSONResponse(['error' => 'not-logged-in'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $filters = [
-            'reportType'       => $this->request->getParam('reportType'),
-            'period'           => $this->request->getParam('period'),
-            'administrationId' => $this->request->getParam('administrationId'),
-            'category'         => $this->request->getParam('category'),
-        ];
+        $requested = trim((string) $this->request->getParam('administrationId', ''));
+        $scope     = $this->context->accessibleAdministrationIds();
+        if ($requested !== '') {
+            if ($this->context->canAccess(administrationId: $requested) === false) {
+                return new JSONResponse(['error' => 'not-found'], Http::STATUS_NOT_FOUND);
+            }
 
-        return new JSONResponse(['reports' => $this->service->listGenerated($filters)]);
+            $scope = [$requested];
+        }
+
+        $reports = [];
+        foreach ($scope as $administrationId) {
+            $reports = array_merge(
+                $reports,
+                $this->service->listGenerated(
+                    [
+                        'reportType'       => $this->request->getParam('reportType'),
+                        'period'           => $this->request->getParam('period'),
+                        'administrationId' => $administrationId,
+                        'category'         => $this->request->getParam('category'),
+                    ]
+                )
+            );
+        }
+
+        return new JSONResponse(['reports' => $reports]);
 
     }//end generated()
 
     /**
      * GET /api/reporting/download/{id} — stream a stored report file.
      *
-     * Resolves the GeneratedReport record and its Nextcloud file (scoped to the
-     * current user's Files home) and returns it as a download. Missing records/files
-     * yield 404.
+     * Loads the GeneratedReport record, authorises the caller against the
+     * administration that record belongs to (ADR-005 / REQ-MA-001), and only
+     * then resolves and streams the stored Nextcloud file. A record the caller
+     * has no membership for is masked as 404, never confirmed.
+     *
+     * ⚠️ This docblock used to claim the file was "scoped to the current user's
+     * Files home". It was not — `resolveFile()` went through `IRootFolder`,
+     * which resolves across every user's storage, so `download/{id}` was an
+     * arbitrary file read for any authenticated user.
      *
      * @param string $id The GeneratedReport id.
      *
@@ -218,7 +265,14 @@ class ReportingController extends Controller
             return new JSONResponse(['error' => 'missing-id'], Http::STATUS_BAD_REQUEST);
         }
 
-        $file = $this->service->resolveFile($id);
+        $record = $this->service->findRecord($id);
+        if ($record === null
+            || $this->context->canAccess(administrationId: (string) ($record['administrationId'] ?? '')) === false
+        ) {
+            return new JSONResponse(['error' => 'not-found'], Http::STATUS_NOT_FOUND);
+        }
+
+        $file = $this->service->resolveRecordFile(record: $record);
         if ($file === null) {
             return new JSONResponse(['error' => 'not-found'], Http::STATUS_NOT_FOUND);
         }

--- a/lib/Controller/RevenueController.php
+++ b/lib/Controller/RevenueController.php
@@ -8,9 +8,15 @@
  * one administration + period end: cumulative recognised, contract asset /
  * liability split, allocated transaction price, and the remaining-performance-
  * obligation amount. The endpoint is available to any authenticated user
- * (#[NoAdminRequired]); the administration scope is validated and reads are
+ * (#[NoAdminRequired]); the administration scope is validated AND authorised
+ * here against the caller's memberships
+ * (AdministrationContextService::canAccess(), ADR-005 IDOR-safety, REQ-MA-001).
+ *
+ * ⚠️ This paragraph used to claim the scope was "validated and reads are
  * delegated to OpenRegister's ObjectService, which enforces multitenancy / RBAC,
- * so no cross-administration data leaks (ADR-005 IDOR-safety). The cut-off is a
+ * so no cross-administration data leaks". The validation was a character-class
+ * regex, no administration term reached OpenRegister, and OpenRegister grants
+ * everything on a schema with no `authorization` block. The cut-off is a
  * derived read — there is no create/update/delete route (the ContractAsset /
  * ContractLiability / RevenueWaterfall schemas are read-only).
  *
@@ -34,6 +40,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\RevenueCutoffService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -53,10 +60,11 @@ class RevenueController extends Controller
     /**
      * Constructor for the RevenueController.
      *
-     * @param IRequest             $request       The request object.
-     * @param RevenueCutoffService $cutoffService The revenue cut-off computation service.
-     * @param IUserSession         $userSession   Session for the auth body-guard.
-     * @param LoggerInterface      $logger        Logger for diagnostics (no stack traces to client).
+     * @param IRequest                     $request       The request object.
+     * @param RevenueCutoffService         $cutoffService The revenue cut-off computation service.
+     * @param IUserSession                 $userSession   Session for the auth body-guard.
+     * @param AdministrationContextService $context       RBAC guard — resolves the user's administration memberships.
+     * @param LoggerInterface              $logger        Logger for diagnostics (no stack traces to client).
      *
      * @return void
      */
@@ -64,6 +72,7 @@ class RevenueController extends Controller
         IRequest $request,
         private readonly RevenueCutoffService $cutoffService,
         private readonly IUserSession $userSession,
+        private readonly AdministrationContextService $context,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
@@ -123,6 +132,12 @@ class RevenueController extends Controller
                 ['error' => 'period_end must be an ISO date (YYYY-MM-DD)'],
                 Http::STATUS_BAD_REQUEST
             );
+        }
+
+        // ⚠️ The checks above are INPUT VALIDATION. The docblock's "ADR-005
+        // IDOR-safety" needs a membership check, which is this (REQ-MA-001).
+        if ($this->context->canAccess(administrationId: $administrationId) === false) {
+            return new JSONResponse(['error' => 'Administration not found'], Http::STATUS_NOT_FOUND);
         }
 
         try {

--- a/lib/Controller/SepaAuditController.php
+++ b/lib/Controller/SepaAuditController.php
@@ -68,8 +68,14 @@ class SepaAuditController extends Controller
      * Export the audit dossier for a single mandate as a ZIP (REQ-SDD-010).
      *
      * Scoped to the authenticated user's accessible administrations by the
-     * service (IDOR-safe per ADR-005): a mandate the caller may not read
-     * yields a 404 rather than leaking its existence.
+     * service (IDOR-safe per ADR-005 / REQ-MA-001): a mandate the caller may not
+     * read yields a 404 rather than leaking its existence.
+     *
+     * ⚠️ This sentence was written before it was true. Until this change the
+     * service scoped to `appConfig('administration_id')` — an instance-wide
+     * constant, never the caller's memberships — and skipped the comparison
+     * entirely when that key was unset (its default). The dossier is mandate +
+     * collections + R-transactions + pre-notifications as a ZIP.
      *
      * @param string $mandateId The SepaMandate UUID/slug to export.
      *

--- a/lib/Controller/TaxPaymentController.php
+++ b/lib/Controller/TaxPaymentController.php
@@ -9,8 +9,14 @@
  * by OpenRegister's generic object API (the shillinq frontend object store
  * already targets /apps/openregister/api/objects); only the bespoke
  * reconciliation lives here. The endpoint is available to any authenticated user
- * (#[NoAdminRequired]); the administration scope is validated and reads are
- * delegated to OpenRegister's ObjectService, which enforces multitenancy / RBAC.
+ * (#[NoAdminRequired]); the administration scope is validated AND authorised here
+ * against the caller's memberships (AdministrationContextService::canAccess(),
+ * ADR-005 / REQ-MA-001).
+ *
+ * ⚠️ This paragraph used to end "reads are delegated to OpenRegister's
+ * ObjectService, which enforces multitenancy / RBAC". It does not — no
+ * administration term is passed in, and a schema with no `authorization` block
+ * grants every action to every authenticated user. This endpoint also WRITES.
  *
  * @category Controller
  * @package  OCA\Shillinq\Controller
@@ -32,6 +38,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\TaxPaymentReconciliationService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -54,6 +61,7 @@ class TaxPaymentController extends Controller
      * @param IRequest                        $request        The request object.
      * @param TaxPaymentReconciliationService $reconciliation The reconciliation service.
      * @param IUserSession                    $userSession    Session for the auth body-guard.
+     * @param AdministrationContextService    $context        RBAC guard — resolves the user's administration memberships.
      * @param LoggerInterface                 $logger         Logger (no stack traces to client).
      *
      * @return void
@@ -62,6 +70,7 @@ class TaxPaymentController extends Controller
         IRequest $request,
         private readonly TaxPaymentReconciliationService $reconciliation,
         private readonly IUserSession $userSession,
+        private readonly AdministrationContextService $context,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
@@ -108,6 +117,13 @@ class TaxPaymentController extends Controller
                 ['error' => 'id must be a valid payment identifier'],
                 Http::STATUS_BAD_REQUEST
             );
+        }
+
+        // ⚠️ Both checks above are character-class tests. The reconciliation
+        // WRITES against the administration named on the wire, so the membership
+        // check has to happen before it (ADR-005 / REQ-MA-001).
+        if ($this->context->canAccess(administrationId: $administrationId) === false) {
+            return new JSONResponse(['error' => 'Administration not found'], Http::STATUS_NOT_FOUND);
         }
 
         try {

--- a/lib/Controller/TaxReportController.php
+++ b/lib/Controller/TaxReportController.php
@@ -6,10 +6,17 @@
  * Tier-2 read-only Vpb quarterly/annual tax-statement API (REQ-VPB-003,
  * REQ-VPB-009, REQ-VPB-010, REQ-VPB-012). Exposes two GET endpoints returning
  * the aggregated income statement for one administration + fiscal period. The
- * endpoints are available to any authenticated user (#[NoAdminRequired]); the
- * administration scope is validated and reads are delegated to OpenRegister's
- * ObjectService, which enforces multitenancy / RBAC, so no cross-administration
- * data leaks. The statement is computed (read-only) — there is no
+ * endpoints are available to any authenticated user (#[NoAdminRequired]) and are
+ * authorised per administration here, against the caller's memberships
+ * (AdministrationContextService::canAccess(), ADR-005 / REQ-MA-001).
+ *
+ * ⚠️ This paragraph used to say the scope "is validated and reads are delegated
+ * to OpenRegister's ObjectService, which enforces multitenancy / RBAC, so no
+ * cross-administration data leaks". Both halves were false: the only check was a
+ * character-class regex on the id, and OpenRegister grants every action on a
+ * schema that declares no `authorization` block — which is all ~871 of them here.
+ *
+ * The statement is computed (read-only) — there is no
  * create/update/delete route; deadline/payment CRUD is served by OpenRegister's
  * generic object API.
  *
@@ -33,6 +40,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\TaxReportService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -53,10 +61,11 @@ class TaxReportController extends Controller
     /**
      * Constructor for the TaxReportController.
      *
-     * @param IRequest         $request          The request object.
-     * @param TaxReportService $taxReportService The tax-statement computation service.
-     * @param IUserSession     $userSession      Session for the auth body-guard.
-     * @param LoggerInterface  $logger           Logger for diagnostics (no stack traces to client).
+     * @param IRequest                     $request          The request object.
+     * @param TaxReportService             $taxReportService The tax-statement computation service.
+     * @param IUserSession                 $userSession      Session for the auth body-guard.
+     * @param AdministrationContextService $context          RBAC guard — resolves the user's administration memberships.
+     * @param LoggerInterface              $logger           Logger for diagnostics (no stack traces to client).
      *
      * @return void
      */
@@ -64,6 +73,7 @@ class TaxReportController extends Controller
         IRequest $request,
         private readonly TaxReportService $taxReportService,
         private readonly IUserSession $userSession,
+        private readonly AdministrationContextService $context,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
@@ -99,7 +109,7 @@ class TaxReportController extends Controller
 
         $administrationId = trim((string) $this->request->getParam('administration_id', ''));
 
-        $error = $this->validateAdministration(administrationId: $administrationId);
+        $error = $this->requireAccessibleAdministration(administrationId: $administrationId);
         if ($error !== null) {
             return $error;
         }
@@ -159,7 +169,7 @@ class TaxReportController extends Controller
 
         $administrationId = trim((string) $this->request->getParam('administration_id', ''));
 
-        $error = $this->validateAdministration(administrationId: $administrationId);
+        $error = $this->requireAccessibleAdministration(administrationId: $administrationId);
         if ($error !== null) {
             return $error;
         }
@@ -195,13 +205,20 @@ class TaxReportController extends Controller
     }//end annual()
 
     /**
-     * Validate the administration_id query parameter (REQ-VPB-003 scoping).
+     * Validate AND authorise the administration_id query parameter (REQ-VPB-003 scoping).
+     *
+     * ⚠️ Renamed from `validateAdministration()`. The old name implied an access
+     * check; the old body was entirely an empty-check plus
+     * `preg_match('/^[A-Za-z0-9_.\-]{1,64}$/')` — a character-class test. Format
+     * validation is not authorisation, and both callers relied on this method for
+     * the latter. It now performs the membership check as well (ADR-005 /
+     * REQ-MA-001), masking a non-member's administration as 404.
      *
      * @param string $administrationId The administration identifier to validate.
      *
-     * @return JSONResponse|null A 400 response when invalid, null when acceptable.
+     * @return JSONResponse|null A 400/404 response when refused, null when acceptable.
      */
-    private function validateAdministration(string $administrationId): ?JSONResponse
+    private function requireAccessibleAdministration(string $administrationId): ?JSONResponse
     {
         if ($administrationId === '') {
             return new JSONResponse(
@@ -217,7 +234,11 @@ class TaxReportController extends Controller
             );
         }
 
+        if ($this->context->canAccess(administrationId: $administrationId) === false) {
+            return new JSONResponse(['error' => 'Administration not found'], Http::STATUS_NOT_FOUND);
+        }
+
         return null;
 
-    }//end validateAdministration()
+    }//end requireAccessibleAdministration()
 }//end class

--- a/lib/Controller/VATDeclarationController.php
+++ b/lib/Controller/VATDeclarationController.php
@@ -9,8 +9,14 @@
  *
  *   GET /api/vat-returns/{returnId}/declarations
  *
- * The endpoint is authenticated (#[NoAdminRequired]); the per-object
- * multitenancy is enforced by OpenRegister's ObjectService.
+ * The endpoint is authenticated (#[NoAdminRequired]) AND scoped to the
+ * caller's administration memberships in this controller
+ * (AdministrationContextService::accessibleAdministrationIds(), ADR-005 /
+ * REQ-MA-001).
+ *
+ * ⚠️ This paragraph previously claimed "the per-object multitenancy is
+ * enforced by OpenRegister's ObjectService". It was not: the query passed
+ * no administration term into OpenRegister at all.
  *
  * @category Controller
  * @package  OCA\Shillinq\Controller
@@ -32,6 +38,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -53,15 +60,17 @@ class VATDeclarationController extends Controller
     /**
      * Constructor.
      *
-     * @param IRequest           $request   The request object.
-     * @param ContainerInterface $container DI container for OR's ObjectService.
-     * @param IUserSession       $session   User session for the authentication guard.
-     * @param LoggerInterface    $logger    Logger.
+     * @param IRequest                     $request   The request object.
+     * @param ContainerInterface           $container DI container for OR's ObjectService.
+     * @param IUserSession                 $session   User session for the authentication guard.
+     * @param AdministrationContextService $context   RBAC guard — resolves the user's administration memberships.
+     * @param LoggerInterface              $logger    Logger.
      */
     public function __construct(
         IRequest $request,
         private readonly ContainerInterface $container,
         private readonly IUserSession $session,
+        private readonly AdministrationContextService $context,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
@@ -87,12 +96,27 @@ class VATDeclarationController extends Controller
             return new JSONResponse(['error' => 'returnId is required'], Http::STATUS_BAD_REQUEST);
         }
 
+        // ADR-005 / REQ-MA-001. VATDeclaration carries administrationId; the
+        // scope is the caller's memberships, one query per administration.
         try {
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-            $declarations  = $objectService
-                ->setRegister(register: 'shillinq')
-                ->setSchema(schema: 'VATDeclaration')
-                ->findAll(['filters' => ['returnId' => $returnId]]);
+            $declarations  = [];
+            foreach ($this->context->accessibleAdministrationIds() as $administrationId) {
+                $declarations = array_merge(
+                    $declarations,
+                    $objectService
+                        ->setRegister(register: 'shillinq')
+                        ->setSchema(schema: 'VATDeclaration')
+                        ->findAll(
+                            [
+                                'filters' => [
+                                    'returnId'         => $returnId,
+                                    'administrationId' => $administrationId,
+                                ],
+                            ]
+                        )
+                );
+            }
         } catch (\Throwable $e) {
             $this->logger->error(
                 'VATDeclarationController: failed to list declarations',

--- a/lib/Controller/VATDeclarationController.php
+++ b/lib/Controller/VATDeclarationController.php
@@ -124,7 +124,7 @@ class VATDeclarationController extends Controller
             );
 
             return new JSONResponse(['error' => 'Failed to list declarations'], Http::STATUS_INTERNAL_SERVER_ERROR);
-        }
+        }//end try
 
         return new JSONResponse(
             [

--- a/lib/Controller/VATLineController.php
+++ b/lib/Controller/VATLineController.php
@@ -169,7 +169,7 @@ class VATLineController extends Controller
             );
 
             return new JSONResponse(['error' => 'Failed to list VAT lines'], Http::STATUS_INTERNAL_SERVER_ERROR);
-        }
+        }//end try
 
         return new JSONResponse(
             [

--- a/lib/Controller/VATLineController.php
+++ b/lib/Controller/VATLineController.php
@@ -10,8 +10,16 @@
  *   GET /api/vat-returns/{returnId}/lines
  *   GET /api/vat-declarations/{declarationId}/lines
  *
- * Both endpoints are authenticated (#[NoAdminRequired]); the per-object
- * multitenancy is enforced by OpenRegister's ObjectService.
+ * Both endpoints are authenticated (#[NoAdminRequired]) AND scoped to the
+ * caller's administration memberships in this controller
+ * (AdministrationContextService::accessibleAdministrationIds(), ADR-005 /
+ * REQ-MA-001).
+ *
+ * ⚠️ This paragraph previously claimed "the per-object multitenancy is
+ * enforced by OpenRegister's ObjectService". It was not: findLines() passed
+ * no administration term into OpenRegister at all, and every one of this
+ * app's schemas declares no `authorization` block, which OpenRegister treats
+ * as grant-to-every-authenticated-user.
  *
  * @category Controller
  * @package  OCA\Shillinq\Controller
@@ -33,6 +41,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -54,15 +63,17 @@ class VATLineController extends Controller
     /**
      * Constructor.
      *
-     * @param IRequest           $request   The request object.
-     * @param ContainerInterface $container DI container for OR's ObjectService.
-     * @param IUserSession       $session   User session for the authentication guard.
-     * @param LoggerInterface    $logger    Logger.
+     * @param IRequest                     $request   The request object.
+     * @param ContainerInterface           $container DI container for OR's ObjectService.
+     * @param IUserSession                 $session   User session for the authentication guard.
+     * @param AdministrationContextService $context   RBAC guard — resolves the user's administration memberships.
+     * @param LoggerInterface              $logger    Logger.
      */
     public function __construct(
         IRequest $request,
         private readonly ContainerInterface $container,
         private readonly IUserSession $session,
+        private readonly AdministrationContextService $context,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
@@ -126,12 +137,31 @@ class VATLineController extends Controller
      */
     private function findLines(string $filterKey, string $filterValue): JSONResponse
     {
+        // ADR-005 / REQ-MA-001. The query used to carry no administration term
+        // at all, so any authenticated user could read any tenant's VAT lines by
+        // quoting a return or declaration id. VATLine carries administrationId,
+        // so the scope is applied as an additional filter, one query per
+        // administration the caller is actually a member of. A caller with no
+        // memberships gets an empty scope and therefore an empty list.
         try {
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-            $lines         = $objectService
-                ->setRegister(register: 'shillinq')
-                ->setSchema(schema: 'VATLine')
-                ->findAll(['filters' => [$filterKey => $filterValue]]);
+            $lines         = [];
+            foreach ($this->context->accessibleAdministrationIds() as $administrationId) {
+                $lines = array_merge(
+                    $lines,
+                    $objectService
+                        ->setRegister(register: 'shillinq')
+                        ->setSchema(schema: 'VATLine')
+                        ->findAll(
+                            [
+                                'filters' => [
+                                    $filterKey         => $filterValue,
+                                    'administrationId' => $administrationId,
+                                ],
+                            ]
+                        )
+                );
+            }
         } catch (\Throwable $e) {
             $this->logger->error(
                 'VATLineController: failed to list VAT lines',

--- a/lib/Controller/VATReturnController.php
+++ b/lib/Controller/VATReturnController.php
@@ -15,11 +15,22 @@
  *   POST   /api/vat-returns/{returnId}/rebase      — re-open + re-derive
  *   DELETE /api/vat-returns/{returnId}             — delete (draft only)
  *
- * The endpoints are authenticated (#[NoAdminRequired]); per-object
- * authorisation is delegated to OpenRegister's ObjectService which
- * enforces administration-scoped multitenancy. Future returns are
- * rejected at the controller (REQ-VAT-001); lifecycle status checks
- * live in VATReturnService.
+ * The endpoints are authenticated (#[NoAdminRequired]) AND authorised
+ * per administration in this controller, via
+ * AdministrationContextService::canAccess() (ADR-005, REQ-MA-001).
+ *
+ * ⚠️ The previous version of this paragraph claimed authorisation was
+ * "delegated to OpenRegister's ObjectService which enforces
+ * administration-scoped multitenancy". That was false in both halves:
+ * none of these endpoints passes an administration term into
+ * OpenRegister at all, and a schema that declares no `authorization`
+ * block — as all ~871 of this app's schemas do — grants every action to
+ * every authenticated user (openregister PermissionHandler::
+ * hasGroupPermission(), `enforce_default_closed` defaults false). The
+ * controller guard is not the outer of two layers; it is the only layer.
+ *
+ * Future returns are rejected at the controller (REQ-VAT-001);
+ * lifecycle status checks live in VATReturnService.
  *
  * @category Controller
  * @package  OCA\Shillinq\Controller
@@ -41,6 +52,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\VATReturnService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -67,17 +79,19 @@ class VATReturnController extends Controller
     /**
      * Constructor.
      *
-     * @param IRequest           $request   The request object.
-     * @param VATReturnService   $service   The VAT return service.
-     * @param ContainerInterface $container DI container for OR's ObjectService.
-     * @param IUserSession       $session   User session (for actor identity).
-     * @param LoggerInterface    $logger    Logger.
+     * @param IRequest                     $request   The request object.
+     * @param VATReturnService             $service   The VAT return service.
+     * @param ContainerInterface           $container DI container for OR's ObjectService.
+     * @param IUserSession                 $session   User session (for actor identity).
+     * @param AdministrationContextService $context   RBAC guard — resolves the user's administration memberships.
+     * @param LoggerInterface              $logger    Logger.
      */
     public function __construct(
         IRequest $request,
         private readonly VATReturnService $service,
         private readonly ContainerInterface $container,
         private readonly IUserSession $session,
+        private readonly AdministrationContextService $context,
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct(appName: Application::APP_ID, request: $request);
@@ -101,12 +115,32 @@ class VATReturnController extends Controller
         $page    = max(1, (int) $this->request->getParam('_page', 1));
         $limit   = max(1, min(200, (int) $this->request->getParam('_limit', 25)));
 
+        // ADR-005 / REQ-MA-001. The administrationId filter used to be OPTIONAL,
+        // so omitting it listed every tenant's statutory VAT returns. The scope
+        // is now always the caller's memberships; an explicit administrationId
+        // may only NARROW it, never widen it.
+        $requested = trim((string) $this->request->getParam('administrationId', ''));
+        $scope     = $this->context->accessibleAdministrationIds();
+        if ($requested !== '') {
+            if ($this->context->canAccess(administrationId: $requested) === false) {
+                return new JSONResponse(['error' => 'Administration not found'], Http::STATUS_NOT_FOUND);
+            }
+
+            $scope = [$requested];
+        }
+
         try {
             $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-            $all           = $objectService
-                ->setRegister(register: 'shillinq')
-                ->setSchema(schema: 'BtwAangifte')
-                ->findAll(['filters' => $filters]);
+            $all           = [];
+            foreach ($scope as $administrationId) {
+                $all = array_merge(
+                    $all,
+                    $objectService
+                        ->setRegister(register: 'shillinq')
+                        ->setSchema(schema: 'BtwAangifte')
+                        ->findAll(['filters' => ($filters + ['administrationId' => $administrationId])])
+                );
+            }
         } catch (\Throwable $e) {
             $this->logger->error(
                 'VATReturnController: failed to list VAT returns',
@@ -163,7 +197,7 @@ class VATReturnController extends Controller
             // VATReturnService::findReturn() performs the entity → array
             // normalisation and returns null only when the row is genuinely absent.
             $vatReturn = $this->service->findReturn(returnId: $returnId);
-            if ($vatReturn === null) {
+            if ($this->mayAccessReturn(vatReturn: $vatReturn) === false) {
                 return new JSONResponse(['error' => 'VAT return not found'], Http::STATUS_NOT_FOUND);
             }
 
@@ -218,6 +252,15 @@ class VATReturnController extends Controller
 
         if ($this->validId(id: $administrationId) === false) {
             return new JSONResponse(['error' => 'administrationId is required'], Http::STATUS_BAD_REQUEST);
+        }
+
+        // ADR-005 / REQ-MA-001. VATReturnService::createReturn() documents its
+        // $administrationId as "Server-resolved administration scope"; this
+        // controller reads it off the wire, so the membership check that makes
+        // that contract true has to happen here. Without it any authenticated
+        // user could inject a statutory Dutch VAT filing into any administration.
+        if ($this->context->canAccess(administrationId: $administrationId) === false) {
+            return new JSONResponse(['error' => 'Administration not found'], Http::STATUS_NOT_FOUND);
         }
 
         if (in_array($period, self::PERIOD_VALUES, true) === false) {
@@ -291,7 +334,7 @@ class VATReturnController extends Controller
             // See show(): find() yields `?ObjectEntity`, so the previous
             // `is_array()` test rejected every existing record as "not found".
             $vatReturn = $this->service->findReturn(returnId: $returnId);
-            if ($vatReturn === null) {
+            if ($this->mayAccessReturn(vatReturn: $vatReturn) === false) {
                 return new JSONResponse(['error' => 'VAT return not found'], Http::STATUS_NOT_FOUND);
             }
 
@@ -341,6 +384,13 @@ class VATReturnController extends Controller
         $userId = $this->resolveUserId();
 
         try {
+            // ADR-005 / REQ-MA-001 — filing another tenant's statutory return.
+            // $userId below is stamped as the actor but was never compared to
+            // anything, so it authorised nothing on its own.
+            if ($this->mayAccessReturn(vatReturn: $this->service->findReturn(returnId: $returnId)) === false) {
+                return new JSONResponse(['error' => 'VAT return not found'], Http::STATUS_NOT_FOUND);
+            }
+
             $vatReturn = $this->service->submitReturn(returnId: $returnId, userId: $userId);
         } catch (\RuntimeException $e) {
             return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_CONFLICT);
@@ -380,6 +430,12 @@ class VATReturnController extends Controller
         $userId = $this->resolveUserId();
 
         try {
+            // ADR-005 / REQ-MA-001 — reverting another tenant's SUBMITTED
+            // statutory filing back to draft.
+            if ($this->mayAccessReturn(vatReturn: $this->service->findReturn(returnId: $returnId)) === false) {
+                return new JSONResponse(['error' => 'VAT return not found'], Http::STATUS_NOT_FOUND);
+            }
+
             $vatReturn = $this->service->rebaseReturn(returnId: $returnId, userId: $userId);
         } catch (\RuntimeException $e) {
             return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_CONFLICT);
@@ -422,7 +478,7 @@ class VATReturnController extends Controller
             // meant a SUBMITTED return answered 404 instead of the 409 the
             // "only draft returns can be deleted" rule is supposed to give.
             $vatReturn = $this->service->findReturn(returnId: $returnId);
-            if ($vatReturn === null) {
+            if ($this->mayAccessReturn(vatReturn: $vatReturn) === false) {
                 return new JSONResponse(['error' => 'VAT return not found'], Http::STATUS_NOT_FOUND);
             }
 
@@ -444,6 +500,31 @@ class VATReturnController extends Controller
         return new JSONResponse(['data' => ['id' => $returnId, 'deleted' => true]], Http::STATUS_OK);
 
     }//end destroy()
+
+    /**
+     * Whether the caller may act on a loaded VAT return (ADR-005 IDOR guard).
+     *
+     * A missing row and a row belonging to an administration the caller has no
+     * membership for are deliberately indistinguishable — canAccess()'s contract
+     * is that a refusal is masked as a 404 and never confirms the record exists.
+     *
+     * @param array<string,mixed>|null $vatReturn The loaded VAT return, or null.
+     *
+     * @return bool True when the row exists AND the caller is a member of its administration.
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    private function mayAccessReturn(?array $vatReturn): bool
+    {
+        if ($vatReturn === null) {
+            return false;
+        }
+
+        return $this->context->canAccess(
+            administrationId: (string) ($vatReturn['administrationId'] ?? '')
+        );
+
+    }//end mayAccessReturn()
 
     /**
      * Build the list-filter map from query params; only allow whitelisted keys.
@@ -469,11 +550,10 @@ class VATReturnController extends Controller
             $filters['statusCode'] = $status;
         }
 
-        $administrationId = (string) $this->request->getParam('administrationId', '');
-        if ($administrationId !== '' && $this->validId(id: $administrationId) === true) {
-            $filters['administrationId'] = $administrationId;
-        }
-
+        // administrationId is deliberately NOT read here: index() resolves the
+        // administration scope from the caller's memberships and only ever
+        // narrows it (ADR-005). Reading it as a plain filter here would let an
+        // unguarded value back in.
         return $filters;
 
     }//end buildListFilters()

--- a/lib/Controller/VATReturnController.php
+++ b/lib/Controller/VATReturnController.php
@@ -250,41 +250,21 @@ class VATReturnController extends Controller
         $periodNumber     = (int) $this->request->getParam('periodNumber', 0);
         $regime           = trim((string) $this->request->getParam('regime', 'standard'));
 
-        if ($this->validId(id: $administrationId) === false) {
-            return new JSONResponse(['error' => 'administrationId is required'], Http::STATUS_BAD_REQUEST);
+        // Authorisation first, then shape. A caller who may not touch this
+        // administration is told nothing about which periods it would accept.
+        $refusal = $this->requireAccessibleAdministration(administrationId: $administrationId);
+        if ($refusal !== null) {
+            return $refusal;
         }
 
-        // ADR-005 / REQ-MA-001. VATReturnService::createReturn() documents its
-        // $administrationId as "Server-resolved administration scope"; this
-        // controller reads it off the wire, so the membership check that makes
-        // that contract true has to happen here. Without it any authenticated
-        // user could inject a statutory Dutch VAT filing into any administration.
-        if ($this->context->canAccess(administrationId: $administrationId) === false) {
-            return new JSONResponse(['error' => 'Administration not found'], Http::STATUS_NOT_FOUND);
-        }
-
-        if (in_array($period, self::PERIOD_VALUES, true) === false) {
-            return new JSONResponse(['error' => 'period must be one of quarter | month | year'], Http::STATUS_BAD_REQUEST);
-        }
-
-        if (in_array($regime, self::REGIME_VALUES, true) === false) {
-            return new JSONResponse(['error' => 'regime must be one of standard | kor | reverse-charge'], Http::STATUS_BAD_REQUEST);
-        }
-
-        if ($periodYear < 2020 || $periodYear > 2099 || $periodNumber < 1) {
-            return new JSONResponse(['error' => 'periodYear / periodNumber must be valid'], Http::STATUS_BAD_REQUEST);
-        }
-
-        if ($period === 'quarter' && $periodNumber > 4) {
-            return new JSONResponse(['error' => 'periodNumber must be 1..4 for quarter'], Http::STATUS_BAD_REQUEST);
-        }
-
-        if ($period === 'month' && $periodNumber > 12) {
-            return new JSONResponse(['error' => 'periodNumber must be 1..12 for month'], Http::STATUS_BAD_REQUEST);
-        }
-
-        if ($this->isPeriodInFuture(periodYear: $periodYear, periodNumber: $periodNumber, period: $period) === true) {
-            return new JSONResponse(['error' => 'Cannot create returns for future periods'], Http::STATUS_BAD_REQUEST);
+        $refusal = $this->validateCreatePeriod(
+            period: $period,
+            periodYear: $periodYear,
+            periodNumber: $periodNumber,
+            regime: $regime
+        );
+        if ($refusal !== null) {
+            return $refusal;
         }
 
         try {
@@ -502,6 +482,84 @@ class VATReturnController extends Controller
     }//end destroy()
 
     /**
+     * Require an administrationId that is well-formed AND one of the caller's (ADR-005).
+     *
+     * VATReturnService::createReturn() documents its $administrationId as
+     * "Server-resolved administration scope". This controller reads it off the
+     * wire, so the membership check that makes that contract true has to happen
+     * here. Without it any authenticated user could inject a statutory Dutch VAT
+     * filing into any administration (REQ-MA-001).
+     *
+     * @param string $administrationId The administration id read from the request.
+     *
+     * @return JSONResponse|null A 400/404 response when refused, null when allowed.
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    private function requireAccessibleAdministration(string $administrationId): ?JSONResponse
+    {
+        if ($this->validId(id: $administrationId) === false) {
+            return new JSONResponse(['error' => 'administrationId is required'], Http::STATUS_BAD_REQUEST);
+        }
+
+        if ($this->context->canAccess(administrationId: $administrationId) === false) {
+            return new JSONResponse(['error' => 'Administration not found'], Http::STATUS_NOT_FOUND);
+        }
+
+        return null;
+
+    }//end requireAccessibleAdministration()
+
+    /**
+     * Validate the period/regime shape of a create request (REQ-VAT-001).
+     *
+     * Split out of create() so the method keeps a readable cyclomatic
+     * complexity now that the ADR-005 membership check lives there too.
+     *
+     * @param string $period       quarter | month | year.
+     * @param int    $periodYear   Fiscal year.
+     * @param int    $periodNumber Period within the year.
+     * @param string $regime       standard | kor | reverse-charge.
+     *
+     * @return JSONResponse|null A 400 response when invalid, null when acceptable.
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    private function validateCreatePeriod(
+        string $period,
+        int $periodYear,
+        int $periodNumber,
+        string $regime
+    ): ?JSONResponse {
+        if (in_array($period, self::PERIOD_VALUES, true) === false) {
+            return new JSONResponse(['error' => 'period must be one of quarter | month | year'], Http::STATUS_BAD_REQUEST);
+        }
+
+        if (in_array($regime, self::REGIME_VALUES, true) === false) {
+            return new JSONResponse(['error' => 'regime must be one of standard | kor | reverse-charge'], Http::STATUS_BAD_REQUEST);
+        }
+
+        if ($periodYear < 2020 || $periodYear > 2099 || $periodNumber < 1) {
+            return new JSONResponse(['error' => 'periodYear / periodNumber must be valid'], Http::STATUS_BAD_REQUEST);
+        }
+
+        if ($period === 'quarter' && $periodNumber > 4) {
+            return new JSONResponse(['error' => 'periodNumber must be 1..4 for quarter'], Http::STATUS_BAD_REQUEST);
+        }
+
+        if ($period === 'month' && $periodNumber > 12) {
+            return new JSONResponse(['error' => 'periodNumber must be 1..12 for month'], Http::STATUS_BAD_REQUEST);
+        }
+
+        if ($this->isPeriodInFuture(periodYear: $periodYear, periodNumber: $periodNumber, period: $period) === true) {
+            return new JSONResponse(['error' => 'Cannot create returns for future periods'], Http::STATUS_BAD_REQUEST);
+        }
+
+        return null;
+
+    }//end validateCreatePeriod()
+
+    /**
      * Whether the caller may act on a loaded VAT return (ADR-005 IDOR guard).
      *
      * A missing row and a row belonging to an administration the caller has no
@@ -550,10 +608,10 @@ class VATReturnController extends Controller
             $filters['statusCode'] = $status;
         }
 
-        // administrationId is deliberately NOT read here: index() resolves the
-        // administration scope from the caller's memberships and only ever
-        // narrows it (ADR-005). Reading it as a plain filter here would let an
-        // unguarded value back in.
+        // The administrationId param is deliberately NOT read here: index()
+        // resolves the administration scope from the caller's memberships and
+        // only ever narrows it (ADR-005). Reading it as a plain filter here
+        // would let an unguarded value back in.
         return $filters;
 
     }//end buildListFilters()

--- a/lib/Reporting/ReportGenerationService.php
+++ b/lib/Reporting/ReportGenerationService.php
@@ -56,7 +56,6 @@ use OCP\Files\File;
 use ReflectionClass;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
-use OCP\Files\NotFoundException;
 use OCP\IUserSession;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
@@ -269,32 +268,75 @@ class ReportGenerationService
             return null;
         }
 
+        return $this->resolveRecordFile(record: $record);
+
+    }//end resolveFile()
+
+    /**
+     * Resolve the stored Nextcloud File for an ALREADY-AUTHORISED GeneratedReport record.
+     *
+     * ⚠️ This method performs NO authorisation. The caller must have established
+     * that the current user may read `$record` — in practice
+     * `AdministrationContextService::canAccess($record['administrationId'])` —
+     * BEFORE calling it. It is split out from resolveFile() precisely so the
+     * caller can interpose that check between "load the record" and "read the
+     * bytes" (ADR-005; see ReportingController::download()).
+     *
+     * Resolution order, tightest first:
+     *  1. the CURRENT user's Files home — the same home storeFile() writes into
+     *     (`:410 getUserFolder($userId)`), so this is the path a report's own
+     *     author always takes;
+     *  2. the instance-wide file cache, but only for a node whose path is exactly
+     *     the `filePath` recorded on the report. Previously this branch was an
+     *     unconstrained `IRootFolder::getById()` followed by an unconstrained
+     *     `IRootFolder::get($path)`, which resolves across EVERY user's storage.
+     *     It is retained (narrowed) so a colleague in the same administration can
+     *     still download a report a co-worker generated.
+     *
+     * @param array<string,mixed> $record The GeneratedReport record.
+     *
+     * @return File|null The stored file, or null when the record/file is not resolvable.
+     */
+    public function resolveRecordFile(array $record): ?File
+    {
         $fileId = ($record['fileId'] ?? null);
-        if (is_numeric($fileId) === true) {
-            $nodes = $this->rootFolder->getById((int) $fileId);
-            foreach ($nodes as $node) {
-                if ($node instanceof File) {
-                    return $node;
+        $path   = ($record['filePath'] ?? null);
+        $userId = ($this->userSession->getUser()?->getUID() ?? '');
+
+        if (is_numeric($fileId) === true && $userId !== '') {
+            try {
+                foreach ($this->rootFolder->getUserFolder($userId)->getById((int) $fileId) as $node) {
+                    if ($node instanceof File) {
+                        return $node;
+                    }
                 }
+            } catch (\Throwable $e) {
+                $this->logger->warning(
+                    'ReportGenerationService: report file not resolvable in the user home',
+                    ['fileId' => $fileId, 'exception' => $e->getMessage()]
+                );
             }
         }
 
-        // Fall back to the stored path when the id no longer resolves.
-        $path = ($record['filePath'] ?? null);
-        if (is_string($path) === true && $path !== '') {
-            try {
-                $node = $this->rootFolder->get($path);
-                if ($node instanceof File) {
+        if (is_numeric($fileId) === true && is_string($path) === true && $path !== '') {
+            foreach ($this->rootFolder->getById((int) $fileId) as $node) {
+                // The recorded path is server-written by storeFile(); requiring an
+                // exact match stops a stale or tampered fileId resolving to some
+                // unrelated node elsewhere on the instance.
+                if ($node instanceof File && $node->getPath() === $path) {
                     return $node;
                 }
-            } catch (NotFoundException $e) {
-                $this->logger->warning('ReportGenerationService: stored report file missing', ['id' => $id, 'path' => $path]);
             }
+
+            $this->logger->warning(
+                'ReportGenerationService: stored report file missing',
+                ['fileId' => $fileId, 'path' => $path]
+            );
         }
 
         return null;
 
-    }//end resolveFile()
+    }//end resolveRecordFile()
 
     /**
      * Look up a single GeneratedReport record by id.

--- a/lib/Reporting/ReportGenerationService.php
+++ b/lib/Reporting/ReportGenerationService.php
@@ -32,7 +32,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Service/BadoControleprotocolService.php
+++ b/lib/Service/BadoControleprotocolService.php
@@ -567,9 +567,31 @@ class BadoControleprotocolService
      */
     public function organisationIdFor(string $protocolId): ?string
     {
-        $protocol = $this->resolveProtocol(protocolId: $protocolId, object: null);
+        if ($protocolId === '') {
+            return null;
+        }
+
+        // ⚠️ Deliberately NOT resolveProtocol()/resolveObject(). Those go through
+        // `findAll(['filters' => ['id' => $id]])`, and `id` is NOT a body
+        // property — it is `@self.id`, a bigint column. Postgres answers that
+        // query with SQLSTATE[22P02] "invalid input syntax for type bigint",
+        // which the service swallows, so the lookup returns null for every
+        // protocol that exists. Using it here would have made this guard refuse
+        // the legitimate owner as well as the attacker — measured on a
+        // two-account rig: owner 200 → 404. ObjectService::find() addresses the
+        // object by its identity and is the call the rest of the app uses.
+        $protocol = $this->objects()->find(
+            id: $protocolId,
+            register: $this->register(),
+            schema: 'Controleprotocol'
+        );
+
         if ($protocol === null) {
             return null;
+        }
+
+        if (is_array($protocol) === false) {
+            $protocol = (array) $protocol->jsonSerialize();
         }
 
         return (string) ($protocol['organisationId'] ?? '');

--- a/lib/Service/BadoControleprotocolService.php
+++ b/lib/Service/BadoControleprotocolService.php
@@ -549,6 +549,34 @@ class BadoControleprotocolService
     }//end allSisaRegelingenCovered()
 
     /**
+     * Resolve the tenant (organisation) a Controleprotocol belongs to.
+     *
+     * `Controleprotocol.organisationId` is the tenant scope for the whole BADO
+     * bundle: none of the six child schemas (ToleranceMatrix, Materialiteit,
+     * AuditSample, AuditFinding, VerklaringDraft, SiSaAssurance) carries a tenant
+     * field of its own — they hang off the protocol's FK. So the protocol's
+     * organisationId is the only value an ADR-005 membership check can be made
+     * against, and this accessor exists so the controller can make it: every
+     * loader in this class and in AccountantsdossierExportService was private.
+     *
+     * @param string $protocolId The Controleprotocol.id.
+     *
+     * @return string|null The organisation id, or null when the protocol does not exist.
+     *
+     * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-12
+     */
+    public function organisationIdFor(string $protocolId): ?string
+    {
+        $protocol = $this->resolveProtocol(protocolId: $protocolId, object: null);
+        if ($protocol === null) {
+            return null;
+        }
+
+        return (string) ($protocol['organisationId'] ?? '');
+
+    }//end organisationIdFor()
+
+    /**
      * Resolve a Controleprotocol from a supplied object or by id.
      *
      * @param string                   $protocolId The Controleprotocol.id.

--- a/lib/Service/SepaAuditService.php
+++ b/lib/Service/SepaAuditService.php
@@ -397,5 +397,4 @@ class SepaAuditService
 
         return $register;
     }//end resolveRegister()
-
 }//end class

--- a/lib/Service/SepaAuditService.php
+++ b/lib/Service/SepaAuditService.php
@@ -5,9 +5,14 @@
  *
  * Assembles the per-mandate audit dossier (REQ-SDD-010): the mandate, its
  * collections, R-transactions, pre-notifications, and archived pain.008 /
- * pain.002 XML, zipped for the 7-year bewaarplicht. All queries are scoped to
- * the administration configured for the app so a caller cannot export another
- * tenant's mandate (IDOR-safe per ADR-005).
+ * pain.002 XML, zipped for the 7-year bewaarplicht. The mandate is scoped to the
+ * CALLER's administration memberships so a caller cannot export another tenant's
+ * mandate (IDOR-safe per ADR-005 / REQ-MA-001).
+ *
+ * ⚠️ This paragraph used to say "scoped to the administration configured for the
+ * app". That is a different thing and it is not access control: the config key
+ * `administration_id` is instance-wide, has no relation to the calling user, and
+ * defaults to '' — at which value the old guard was skipped entirely.
  *
  * @category Service
  * @package  OCA\Shillinq\Service
@@ -44,23 +49,32 @@ class SepaAuditService
     /**
      * Construct the service.
      *
-     * @param ContainerInterface $container DI container for lazy ObjectService resolution.
-     * @param IAppConfig         $appConfig App config for register slug + administration scope.
-     * @param LoggerInterface    $logger    Logger.
+     * @param ContainerInterface           $container DI container for lazy ObjectService resolution.
+     * @param IAppConfig                   $appConfig App config for the register slug.
+     * @param AdministrationContextService $context   RBAC guard — the caller's administration memberships.
+     * @param LoggerInterface              $logger    Logger.
      */
     public function __construct(
         private readonly ContainerInterface $container,
         private readonly IAppConfig $appConfig,
+        private readonly AdministrationContextService $context,
         private readonly LoggerInterface $logger,
     ) {
     }//end __construct()
 
     /**
-     * Build the audit dossier for one mandate, scoped to the app administration.
+     * Build the audit dossier for one mandate, scoped to the CALLER's administrations.
      *
-     * Returns null when the mandate does not exist or is outside the
-     * configured administration (treated as not-found to avoid leaking
-     * existence; IDOR-safe per ADR-005).
+     * Returns null when the mandate does not exist or belongs to an
+     * administration the caller has no membership for (treated as not-found to
+     * avoid leaking existence; IDOR-safe per ADR-005 / REQ-MA-001).
+     *
+     * ⚠️ This used to read "outside the CONFIGURED administration", and that is
+     * exactly what it did: `resolveAdministration()` returned
+     * `appConfig->getValueString(APP_ID, 'administration_id', '')` — an
+     * instance-wide constant with no relation to the calling user — and the
+     * `$administration !== ''` short-circuit made the guard a complete no-op
+     * whenever that key was unset, which is its default.
      *
      * @param string $mandateId The SepaMandate UUID/slug.
      *
@@ -74,9 +88,8 @@ class SepaAuditService
             return null;
         }
 
-        $register       = $this->resolveRegister();
-        $administration = $this->resolveAdministration();
-        $objectService  = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+        $register      = $this->resolveRegister();
+        $objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
         $mandate = $this->findOne(
             objectService: $objectService,
@@ -89,8 +102,10 @@ class SepaAuditService
             return null;
         }
 
-        // Tenant guard: refuse mandates outside the configured administration.
-        if ($administration !== '' && (string) ($mandate['administrationId'] ?? '') !== $administration) {
+        // Tenant guard: refuse mandates outside the CALLER's administrations.
+        // canAccess() fails closed on '' — a mandate with no administrationId is
+        // refused rather than exported (AdministrationContextService:220).
+        if ($this->context->canAccess(administrationId: (string) ($mandate['administrationId'] ?? '')) === false) {
             return null;
         }
 
@@ -383,13 +398,4 @@ class SepaAuditService
         return $register;
     }//end resolveRegister()
 
-    /**
-     * Resolve the configured administration id used to scope the export.
-     *
-     * @return string The administration id, or '' if unconfigured.
-     */
-    private function resolveAdministration(): string
-    {
-        return $this->appConfig->getValueString(Application::APP_ID, 'administration_id', '');
-    }//end resolveAdministration()
 }//end class

--- a/tests/Unit/Controller/BadoControleprotocolControllerTest.php
+++ b/tests/Unit/Controller/BadoControleprotocolControllerTest.php
@@ -1,0 +1,265 @@
+<?php
+
+/**
+ * Unit tests for the ADR-005 tenant guard on BadoControleprotocolController.
+ *
+ * Both endpoints previously authorised nothing: `preg_match()` on the id is a
+ * character-class test, not a membership check, so any authenticated user could
+ * read another organisation's audit aggregation — including the proposed audit
+ * opinion — or export its complete accountantsdossier. Measured live on a
+ * two-account rig before #520: attacker HTTP 200 with `proposedOpinion`.
+ *
+ * A protocol that does not exist and a protocol the caller may not see answer
+ * the SAME 404, deliberately: the endpoint must not confirm existence.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\BadoControleprotocolController;
+use OCA\Shillinq\Service\AccountantsdossierExportService;
+use OCA\Shillinq\Service\AdministrationContextService;
+use OCA\Shillinq\Service\BadoControleprotocolService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Tests the BADO controleprotocol tenant guard.
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+final class BadoControleprotocolControllerTest extends TestCase
+{
+
+    /**
+     * Mock request.
+     *
+     * @var IRequest&MockObject
+     */
+    private IRequest&MockObject $request;
+
+    /**
+     * Mock BADO service.
+     *
+     * @var BadoControleprotocolService&MockObject
+     */
+    private BadoControleprotocolService&MockObject $service;
+
+    /**
+     * Mock exporter.
+     *
+     * @var AccountantsdossierExportService&MockObject
+     */
+    private AccountantsdossierExportService&MockObject $exporter;
+
+    /**
+     * Mock membership guard.
+     *
+     * @var AdministrationContextService&MockObject
+     */
+    private AdministrationContextService&MockObject $context;
+
+    /**
+     * What canAccess() answers, read through a callback so a test can flip it
+     * without appending a second matcher to the same mocked method.
+     *
+     * @var bool
+     */
+    private bool $canAccess = true;
+
+    /**
+     * Controller under test.
+     *
+     * @var BadoControleprotocolController
+     */
+    private BadoControleprotocolController $controller;
+
+    /**
+     * Set up fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->request  = $this->createMock(IRequest::class);
+        $this->service  = $this->createMock(BadoControleprotocolService::class);
+        $this->exporter = $this->createMock(AccountantsdossierExportService::class);
+        $this->context  = $this->createMock(AdministrationContextService::class);
+        $session        = $this->createMock(IUserSession::class);
+
+        $this->canAccess = true;
+        $this->context->method('canAccess')->willReturnCallback(fn (): bool => $this->canAccess);
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $session->method('getUser')->willReturn($user);
+
+        $this->request->method('getParam')->willReturnCallback(
+            static function (string $key, mixed $default=null): mixed {
+                return $key === 'protocol_id' ? 'proto-1' : $default;
+            }
+        );
+
+        $this->controller = new BadoControleprotocolController(
+            request: $this->request,
+            service: $this->service,
+            logger: new NullLogger(),
+            userSession: $session,
+            exporter: $this->exporter,
+            context: $this->context,
+        );
+
+    }//end setUp()
+
+    /**
+     * aggregation() masks a protocol belonging to a foreign organisation as 404.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-12
+     */
+    public function testAggregationMasksAForeignProtocolAs404(): void
+    {
+        $this->canAccess = false;
+        $this->service->method('organisationIdFor')->willReturn('adm-9');
+        $this->service->expects($this->never())->method('computeAggregation');
+
+        $response = $this->controller->aggregation();
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        self::assertSame('Controleprotocol not found', $response->getData()['error']);
+
+    }//end testAggregationMasksAForeignProtocolAs404()
+
+    /**
+     * A protocol with no organisationId at all is refused, not admitted.
+     *
+     * organisationIdFor() answers null for a protocol that does not exist; the
+     * guard must fail closed on it rather than skip the membership check.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-12
+     */
+    public function testATenantlessProtocolIsRefused(): void
+    {
+        $this->service->method('organisationIdFor')->willReturn(null);
+        $this->service->expects($this->never())->method('computeAggregation');
+
+        $response = $this->controller->aggregation();
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        self::assertSame('Controleprotocol not found', $response->getData()['error']);
+
+    }//end testATenantlessProtocolIsRefused()
+
+    /**
+     * A failure while resolving the tenant refuses, it does not fall through.
+     *
+     * The resolver reaches OpenRegister, so it can throw. A guard that treated
+     * "the tenant could not be resolved" as "no objection" would open the
+     * endpoint on exactly the failure it is there to survive.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-12
+     */
+    public function testAFailedTenantResolutionRefuses(): void
+    {
+        $this->service->method('organisationIdFor')
+            ->willThrowException(new \RuntimeException('OpenRegister unavailable'));
+        $this->service->expects($this->never())->method('computeAggregation');
+
+        $response = $this->controller->aggregation();
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        self::assertSame('Controleprotocol not found', $response->getData()['error']);
+
+    }//end testAFailedTenantResolutionRefuses()
+
+    /**
+     * A member of the owning organisation still gets the aggregation.
+     *
+     * The owner-side arm is the half that a refusal-only suite cannot see: an
+     * endpoint that denies everyone passes every attacker probe.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-12
+     */
+    public function testAMemberStillGetsTheAggregation(): void
+    {
+        $this->service->method('organisationIdFor')->willReturn('adm-1');
+        $this->service->expects($this->once())
+            ->method('computeAggregation')
+            ->willReturn(['proposedOpinion' => 'goedkeurend']);
+
+        $response = $this->controller->aggregation();
+
+        self::assertSame(Http::STATUS_OK, $response->getStatus());
+        self::assertSame('goedkeurend', $response->getData()['proposedOpinion']);
+
+    }//end testAMemberStillGetsTheAggregation()
+
+    /**
+     * exportAccountantsdossier() masks a foreign protocol as 404.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-16
+     */
+    public function testExportMasksAForeignProtocolAs404(): void
+    {
+        $this->canAccess = false;
+        $this->service->method('organisationIdFor')->willReturn('adm-9');
+        $this->exporter->expects($this->never())->method('exportDossier');
+
+        $response = $this->controller->exportAccountantsdossier();
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        self::assertSame('Controleprotocol not found', $response->getData()['error']);
+
+    }//end testExportMasksAForeignProtocolAs404()
+
+    /**
+     * A member of the owning organisation still gets the export envelope.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-16
+     */
+    public function testAMemberStillGetsTheExport(): void
+    {
+        $this->service->method('organisationIdFor')->willReturn('adm-1');
+        $this->exporter->expects($this->once())
+            ->method('exportDossier')
+            ->willReturn(['signaturePending' => true]);
+
+        $response = $this->controller->exportAccountantsdossier();
+
+        self::assertSame(Http::STATUS_OK, $response->getStatus());
+        self::assertTrue($response->getData()['signaturePending']);
+
+    }//end testAMemberStillGetsTheExport()
+}//end class

--- a/tests/Unit/Controller/InventoryScanControllerTest.php
+++ b/tests/Unit/Controller/InventoryScanControllerTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Tests\Unit\Controller;
 
 use OCA\Shillinq\Controller\InventoryScanController;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\InventoryScanService;
 use OCP\AppFramework\Http;
 use OCP\IGroupManager;
@@ -83,6 +84,23 @@ class InventoryScanControllerTest extends TestCase
     private LoggerInterface&MockObject $logger;
 
     /**
+     * Mock AdministrationContextService — the ADR-005 membership guard.
+     *
+     * @var AdministrationContextService&MockObject
+     */
+    private AdministrationContextService&MockObject $context;
+
+    /**
+     * What canAccess() answers. Flipped by the ADR-005 refusal tests.
+     *
+     * Read through a callback rather than re-stubbed per test: a second
+     * `->method('canAccess')` APPENDS a matcher instead of replacing the first.
+     *
+     * @var bool
+     */
+    private bool $canAccess = true;
+
+    /**
      * Set up test fixtures.
      *
      * @return void
@@ -96,6 +114,10 @@ class InventoryScanControllerTest extends TestCase
         $this->groupManager = $this->createMock(IGroupManager::class);
         $this->scanService  = $this->createMock(InventoryScanService::class);
         $this->logger       = $this->createMock(LoggerInterface::class);
+        $this->context      = $this->createMock(AdministrationContextService::class);
+
+        $this->canAccess = true;
+        $this->context->method('canAccess')->willReturnCallback(fn (): bool => $this->canAccess);
 
     }//end setUp()
 
@@ -111,6 +133,7 @@ class InventoryScanControllerTest extends TestCase
             userSession: $this->userSession,
             groupManager: $this->groupManager,
             scanService: $this->scanService,
+            context: $this->context,
             logger: $this->logger,
         );
 
@@ -139,7 +162,7 @@ class InventoryScanControllerTest extends TestCase
     public function testScanRejectsAnonymous(): void
     {
         $this->userSession->method('getUser')->willReturn(null);
-        $response = $this->controller()->scan([['type' => 'receive', 'transactionId' => 't1']]);
+        $response = $this->controller()->scan([['type' => 'receive', 'transactionId' => 't1']], 'adm-1');
         $this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 
     }//end testScanRejectsAnonymous()
@@ -158,7 +181,8 @@ class InventoryScanControllerTest extends TestCase
         $this->scanService->expects($this->never())->method('applyOperation');
 
         $response = $this->controller()->scan(
-            [['type' => 'receive', 'transactionId' => 't1', 'sku' => 'X', 'location' => 'L']]
+            [['type' => 'receive', 'transactionId' => 't1', 'sku' => 'X', 'location' => 'L']],
+            'adm-1'
         );
 
         $data = $response->getData();
@@ -181,7 +205,8 @@ class InventoryScanControllerTest extends TestCase
             ->willReturn(['status' => 'applied', 'transactionId' => 't1', 'syncedAt' => 'now', 'resultingQuantity' => 95.0]);
 
         $response = $this->controller()->scan(
-            [['type' => 'receive', 'transactionId' => 't1', 'sku' => 'X', 'location' => 'L', 'quantity' => 50]]
+            [['type' => 'receive', 'transactionId' => 't1', 'sku' => 'X', 'location' => 'L', 'quantity' => 50]],
+            'adm-1'
         );
 
         $data = $response->getData();
@@ -220,7 +245,7 @@ class InventoryScanControllerTest extends TestCase
             'quantity'      => 5,
             'performedBy'   => 'mallory',
         ];
-        $response = $this->controller()->scan([$op]);
+        $response = $this->controller()->scan([$op], 'adm-1');
 
         $this->assertSame(Http::STATUS_OK, $response->getStatus());
 
@@ -236,7 +261,7 @@ class InventoryScanControllerTest extends TestCase
         $this->loginAs('alice');
         $this->scanService->expects($this->never())->method('applyOperation');
 
-        $response = $this->controller()->scan([['type' => 'receive', 'sku' => 'X', 'location' => 'L']]);
+        $response = $this->controller()->scan([['type' => 'receive', 'sku' => 'X', 'location' => 'L']], 'adm-1');
         $data     = $response->getData();
         $this->assertSame('rejected', $data['results'][0]['status']);
 
@@ -250,7 +275,7 @@ class InventoryScanControllerTest extends TestCase
     public function testScanRejectsEmptyBatch(): void
     {
         $this->loginAs('alice');
-        $response = $this->controller()->scan([]);
+        $response = $this->controller()->scan([], 'adm-1');
         $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 
     }//end testScanRejectsEmptyBatch()
@@ -264,7 +289,7 @@ class InventoryScanControllerTest extends TestCase
     {
         $this->loginAs('alice');
         $batch    = array_fill(0, 201, ['type' => 'count', 'transactionId' => 't', 'sku' => 'X', 'location' => 'L']);
-        $response = $this->controller()->scan($batch);
+        $response = $this->controller()->scan($batch, 'adm-1');
         $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 
     }//end testScanRejectsOversizedBatch()
@@ -280,11 +305,11 @@ class InventoryScanControllerTest extends TestCase
         $this->scanService->method('resolveBarcode')
             ->willReturnOnConsecutiveCalls(['sku' => 'WIDGET-001', 'name' => 'Blue Widget'], null);
 
-        $found = $this->controller()->resolve('5901234123457');
+        $found = $this->controller()->resolve('5901234123457', 'adm-1');
         $this->assertTrue($found->getData()['found']);
         $this->assertSame('WIDGET-001', $found->getData()['item']['sku']);
 
-        $missing = $this->controller()->resolve('NOPE');
+        $missing = $this->controller()->resolve('NOPE', 'adm-1');
         $this->assertFalse($missing->getData()['found']);
 
     }//end testResolveReturnsItemOrNotFound()
@@ -297,7 +322,7 @@ class InventoryScanControllerTest extends TestCase
     public function testResolveRejectsEmptyBarcode(): void
     {
         $this->loginAs('alice');
-        $response = $this->controller()->resolve('');
+        $response = $this->controller()->resolve('', 'adm-1');
         $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 
     }//end testResolveRejectsEmptyBarcode()
@@ -313,10 +338,65 @@ class InventoryScanControllerTest extends TestCase
         $this->scanService->method('getStockDelta')
             ->willReturn([['sku' => 'WIDGET-001', 'location' => 'WH-A1', 'quantity' => 45]]);
 
-        $response = $this->controller()->sync('2026-05-15T00:00:00Z');
+        $response = $this->controller()->sync('2026-05-15T00:00:00Z', 'adm-1');
         $data     = $response->getData();
         $this->assertArrayHasKey('serverTime', $data);
         $this->assertCount(1, $data['stock']);
 
     }//end testSyncReturnsStockDelta()
+
+    /**
+     * An OMITTED administrationId is a 400, not a silent fallback to 'adm-1' (#518).
+     *
+     * The parameter used to default to the literal `'adm-1'` on resolve(),
+     * sync() and scan(), so a request that named no tenant read and wrote a real
+     * one. A tenant is never a default.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/inventory-mobile-scanner/tasks.md#T1.3
+     */
+    public function testOmittedAdministrationNoLongerDefaultsToAdm1(): void
+    {
+        $this->loginAs('alice');
+        $this->scanService->expects($this->never())->method('getStockDelta');
+        $this->scanService->expects($this->never())->method('resolveBarcode');
+
+        self::assertSame(Http::STATUS_BAD_REQUEST, $this->controller()->sync('2026-05-15T00:00:00Z')->getStatus());
+        self::assertSame(Http::STATUS_BAD_REQUEST, $this->controller()->resolve('5901234123457')->getStatus());
+
+    }//end testOmittedAdministrationNoLongerDefaultsToAdm1()
+
+    /**
+     * A foreign administrationId yields 404 on every endpoint (ADR-005 / #518).
+     *
+     * @return void
+     *
+     * @spec openspec/changes/inventory-mobile-scanner/tasks.md#T1.3
+     */
+    public function testForeignAdministrationReturns404OnEveryEndpoint(): void
+    {
+        $this->loginAs('alice');
+        $this->canAccess = false;
+        $this->scanService->expects($this->never())->method('getStockDelta');
+        $this->scanService->expects($this->never())->method('resolveBarcode');
+        $this->scanService->expects($this->never())->method('applyOperation');
+
+        self::assertSame(
+            Http::STATUS_NOT_FOUND,
+            $this->controller()->sync('2026-05-15T00:00:00Z', 'adm-not-mine')->getStatus()
+        );
+        self::assertSame(
+            Http::STATUS_NOT_FOUND,
+            $this->controller()->resolve('5901234123457', 'adm-not-mine')->getStatus()
+        );
+        self::assertSame(
+            Http::STATUS_NOT_FOUND,
+            $this->controller()->scan(
+                [['type' => 'receive', 'transactionId' => 't1', 'sku' => 'X', 'location' => 'L']],
+                'adm-not-mine'
+            )->getStatus()
+        );
+
+    }//end testForeignAdministrationReturns404OnEveryEndpoint()
 }//end class

--- a/tests/Unit/Controller/OssControllerTest.php
+++ b/tests/Unit/Controller/OssControllerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * Unit tests for the ADR-005 tenant guard on OssController::generateReturn().
+ *
+ * The OSS return draft exposes cross-border EU turnover per member state for
+ * one administration. Before #520 the only thing standing in front of it was
+ * `preg_match('/^[A-Za-z0-9_.\-]{1,64}$/', $administrationId)` — a
+ * character-class test on the id's SHAPE, not a check that the caller belongs
+ * to it — so any authenticated user could draft any tenant's OSS return.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/bookkeeping-btw-oss-eu/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\OssController;
+use OCA\Shillinq\Service\AdministrationContextService;
+use OCA\Shillinq\Service\OssRateResolver;
+use OCA\Shillinq\Service\OssReturnGenerator;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Tests the OSS return-draft tenant guard.
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+final class OssControllerTest extends TestCase
+{
+
+    /**
+     * Mock return generator.
+     *
+     * @var OssReturnGenerator&MockObject
+     */
+    private OssReturnGenerator&MockObject $generator;
+
+    /**
+     * Mock membership guard.
+     *
+     * @var AdministrationContextService&MockObject
+     */
+    private AdministrationContextService&MockObject $context;
+
+    /**
+     * What canAccess() answers, read through a callback so a test can flip it
+     * without appending a second matcher to the same mocked method.
+     *
+     * @var bool
+     */
+    private bool $canAccess = true;
+
+    /**
+     * Controller under test.
+     *
+     * @var OssController
+     */
+    private OssController $controller;
+
+    /**
+     * Set up fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $request         = $this->createMock(IRequest::class);
+        $this->generator = $this->createMock(OssReturnGenerator::class);
+        $this->context   = $this->createMock(AdministrationContextService::class);
+        $session         = $this->createMock(IUserSession::class);
+
+        $this->canAccess = true;
+        $this->context->method('canAccess')->willReturnCallback(fn (): bool => $this->canAccess);
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $session->method('getUser')->willReturn($user);
+
+        $params = [
+            'administration_id' => 'adm-1',
+            'period_year'       => 2024,
+            'period_quarter'    => 'Q1',
+            'registration_id'   => 'reg-1',
+        ];
+        $request->method('getParam')->willReturnCallback(
+            static function (string $key, mixed $default=null) use ($params): mixed {
+                return $params[$key] ?? $default;
+            }
+        );
+
+        $this->controller = new OssController(
+            request: $request,
+            rateResolver: $this->createMock(OssRateResolver::class),
+            returnGenerator: $this->generator,
+            logger: new NullLogger(),
+            userSession: $session,
+            context: $this->context,
+        );
+
+    }//end setUp()
+
+    /**
+     * generateReturn() refuses an administration the caller is not a member of.
+     *
+     * The refusal must happen before the generator runs: the draft itself is
+     * the disclosure, so producing it and then hiding it would not be a guard.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-btw-oss-eu/spec.md
+     */
+    public function testGenerateReturnRefusesAForeignAdministration(): void
+    {
+        $this->canAccess = false;
+        $this->generator->expects($this->never())->method('generateDraft');
+
+        $response = $this->controller->generateReturn();
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        self::assertSame('Administration not found', $response->getData()['error']);
+
+    }//end testGenerateReturnRefusesAForeignAdministration()
+
+    /**
+     * A member still gets the draft — the guard scopes, it does not disable.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-btw-oss-eu/spec.md
+     */
+    public function testAMemberStillGetsTheDraft(): void
+    {
+        $this->generator->expects($this->once())
+            ->method('generateDraft')
+            ->willReturn(['administrationId' => 'adm-1', 'lines' => []]);
+
+        $response = $this->controller->generateReturn();
+
+        self::assertSame(Http::STATUS_OK, $response->getStatus());
+        self::assertSame('adm-1', $response->getData()['administrationId']);
+
+    }//end testAMemberStillGetsTheDraft()
+}//end class

--- a/tests/Unit/Controller/RecognitionControllerTest.php
+++ b/tests/Unit/Controller/RecognitionControllerTest.php
@@ -24,6 +24,7 @@ namespace OCA\Shillinq\Tests\Unit\Controller;
 
 use OCA\Shillinq\Controller\RecognitionController;
 use OCA\Shillinq\Recognition\RevenueRecognitionService;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -74,6 +75,24 @@ final class RecognitionControllerTest extends TestCase
     private LoggerInterface&MockObject $logger;
 
     /**
+     * Mock AdministrationContextService — the ADR-005 membership guard.
+     *
+     * @var AdministrationContextService&MockObject
+     */
+    private AdministrationContextService&MockObject $context;
+
+    /**
+     * What canAccess() answers. Flipped by the ADR-005 refusal test.
+     *
+     * Read through a callback rather than re-stubbed per test: a second
+     * `->method('canAccess')` APPENDS a matcher instead of replacing the first,
+     * so re-stubbing would silently keep answering true.
+     *
+     * @var bool
+     */
+    private bool $canAccess = true;
+
+    /**
      * The controller under test.
      *
      * @var RecognitionController
@@ -92,6 +111,10 @@ final class RecognitionControllerTest extends TestCase
         $this->service     = $this->createMock(RevenueRecognitionService::class);
         $this->userSession = $this->createMock(IUserSession::class);
         $this->logger      = $this->createMock(LoggerInterface::class);
+        $this->context     = $this->createMock(AdministrationContextService::class);
+
+        $this->canAccess = true;
+        $this->context->method('canAccess')->willReturnCallback(fn (): bool => $this->canAccess);
 
         $user = $this->createMock(IUser::class);
         $user->method('getUID')->willReturn('alice');
@@ -101,6 +124,7 @@ final class RecognitionControllerTest extends TestCase
             request: $this->request,
             recognitionService: $this->service,
             userSession: $this->userSession,
+            context: $this->context,
             logger: $this->logger,
         );
 
@@ -147,6 +171,7 @@ final class RecognitionControllerTest extends TestCase
             request: $request,
             recognitionService: $service,
             userSession: $userSession,
+            context: $this->context,
             logger: $this->logger,
         );
 
@@ -265,4 +290,27 @@ final class RecognitionControllerTest extends TestCase
         self::assertStringNotContainsStringIgnoringCase('boom', (string) $data['error']);
 
     }//end testServiceExceptionReturns500WithoutStackTrace()
+
+    /**
+     * A well-formed administrationId the caller has NO membership for yields 404 (ADR-005 / #518).
+     *
+     * The id passes every format check in the method; the docblock's
+     * "ADR-005 IDOR-safety" used to be satisfied by a character-class regex
+     * alone. The service must never be reached.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-revenue-recognition/spec.md
+     */
+    public function testForeignAdministrationReturns404AndNeverReachesTheService(): void
+    {
+        $this->canAccess = false;
+        $this->withParams('adm-not-mine', '2026-01-01', '2026-03-31');
+        $this->service->expects($this->never())->method('computeRecurring');
+
+        $response = $this->controller->recurringRevenue();
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+    }//end testForeignAdministrationReturns404AndNeverReachesTheService()
 }//end class

--- a/tests/Unit/Controller/RecognitionControllerTest.php
+++ b/tests/Unit/Controller/RecognitionControllerTest.php
@@ -300,7 +300,7 @@ final class RecognitionControllerTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/specs/bookkeeping-revenue-recognition/spec.md
+     * @spec openspec/specs/recurring-revenue-recognition/spec.md
      */
     public function testForeignAdministrationReturns404AndNeverReachesTheService(): void
     {

--- a/tests/Unit/Controller/RevenueControllerTest.php
+++ b/tests/Unit/Controller/RevenueControllerTest.php
@@ -263,7 +263,7 @@ final class RevenueControllerTest extends TestCase
      *
      * @return void
      *
-     * @spec openspec/specs/bookkeeping-revenue-recognition/spec.md
+     * @spec openspec/specs/bookkeeping-ifrs15-revenue/spec.md
      */
     public function testForeignAdministrationReturns404AndNeverReachesTheService(): void
     {

--- a/tests/Unit/Controller/RevenueControllerTest.php
+++ b/tests/Unit/Controller/RevenueControllerTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Tests\Unit\Controller;
 
 use OCA\Shillinq\Controller\RevenueController;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\RevenueCutoffService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -73,6 +74,24 @@ final class RevenueControllerTest extends TestCase
     private LoggerInterface&MockObject $logger;
 
     /**
+     * Mock AdministrationContextService — the ADR-005 membership guard.
+     *
+     * @var AdministrationContextService&MockObject
+     */
+    private AdministrationContextService&MockObject $context;
+
+    /**
+     * What canAccess() answers. Flipped by the ADR-005 refusal tests.
+     *
+     * Read through a callback rather than re-stubbed per test: a second
+     * `->method('canAccess')` on the same mock APPENDS a matcher, it does not
+     * replace the first, so re-stubbing would silently keep answering true.
+     *
+     * @var bool
+     */
+    private bool $canAccess = true;
+
+    /**
      * The controller under test.
      *
      * @var RevenueController
@@ -91,6 +110,12 @@ final class RevenueControllerTest extends TestCase
         $this->service     = $this->createMock(RevenueCutoffService::class);
         $this->userSession = $this->createMock(IUserSession::class);
         $this->logger      = $this->createMock(LoggerInterface::class);
+        $this->context     = $this->createMock(AdministrationContextService::class);
+
+        // Default: the caller IS a member. $this->canAccess is flipped by the
+        // ADR-005 refusal test.
+        $this->canAccess = true;
+        $this->context->method('canAccess')->willReturnCallback(fn (): bool => $this->canAccess);
 
         $user = $this->createMock(IUser::class);
         $user->method('getUID')->willReturn('alice');
@@ -100,6 +125,7 @@ final class RevenueControllerTest extends TestCase
             request: $this->request,
             cutoffService: $this->service,
             userSession: $this->userSession,
+            context: $this->context,
             logger: $this->logger,
         );
 
@@ -226,4 +252,28 @@ final class RevenueControllerTest extends TestCase
         self::assertStringNotContainsStringIgnoringCase('boom', (string) $data['error']);
 
     }//end testServiceExceptionReturns500WithoutStackTrace()
+
+    /**
+     * A well-formed administration_id the caller has NO membership for yields 404 (ADR-005 / #518).
+     *
+     * The id passes every format check in the method — this is exactly the case
+     * the old code allowed through, because a character-class regex was the only
+     * thing between an authenticated user and another tenant's revenue cut-off.
+     * The service must never be reached.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-revenue-recognition/spec.md
+     */
+    public function testForeignAdministrationReturns404AndNeverReachesTheService(): void
+    {
+        $this->canAccess = false;
+        $this->withParams('adm-not-mine', '2026-06-30');
+        $this->service->expects($this->never())->method('compute');
+
+        $response = $this->controller->cutoff();
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+    }//end testForeignAdministrationReturns404AndNeverReachesTheService()
 }//end class

--- a/tests/Unit/Controller/TaxPaymentControllerTest.php
+++ b/tests/Unit/Controller/TaxPaymentControllerTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Tests\Unit\Controller;
 
 use OCA\Shillinq\Controller\TaxPaymentController;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\TaxPaymentReconciliationService;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
@@ -71,6 +72,23 @@ final class TaxPaymentControllerTest extends TestCase
     private LoggerInterface&MockObject $logger;
 
     /**
+     * Mock AdministrationContextService — the ADR-005 membership guard.
+     *
+     * @var AdministrationContextService&MockObject
+     */
+    private AdministrationContextService&MockObject $context;
+
+    /**
+     * What canAccess() answers. Flipped by the ADR-005 refusal test.
+     *
+     * Read through a callback rather than re-stubbed per test: a second
+     * `->method('canAccess')` APPENDS a matcher instead of replacing the first.
+     *
+     * @var bool
+     */
+    private bool $canAccess = true;
+
+    /**
      * The controller under test.
      *
      * @var TaxPaymentController
@@ -89,6 +107,10 @@ final class TaxPaymentControllerTest extends TestCase
         $this->service     = $this->createMock(TaxPaymentReconciliationService::class);
         $this->userSession = $this->createMock(IUserSession::class);
         $this->logger      = $this->createMock(LoggerInterface::class);
+        $this->context     = $this->createMock(AdministrationContextService::class);
+
+        $this->canAccess = true;
+        $this->context->method('canAccess')->willReturnCallback(fn (): bool => $this->canAccess);
 
         $user = $this->createMock(IUser::class);
         $user->method('getUID')->willReturn('alice');
@@ -98,6 +120,7 @@ final class TaxPaymentControllerTest extends TestCase
             request: $this->request,
             reconciliation: $this->service,
             userSession: $this->userSession,
+            context: $this->context,
             logger: $this->logger,
         );
 
@@ -196,4 +219,27 @@ final class TaxPaymentControllerTest extends TestCase
         self::assertSame(['error' => 'Failed to reconcile payment'], $response->getData());
 
     }//end testReconcileServiceFailureReturns500()
+
+    /**
+     * A well-formed administration_id the caller has NO membership for yields 404 (ADR-005 / #518).
+     *
+     * reconcile() WRITES against the administration named on the wire, and both
+     * of the old checks were character-class tests. The service must never be
+     * reached.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vpb-corporate-tax/spec.md
+     */
+    public function testForeignAdministrationReturns404AndNeverReachesTheService(): void
+    {
+        $this->canAccess = false;
+        $this->withAdmin('adm-not-mine');
+        $this->service->expects($this->never())->method('reconcile');
+
+        $response = $this->controller->reconcile('tp-001');
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+    }//end testForeignAdministrationReturns404AndNeverReachesTheService()
 }//end class

--- a/tests/Unit/Controller/TaxReportControllerTest.php
+++ b/tests/Unit/Controller/TaxReportControllerTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Tests\Unit\Controller;
 
 use OCA\Shillinq\Controller\TaxReportController;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\TaxReportService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -73,6 +74,23 @@ final class TaxReportControllerTest extends TestCase
     private LoggerInterface&MockObject $logger;
 
     /**
+     * Mock AdministrationContextService — the ADR-005 membership guard.
+     *
+     * @var AdministrationContextService&MockObject
+     */
+    private AdministrationContextService&MockObject $context;
+
+    /**
+     * What canAccess() answers. Flipped by the ADR-005 refusal tests.
+     *
+     * Read through a callback rather than re-stubbed per test: a second
+     * `->method('canAccess')` APPENDS a matcher instead of replacing the first.
+     *
+     * @var bool
+     */
+    private bool $canAccess = true;
+
+    /**
      * The controller under test.
      *
      * @var TaxReportController
@@ -91,6 +109,10 @@ final class TaxReportControllerTest extends TestCase
         $this->service     = $this->createMock(TaxReportService::class);
         $this->userSession = $this->createMock(IUserSession::class);
         $this->logger      = $this->createMock(LoggerInterface::class);
+        $this->context     = $this->createMock(AdministrationContextService::class);
+
+        $this->canAccess = true;
+        $this->context->method('canAccess')->willReturnCallback(fn (): bool => $this->canAccess);
 
         $user = $this->createMock(IUser::class);
         $user->method('getUID')->willReturn('alice');
@@ -100,6 +122,7 @@ final class TaxReportControllerTest extends TestCase
             request: $this->request,
             taxReportService: $this->service,
             userSession: $this->userSession,
+            context: $this->context,
             logger: $this->logger,
         );
 
@@ -233,4 +256,45 @@ final class TaxReportControllerTest extends TestCase
         self::assertSame($payload, $response->getData());
 
     }//end testAnnualValidReturns200()
+
+    /**
+     * quarter(): a foreign administration_id yields 404 and never reaches the service (ADR-005 / #518).
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vpb-corporate-tax/spec.md
+     */
+    public function testQuarterForeignAdministrationReturns404(): void
+    {
+        $this->canAccess = false;
+        $this->withAdmin('adm-not-mine');
+        $this->service->expects($this->never())->method('computeQuarter');
+
+        $response = $this->controller->quarter('2026', '1');
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+    }//end testQuarterForeignAdministrationReturns404()
+
+    /**
+     * annual(): a foreign administration_id yields 404 and never reaches the service (ADR-005 / #518).
+     *
+     * Both endpoints route through the same helper, which used to be named
+     * `validateAdministration()` and was entirely a character-class regex.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vpb-corporate-tax/spec.md
+     */
+    public function testAnnualForeignAdministrationReturns404(): void
+    {
+        $this->canAccess = false;
+        $this->withAdmin('adm-not-mine');
+        $this->service->expects($this->never())->method('computeAnnual');
+
+        $response = $this->controller->annual('2026');
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+    }//end testAnnualForeignAdministrationReturns404()
 }//end class

--- a/tests/Unit/Controller/VATDeclarationControllerTest.php
+++ b/tests/Unit/Controller/VATDeclarationControllerTest.php
@@ -1,0 +1,339 @@
+<?php
+
+/**
+ * Unit tests for VATDeclarationController.
+ *
+ * Covers the ADR-005 / REQ-MA-001 administration scoping added by #520.
+ * `listByReturn()` used to run ONE query keyed only on `returnId`, so quoting
+ * another tenant's return id returned that tenant's VAT declarations — the
+ * per-rubriek breakdown of a statutory Dutch filing. The scope is now the
+ * caller's memberships, one query per administration.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\VATDeclarationController;
+use OCA\Shillinq\Service\AdministrationContextService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests the VAT-declaration read API.
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+final class VATDeclarationControllerTest extends TestCase
+{
+
+    /**
+     * Mock request.
+     *
+     * @var IRequest&MockObject
+     */
+    private IRequest&MockObject $request;
+
+    /**
+     * Mock container.
+     *
+     * @var ContainerInterface&MockObject
+     */
+    private ContainerInterface&MockObject $container;
+
+    /**
+     * Mock user session.
+     *
+     * @var IUserSession&MockObject
+     */
+    private IUserSession&MockObject $session;
+
+    /**
+     * Mock membership guard.
+     *
+     * @var AdministrationContextService&MockObject
+     */
+    private AdministrationContextService&MockObject $context;
+
+    /**
+     * Mock logger.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface&MockObject $logger;
+
+    /**
+     * The caller's memberships, read through a callback so a test can change
+     * them without appending a second matcher to the same mocked method.
+     *
+     * @var array<int,string>
+     */
+    private array $accessible = ['adm-1'];
+
+    /**
+     * Controller under test.
+     *
+     * @var VATDeclarationController
+     */
+    private VATDeclarationController $controller;
+
+    /**
+     * Set up fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->request   = $this->createMock(IRequest::class);
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->session   = $this->createMock(IUserSession::class);
+        $this->context   = $this->createMock(AdministrationContextService::class);
+        $this->logger    = $this->createMock(LoggerInterface::class);
+
+        $this->accessible = ['adm-1'];
+        $this->context->method('accessibleAdministrationIds')->willReturnCallback(
+            fn (): array => $this->accessible
+        );
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $this->session->method('getUser')->willReturn($user);
+
+        $this->controller = new VATDeclarationController(
+            request: $this->request,
+            container: $this->container,
+            session: $this->session,
+            context: $this->context,
+            logger: $this->logger,
+        );
+
+    }//end setUp()
+
+    /**
+     * Build an ObjectService double whose signatures mirror the real service.
+     *
+     * @param array<int,array<string,mixed>> $rows VATDeclaration rows to serve.
+     *
+     * @return object
+     */
+    private function fakeObjectService(array $rows): object
+    {
+        return new class($rows)
+        {
+
+            /**
+             * Rows to serve.
+             *
+             * @var array<int,array<string,mixed>>
+             */
+            private array $rows;
+
+            /**
+             * Filter sets received, in call order.
+             *
+             * @var array<int,array<string,mixed>>
+             */
+            public array $seenFilters = [];
+
+            /**
+             * Constructor.
+             *
+             * @param array<int,array<string,mixed>> $rows Rows to serve.
+             */
+            public function __construct(array $rows)
+            {
+                $this->rows = $rows;
+            }//end __construct()
+
+            /**
+             * Fluent register setter (mirrors ObjectService::setRegister).
+             *
+             * @param string $register Register slug.
+             *
+             * @return static
+             */
+            public function setRegister(string $register): static
+            {
+                return $this;
+            }//end setRegister()
+
+            /**
+             * Fluent schema setter (mirrors ObjectService::setSchema).
+             *
+             * @param string $schema Schema slug.
+             *
+             * @return static
+             */
+            public function setSchema(string $schema): static
+            {
+                return $this;
+            }//end setSchema()
+
+            /**
+             * Equality-filter findAll (mirrors ObjectService::findAll).
+             *
+             * @param array<string,mixed> $config Query configuration.
+             *
+             * @return array<int,array<string,mixed>>
+             */
+            public function findAll(array $config=[]): array
+            {
+                $filters             = ($config['filters'] ?? []);
+                $this->seenFilters[] = $filters;
+
+                return array_values(
+                    array_filter(
+                        $this->rows,
+                        static function (array $row) use ($filters): bool {
+                            foreach ($filters as $key => $value) {
+                                if (($row[$key] ?? null) !== $value) {
+                                    return false;
+                                }
+                            }
+
+                            return true;
+                        }
+                    )
+                );
+            }//end findAll()
+        };
+
+    }//end fakeObjectService()
+
+    /**
+     * listByReturn() returns only declarations the caller's tenants own.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testListByReturnIsScopedToTheCallersMemberships(): void
+    {
+        $stub = $this->fakeObjectService(
+            [
+                ['id' => 'd-1', 'returnId' => 'ret-1', 'administrationId' => 'adm-1'],
+                ['id' => 'd-9', 'returnId' => 'ret-1', 'administrationId' => 'adm-9'],
+            ]
+        );
+        $this->container->method('get')->willReturn($stub);
+
+        $response = $this->controller->listByReturn(returnId: 'ret-1');
+        $payload  = $response->getData();
+
+        self::assertSame(Http::STATUS_OK, $response->getStatus());
+        self::assertSame(1, $payload['total']);
+        self::assertSame('d-1', $payload['data'][0]['id']);
+        self::assertSame(
+            [['returnId' => 'ret-1', 'administrationId' => 'adm-1']],
+            $stub->seenFilters,
+            'the administration term must be part of the query, not applied afterwards'
+        );
+
+    }//end testListByReturnIsScopedToTheCallersMemberships()
+
+    /**
+     * Every membership is unioned, one query each.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testEveryMembershipIsUnioned(): void
+    {
+        $this->accessible = ['adm-1', 'adm-2'];
+        $stub             = $this->fakeObjectService(
+            [
+                ['id' => 'd-1', 'returnId' => 'ret-1', 'administrationId' => 'adm-1'],
+                ['id' => 'd-2', 'returnId' => 'ret-1', 'administrationId' => 'adm-2'],
+                ['id' => 'd-9', 'returnId' => 'ret-1', 'administrationId' => 'adm-9'],
+            ]
+        );
+        $this->container->method('get')->willReturn($stub);
+
+        $payload = $this->controller->listByReturn(returnId: 'ret-1')->getData();
+
+        self::assertSame(2, $payload['total']);
+        self::assertSame(['d-1', 'd-2'], array_column($payload['data'], 'id'));
+        self::assertCount(2, $stub->seenFilters, 'one query per administration');
+
+    }//end testEveryMembershipIsUnioned()
+
+    /**
+     * A caller with no memberships issues no query and sees nothing.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testACallerWithNoMembershipsSeesNothing(): void
+    {
+        $this->accessible = [];
+        $stub             = $this->fakeObjectService(
+            [['id' => 'd-1', 'returnId' => 'ret-1', 'administrationId' => 'adm-1']]
+        );
+        $this->container->method('get')->willReturn($stub);
+
+        $payload = $this->controller->listByReturn(returnId: 'ret-1')->getData();
+
+        self::assertSame(0, $payload['total']);
+        self::assertSame([], $payload['data']);
+        self::assertSame([], $stub->seenFilters);
+
+    }//end testACallerWithNoMembershipsSeesNothing()
+
+    /**
+     * A malformed returnId is refused with 400 before the data layer is touched.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testAMalformedReturnIdIsRefused(): void
+    {
+        $this->container->expects($this->never())->method('get');
+
+        $response = $this->controller->listByReturn(returnId: '');
+
+        self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+
+    }//end testAMalformedReturnIdIsRefused()
+
+    /**
+     * A data-layer failure is reported as 500, never as an empty success.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testADataLayerFailureIsNotReportedAsAnEmptyList(): void
+    {
+        $this->container->method('get')->willThrowException(new \RuntimeException('no ObjectService'));
+
+        $response = $this->controller->listByReturn(returnId: 'ret-1');
+
+        self::assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+        self::assertSame('Failed to list declarations', $response->getData()['error']);
+
+    }//end testADataLayerFailureIsNotReportedAsAnEmptyList()
+}//end class

--- a/tests/Unit/Controller/VATLineControllerTest.php
+++ b/tests/Unit/Controller/VATLineControllerTest.php
@@ -1,0 +1,355 @@
+<?php
+
+/**
+ * Unit tests for VATLineController.
+ *
+ * Covers the ADR-005 / REQ-MA-001 administration scoping added by #520.
+ * `findLines()` used to run ONE query keyed only on `returnId` /
+ * `declarationId`, with no administration term at all, so quoting another
+ * tenant's return id was enough to read its VAT lines. The scope is now the
+ * caller's memberships, one query per administration, and a caller with no
+ * memberships gets an empty list rather than everything.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\VATLineController;
+use OCA\Shillinq\Service\AdministrationContextService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests the VAT-line read API.
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+final class VATLineControllerTest extends TestCase
+{
+
+    /**
+     * Mock request.
+     *
+     * @var IRequest&MockObject
+     */
+    private IRequest&MockObject $request;
+
+    /**
+     * Mock container.
+     *
+     * @var ContainerInterface&MockObject
+     */
+    private ContainerInterface&MockObject $container;
+
+    /**
+     * Mock user session.
+     *
+     * @var IUserSession&MockObject
+     */
+    private IUserSession&MockObject $session;
+
+    /**
+     * Mock membership guard.
+     *
+     * @var AdministrationContextService&MockObject
+     */
+    private AdministrationContextService&MockObject $context;
+
+    /**
+     * Mock logger.
+     *
+     * @var LoggerInterface&MockObject
+     */
+    private LoggerInterface&MockObject $logger;
+
+    /**
+     * The caller's memberships, read through a callback so a test can change
+     * them without re-stubbing (a second ->method() APPENDS a matcher rather
+     * than replacing the first, so a re-stub would silently keep the old answer).
+     *
+     * @var array<int,string>
+     */
+    private array $accessible = ['adm-1'];
+
+    /**
+     * Controller under test.
+     *
+     * @var VATLineController
+     */
+    private VATLineController $controller;
+
+    /**
+     * Set up fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->request   = $this->createMock(IRequest::class);
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->session   = $this->createMock(IUserSession::class);
+        $this->context   = $this->createMock(AdministrationContextService::class);
+        $this->logger    = $this->createMock(LoggerInterface::class);
+
+        $this->accessible = ['adm-1'];
+        $this->context->method('accessibleAdministrationIds')->willReturnCallback(
+            fn (): array => $this->accessible
+        );
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn('alice');
+        $this->session->method('getUser')->willReturn($user);
+
+        $this->controller = new VATLineController(
+            request: $this->request,
+            container: $this->container,
+            session: $this->session,
+            context: $this->context,
+            logger: $this->logger,
+        );
+
+    }//end setUp()
+
+    /**
+     * Build an ObjectService double whose signatures mirror the real service.
+     *
+     * Parameter NAMES matter: the controller calls `setRegister(register:)`,
+     * `setSchema(schema:)` and merges `findAll()`'s result, so a double that
+     * renamed them would accept a call the real OpenRegister rejects with
+     * "Unknown named parameter" — the shape that kept a 912-line suite green
+     * over a live outage elsewhere in the fleet.
+     *
+     * @param array<int,array<string,mixed>> $rows VATLine rows to serve.
+     *
+     * @return object
+     */
+    private function fakeObjectService(array $rows): object
+    {
+        return new class($rows)
+        {
+
+            /**
+             * Rows to serve.
+             *
+             * @var array<int,array<string,mixed>>
+             */
+            private array $rows;
+
+            /**
+             * Filter sets received, in call order — the assertion subject for
+             * "one query per administration".
+             *
+             * @var array<int,array<string,mixed>>
+             */
+            public array $seenFilters = [];
+
+            /**
+             * Constructor.
+             *
+             * @param array<int,array<string,mixed>> $rows Rows to serve.
+             */
+            public function __construct(array $rows)
+            {
+                $this->rows = $rows;
+            }//end __construct()
+
+            /**
+             * Fluent register setter (mirrors ObjectService::setRegister).
+             *
+             * @param string $register Register slug.
+             *
+             * @return static
+             */
+            public function setRegister(string $register): static
+            {
+                return $this;
+            }//end setRegister()
+
+            /**
+             * Fluent schema setter (mirrors ObjectService::setSchema).
+             *
+             * @param string $schema Schema slug.
+             *
+             * @return static
+             */
+            public function setSchema(string $schema): static
+            {
+                return $this;
+            }//end setSchema()
+
+            /**
+             * Equality-filter findAll (mirrors ObjectService::findAll).
+             *
+             * @param array<string,mixed> $config Query configuration.
+             *
+             * @return array<int,array<string,mixed>>
+             */
+            public function findAll(array $config=[]): array
+            {
+                $filters             = ($config['filters'] ?? []);
+                $this->seenFilters[] = $filters;
+
+                return array_values(
+                    array_filter(
+                        $this->rows,
+                        static function (array $row) use ($filters): bool {
+                            foreach ($filters as $key => $value) {
+                                if (($row[$key] ?? null) !== $value) {
+                                    return false;
+                                }
+                            }
+
+                            return true;
+                        }
+                    )
+                );
+            }//end findAll()
+        };
+
+    }//end fakeObjectService()
+
+    /**
+     * listByReturn() returns only lines in an administration the caller holds.
+     *
+     * Two rows share one returnId across two tenants — the pre-#520 query would
+     * have returned both, because it carried no administration term.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testListByReturnIsScopedToTheCallersMemberships(): void
+    {
+        $stub = $this->fakeObjectService(
+            [
+                ['id' => 'l-1', 'returnId' => 'ret-1', 'administrationId' => 'adm-1'],
+                ['id' => 'l-9', 'returnId' => 'ret-1', 'administrationId' => 'adm-9'],
+            ]
+        );
+        $this->container->method('get')->willReturn($stub);
+
+        $response = $this->controller->listByReturn(returnId: 'ret-1');
+        $payload  = $response->getData();
+
+        self::assertSame(Http::STATUS_OK, $response->getStatus());
+        self::assertSame(1, $payload['total']);
+        self::assertSame('l-1', $payload['data'][0]['id']);
+        self::assertSame(
+            [['returnId' => 'ret-1', 'administrationId' => 'adm-1']],
+            $stub->seenFilters,
+            'the administration term must be part of the query, not applied afterwards'
+        );
+
+    }//end testListByReturnIsScopedToTheCallersMemberships()
+
+    /**
+     * listByDeclaration() unions the caller's administrations, one query each.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testListByDeclarationUnionsEveryMembership(): void
+    {
+        $this->accessible = ['adm-1', 'adm-2'];
+        $stub             = $this->fakeObjectService(
+            [
+                ['id' => 'l-1', 'declarationId' => 'dec-1', 'administrationId' => 'adm-1'],
+                ['id' => 'l-2', 'declarationId' => 'dec-1', 'administrationId' => 'adm-2'],
+                ['id' => 'l-9', 'declarationId' => 'dec-1', 'administrationId' => 'adm-9'],
+            ]
+        );
+        $this->container->method('get')->willReturn($stub);
+
+        $payload = $this->controller->listByDeclaration(declarationId: 'dec-1')->getData();
+
+        self::assertSame(2, $payload['total']);
+        self::assertSame(['l-1', 'l-2'], array_column($payload['data'], 'id'));
+        self::assertCount(2, $stub->seenFilters, 'one query per administration');
+
+    }//end testListByDeclarationUnionsEveryMembership()
+
+    /**
+     * A caller with no memberships gets an empty list, not everything.
+     *
+     * The empty scope means the loop body never runs, so no query is issued at
+     * all — the assertion on seenFilters is what separates "scoped to nothing"
+     * from "queried without a scope and happened to match nothing".
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testACallerWithNoMembershipsSeesNothing(): void
+    {
+        $this->accessible = [];
+        $stub             = $this->fakeObjectService(
+            [['id' => 'l-1', 'returnId' => 'ret-1', 'administrationId' => 'adm-1']]
+        );
+        $this->container->method('get')->willReturn($stub);
+
+        $payload = $this->controller->listByReturn(returnId: 'ret-1')->getData();
+
+        self::assertSame(0, $payload['total']);
+        self::assertSame([], $payload['data']);
+        self::assertSame([], $stub->seenFilters);
+
+    }//end testACallerWithNoMembershipsSeesNothing()
+
+    /**
+     * A malformed id is refused with 400 before the data layer is touched.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testAMalformedReturnIdIsRefused(): void
+    {
+        $this->container->expects($this->never())->method('get');
+
+        $response = $this->controller->listByReturn(returnId: '');
+
+        self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+
+    }//end testAMalformedReturnIdIsRefused()
+
+    /**
+     * A data-layer failure is reported as 500, never as an empty success.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testADataLayerFailureIsNotReportedAsAnEmptyList(): void
+    {
+        $this->container->method('get')->willThrowException(new \RuntimeException('no ObjectService'));
+
+        $response = $this->controller->listByReturn(returnId: 'ret-1');
+
+        self::assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+        self::assertSame('Failed to list VAT lines', $response->getData()['error']);
+
+    }//end testADataLayerFailureIsNotReportedAsAnEmptyList()
+}//end class

--- a/tests/Unit/Controller/VATReturnControllerTest.php
+++ b/tests/Unit/Controller/VATReturnControllerTest.php
@@ -101,6 +101,18 @@ final class VATReturnControllerTest extends TestCase
     private bool $canAccess = true;
 
     /**
+     * What accessibleAdministrationIds() answers when canAccess is true.
+     *
+     * Separate from $canAccess so a test can hold MORE than one membership and
+     * still distinguish "the scope is the caller's memberships" from "the scope
+     * was narrowed to the requested administration" — with a single-element
+     * default the two are indistinguishable and a narrowing bug reads as green.
+     *
+     * @var array<int,string>
+     */
+    private array $accessible = ['adm-1'];
+
+    /**
      * Controller under test.
      *
      * @var VATReturnController
@@ -129,10 +141,11 @@ final class VATReturnControllerTest extends TestCase
         $this->logger     = $this->createMock(LoggerInterface::class);
         $this->context    = $this->createMock(AdministrationContextService::class);
 
-        $this->canAccess = true;
+        $this->canAccess  = true;
+        $this->accessible = ['adm-1'];
         $this->context->method('canAccess')->willReturnCallback(fn (): bool => $this->canAccess);
         $this->context->method('accessibleAdministrationIds')->willReturnCallback(
-            fn (): array => $this->canAccess === true ? ['adm-1'] : []
+            fn (): array => $this->canAccess === true ? $this->accessible : []
         );
 
         $this->controller = new VATReturnController(
@@ -713,4 +726,200 @@ final class VATReturnControllerTest extends TestCase
         self::assertSame('r-1', $payload['data'][0]['id']);
 
     }//end testIndexIsScopedToTheCallersMemberships()
+
+    /**
+     * create() refuses an omitted administrationId with 400, before any lookup.
+     *
+     * The membership guard runs first and its "not well-formed" arm is the only
+     * one that answers 400 rather than 404: an empty administration is a client
+     * error, an inaccessible one is masked as absent.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testCreateRefusesAnOmittedAdministrationId(): void
+    {
+        $this->withParams(
+            [
+                'administrationId' => '',
+                'period'           => 'quarter',
+                'periodYear'       => 2024,
+                'periodNumber'     => 1,
+                'regime'           => 'standard',
+            ]
+        );
+        $this->service->expects($this->never())->method('createReturn');
+
+        $response = $this->controller->create();
+
+        self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        self::assertSame('administrationId is required', $response->getData()['error']);
+
+    }//end testCreateRefusesAnOmittedAdministrationId()
+
+    /**
+     * create() rejects a period unit outside quarter | month | year.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testCreateRejectsAnUnknownPeriodUnit(): void
+    {
+        $this->withParams(
+            [
+                'administrationId' => 'adm-1',
+                'period'           => 'fortnight',
+                'periodYear'       => 2024,
+                'periodNumber'     => 1,
+                'regime'           => 'standard',
+            ]
+        );
+        $this->service->expects($this->never())->method('createReturn');
+
+        $response = $this->controller->create();
+
+        self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        self::assertSame('period must be one of quarter | month | year', $response->getData()['error']);
+
+    }//end testCreateRejectsAnUnknownPeriodUnit()
+
+    /**
+     * create() rejects a fiscal year outside the 2020..2099 window.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testCreateRejectsAnOutOfRangeFiscalYear(): void
+    {
+        $this->withParams(
+            [
+                'administrationId' => 'adm-1',
+                'period'           => 'quarter',
+                'periodYear'       => 1999,
+                'periodNumber'     => 1,
+                'regime'           => 'standard',
+            ]
+        );
+        $this->service->expects($this->never())->method('createReturn');
+
+        $response = $this->controller->create();
+
+        self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        self::assertSame('periodYear / periodNumber must be valid', $response->getData()['error']);
+
+    }//end testCreateRejectsAnOutOfRangeFiscalYear()
+
+    /**
+     * create() rejects a fifth quarter — the period unit bounds its number.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testCreateRejectsAFifthQuarter(): void
+    {
+        $this->withParams(
+            [
+                'administrationId' => 'adm-1',
+                'period'           => 'quarter',
+                'periodYear'       => 2024,
+                'periodNumber'     => 5,
+                'regime'           => 'standard',
+            ]
+        );
+        $this->service->expects($this->never())->method('createReturn');
+
+        $response = $this->controller->create();
+
+        self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        self::assertSame('periodNumber must be 1..4 for quarter', $response->getData()['error']);
+
+    }//end testCreateRejectsAFifthQuarter()
+
+    /**
+     * create() rejects a thirteenth month.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testCreateRejectsAThirteenthMonth(): void
+    {
+        $this->withParams(
+            [
+                'administrationId' => 'adm-1',
+                'period'           => 'month',
+                'periodYear'       => 2024,
+                'periodNumber'     => 13,
+                'regime'           => 'standard',
+            ]
+        );
+        $this->service->expects($this->never())->method('createReturn');
+
+        $response = $this->controller->create();
+
+        self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+        self::assertSame('periodNumber must be 1..12 for month', $response->getData()['error']);
+
+    }//end testCreateRejectsAThirteenthMonth()
+
+    /**
+     * index() refuses an explicit administrationId the caller is not a member of.
+     *
+     * The filter may only NARROW the membership scope; a value outside it is
+     * masked as 404 rather than silently ignored, because silently ignoring it
+     * would answer 200 with the caller's own rows and read as success.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testIndexRefusesAForeignAdministrationFilter(): void
+    {
+        $this->canAccess = false;
+        $this->withParams(['administrationId' => 'adm-9', '_page' => 1, '_limit' => 10]);
+        $this->container->expects($this->never())->method('get');
+
+        $response = $this->controller->index();
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+        self::assertSame('Administration not found', $response->getData()['error']);
+
+    }//end testIndexRefusesAForeignAdministrationFilter()
+
+    /**
+     * index() narrows the scope to an explicit administration inside it.
+     *
+     * The caller holds two memberships and asks for one; the other's rows must
+     * not appear. With a single-membership fixture this assertion cannot fail,
+     * which is why $accessible carries two ids here.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testIndexNarrowsToAnExplicitAdministrationInScope(): void
+    {
+        $this->accessible = ['adm-1', 'adm-2'];
+        $this->withParams(['administrationId' => 'adm-2', '_page' => 1, '_limit' => 10]);
+        $this->withObjectService(
+            $this->fakeObjectService(
+                [
+                    'BtwAangifte' => [
+                        ['id' => 'r-1', 'administrationId' => 'adm-1', 'period' => 'quarter', 'regime' => 'standard', 'statusCode' => 'draft'],
+                        ['id' => 'r-2', 'administrationId' => 'adm-2', 'period' => 'quarter', 'regime' => 'standard', 'statusCode' => 'draft'],
+                    ],
+                ]
+            )
+        );
+
+        $payload = $this->controller->index()->getData();
+
+        self::assertSame(1, $payload['total']);
+        self::assertSame('r-2', $payload['data'][0]['id']);
+
+    }//end testIndexNarrowsToAnExplicitAdministrationInScope()
 }//end class

--- a/tests/Unit/Controller/VATReturnControllerTest.php
+++ b/tests/Unit/Controller/VATReturnControllerTest.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Tests\Unit\Controller;
 
 use OCA\Shillinq\Controller\VATReturnController;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\VATReturnService;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
@@ -82,6 +83,24 @@ final class VATReturnControllerTest extends TestCase
     private LoggerInterface&MockObject $logger;
 
     /**
+     * Mock AdministrationContextService — the ADR-005 membership guard.
+     *
+     * @var AdministrationContextService&MockObject
+     */
+    private AdministrationContextService&MockObject $context;
+
+    /**
+     * What canAccess() answers. Flipped by the ADR-005 refusal tests.
+     *
+     * Read through a callback rather than re-stubbed per test: a second
+     * `->method('canAccess')` APPENDS a matcher instead of replacing the first,
+     * so re-stubbing would silently keep answering true.
+     *
+     * @var bool
+     */
+    private bool $canAccess = true;
+
+    /**
      * Controller under test.
      *
      * @var VATReturnController
@@ -108,11 +127,20 @@ final class VATReturnControllerTest extends TestCase
         $this->container  = $this->createMock(ContainerInterface::class);
         $this->session    = $this->createMock(IUserSession::class);
         $this->logger     = $this->createMock(LoggerInterface::class);
+        $this->context    = $this->createMock(AdministrationContextService::class);
+
+        $this->canAccess = true;
+        $this->context->method('canAccess')->willReturnCallback(fn (): bool => $this->canAccess);
+        $this->context->method('accessibleAdministrationIds')->willReturnCallback(
+            fn (): array => $this->canAccess === true ? ['adm-1'] : []
+        );
+
         $this->controller = new VATReturnController(
             request: $this->request,
             service: $this->service,
             container: $this->container,
             session: $this->session,
+            context: $this->context,
             logger: $this->logger,
         );
 
@@ -326,9 +354,11 @@ final class VATReturnControllerTest extends TestCase
         $this->withObjectService(
             $this->fakeObjectService(
                 [
+                    // administrationId is now part of every index() query: the
+                    // listing is scoped to the caller's memberships (ADR-005).
                     'BtwAangifte' => [
-                        ['id' => 'r-1', 'period' => 'quarter', 'regime' => 'standard', 'statusCode' => 'draft'],
-                        ['id' => 'r-2', 'period' => 'quarter', 'regime' => 'kor', 'statusCode' => 'submitted'],
+                        ['id' => 'r-1', 'administrationId' => 'adm-1', 'period' => 'quarter', 'regime' => 'standard', 'statusCode' => 'draft'],
+                        ['id' => 'r-2', 'administrationId' => 'adm-1', 'period' => 'quarter', 'regime' => 'kor', 'statusCode' => 'submitted'],
                     ],
                 ]
             )
@@ -354,9 +384,11 @@ final class VATReturnControllerTest extends TestCase
         $this->withObjectService(
             $this->fakeObjectService(
                 [
+                    // administrationId is now part of every index() query: the
+                    // listing is scoped to the caller's memberships (ADR-005).
                     'BtwAangifte' => [
-                        ['id' => 'r-1', 'period' => 'quarter', 'regime' => 'standard', 'statusCode' => 'draft'],
-                        ['id' => 'r-2', 'period' => 'quarter', 'regime' => 'kor', 'statusCode' => 'submitted'],
+                        ['id' => 'r-1', 'administrationId' => 'adm-1', 'period' => 'quarter', 'regime' => 'standard', 'statusCode' => 'draft'],
+                        ['id' => 'r-2', 'administrationId' => 'adm-1', 'period' => 'quarter', 'regime' => 'kor', 'statusCode' => 'submitted'],
                     ],
                 ]
             )
@@ -499,6 +531,10 @@ final class VATReturnControllerTest extends TestCase
     public function testSubmitReturns200(): void
     {
         $this->withUser(uid: 'alice');
+        // submit() now loads the return first to authorise the caller against
+        // its administration (ADR-005) before filing it.
+        $this->service->method('findReturn')
+            ->willReturn(['id' => 'ret-1', 'administrationId' => 'adm-1', 'statusCode' => 'draft']);
         $this->service->expects($this->once())
             ->method('submitReturn')
             ->with('ret-1', 'alice')
@@ -519,6 +555,8 @@ final class VATReturnControllerTest extends TestCase
     public function testSubmitReturns409OnConflict(): void
     {
         $this->withUser(uid: 'alice');
+        $this->service->method('findReturn')
+            ->willReturn(['id' => 'ret-1', 'administrationId' => 'adm-1', 'statusCode' => 'submitted']);
         $this->service->method('submitReturn')->willThrowException(new \RuntimeException('not draft'));
 
         $response = $this->controller->submit(returnId: 'ret-1');
@@ -535,6 +573,8 @@ final class VATReturnControllerTest extends TestCase
     public function testRebaseReturns200(): void
     {
         $this->withUser(uid: 'bob');
+        $this->service->method('findReturn')
+            ->willReturn(['id' => 'ret-1', 'administrationId' => 'adm-1', 'statusCode' => 'submitted']);
         $this->service->expects($this->once())
             ->method('rebaseReturn')
             ->with('ret-1', 'bob')
@@ -577,4 +617,100 @@ final class VATReturnControllerTest extends TestCase
         self::assertSame(Http::STATUS_CONFLICT, $response->getStatus());
 
     }//end testDestroyRejectsNonDraft()
+
+    /**
+     * create() refuses to file a statutory VAT return into a foreign administration (#518).
+     *
+     * This is the worst of the 23 findings: `POST /api/vat-returns` took
+     * `administrationId` straight off the wire behind nothing but
+     * `preg_match('/^[A-Za-z0-9_.\-]{1,64}$/')`, while
+     * VATReturnService::createReturn()'s own docblock declares the parameter
+     * "Server-resolved administration scope". Live on a two-account rig the
+     * pre-fix call answered **HTTP 201**.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testCreateRefusesAForeignAdministration(): void
+    {
+        $this->canAccess = false;
+        $this->withParams(
+            [
+                'administrationId' => 'adm-not-mine',
+                'period'           => 'quarter',
+                'periodYear'       => 2020,
+                'periodNumber'     => 1,
+                'regime'           => 'standard',
+            ]
+        );
+        $this->service->expects($this->never())->method('createReturn');
+
+        $response = $this->controller->create();
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+    }//end testCreateRefusesAForeignAdministration()
+
+    /**
+     * show/update/submit/rebase/destroy all mask a foreign return as 404 (#518).
+     *
+     * The whole BtwAangifte chain resolved `returnId` with
+     * `->setSchema('BtwAangifte')->find($returnId)` and no administration
+     * filter, so quoting another tenant's id was enough to read it, edit it,
+     * file it, or revert a submitted filing to draft. Every one answered 200
+     * live before this change.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testForeignReturnIsMaskedAs404OnEveryVerb(): void
+    {
+        $this->canAccess = false;
+        $this->withParams(['notes' => 'owned by someone else']);
+        $this->service->method('findReturn')
+            ->willReturn(['id' => 'ret-1', 'administrationId' => 'adm-not-mine', 'statusCode' => 'draft']);
+        $this->service->expects($this->never())->method('submitReturn');
+        $this->service->expects($this->never())->method('rebaseReturn');
+        $this->withObjectService($this->fakeObjectService(['BtwAangifte' => []]));
+
+        self::assertSame(Http::STATUS_NOT_FOUND, $this->controller->show(returnId: 'ret-1')->getStatus());
+        self::assertSame(Http::STATUS_NOT_FOUND, $this->controller->update(returnId: 'ret-1')->getStatus());
+        self::assertSame(Http::STATUS_NOT_FOUND, $this->controller->submit(returnId: 'ret-1')->getStatus());
+        self::assertSame(Http::STATUS_NOT_FOUND, $this->controller->rebase(returnId: 'ret-1')->getStatus());
+        self::assertSame(Http::STATUS_NOT_FOUND, $this->controller->destroy(returnId: 'ret-1')->getStatus());
+
+    }//end testForeignReturnIsMaskedAs404OnEveryVerb()
+
+    /**
+     * index() lists only administrations the caller is a member of (#518).
+     *
+     * `administrationId` used to be an OPTIONAL filter, so omitting it returned
+     * every tenant's statutory returns in one page.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+     */
+    public function testIndexIsScopedToTheCallersMemberships(): void
+    {
+        $this->withParams(['_page' => 1, '_limit' => 10]);
+        $this->withObjectService(
+            $this->fakeObjectService(
+                [
+                    'BtwAangifte' => [
+                        ['id' => 'r-1', 'administrationId' => 'adm-1', 'period' => 'quarter', 'regime' => 'standard', 'statusCode' => 'draft'],
+                        ['id' => 'r-9', 'administrationId' => 'adm-9', 'period' => 'quarter', 'regime' => 'standard', 'statusCode' => 'draft'],
+                    ],
+                ]
+            )
+        );
+
+        $payload = $this->controller->index()->getData();
+
+        self::assertSame(1, $payload['total']);
+        self::assertSame('r-1', $payload['data'][0]['id']);
+
+    }//end testIndexIsScopedToTheCallersMemberships()
 }//end class

--- a/tests/Unit/Service/BadoControleprotocolTenantTest.php
+++ b/tests/Unit/Service/BadoControleprotocolTenantTest.php
@@ -1,0 +1,301 @@
+<?php
+
+/**
+ * Unit tests for BadoControleprotocolService::organisationIdFor().
+ *
+ * `Controleprotocol.organisationId` is the ONLY tenant field in the whole BADO
+ * bundle — the six child schemas carry none and hang off the protocol's FK — so
+ * this accessor is what the ADR-005 membership check in
+ * BadoControleprotocolController is made against. It was added by #520 and had
+ * no test.
+ *
+ * The lookup shape is load-bearing and is asserted here: it must address the
+ * object by identity through `find(id:, register:, schema:)`. The obvious
+ * alternative, `findAll(['filters' => ['id' => $uuid]])`, cannot ever match —
+ * `id` is `@self.id`, a bigint column, and Postgres answers with SQLSTATE[22P02]
+ * which the service swallows. A guard built on it refuses the legitimate owner
+ * as well as the attacker; that was measured live on a two-account rig as
+ * owner 200 -> 404 before the shape was corrected.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Service;
+
+use JsonSerializable;
+use OCA\Shillinq\Service\BadoControleprotocolCalculator;
+use OCA\Shillinq\Service\BadoControleprotocolService;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Tests the BADO tenant accessor.
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+final class BadoControleprotocolTenantTest extends TestCase
+{
+
+    /**
+     * Mock container.
+     *
+     * @var ContainerInterface&MockObject
+     */
+    private ContainerInterface&MockObject $container;
+
+    /**
+     * Mock app config.
+     *
+     * @var IAppConfig&MockObject
+     */
+    private IAppConfig&MockObject $appConfig;
+
+    /**
+     * Service under test.
+     *
+     * @var BadoControleprotocolService
+     */
+    private BadoControleprotocolService $service;
+
+    /**
+     * Set up fixtures.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->appConfig = $this->createMock(IAppConfig::class);
+        $this->appConfig->method('getValueString')->willReturn('shillinq');
+
+        $this->service = new BadoControleprotocolService(
+            container: $this->container,
+            appConfig: $this->appConfig,
+            calculator: $this->createMock(BadoControleprotocolCalculator::class),
+            logger: new NullLogger(),
+        );
+
+    }//end setUp()
+
+    /**
+     * Build an ObjectService double that mirrors ObjectService::find().
+     *
+     * The real signature is
+     * `find(int|string $id, ?array $_extend = [], bool $files = false,
+     *       Register|string|int|null $register = null,
+     *       Schema|string|int|null $schema = null, ...): ?ObjectEntity`.
+     * The parameter NAMES are reproduced because the caller passes them by
+     * name; a double that renamed them would accept a call the real service
+     * rejects with "Unknown named parameter".
+     *
+     * @param mixed $result What find() returns.
+     *
+     * @return object
+     */
+    private function fakeObjectService(mixed $result): object
+    {
+        return new class($result)
+        {
+
+            /**
+             * What find() returns.
+             *
+             * @var mixed
+             */
+            private mixed $result;
+
+            /**
+             * The arguments find() was called with.
+             *
+             * @var array<string,mixed>
+             */
+            public array $seenFind = [];
+
+            /**
+             * Constructor.
+             *
+             * @param mixed $result What find() returns.
+             */
+            public function __construct(mixed $result)
+            {
+                $this->result = $result;
+            }//end __construct()
+
+            /**
+             * Identity lookup (mirrors ObjectService::find).
+             *
+             * @param int|string  $id       Object identity.
+             * @param array|null  $_extend  Properties to extend.
+             * @param bool        $files    Whether to include files.
+             * @param string|null $register Register slug.
+             * @param string|null $schema   Schema slug.
+             *
+             * @return mixed
+             */
+            public function find(
+                int | string $id,
+                ?array $_extend=[],
+                bool $files=false,
+                string | null $register=null,
+                string | null $schema=null
+            ): mixed {
+                $this->seenFind = [
+                    'id'       => $id,
+                    'register' => $register,
+                    'schema'   => $schema,
+                ];
+
+                return $this->result;
+            }//end find()
+
+            /**
+             * Present so a regression onto the broken lookup fails loudly
+             * instead of silently returning null, the way it does live.
+             *
+             * @param array<string,mixed> $config Query configuration.
+             *
+             * @return array<int,mixed>
+             */
+            public function findAll(array $config=[]): array
+            {
+                throw new \LogicException(
+                    'organisationIdFor() must address the protocol by identity: '
+                    ."findAll(['filters' => ['id' => ...]]) cannot match a bigint @self.id."
+                );
+            }//end findAll()
+
+            /**
+             * Fluent register setter (mirrors ObjectService::setRegister).
+             *
+             * @param string $register Register slug.
+             *
+             * @return static
+             */
+            public function setRegister(string $register): static
+            {
+                return $this;
+            }//end setRegister()
+
+            /**
+             * Fluent schema setter (mirrors ObjectService::setSchema).
+             *
+             * @param string $schema Schema slug.
+             *
+             * @return static
+             */
+            public function setSchema(string $schema): static
+            {
+                return $this;
+            }//end setSchema()
+        };
+
+    }//end fakeObjectService()
+
+    /**
+     * An empty protocol id resolves to null without touching the data layer.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-12
+     */
+    public function testAnEmptyProtocolIdResolvesToNull(): void
+    {
+        $this->container->expects($this->never())->method('get');
+
+        self::assertNull($this->service->organisationIdFor(protocolId: ''));
+
+    }//end testAnEmptyProtocolIdResolvesToNull()
+
+    /**
+     * A protocol that does not exist resolves to null, and the lookup addresses
+     * the object by identity with the configured register and schema.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-12
+     */
+    public function testAnAbsentProtocolResolvesToNull(): void
+    {
+        $stub = $this->fakeObjectService(null);
+        $this->container->method('get')->willReturn($stub);
+
+        self::assertNull($this->service->organisationIdFor(protocolId: 'proto-1'));
+        self::assertSame(
+            ['id' => 'proto-1', 'register' => 'shillinq', 'schema' => 'Controleprotocol'],
+            $stub->seenFind
+        );
+
+    }//end testAnAbsentProtocolResolvesToNull()
+
+    /**
+     * An ObjectEntity is normalised through jsonSerialize().
+     *
+     * ObjectService::find() is declared `: ?ObjectEntity` and ObjectEntity
+     * implements JsonSerializable, so the entity arm — not the array arm — is
+     * the one production actually takes.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-12
+     */
+    public function testAnEntityIsNormalisedThroughJsonSerialize(): void
+    {
+        $entity = new class implements JsonSerializable
+        {
+
+            /**
+             * Serialise the object body.
+             *
+             * @return array<string,mixed>
+             */
+            public function jsonSerialize(): array
+            {
+                return ['id' => 'proto-1', 'organisationId' => 'adm-1'];
+            }//end jsonSerialize()
+        };
+
+        $this->container->method('get')->willReturn($this->fakeObjectService($entity));
+
+        self::assertSame('adm-1', $this->service->organisationIdFor(protocolId: 'proto-1'));
+
+    }//end testAnEntityIsNormalisedThroughJsonSerialize()
+
+    /**
+     * A protocol carrying no organisationId resolves to the empty string.
+     *
+     * The caller treats '' as a refusal — AdministrationContextService::canAccess()
+     * fails closed on it — so a tenant-less protocol is inaccessible rather than
+     * accessible to everyone.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-12
+     */
+    public function testAProtocolWithoutATenantResolvesToTheEmptyString(): void
+    {
+        $this->container->method('get')->willReturn(
+            $this->fakeObjectService(['id' => 'proto-1'])
+        );
+
+        self::assertSame('', $this->service->organisationIdFor(protocolId: 'proto-1'));
+
+    }//end testAProtocolWithoutATenantResolvesToTheEmptyString()
+}//end class

--- a/tests/Unit/Service/SepaAuditServiceTest.php
+++ b/tests/Unit/Service/SepaAuditServiceTest.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\SepaAuditService;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -141,29 +142,33 @@ final class SepaAuditServiceTest extends TestCase
 
 
     /**
-     * Build the subject with the given administration scope + fake OR rows.
+     * Build the subject with the CALLER's administration memberships + fake OR rows.
      *
-     * @param string                                              $admin Administration scope (empty = unconfigured).
-     * @param array<string, array<int, array<string,mixed>>>      $rows  Seed rows per schema.
+     * ⚠️ `$admin` used to be `appConfig('administration_id')` — an instance-wide
+     * constant with no relation to the calling user. It is now the
+     * administration the caller is actually a member of, which is what
+     * AdministrationContextService::canAccess() answers on. An empty string
+     * means "member of nothing" and, unlike before, refuses everything: the old
+     * empty value SKIPPED the comparison entirely.
+     *
+     * @param string                                         $admin The administration the caller is a member of ('' = none).
+     * @param array<string, array<int, array<string,mixed>>> $rows  Seed rows per schema.
      *
      * @return SepaAuditService
      */
     private function svc(string $admin, array $rows): SepaAuditService
     {
-        $this->appConfig->method('getValueString')->willReturnCallback(
-            static function (string $appId, string $key, string $default) use ($admin): string {
-                if ($key === 'administration_id') {
-                    return $admin;
-                }
+        $this->appConfig->method('getValueString')->willReturn('shillinq');
 
-                return 'shillinq';
-            }
+        $context = $this->createMock(AdministrationContextService::class);
+        $context->method('canAccess')->willReturnCallback(
+            static fn (string $administrationId): bool => $administrationId !== '' && $administrationId === $admin
         );
 
         $fake = new FakeSepaObjectService($rows);
         $this->container->method('get')->willReturn($fake);
 
-        return new SepaAuditService($this->container, $this->appConfig, $this->logger);
+        return new SepaAuditService($this->container, $this->appConfig, $context, $this->logger);
 
     }//end svc()
 
@@ -178,7 +183,12 @@ final class SepaAuditServiceTest extends TestCase
         $this->container->expects(self::never())->method('get');
         $this->appConfig->method('getValueString')->willReturn('shillinq');
 
-        $svc = new SepaAuditService($this->container, $this->appConfig, $this->logger);
+        $svc = new SepaAuditService(
+            $this->container,
+            $this->appConfig,
+            $this->createMock(AdministrationContextService::class),
+            $this->logger
+        );
 
         self::assertNull($svc->buildMandateDossier(''));
 
@@ -319,10 +329,10 @@ final class SepaAuditServiceTest extends TestCase
     public function testFilenameSlugsUnsafeChars(): void
     {
         $svc = $this->svc(
-            '',
+            'admin-A',
             [
                 'SepaMandate' => [
-                    ['id' => 'm', 'mandateReference' => 'M/2026 #01'],
+                    ['id' => 'm', 'administrationId' => 'admin-A', 'mandateReference' => 'M/2026 #01'],
                 ],
                 'DirectDebitCollection' => [],
             ]
@@ -337,12 +347,22 @@ final class SepaAuditServiceTest extends TestCase
 
 
     /**
-     * Unconfigured administration_id ('') accepts mandates regardless of
-     * administrationId — single-tenant mode.
+     * A caller with NO memberships gets nothing — the inverse of the old assertion (#518).
+     *
+     * ⚠️ This test replaces `testUnconfiguredAdminAcceptsAnyMandate`, which
+     * asserted that an unset `administration_id` "accepts mandates regardless of
+     * administrationId — single-tenant mode". That was the defect, written down
+     * as a requirement: `administration_id` is instance-wide config with no
+     * relation to the caller, its default is '', and at that value the guard was
+     * skipped entirely — so the audit dossier of ANY mandate on the instance was
+     * exportable by ANY authenticated user. The green test is exactly why nobody
+     * looked. Access is now decided by the caller's memberships.
      *
      * @return void
+     *
+     * @spec openspec/specs/bookkeeping-sepa-direct-debit/spec.md
      */
-    public function testUnconfiguredAdminAcceptsAnyMandate(): void
+    public function testCallerWithNoMembershipsGetsNothing(): void
     {
         $svc = $this->svc(
             '',
@@ -354,12 +374,35 @@ final class SepaAuditServiceTest extends TestCase
             ]
         );
 
-        $result = $svc->buildMandateDossier('mandate-1');
+        self::assertNull($svc->buildMandateDossier('mandate-1'));
 
-        self::assertIsArray($result);
-        self::assertSame('sepa-dossier-M1.zip', $result['filename']);
+    }//end testCallerWithNoMembershipsGetsNothing()
 
-    }//end testUnconfiguredAdminAcceptsAnyMandate()
+    /**
+     * A mandate carrying NO administrationId is refused, not exported (#518).
+     *
+     * canAccess('') fails closed. Under the old config-based guard an untagged
+     * mandate compared equal to nothing and fell straight through.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/bookkeeping-sepa-direct-debit/spec.md
+     */
+    public function testUntaggedMandateIsRefused(): void
+    {
+        $svc = $this->svc(
+            'admin-A',
+            [
+                'SepaMandate' => [
+                    ['id' => 'mandate-1', 'mandateReference' => 'M1'],
+                ],
+                'DirectDebitCollection' => [],
+            ]
+        );
+
+        self::assertNull($svc->buildMandateDossier('mandate-1'));
+
+    }//end testUntaggedMandateIsRefused()
 
 
     /**
@@ -370,10 +413,10 @@ final class SepaAuditServiceTest extends TestCase
     public function testCsvCellsAreEscaped(): void
     {
         $svc = $this->svc(
-            '',
+            'admin-A',
             [
                 'SepaMandate' => [
-                    ['id' => 'm', 'mandateReference' => 'M'],
+                    ['id' => 'm', 'administrationId' => 'admin-A', 'mandateReference' => 'M'],
                 ],
                 'DirectDebitCollection' => [
                     [

--- a/tests/integration/VAT_Filings.postman_collection.json
+++ b/tests/integration/VAT_Filings.postman_collection.json
@@ -35,6 +35,67 @@
 	],
 	"item": [
 		{
+			"name": "Setup — grant the caller a membership in the administration (ADR-005)",
+			"item": [
+				{
+					"name": "POST AdministrationMembership for {{admin_user}} on {{administration_id}}",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"// Every /api/vat-returns endpoint is #[NoAdminRequired] AND authorised per",
+									"// administration by AdministrationContextService::canAccess(), which grants",
+									"// access on a valid AdministrationMembership and NOTHING else — being a",
+									"// Nextcloud admin does not imply a membership. That is the same guard the 29",
+									"// other shillinq controllers already use, so this collection has to supply the",
+									"// precondition a real tenant user would have.",
+									"//",
+									"// Until the guard landed these endpoints read administrationId straight off the",
+									"// wire, so the collection was green precisely BECAUSE nothing was checked.",
+									"// This request is the fixture, not a workaround: seeding what it needs and",
+									"// tearing it down is this suite's stated contract (see run-newman.sh).",
+									"pm.test('membership created or already present', () => pm.expect(pm.response.code).to.be.oneOf([200, 201]));",
+									"const body = pm.response.json();",
+									"const id = body.id || body['@self']?.id;",
+									"if (id) { pm.collectionVariables.set('membership_id', id); }"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{base_url}}/index.php/apps/openregister/api/objects/shillinq/AdministrationMembership",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"index.php",
+								"apps",
+								"openregister",
+								"api",
+								"objects",
+								"shillinq",
+								"AdministrationMembership"
+							]
+						},
+						"body": {
+							"mode": "raw",
+							"raw": "{\"userId\":\"{{admin_user}}\",\"administrationId\":\"{{administration_id}}\",\"role\":\"eigenaar\",\"mayPostJournalEntries\":true,\"mayCloseFiscalYear\":true}"
+						}
+					}
+				}
+			]
+		},
+		{
 			"name": "Happy path — create + derive + submit",
 			"item": [
 				{
@@ -262,6 +323,38 @@
 					"request": {
 						"method": "GET",
 						"url": {"raw": "{{base_url}}/index.php/apps/shillinq/api/vat-returns/{{return_id}}/declarations", "host": ["{{base_url}}"], "path": ["index.php", "apps", "shillinq", "api", "vat-returns", "{{return_id}}", "declarations"]}
+					}
+				}
+			]
+		},
+		{
+			"name": "Teardown — revoke the membership seeded by Setup",
+			"item": [
+				{
+					"name": "DELETE the AdministrationMembership",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"// Idempotent teardown: this suite's contract is that a collection seeds what",
+									"// it needs and removes it again, so a later run starts from the same state.",
+									"// Skipped rather than failed when Setup did not record an id, so a partial",
+									"// run cannot turn a teardown into a spurious red.",
+									"if (!pm.collectionVariables.get('membership_id')) {",
+									"    pm.test('nothing to revoke', () => pm.expect(true).to.be.true);",
+									"} else {",
+									"    pm.test('membership revoked', () => pm.expect(pm.response.code).to.be.oneOf([200, 204, 404]));",
+									"}",
+									"pm.collectionVariables.unset('membership_id');"
+								]
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"url": {"raw": "{{base_url}}/index.php/apps/openregister/api/objects/shillinq/AdministrationMembership/{{membership_id}}", "host": ["{{base_url}}"], "path": ["index.php", "apps", "openregister", "api", "objects", "shillinq", "AdministrationMembership", "{{membership_id}}"]}
 					}
 				}
 			]


### PR DESCRIPTION
Closes the 23 `#[NoAdminRequired]` IDORs of #518 by calling the guard this app
already has: **`AdministrationContextService::canAccess()`, which 29 controllers
call and 0 of the 14 offenders did.** No new access model was invented.

Every number below was produced on a **single-owner rig** (`docker compose -p sqnm`,
nextcloud:34.0.0-apache + openregister + shillinq, port 8117) with **two real
accounts** and the **status code printed on every request**:

- `sqalice` — member of `adm-1` only
- `sqmallory` — member of `adm-2` only

## The worst one, reproduced live

`POST /api/vat-returns` — a **statutory Dutch VAT filing into any administration**:

| | before | after |
|---|---|---|
| mallory → `administrationId: adm-1` (no membership) | **HTTP 201** — filing created | **HTTP 404** |
| alice → `administrationId: adm-1` (member) | HTTP 201 | **HTTP 201** — unchanged |

The service's own contract already said this should be impossible —
`VATReturnService.php:89` declares the parameter *"Server-resolved administration
scope"* while `VATReturnController.php:213` read it off the wire.

## Two-sided probe, every guarded endpoint

The owner is probed in the same run as the attacker, so a guard that denies
*everyone* is visible rather than scoring as a win.

| endpoint | owner | attacker |
|---|---|---|
| `POST /api/vat-returns` | 201 | **404** |
| `GET/PUT/DELETE /api/vat-returns/{id}` | 200 | **404** |
| `POST /api/vat-returns/{id}/submit` · `/rebase` | 200 | **404** |
| `GET /api/vat-returns` (list) | 200 | **404** |
| `GET /api/vat-returns/{id}/lines` · `/declarations` | 200 | 200 — **scoped**, see below |
| `GET /api/tax-reports/{year}` · `/{year}/{quarter}` | 200 | **404** |
| `GET /api/revenue/cutoff` | 200 | **404** |
| `GET /api/recognition/recurring-revenue` | 200 | **404** |
| `POST /api/tax-payments/{id}/reconcile` | 200 | **404** |
| `GET /api/oss/return` | 200 | **404** |
| `GET /api/bado/controleprotocol/aggregation` | 200 | **404** |
| `GET /api/inventory/sync` · `/resolve` | 200 | **404** |

**The list endpoints are scoped, not blocked.** Positive control against a
populated slice — two VATLine rows and two VATDeclaration rows under the **same
`returnId`**, one in `adm-1` and one in `adm-2`:

| | before | after |
|---|---|---|
| alice | `total=2`, `admins=['adm-1','adm-2']` | `total=1`, `['adm-1']` |
| mallory | `total=2`, `admins=['adm-1','adm-2']` | `total=1`, `['adm-2']` |

## What is NOT claimed

⚠️ **`GET /api/sepa/mandates/{id}/audit-export` was never exploitable — it is a
dead endpoint**, 404 for owner and attacker alike, before and after, against a
mandate created at HTTP 201 moments earlier. Cause, from the server log:

```
[MagicMapper] Failed to search register+schema table
SQLSTATE[22P02]: invalid input syntax for type bigint: "3227284f-…"
```

`findAll(['filters' => ['id' => $uuid]])` cannot match — `id` is `@self.id`, a
bigint column — and the service swallows the exception. **The crash is the only
thing that has ever protected this endpoint**, because its "tenant guard" read
`appConfig('administration_id')`: instance-wide, unrelated to the caller, and
skipped entirely at its default `''`. This PR **replaces that guard and
deliberately does not repair the lookup**, so repairing it later cannot open a
hole (pipelinq#805 sequencing). Filed separately.

⚠️ `GET /api/reporting/generated` is scoped in code and unit-tested, but the rig
had no `GeneratedReport` rows, so its scoping is **not live-proven**.

## Retraction

🔴 **The `NotificationController::listForBooking` finding in #518 is a false
positive.** `/api/bookings/{id}/notification-triggers` is registered **twice** in
`appinfo/routes.php` (`:85` and `:207`); the first wins, so the accused method
never executes, and the controller that does serve it already calls
`canAccess()`. Caught because the attacker's refusal came back as **500**, not
the 404 my guard produces — the wrong dialect meant something else refused.
The guard is kept as defence-in-depth. Two real defects fall out and are filed
separately: the duplicate route, and `OCSForbiddenException` on a non-OCS route
rendering as a 500 HTML page instead of a 403.

## A bug this PR introduced and then fixed

🔴 My first BADO guard resolved the protocol's tenant through the app's existing
`resolveObject()` — **the same broken `filters['id']` call**. Measured:
`/api/bado/.../aggregation` went **owner 200 → owner 404**. I had turned a
working (and leaking) endpoint into one that works for nobody, and the
attacker-side 404 looked exactly like success. Fixed by resolving through
`ObjectService::find(id:, register:, schema:)`; owner is 200 again.
**Only the owner-side probe could have caught this.**

## False assurances deleted

Every docblock that claimed a guard which did not exist is removed in the same
commit as the real guard, and replaced with what was actually true — they are the
reason nobody looked:

- 6 × *"reads are delegated to OpenRegister's ObjectService, which enforces
  multitenancy / RBAC"* — no administration term was ever passed in, and
  **0 of shillinq's ~871 schemas declare an `authorization` block**, which
  OpenRegister treats as grant-to-every-authenticated-user
  (`enforce_default_closed` defaults `false`).
- `SepaAuditController:70` *"Scoped to the authenticated user's accessible
  administrations … IDOR-safe per ADR-005"*.
- `ReportingController:200` *"scoped to the current user's Files home"* — it used
  `IRootFolder`, which resolves across **every** user's storage.
- `InventoryScanController` *"IDOR-safe"* — true of the user id, irrelevant to the
  tenant id, which was a request parameter defaulting to the literal `'adm-1'`.
  **That default is gone**; an omitted administration is now a 400.
- `TaxReportController::validateAdministration()` → renamed
  `requireAccessibleAdministration()`, because the old body was entirely
  `preg_match('/^[A-Za-z0-9_.\-]{1,64}$/')` — a character-class test, not a check.

## Tests

`4067 tests, 43238 assertions, 0 failures.` New security tests in 7 classes,
**proven able to fail**: neutering the VAT guard turns exactly
`testCreateRefusesAForeignAdministration` (`500 !== 404`) and
`testForeignReturnIsMaskedAs404OnEveryVerb` (`200 !== 404`) red, and nothing else.

⚠️ `SepaAuditServiceTest::testUnconfiguredAdminAcceptsAnyMandate` is **replaced**,
not adapted. It asserted that an unset `administration_id` *"accepts mandates
regardless of administrationId — single-tenant mode"*. That was the defect
written down as a requirement, and it was green for its whole life.

## Also in this PR

- `composer.lock`: **CVE-2026-65954** — `phpcsstandards/phpcsutils` 1.2.2 → 1.2.3.
  Exercised by *running* phpcs 3.13.6 (exit 0), not merely by locking it.
- Pre-existing phpcs errors fixed (2 missing `//end try`, 2 lowercase inline
  comments) and a phpmd `CyclomaticComplexity` on `create()` that my guard pushed
  to 16, resolved by extracting `validateCreatePeriod()`.

`phpcs` 0 · `phpmd` 0 · `psalm` 0 · `phpstan` [OK] No errors · `composer audit --locked` clean.
