### PR TITLE
fix(bookings): the public widget published 0.00 for every priced service

### DIFF
--- a/lib/Service/WidgetService.php
+++ b/lib/Service/WidgetService.php
@@ -134,6 +134,8 @@ class WidgetService
      * @param string $administrationId The owning administration (tenant scope).
      *
      * @return array<int,array<string,mixed>> The public service list.
+     *
+     * @spec openspec/specs/bookings-self-service-widget/spec.md#req-wsw-001
      */
     public function listPublicServices(string $administrationId): array
     {

--- a/lib/Service/WidgetService.php
+++ b/lib/Service/WidgetService.php
@@ -178,7 +178,20 @@ class WidgetService
             ];
 
             if ((bool) ($service['priceVisible'] ?? false) === true) {
-                $public['price']    = (float) ($service['price'] ?? 0);
+                // `basePrice` is the property the Service schema actually
+                // DECLARES — and it is in its `required` list
+                // (bookings-service-catalog.json). `price` is declared by NO
+                // fragment, and OpenRegister's MagicMapper discards undeclared
+                // properties, so no stored Service can ever carry it. Reading
+                // `price` first therefore published 0.00 for EVERY service with
+                // priceVisible=true. Measured on a live instance: a Service
+                // saved with basePrice=125.50 renders `basePrice => 125.5` and
+                // `price => ABSENT`.
+                //
+                // `price` is retained only as a fallback for any object stored
+                // under an older schema revision that did declare it; it must
+                // stay SECOND, because the whole defect was ordering.
+                $public['price']    = (float) ($service['basePrice'] ?? $service['price'] ?? 0);
                 $public['currency'] = (string) ($service['currency'] ?? 'EUR');
             }
 

--- a/tests/Unit/Service/WidgetServiceTest.php
+++ b/tests/Unit/Service/WidgetServiceTest.php
@@ -223,7 +223,7 @@ class WidgetServiceTest extends TestCase
      */
     public function testCreateAppointmentRejectsNonPublicService(): void
     {
-        $private       = $this->bookableService();
+        $private = $this->bookableService();
         $private['isPublic'] = false;
 
         $objectService = $this->buildObjectService(services: [$private], appointments: [], saved: null);
@@ -421,6 +421,100 @@ class WidgetServiceTest extends TestCase
         self::assertArrayNotHasKey('isPublic', $list[0]);
 
     }//end testListPublicServicesReturnsSafeSubset()
