### PR TITLE
chore(deps): pin @conduction/nextcloud-vue to 2.2.0-vue3.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.1",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@conduction/nextcloud-vue": "2.2.0-vue3.9",
+        "@conduction/nextcloud-vue": "2.2.0-vue3.16",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "~2.5.2",
         "@nextcloud/capabilities": "^1.2.1",
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.2.0-vue3.9",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.9.tgz",
-      "integrity": "sha512-9HC1dhYfCqw7JeZ3mn4Zr260iBCWlWa/1slrPTdmIbODvbWlf82guAZEnMq17XvWmDJRcAVNBzYtIT2kWwZutA==",
+      "version": "2.2.0-vue3.16",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.16.tgz",
+      "integrity": "sha512-eqKSYzS8hrvqzedbgwAch5M/rn2uPEBDBccZZPIRVZ/XrQMYd0yzseTCLyalsBDrWtdb9HoTOp5OBW+p2WFdwQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "extends @nextcloud/browserslist-config"
   ],
   "dependencies": {
-    "@conduction/nextcloud-vue": "2.2.0-vue3.9",
+    "@conduction/nextcloud-vue": "2.2.0-vue3.16",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "~2.5.2",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
Moves the pin from `2.2.0-vue3.9` to `2.2.0-vue3.16`, the current `vue3` dist-tag — a seven-prerelease jump.

## Why

`scripts/` — 13 shared check scripts including `check-integration-parity.js` — first appears in the published tarball at 2.2.0-vue3.14. On `2.2.0-vue3.9` this app ships hydra gate-24 with no checker to find, so the gate verifies nothing. vue3.16 additionally fixes that checker so it can no longer report a pass while correlating nothing.

Confirmed present after install: `node_modules/@conduction/nextcloud-vue/scripts/` with all 13 scripts.

## Lockfile

Regenerated with **npm 10.8.2** to match the Node 20 / npm 10 toolchain CI uses. npm 11 drops nested entries under `node_modules/@nextcloud/vue/node_modules/` that npm 10 keeps, which makes `npm ci` reject the lock and fails every npm job — including License and Security, which never touch Vue. Nested entry count unchanged at 10; total package count unchanged at 1493. `npm ci` verified from a clean `node_modules`.

Exact pin retained deliberately — a caret on a prerelease line silently pulls in component changes.

## Verification (measured locally, after the bump)

| check | result |
|---|---|
| `npm ci` (clean tree) | pass |
| `npm run build` | pass |
| `npm run test:unit` | 15 files / 171 tests pass |
| `npm run lint` (eslint) | pass |
| `npm run stylelint` | pass |

Everything is green, so no `development` comparison was needed to attribute a failure. No call-site migration was required despite the seven-prerelease jump. Only `package.json` and `package-lock.json` are touched.