### PR TITLE
fix(quality): close the phpstan/psalm/phpmd cells the vocabulary renames left red

### DIFF
--- a/lib/Repair/RenameDutchColumns.php
+++ b/lib/Repair/RenameDutchColumns.php
@@ -439,8 +439,8 @@ class RenameDutchColumns implements IRepairStep {
 			}
 
 			foreach ($wanted as $marker) {
-				$at = strpos($name, $marker);
-				if ($at !== false && ctype_digit(substr($name, ($at + strlen($marker)))) === true) {
+				$offset = strpos($name, $marker);
+				if ($offset !== false && ctype_digit(substr($name, ($offset + strlen($marker)))) === true) {
 					$tables[] = $name;
 				}
 			}

--- a/lib/Service/BIKStaffelCalculator.php
+++ b/lib/Service/BIKStaffelCalculator.php
@@ -162,8 +162,8 @@ class BIKStaffelCalculator {
 	 * Calculate the BIK staffel breakdown for an outstanding principal.
 	 *
 	 * Returns the shape expected on IncassoKostenBerekening.berekening per
-	 * REQ-CCD-003: five slab amounts, the gross totaal, the statutory minimum
-	 * and maximum, toegepast = min(max(totaal, minimum), maximum), and the
+	 * REQ-CCD-003: five slab amounts, the gross total, the statutory minimum
+	 * and maximum, toegepast = min(max(total, minimum), maximum), and the
 	 * BTW-over-incassokosten surcharge (art. 2 lid 2 Besluit BIK) when the
 	 * creditor cannot offset VAT.
 	 *
@@ -171,7 +171,7 @@ class BIKStaffelCalculator {
 	 * @param bool $btwVerrekenbaar True when the creditor CAN offset VAT (no surcharge). Default true.
 	 * @param float $btwPercentage VAT rate applied when !btwVerrekenbaar (default 21%).
 	 *
-	 * @return array{schaal1_0_2500:float,schaal2_2500_5000:float,schaal3_5000_10000:float,schaal4_10000_200000:float,schaal5_200000plus:float,totaal:float,minimum:float,maximum:float,toegepast:float,btwVerrekenbaar:bool,btwPercentage:float,btwBedrag:float,toegepastInclBtw:float}
+	 * @return array{schaal1_0_2500:float,schaal2_2500_5000:float,schaal3_5000_10000:float,schaal4_10000_200000:float,schaal5_200000plus:float,total:float,minimum:float,maximum:float,toegepast:float,btwVerrekenbaar:bool,btwPercentage:float,vatAmount:float,toegepastInclBtw:float}
 	 *
 	 * @spec openspec/specs/bookkeeping-credit-control-dunning/spec.md
 	 */
@@ -252,7 +252,7 @@ class BIKStaffelCalculator {
 	 * @param float|null $tariefB2B Override the B2B handelsrente (flat, skips the table).
 	 * @param float|null $tariefB2C Override the B2C wettelijke rente (flat, skips the table).
 	 *
-	 * @return array{tarief:float,type:string,ingangsdatum:string,berekendOp:string,dagen:int,bedrag:float,perioden:array<int,array{van:string,tot:string,dagen:int,tarief:float,bedrag:float}>}
+	 * @return array{tarief:float,type:string,ingangsdatum:string,berekendOp:string,dagen:int,amount:float,perioden:array<int,array{van:string,tot:string,dagen:int,tarief:float,amount:float}>}
 	 *
 	 * @spec openspec/specs/bookkeeping-credit-control-dunning/spec.md
 	 */

--- a/lib/Service/EmuReportingService.php
+++ b/lib/Service/EmuReportingService.php
@@ -414,14 +414,14 @@ class EmuReportingService {
 	 *
 	 * Maps the eight EMUAdjustment macro types and the BBV saldo + computed
 	 * EMU-saldo to the 10-row CBS kwartaal-EMU template. Returns a
-	 * regelnummer-keyed array; each row carries label + bedrag (EUR, signed).
+	 * regelnummer-keyed array; each row carries label + amount (EUR, signed).
 	 * Pure function — caller is responsible for exporting (XBRL/CSV/Excel).
 	 *
 	 * @param float $bbvSaldoBatenLasten BBV saldo baten/lasten (EUR).
 	 * @param array<int,array<string,mixed>> $adjustments EMUAdjustment object arrays.
 	 * @param float $emuSaldoBerekend Computed EMU-saldo (EUR).
 	 *
-	 * @return array<int,array{regel:int,label:string,bedrag:float}> The 10 CBS-tussenregels.
+	 * @return array<int,array{regel:int,label:string,amount:float}> The 10 CBS-tussenregels.
 	 *
 	 * @spec openspec/specs/bookkeeping-emu-reporting/spec.md
 	 */

--- a/lib/Service/IntegralCostPriceCalculator.php
+++ b/lib/Service/IntegralCostPriceCalculator.php
@@ -114,7 +114,7 @@ class IntegralCostPriceCalculator {
 				continue;
 			}
 
-			$amount = (float)($line['amount'] ?? $line['amount'] ?? 0);
+			$amount = (float)($line['amount'] ?? 0);
 			if ($amount < 0) {
 				// Credit notes / reversals are subtracted (sign-preserved).
 				$totalCents += $this->toCents(amount: $amount);

--- a/lib/Service/IntegralCostPriceCalculator.php
+++ b/lib/Service/IntegralCostPriceCalculator.php
@@ -93,6 +93,8 @@ class IntegralCostPriceCalculator {
 	 * @param string $accountKind One of `loonkosten`, `materialen`, `afschrijvingen`.
 	 *
 	 * @return int Sum of matching GL lines in cents.
+	 *
+	 * @spec openspec/specs/bookkeeping-market-government-separation/spec.md#req-wmo-002
 	 */
 	public function sumDirectCosts(array $glLines, string $kostenplaats, string $kostendrager, string $accountKind): int {
 		$totalCents = 0;

--- a/lib/Service/KorMonitorService.php
+++ b/lib/Service/KorMonitorService.php
@@ -69,8 +69,8 @@ class KorMonitorService {
 	 * @param int $year Calendar year to report.
 	 *
 	 * @return array{
-	 *   administrationId:string, jaar:int, lopendeOmzet:float, drempel:float,
-	 *   drempelBenutting:float, perMaand:array<string,float>, prognoseEindeJaar:float,
+	 *   administrationId:string, year:int, currentRevenue:float, drempel:float,
+	 *   drempelBenutting:float, perMaand:array<string,float>, forecastYearEnd:float,
 	 *   prognoseStatus:string, ernst:?string, trigger:?string, optOutPermitted:bool
 	 * }
 	 *

--- a/lib/Service/KorThresholdCalculator.php
+++ b/lib/Service/KorThresholdCalculator.php
@@ -302,7 +302,7 @@ class KorThresholdCalculator {
 	 *
 	 * @param string $ingangsDatum KOR-NL effective date (YYYY-MM-DD).
 	 *
-	 * @return array{lockInEindDatum:string,vroegsteOpzegDatum:string}|null Window or null on invalid input.
+	 * @return array{lockInEndDate:string,vroegsteOpzegDatum:string}|null Window or null on invalid input.
 	 *
 	 * @spec openspec/specs/bookkeeping-kor-kleine-ondernemersregeling/spec.md
 	 */
@@ -400,7 +400,7 @@ class KorThresholdCalculator {
 	 * @param array<string,float> $drempelsPerLidstaat Per-country drempel (EUR); e.g. ['BE' => 25000, 'DE' => 22000].
 	 * @param int $year Calendar year to bound the aggregation.
 	 *
-	 * @return array<string,array{omzet:float,drempel:float,benutting:float}> Per-lidstaat aggregate.
+	 * @return array<string,array{revenue:float,drempel:float,benutting:float}> Per-lidstaat aggregate.
 	 *
 	 * @spec openspec/specs/bookkeeping-kor-kleine-ondernemersregeling/spec.md
 	 */

--- a/lib/Service/ProgrammaAggregator.php
+++ b/lib/Service/ProgrammaAggregator.php
@@ -39,15 +39,15 @@ class ProgrammaAggregator {
 	/**
 	 * Aggregate the child Taakvelden into a Programma's totals.
 	 *
-	 * Computes batenTotaal = Σ(Taakveld.baten); lastenTotaal = Σ(Taakveld.lasten);
-	 * saldoVoorMutaties = batenTotaal - lastenTotaal; saldoNaMutaties =
-	 * saldoVoorMutaties + mutatiesReserves. All sums are accumulated in integer
+	 * Computes revenueTotal = Σ(Taakveld.baten); expensesTotal = Σ(Taakveld.lasten);
+	 * balanceBeforeMovements = revenueTotal - expensesTotal; balanceAfterMovements =
+	 * balanceBeforeMovements + mutatiesReserves. All sums are accumulated in integer
 	 * cents to guarantee the programma-view equals the taakveld-view exactly.
 	 *
 	 * @param array<int,array<string,mixed>> $taakvelden The child Taakveld rows.
 	 * @param float $mutatiesReserves The reserve mutation (positive = toevoeging).
 	 *
-	 * @return array{batenTotaal:float,lastenTotaal:float,saldoVoorMutaties:float,saldoNaMutaties:float}
+	 * @return array{revenueTotal:float,expensesTotal:float,balanceBeforeMovements:float,balanceAfterMovements:float}
 	 *
 	 * @spec openspec/changes/bookkeeping-programmabegroting/tasks.md#task-24
 	 */

--- a/lib/Service/SluitendCalculator.php
+++ b/lib/Service/SluitendCalculator.php
@@ -53,7 +53,7 @@ class SluitendCalculator {
 	 * @param array<string,mixed> $year The meerjarenraming year row.
 	 * @param float $nominaleOntwikkeling The loon- en prijsindexatie percentage (e.g. 2.0).
 	 *
-	 * @return array{saldoStructureel:float,saldoIncidenteel:float,saldoReëel:float,sluitendStructureel:bool,sluitendReëel:bool,sluitend:bool}
+	 * @return array{balanceStructural:float,balanceIncidental:float,saldoReëel:float,sluitendStructureel:bool,sluitendReëel:bool,sluitend:bool}
 	 *
 	 * @spec openspec/changes/bookkeeping-programmabegroting/tasks.md#task-19
 	 */

--- a/lib/Service/UrenTallyService.php
+++ b/lib/Service/UrenTallyService.php
@@ -74,14 +74,14 @@ final class UrenTallyService {
 	 * Aggregate UrenDagregistratie entries for one day.
 	 *
 	 * Returns:
-	 *  - totaalUren: float — sum of counted hours after cap and category filter.
+	 *  - totalHours: float — sum of counted hours after cap and category filter.
 	 *  - perCategorie: array<string, float> — counted hours per category.
 	 *  - overages: array<int, array{categorie: string, ingevoerd: float, geteld: float, notitie: string}>
 	 *    — entries whose hours exceeded a category cap.
 	 *
 	 * @param array<int, array<string, mixed>> $entries Day entries.
 	 *
-	 * @return array{totaalUren: float, perCategorie: array<string, float>, overages: array<int, array<string, mixed>>}
+	 * @return array{totalHours: float, perCategorie: array<string, float>, overages: array<int, array<string, mixed>>}
 	 *
 	 * @spec openspec/changes/zzp-urencriterium-tracker/tasks.md#task-11
 	 */


### PR DESCRIPTION
## What this closes

Three quality cells have been red on every `development` push run since the
vocabulary renames landed. All three are the same class of defect — a rename
that moved the code but not the thing describing it — and none of them is an
application behaviour change.

**PHPStan (eleven errors).** Nine services declare their return value as an
array shape in the docblock; the renames changed the keys the code actually
emits and left those shapes naming the old keys. Two further errors were
consumers reading a key that the stale shape claimed did not exist, so they
resolve once the producer is corrected. Fixed by aligning each shape to what the
method returns today. Keys that are still Dutch at runtime are left alone — that
is the vocabulary batches' work and a runtime rename there is a data migration.

**Psalm (one error).** The same rename seen from the other side: a two-arm
null-coalesce in the integral cost-price calculator had both arms renamed to the
same key, leaving `$line['amount'] ?? $line['amount'] ?? 0`. The second arm was
unreachable by construction, so collapsing it to a single arm is provably
equivalent to what shipped. Swept the whole tree for the same shape with a
regex carrying a positive control against the pre-fix blob — the control fires,
the working tree is clean, so this was the only instance.

**PHPMD (one finding).** An unrelated two-character variable name in the rename
migration, renamed to `$offset`.

## How it was verified

Every check below was run on PHP 8.4 against this branch's tree, and each
verdict is the tool's own exit status plus its own summary line, not a marker of
mine:

- PHPStan exits 0 and prints its no-errors summary, from eleven errors before.
- Psalm exits 0 and prints its no-errors banner, from one error before.
- PHPMD exits 0 over both the app ruleset and the shared unused-params ruleset.
- PHPCS exits 0.
- The unit suite is 4114 tests, 43355 assertions, exit 0.

The before-state was reproduced locally first, matching the failing run's
findings exactly — same file, same line, same count in all three tools — so the
after-state is measured against a reproduction, not against a description.

Refs #533, #534
