### PR TITLE
chore(quality): adopt the central PHPStan base config

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -516,16 +516,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.7.0",
+            "version": "v1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "b9c6520a648468ab2055ba4ce498348b31ab1f57"
+                "reference": "487e8d235b650a211328d5dfd1dbf90531b26436"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/b9c6520a648468ab2055ba4ce498348b31ab1f57",
-                "reference": "b9c6520a648468ab2055ba4ce498348b31ab1f57",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/487e8d235b650a211328d5dfd1dbf90531b26436",
+                "reference": "487e8d235b650a211328d5dfd1dbf90531b26436",
                 "shasum": ""
             },
             "require": {
@@ -564,9 +564,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.7.0"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.7.1"
             },
-            "time": "2026-08-12T09:38:06+00:00"
+            "time": "2026-08-12T12:57:31+00:00"
         },
         {
             "name": "consolidation/annotated-command",
@@ -8158,9 +8158,9 @@
         "php": "^8.3",
         "ext-zip": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,24 +1,24 @@
+# Shillinq — Conduction PHPStan config.
+#
+# The shared base is the single source of truth. Everything here is either the
+# app's own tracked debt or an ignore naming a symbol that exists in no other
+# fleet app. Anything you are tempted to add that another app would also need
+# belongs in the base, not here.
 includes:
-    # Per-app tracked lint debt lives here (auto-generated via `phpstan --generate-baseline`).
-    # Apps without debt ship an empty baseline file; canonical includes are otherwise byte-identical
-    # across the fleet.
+    - vendor/conduction/hydra-gates/quality-config/phpstan-base.neon
+    # Per-app tracked lint debt (auto-generated via `phpstan --generate-baseline`).
     - phpstan-baseline.neon
 
 parameters:
-    level: 5
-    paths:
-        - lib
-    bootstrapFiles:
-        - phpstan-bootstrap.php
+    # App-specific only. The base already sets level, paths, bootstrapFiles,
+    # excludePaths, scanDirectories and every fleet-wide ignore.
+
     # PHPDoc @return bool / @return array types are often intentionally broader than the
     # inferred type (e.g. SimpleXMLElement methods, third-party SDKs). Treating PHPDoc
     # types as certain causes spurious `=== true/false` / `=== null` "always false" errors.
     treatPhpDocTypesAsCertain: false
+
     excludePaths:
-        - vendor
-        - vendor-bin
-        # Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt).
-        - lib/Resources/template
         # CustomerBridgeMetricsService implements OCA\OpenRegister\AppHost\IMetricsProvider which is
         # unavailable at analysis time (cross-app interface, present only at runtime). PHPStan requires
         # excludePaths for this class of error (not suppressible via ignoreErrors or baseline).
@@ -40,28 +40,8 @@ parameters:
         # OCA\OpenRegister\Lifecycle\LifecycleActionInterface — same non-ignorable
         # "implements unknown interface" class as the guards above.
         - lib/Lifecycle/Action/AppendReopenHistoryAction.php
-    scanDirectories:
-        - vendor/nextcloud/ocp
-    reportUnmatchedIgnoredErrors: false
+
     ignoreErrors:
-        # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp
-        - '#Call to an undefined method OC::#'
-        - '#Class OC not found#'
-        - '#Access to static property \$server on an unknown class OC#'
-        - '#unknown class OC\\#'
-        - '#Caught class OC\\#'
-        - '#unknown class OC_App#'
-        - '#Class OC_App not found#'
-        # OCA\DAV is server-internal and not in nextcloud/ocp stubs
-        - '#unknown class OCA\\DAV\\#'
-        - '#Class OCA\\DAV\\#'
-        # OCA classes from other apps (OpenRegister) not available during static analysis
-        - '#unknown class OCA\\OpenRegister\\#'
-        - '#OCA\\OpenRegister\\[a-zA-Z\\]+.*not found#'
-        - '#on an unknown class OCA\\OpenRegister\\#'
-        - '#has invalid return type OCA\\OpenRegister\\#'
-        - '#has invalid type OCA\\OpenRegister\\#'
-        - '#implements unknown interface OCA\\OpenRegister\\#'
         # OCA\Decidesk (decision module) — cross-app dep, present only at runtime
         - '#unknown class OCA\\Decidesk\\#'
         - '#OCA\\Decidesk\\[a-zA-Z\\]+.*not found#'
@@ -97,23 +77,10 @@ parameters:
         - '#Instantiated class PhpOffice\\#'
         - '#Call to method .+ on an unknown class PhpOffice\\#'
         - '#Call to static method .+ on an unknown class PhpOffice\\#'
-        # GuzzleHttp is available at runtime via Nextcloud but not in composer require
-        - '#unknown class GuzzleHttp\\#'
-        - '#GuzzleHttp\\[a-zA-Z\\]+.*not found#'
-        - '#on an unknown class GuzzleHttp\\#'
-        - '#invalid type GuzzleHttp\\#'
-        - '#Caught class GuzzleHttp\\#'
-        # Doctrine\DBAL is shipped by Nextcloud server but not stubbed in nextcloud/ocp
-        - '#unknown class Doctrine\\DBAL\\#'
-        - '#Doctrine\\DBAL\\[a-zA-Z\\]+.*not found#'
-        - '#on an unknown class Doctrine\\DBAL\\#'
         # AuthorizedAdminSetting attribute — NC allows passing the app-id string (e.g. Application::APP_ID)
         # at runtime; PHPStan's attribute ctor type is stricter (class-string<IDelegatedSettings>).
         # This is intentional: all controllers use the fleet-canonical app-id pattern.
         - '#Parameter (\#\d+ )?\$settings of attribute class OCP\\AppFramework\\Http\\Attribute\\AuthorizedAdminSetting#'
-        # Dynamic HTTP status codes from business rule validation results
-        # (matches both `Parameter $statusCode` and `Parameter #N $statusCode` forms emitted by phpstan)
-        - '#Parameter (\#\d+ )?\$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'
         # DataResponse body type — NC31's DataResponseType generic is `array<int|string,mixed>|string|int|bool|float|null`
         # but PHPStan infers stricter union types for complex nested arrays and string bodies (e.g. markdown/PDF).
         # At runtime DataResponse accepts any serialisable value; the mismatch is a PHPStan generic inference gap.
@@ -124,13 +91,6 @@ parameters:
         # RuleEngine::providerSeedObjects narrows via class_implements, but PHPStan still sees
         # CheckProvider (the base type) which does not declare seedObjects().
         - '#Call to an undefined static method OCA\\Shillinq\\Standards\\Checks\\CheckProvider::seedObjects#'
-        # registerRepairStep exists on server; not yet in nextcloud/ocp stub used for analysis
-        - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerRepairStep#'
-        # OCP stub gaps for methods that exist at runtime
-        - '#Call to an undefined method OCP\\IRequest::getContent\(\)#'
-        - '#Call to an undefined method OCP\\IRequest::setParameter\(\)#'
-        - '#Call to an undefined method OCP\\Mail\\IMessage::attachFile\(\)#'
-        - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::jsonSerialize#'
         # OpenRegister's stoppable pre-save events (ObjectCreatingEvent /
         # ObjectUpdatingEvent) declare setErrors(); they are cross-app classes
         # absent at analysis time, so PHPStan only sees the OCP base Event and


### PR DESCRIPTION
## What

`phpstan.neon` now includes the shared base that ships in `conduction/hydra-gates`
(`quality-config/phpstan-base.neon`). Everything the base already provides — level,
paths, bootstrapFiles, excludePaths, scanDirectories and the fleet-wide ignore list —
is removed from the app file. What stays is only what is genuinely local:

- the app's own `phpstan-baseline.neon` include
- `treatPhpDocTypesAsCertain: false`
- six `excludePaths` entries for classes implementing cross-app OpenRegister
  interfaces available only at runtime
- thirty-one ignores this app alone needs: the Decidesk, DocuDesk and Pipelinq
  cross-app types, the `PhpOffice` family, `AuthorizedAdminSetting`, `DataResponse`'s
  generic bound, the Dompdf `ReflectionClass` narrowing, `CheckProvider::seedObjects`,
  and OpenRegister's `setErrors()` veto contract

This is step 2b of the Nextcloud CI/CD alignment programme.

## Why hydra-gates moves to v1.7.1

v1.7.0 shipped the base file with bare relative paths. PHPStan resolves a relative
path against the directory of the config that *declares* it, so `lib` there meant
`vendor/conduction/hydra-gates/quality-config/lib` and the run aborted before
analysing anything. v1.7.1 prefixes every path with `%currentWorkingDirectory%/`.
`composer.lock` is regenerated for that one package; nothing else moved.

## How it was verified

`phpstan dump-parameters` was captured on both sides in a PHP 8.3 container. The five
load-bearing keys — level, paths, excludePaths, bootstrapFiles, scanDirectories —
resolve byte-identically, same sha256 over the extracted block. The analysis ran over
669 files before and 669 files after, with 11 findings before and 11 after — and not merely the same count: the eleven error lines are byte-identical, same messages in the same files at the same lines. They are pre-existing return-type and array-offset debt on `development`, untouched by this change.
The remaining difference in the full parameter dump is the extra ignore patterns the
base contributes (ContextChat, SystemTag, Bookmarks), which can only suppress, never
add.

The method was positive-controlled on the first app migrated: dropping an app-local
ignore makes real errors appear, and adding an entry under `paths` moves the resolved
key — so a byte-identical comparison here is a result, not an instrument that reports
"same" whatever it is fed.

## Scope

Only PHPStan files. `phpmd.xml`, stylelint and prettier are untouched here; a
separate change covers those.
