### PR TITLE
fix(seeds): every seeded DepreciationSchedule was orphaned from its FixedAsset

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Util\ObjectIdentifier;
 use OCP\App\IAppManager;
 use OCP\IAppConfig;
 use OCP\IGroupManager;
@@ -538,10 +539,9 @@ class SettingsService {
 					$skippedAssets++;
 					// Cache the existing UUID for schedule linking.
 					$firstRow = $existing[0];
-					if (is_array($firstRow) === true && isset($firstRow['id']) === true) {
-						$assetUuidByNumber[$asset['assetNumber']] = (string)$firstRow['id'];
-					} elseif (is_object($firstRow) === true && method_exists($firstRow, 'getId') === true) {
-						$assetUuidByNumber[$asset['assetNumber']] = (string)$firstRow->getId();
+					$existingUuid = ObjectIdentifier::resolve(saved: $firstRow);
+					if ($existingUuid !== '') {
+						$assetUuidByNumber[$asset['assetNumber']] = $existingUuid;
 					}
 
 					continue;
@@ -554,10 +554,9 @@ class SettingsService {
 				);
 				$seededAssets++;
 
-				if (is_array($saved) === true && isset($saved['id']) === true) {
-					$assetUuidByNumber[$asset['assetNumber']] = (string)$saved['id'];
-				} elseif (is_object($saved) === true && method_exists($saved, 'getId') === true) {
-					$assetUuidByNumber[$asset['assetNumber']] = (string)$saved->getId();
+				$savedUuid = ObjectIdentifier::resolve(saved: $saved);
+				if ($savedUuid !== '') {
+					$assetUuidByNumber[$asset['assetNumber']] = $savedUuid;
 				}
 			}//end foreach
 

--- a/lib/Settings/register.d/bookkeeping-single-audit-eu-fondsen.json
+++ b/lib/Settings/register.d/bookkeeping-single-audit-eu-fondsen.json
@@ -1402,7 +1402,7 @@
       },
       "AuditTrail": {
         "slug": "AuditTrail",
-        "icon": "ClipboardTextClockOutline",
+        "icon": "History",
         "version": "0.1.0",
         "title": "Audit-trail",
         "description": "Onveranderlijk append-only event-log voor alle EU-fondsen state-transities (boeking → declaratie → certificering → betaling → correctie → audit) met before/after-state en bewijs-URI (REQ-EUF-009, art 69 + 82 CPR). Maakt 5+ jaar reconstructie na project-sluiting mogelijk.",

--- a/tests/Unit/Service/SettingsServiceFixedAssetLinkTest.php
+++ b/tests/Unit/Service/SettingsServiceFixedAssetLinkTest.php
@@ -1,0 +1,307 @@
+<?php
+
+/**
+ * Unit tests for the asset -> schedule link in SettingsService::seedFixedAssetsDemo().
+ *
+ * The shipped code resolved the saved FixedAsset's identifier with
+ * `method_exists($saved, 'getId')`. OpenRegister's `ObjectEntity` reaches every
+ * `get*` accessor through `OCP\AppFramework\Db\Entity::__call()`, so that probe
+ * is permanently FALSE, neither arm ran, and `$assetUuidByNumber` stayed empty.
+ *
+ * The consumer then guards the assignment with `isset($assetUuidByNumber[...])`
+ * and saves the schedule ANYWAY — so every seeded DepreciationSchedule was
+ * written without `assetRef`, with `assetNumber` already unset, and the link
+ * could not be reconstructed afterwards. Nothing threw and nothing was logged
+ * (shillinq#527).
+ *
+ * ⚠️ Two distinct wrong answers are possible here, so this file carries a
+ * control for each:
+ *
+ *   1. The ORIGINAL defect — no `assetRef` key at all.
+ *   2. The PLAUSIBLE WRONG REPAIR — `property_exists($saved,'id')` then
+ *      `getId()`, which yields the numeric bigint row id. `assetRef` is a
+ *      declared relation to `FixedAsset.id`, which OpenRegister renders as the
+ *      UUID, so that repair stores a dangling reference. A test that only
+ *      asserts "assetRef is present" passes that repair.
+ *
+ * Therefore every assertion below is on the VALUE, and the numeric row id is
+ * asserted absent by name.
+ *
+ * ⚠️ The shared stub at `tests/stubs/OpenRegister/Db/ObjectEntity.php` declares
+ * `getId()` and `getUuid()` concretely, which INVERTS the predicate under test.
+ * The double in this file therefore mirrors the real entity's shape — magic
+ * accessors via `__call`, a concrete `jsonSerialize()` — and one test asserts
+ * that shape so a future edit cannot quietly make this file vacuous.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/bookkeeping-fixed-assets-depreciation/tasks.md#task-15
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Service;
+
+use OCA\Shillinq\Service\SettingsService;
+use OCP\App\IAppManager;
+use OCP\IAppConfig;
+use OCP\IGroupManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests that every seeded DepreciationSchedule carries its asset's UUID.
+ */
+class SettingsServiceFixedAssetLinkTest extends TestCase {
+
+	/**
+	 * The numeric bigint row id a saveObject() return yields from getId().
+	 *
+	 * Asserted ABSENT from every assetRef — it is the wrong identifier space.
+	 *
+	 * @var integer
+	 */
+	private const ROW_ID = 7;
+
+	/**
+	 * The fake ObjectService the service under test is handed.
+	 *
+	 * @var object
+	 */
+	private object $objectService;
+
+	/**
+	 * Build a SettingsService wired to a recording fake ObjectService.
+	 *
+	 * @return SettingsService
+	 */
+	private function service(): SettingsService {
+		$appManager = $this->createMock(IAppManager::class);
+		$appManager->method('isInstalled')->willReturn(true);
+		$appManager->method('isEnabledForUser')->willReturn(true);
+
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willReturn($this->objectService);
+
+		return new SettingsService(
+			$this->createMock(IAppConfig::class),
+			$appManager,
+			$container,
+			$this->createMock(IGroupManager::class),
+			$this->createMock(IUserSession::class),
+			$this->createMock(LoggerInterface::class)
+		);
+
+	}//end service()
+
+	/**
+	 * Stand up the recording fake before each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// phpcs:disable Generic.Commenting.DocComment,Squiz.Commenting,PEAR.Commenting
+		$this->objectService = new class(self::ROW_ID) {
+			/** @var array<int,array<string,mixed>> */
+			public array $savedSchedules = [];
+
+			/** @var array<string,string> */
+			public array $assetUuids = [];
+
+			private string $schema = '';
+
+			public function __construct(
+				private int $rowId,
+			) {
+			}
+
+			public function setRegister(string $register): static {
+				return $this;
+			}
+
+			public function setSchema(string $schema): static {
+				$this->schema = $schema;
+				return $this;
+			}
+
+			/**
+			 * Nothing exists yet, so every seed row takes the create path.
+			 */
+			public function findAll(array $query = []): array {
+				return [];
+			}
+
+			public function saveObject(array $object, string $register, string $schema): object {
+				if ($schema === 'DepreciationSchedule') {
+					$this->savedSchedules[] = $object;
+					return $this->entity(uuid: 'schedule-' . count($this->savedSchedules));
+				}
+
+				// A FixedAsset. Mint a per-asset UUID the test can assert against.
+				$uuid = 'uuid-' . $object['assetNumber'];
+				$this->assetUuids[$object['assetNumber']] = $uuid;
+				return $this->entity(uuid: $uuid);
+			}
+
+			/**
+			 * A double shaped like the REAL ObjectEntity, not like the caller's
+			 * wishes: getId()/getUuid() are magic, jsonSerialize() is concrete
+			 * and renders `id` as the UUID.
+			 */
+			public function entity(string $uuid): object {
+				return new class($uuid, $this->rowId) {
+					/**
+					 * Both backing properties are declared, exactly as on the real
+					 * ObjectEntity — `property_exists()` must answer TRUE for `id`
+					 * AND `uuid`, or the wrong-repair control below cannot fire.
+					 */
+					public function __construct(
+						private string $uuid,
+						private int $id,
+					) {
+					}
+
+					public function __call(string $name, array $arguments): mixed {
+						return match ($name) {
+							'getId' => $this->id,
+							'getUuid' => $this->uuid,
+							default => throw new \BadMethodCallException($name),
+						};
+					}
+
+					public function jsonSerialize(): array {
+						return ['id' => $this->uuid, 'name' => 'probe'];
+					}
+				};
+			}
+		};
+		// phpcs:enable Generic.Commenting.DocComment,Squiz.Commenting,PEAR.Commenting
+
+	}//end setUp()
+
+	/**
+	 * The double must mirror the real entity's shape, not the caller's wishes.
+	 *
+	 * Fixture-faithfulness assertion. If this fails, every other test in this
+	 * file has stopped testing the defect it is named for.
+	 *
+	 * @return void
+	 */
+	public function testTheDoubleIsFaithfulToTheRealEntityShape(): void {
+		$entity = $this->objectService->entity(uuid: 'probe-uuid');
+
+		$this->assertFalse(
+			method_exists($entity, 'getId'),
+			'getId() must be magic on the double, as it is on the real ObjectEntity'
+		);
+		$this->assertFalse(
+			method_exists($entity, 'getUuid'),
+			'getUuid() must be magic on the double, as it is on the real ObjectEntity'
+		);
+		$this->assertTrue(
+			method_exists($entity, 'jsonSerialize'),
+			'POSITIVE CONTROL: jsonSerialize() is concrete on the real ObjectEntity'
+		);
+		$this->assertTrue(
+			property_exists($entity, 'id'),
+			'the real ObjectEntity declares $id, so the wrong-repair control can fire'
+		);
+		$this->assertTrue(
+			property_exists($entity, 'uuid'),
+			'the real ObjectEntity declares $uuid, which is what the correct probe reads'
+		);
+
+	}//end testTheDoubleIsFaithfulToTheRealEntityShape()
+
+	/**
+	 * The seed must actually run, so a later zero is a measurement not an artefact.
+	 *
+	 * POSITIVE CONTROL for the assertions below: without this, "no schedule is
+	 * missing its assetRef" would also be satisfied by no schedule being saved.
+	 *
+	 * @return void
+	 */
+	public function testTheSeedReachesTheScheduleWritePath(): void {
+		$result = $this->service()->seedFixedAssetsDemo(administrationId: 'adm-1');
+
+		$this->assertTrue($result['success'], 'seed must succeed for the rest to mean anything');
+		$this->assertNotEmpty($this->objectService->assetUuids, 'assets must have been saved');
+		$this->assertCount(
+			count($this->objectService->assetUuids),
+			$this->objectService->savedSchedules,
+			'the demo seed pairs one schedule with each asset'
+		);
+
+	}//end testTheSeedReachesTheScheduleWritePath()
+
+	/**
+	 * Every seeded schedule carries its asset's UUID in assetRef.
+	 *
+	 * Asserts the VALUE, not merely the key: the plausible wrong repair
+	 * (`property_exists('id')` + `getId()`) supplies the key with the numeric
+	 * bigint row id, which is a dangling reference into a UUID-typed relation.
+	 *
+	 * @return void
+	 */
+	public function testEverySeededScheduleLinksToItsAssetByUuid(): void {
+		$this->service()->seedFixedAssetsDemo(administrationId: 'adm-1');
+
+		$linked = [];
+		foreach ($this->objectService->savedSchedules as $schedule) {
+			$this->assertArrayHasKey(
+				'assetRef',
+				$schedule,
+				'a schedule saved without assetRef is orphaned from its asset for good — '
+				. 'assetNumber is unset before the write, so the link cannot be rebuilt'
+			);
+			$this->assertNotSame(
+				(string)self::ROW_ID,
+				$schedule['assetRef'],
+				'assetRef must be the UUID; the numeric row id is a different identifier '
+				. 'space and stores a dangling reference'
+			);
+			$linked[] = $schedule['assetRef'];
+		}
+
+		// Each schedule points at the UUID minted for ITS OWN asset, so a fix
+		// that linked every schedule to the same (e.g. last) asset also fails.
+		$this->assertSame(
+			array_values($this->objectService->assetUuids),
+			$linked,
+			'each schedule must carry the UUID of the asset it names'
+		);
+
+	}//end testEverySeededScheduleLinksToItsAssetByUuid()
+
+	/**
+	 * The asset number is still stripped before the write.
+	 *
+	 * Pins the behaviour the defect made irreversible: the schedule payload
+	 * drops assetNumber, so assetRef is the only surviving link.
+	 *
+	 * @return void
+	 */
+	public function testAssetNumberIsStrippedFromTheStoredSchedule(): void {
+		$this->service()->seedFixedAssetsDemo(administrationId: 'adm-1');
+
+		foreach ($this->objectService->savedSchedules as $schedule) {
+			$this->assertArrayNotHasKey('assetNumber', $schedule);
+		}
+
+	}//end testAssetNumberIsStrippedFromTheStoredSchedule()
+
+}//end class