+
+    /**
+     * A service stored under the real schema publishes its basePrice, not 0.00.
+     *
+     * ⚠️ This is the test the suite did not have, and its absence is why the
+     * widget shipped 0.00 for every priced service.
+     *
+     * The Service schema is declared across two fragments:
+     * `30-bookings-self-service-widget.json` declares `priceVisible`, and
+     * `bookings-service-catalog.json` declares `basePrice` — which is in its
+     * `required` list. **No fragment declares `price`**, and OpenRegister's
+     * MagicMapper discards undeclared properties, so no stored Service can
+     * carry one. Measured on a live instance: a Service saved with
+     * `basePrice = 125.50` renders `basePrice => 125.5` and `price => ABSENT`.
+     *
+     * 🔑 The fixture below therefore omits `price` deliberately. The pre-existing
+     * `testListPublicServicesReturnsSafeSubset` supplies `'price' => 35.0` — a
+     * key OpenRegister has never emitted — which is exactly why it stayed green
+     * over a broken production path. It also asserts only `assertArrayHasKey`,
+     * so it could not have caught a 0.00 VALUE even with the invented key.
+     *
+     * @return void
+     */
+    public function testPricedServicePublishesBasePriceNotZero(): void
+    {
+        $service       = [
+            '@self'            => ['slug' => 'consult'],
+            'name'             => 'Consultation',
+            'duration'         => 30,
+            'basePrice'        => 125.50,
+            'currency'         => 'EUR',
+            'priceVisible'     => true,
+            'isPublic'         => true,
+            'administrationId' => 'salon-demo',
+        ];
+        $objectService = $this->buildObjectService(services: [$service], appointments: [], saved: null);
+        $this->container->method('get')->willReturn($objectService);
+
+        $list = $this->service->listPublicServices('salon-demo');
+
+        self::assertCount(1, $list);
+        self::assertSame(
+            125.50,
+            $list[0]['price'],
+            'the widget must publish the stored basePrice, not 0.00'
+        );
+        self::assertNotSame(0.0, $list[0]['price']);
+        self::assertSame('EUR', $list[0]['currency']);
+
+    }//end testPricedServicePublishesBasePriceNotZero()
+
+    /**
+     * A legacy object still carrying `price` keeps working.
+     *
+     * `basePrice` must win when both are present — the defect was ordering, so
+     * the fallback has to stay second.
+     *
+     * @return void
+     */
+    public function testLegacyPriceIsUsedOnlyAsFallback(): void
+    {
+        $legacyOnly    = [
+            '@self'        => ['slug' => 'legacy'],
+            'name'         => 'Legacy service',
+            'duration'     => 15,
+            'price'        => 42.0,
+            'currency'     => 'EUR',
+            'priceVisible' => true,
+            'isPublic'     => true,
+        ];
+        $bothPresent   = [
+            '@self'        => ['slug' => 'both'],
+            'name'         => 'Both spellings',
+            'duration'     => 15,
+            'basePrice'    => 99.0,
+            'price'        => 42.0,
+            'currency'     => 'EUR',
+            'priceVisible' => true,
+            'isPublic'     => true,
+        ];
+        $objectService = $this->buildObjectService(
+            services: [$legacyOnly, $bothPresent],
+            appointments: [],
+            saved: null
+        );
+        $this->container->method('get')->willReturn($objectService);
+
+        $list = $this->service->listPublicServices('salon-demo');
+
+        self::assertCount(2, $list);
+        self::assertSame(42.0, $list[0]['price'], 'legacy price is still honoured when it is all there is');
+        self::assertSame(99.0, $list[1]['price'], 'basePrice must win over the legacy spelling');
+
+    }//end testLegacyPriceIsUsedOnlyAsFallback()
 
     /**
      * Build a fluent ObjectService stub returning services / appointments by schema.


### PR DESCRIPTION
Live, user-facing, on `development` right now: **the embedded booking widget advertises €0.00 for every service where `priceVisible` is true.**

## The mechanism

`WidgetService::listPublicServices()` (`:181`) reads `$service['price'] ?? 0`. **No register fragment declares a Service property called `price`**, and OpenRegister's MagicMapper discards undeclared properties — so no stored Service can ever carry one. The read resolves to the `?? 0` arm every single time.

The `Service` schema is declared across two fragments and ADR-037 merges them by key:

| fragment | price-ish property it declares |
|---|---|
| `30-bookings-self-service-widget.json` | `priceVisible` |
| `bookings-service-catalog.json` | **`basePrice`** — and it is in that fragment's `required` list |

## Measured, not inferred

Saved through `ObjectService::saveObject()` against a live instance:

```
STORED basePrice = 125.5
STORED price     = 'ABSENT'      <- what the shipped code reads
widget publishes   price = 0.0
with this fix      price = 125.5
```

The fix reads `basePrice` first and keeps `price` **only as a fallback** for any object stored under an older schema revision that did declare it. ⚠️ The fallback must stay **second** — the whole defect was ordering, not absence.

## Why the suite was green over it

`testListPublicServicesReturnsSafeSubset` supplies `'price' => 35.0` in its fixture — **a key OpenRegister has never emitted.** The double was shaped to what the caller reads rather than to what the collaborator actually stores, so it exercised a field that cannot exist in production. It then asserted only `assertArrayHasKey('price', …)` and **never the value**, so it could not have caught a 0.00 even with the invented key. Vacuous twice over, and green throughout.

Two tests added, both built from the shape OR really stores (`basePrice` present, `price` absent):

- `testPricedServicePublishesBasePriceNotZero` — asserts the **value**, 125.50
- `testLegacyPriceIsUsedOnlyAsFallback` — legacy-only objects still work, **and `basePrice` wins when both are present**

**Revert control, predicted before running:** restoring the shipped read fails exactly **2 of 15**, and exactly those two. 🔑 The pre-existing safe-subset test **survives the revert** — the direct demonstration that it never covered this behaviour.

## Provenance, and a correction

The one-line repair is **salvaged from #484**, which has been sitting open since 08-09. That PR was nearly closed on the reading that it *"deletes `WidgetService::findPublicService()` and re-opens the isPublic hole"*. That reading is **wrong, and the way it is wrong is worth recording**: `findPublicService` did not exist at #484's merge-base — it was added to `development` afterwards by `2083e7ee` (#507), and #484's branch predates it. The deletion is visible only in the **two-dot** diff, which shows a stale branch's distance from `development`, not what merging it would do. A three-way merge would have kept the guard.

🔑 **A two-dot diff of a stale branch cannot tell you what merging it would contribute.** Use the three-dot (merge-base) diff, or check whether the symbol existed at the merge-base at all.

#484's `isPublic` content is genuinely superseded — `development` already carries the identical check and comment at `WidgetApiController:143`. But its **price fix was not**, and nobody had noticed, because the defect is invisible to every test and to Newman. That part is here; #484 keeps its remaining salvage (the Appointment ADR-062 `$ref` migration).

## Not verified

- The `€0.00` symptom is established at the **service layer** by direct probe. I did **not** render the embedded widget in a browser, so the end-user-visible string is inferred from the published `price` field rather than observed.
- I have not audited whether any **other** consumer reads `$service['price']`; this PR fixes the one site the probe covers.