### PR TITLE
fix(seeds): three more Calendar seeds sent null weekdays and never imported

### DIFF
--- a/lib/Settings/register.d/10-bookings-resource-calendar.json
+++ b/lib/Settings/register.d/10-bookings-resource-calendar.json
@@ -84,15 +84,14 @@
           "workingHours": {
             "type": "object",
             "nullable": true,
-            "description": "Optional working-hours template keyed by weekday (e.g. {\"monday\": \"09:00-17:00\"}). Null means 24/7 availability.",
+            "description": "Optional working-hours template keyed by weekday (e.g. {\"monday\": \"09:00-17:00\"}). A weekday that is OMITTED means the resource is closed that day. Omit it, do not send null: OpenRegister's validator reads JSON-Schema types and rejects null against type \"string\" regardless of the OpenAPI `nullable` keyword, which is honoured only at the TOP level of a schema and never inside a nested object's additionalProperties. Sending null is what dropped the seeded Calendar below (\"Property 'workingHours.saturday' should be type 'string' but is 'null'\"). A null value for the whole workingHours object still means 24/7 availability — that is top-level and is accepted.",
             "additionalProperties": {
               "type": "string",
               "nullable": true
             },
             "example": {
               "monday": "09:00-17:00",
-              "saturday": null,
-              "sunday": null
+              "friday": "09:00-17:00"
             },
             "title": "Working Hours"
           },
@@ -263,9 +262,7 @@
           "tuesday": "09:00-17:00",
           "wednesday": "09:00-17:00",
           "thursday": "09:00-17:00",
-          "friday": "09:00-17:00",
-          "saturday": null,
-          "sunday": null
+          "friday": "09:00-17:00"
         },
         "organization": "org-001",
         "status": "active"
@@ -284,8 +281,7 @@
           "wednesday": "08:00-18:00",
           "thursday": "08:00-18:00",
           "friday": "08:00-18:00",
-          "saturday": "09:00-13:00",
-          "sunday": null
+          "saturday": "09:00-13:00"
         },
         "organization": "org-001",
         "status": "active"
@@ -304,8 +300,7 @@
           "wednesday": "10:00-18:00",
           "thursday": "10:00-18:00",
           "friday": "10:00-20:00",
-          "saturday": "10:00-16:00",
-          "sunday": null
+          "saturday": "10:00-16:00"
         },
         "organization": "org-001",
         "status": "active"


### PR DESCRIPTION
The defect #515 fixed in `bookings-resource-calendar.json` is **still live in the parallel file** `10-bookings-resource-calendar.json`. Three seeded Calendars are silently dropped at import on `development` today.

## Mechanism

OpenRegister's validator reads JSON-Schema types and rejects `null` against `type: "string"`. The OpenAPI `nullable` keyword is honoured **only at the top level of a schema** and is ignored inside a nested object — here, inside `workingHours`' `additionalProperties`. A weekday sent as `null` therefore fails validation and the **whole Calendar object is dropped**, logged and not raised.

⚠️ A null value for the **whole** `workingHours` object still means 24/7 and is still accepted — that is top-level, where `nullable` *is* honoured. Only the nested per-weekday nulls are rejected. The two cases look identical in the schema and behave oppositely.

## Measured live, two arms, identical apart from the weekend keys

```
ARM A  workingHours: {monday:"09:00-17:00", saturday:null, sunday:null}
       -> REJECTED  Property 'workingHours.saturday' should be type 'string' but is 'null'
ARM B  workingHours: {monday:"09:00-17:00"}                    <- POSITIVE CONTROL
       -> ACCEPTED  uuid=bd9630c7-1875-4a48-9998-2f1fdfd9b8a4
```

⚠️ **My first probe was invalid and said nothing.** Both arms failed on a missing required `resource`, so they agreed for a reason unrelated to the thing under test. **A control that fails on both arms is not a control** — I nearly recorded "null is fine here" from it.

## Scope, by structural sweep rather than text match

Keyed on a **null-valued weekday property** across all 232 JSON files under `lib/Settings`:

| ref | null weekday keys |
|---|---:|
| `origin/development` | **6** — POSITIVE CONTROL, the instrument finds them |
| this branch | **0** |

Four are in seeds, across **3 Calendar objects** (`components/objects[5]`, `[6]`, `[7]`). The other two were in the schema's own `example`, which taught the wrong pattern to the next author — corrected too, and the property `description` now states the rule **and the reason**, so it cannot be read as arbitrary.

🔑 A text grep for `"saturday": null` would have missed two of these: they carry a real Saturday and only `sunday` is null. **Key the sweep on the shape, not on the string.**

## Relationship to #496

#496 fixed the *other* file and is superseded by #515, but it also carried a regression (three `x-openregister-relations` definitions deleted with no `$ref` replacement). This PR takes the part that is still needed and leaves that regression behind.

## Not verified

- I confirmed the **mechanism** on both arms and swept the **seed data** structurally, but I did not re-run the full register import end-to-end and count Calendars before/after. The three objects are established as currently-rejected; the post-fix import is inferred from ARM B rather than observed at import time.