### PR TITLE
fix(deps): bump phpcsstandards/phpcsutils to 1.2.3 (CVE-2026-65954)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2599,16 +2599,16 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
                 "shasum": ""
             },
             "require": {
@@ -2688,7 +2688,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-12-08T14:27:58+00:00"
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -7781,9 +7781,9 @@
         "php": "^8.3",
         "ext-zip": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## What

Bumps `phpcsstandards/phpcsutils` **1.2.2 → 1.2.3** in `composer.lock`.

```
Package:  phpcsstandards/phpcsutils
CVE:      CVE-2026-65954 — Arbitrary code execution
Affected: >=1.0.0-alpha1,<1.2.3
Reported: 2026-07-27
```

Transitive dev dependency via `phpcsstandards/phpcsextra`, so **nothing in `composer.json` changes** — only the lock.

## Why it surfaces now

The advisory reached the audit database **after** this repo's last green Code Quality run. The gate didn't fail then and does now. Nothing regressed — the check got new information.

Worth stating plainly: **this repo's `Security (composer)` job passed as recently as today while locking 1.2.2.** A green audit is evidence about *when the job ran*, not about the lock being clean.

## Blast radius

**Exactly one package version line**, verified by counting changed `"version"` keys in the diff.

## The bump is exercised, not merely installed

`phpcsutils` is the library **phpcs itself runs on**, so a clean `composer audit` isn't the only evidence: phpcs was executed over `lib/` after the bump and ran to completion.

A dependency bump that no build exercises is not a verified bump.

## Verification

- `composer audit` → **"No security vulnerability advisories found."**
- 1.2.2 → 1.2.3; **one** package changed
- `vendor/bin/phpcs` executes over `lib/` after the bump

## How it was found

A measured sweep of every app's `composer.lock` at `origin/development`:

| status | apps |
|---|---|
| **VULNERABLE (1.2.2)** | procest, **openconnector**, **shillinq** |
| SAFE (1.2.3) | openregister, opencatalogi, docudesk, decidesk, pipelinq, openbuild, softwarecatalog |
| no lock | hrmq |

3 of 11 — not fleet-wide, which was my first assumption before measuring.

Companion PRs: ConductionNL/procest#812, and the sibling in the other affected repo.