### PR DESCRIPTION
Closes #527.

## The defect

`SettingsService::seedFixedAssetsDemo()` seeds `FixedAsset` rows and then links
each seeded `DepreciationSchedule` to its asset. **The link was never made.**

Both resolution sites asked `method_exists($saved, 'getId')`. OpenRegister's
`ObjectEntity` reaches every `get*` accessor through
`OCP\AppFramework\Db\Entity::__call()`, so that probe is permanently false and
neither arm ever ran. The lookup map stayed empty.

What makes this worse than a missed link is the consumer. It guards the
assignment with `isset()`, then **saves the schedule anyway** — and
`assetNumber` has already been unset by that point. So the schedule is written
with no reference to its asset and no field from which the reference could be
rebuilt afterwards. Nothing threw, nothing was logged, and the seed reported
success.

## The fix

Both sites now call the existing `ObjectIdentifier::resolve()`. That helper was
extracted precisely so this logic is not re-derived per call site, and it
already carries the reasoning for why neither the original probe nor the obvious
repair is correct — including which identifier space the value has to be in.

## Why there are two controls, not one

There are two distinct wrong answers available here, so the tests are built to
separate them, and both predictions were written down before either was run:

- Restoring the shipped probe fails one test on the **missing key**.
- Applying the plausible repair — probe the backing property, then call the
  numeric accessor — fails the **same** test on the **value**, because that
  accessor answers in the row-id space while the relation is declared against
  the UUID. It would store a dangling reference: strictly worse than the dead
  path it replaces, and invisible until something tries to follow it.

Both fired exactly as predicted. The second is the one that matters: a test
asserting only that `assetRef` is present would have passed that repair and
certified a new defect as a fix.

The double mirrors the real entity's shape rather than the caller's wishes —
magic accessors, a concrete serialiser, and **both** backing properties
declared, since without the second the wrong-repair control could not fire at
all. One test asserts that shape, so a future edit cannot quietly make this file
vacuous. This matters here because the shared entity stub in the test tree
declares those accessors concretely and therefore inverts the exact predicate
under test.

## Also in this PR

The one blocking icon finding: the EU-fondsen `AuditTrail` schema used a
non-canonical icon for the audit-trail concept. Every other audit-trail surface
in this app already uses the canonical one. Re-measured with the checker the
gate runs: the blocking count goes to zero; the remaining advisory findings are
untouched and still reported.

## Verified

Unit suite 4118 tests, exit 0. PHPCS, PHPStan and PHPMD all exit 0. The register
and seed validators both exit 0, the seed validator still at its baseline.

## Deliberately NOT in this PR

The guard-tag registration in #526. The identifier repair has to be understood
first — registering the tag ahead of it converts a path that currently refuses
into one that writes, and an unlinked write here accumulates silently.
