### PR TITLE
fix(budget): an unreadable commitment amount was approved as zero

### DIFF
--- a/lib/Lifecycle/BudgetBlocker.php
+++ b/lib/Lifecycle/BudgetBlocker.php
@@ -204,7 +204,33 @@ class BudgetBlocker {
 			return false;
 		}
 
-		return $this->fits(budget: $budget, bedrag: (int)($regel['amount_excl_vat'] ?? 0));
+		// AN UNREADABLE AMOUNT IS NOT A ZERO AMOUNT.
+		//
+		// This used to be `(int) ($regel['amount_excl_vat'] ?? 0)`, so a regel
+		// carrying its amount under any other key produced 0 — and `fits()` is
+		// `$bedrag <= freeRoom()`, so 0 fits every budget that is not already
+		// overcommitted. The commitment was then APPROVED against a figure that
+		// had never been read: a budget control passing for the wrong reason
+		// (CWE-863).
+		//
+		// Deny instead. Fail-closed matches the rest of this guard — a missing
+		// Budget row above already denies.
+		if (array_key_exists('amount_excl_vat', $regel) === false
+			|| is_numeric($regel['amount_excl_vat']) === false
+		) {
+			$this->logger->error(
+				'BudgetBlocker: regel carries no readable amount — denying commitment (fail-closed)',
+				[
+					'administrationId' => $administrationId,
+					'programme' => ($regel['programme'] ?? null),
+					'financialYear' => ($regel['financialYear'] ?? null),
+					'regelKeys' => array_keys($regel),
+				]
+			);
+			return false;
+		}
+
+		return $this->fits(budget: $budget, bedrag: (int)$regel['amount_excl_vat']);
 	}//end regelFitsBudget()
 
 	/**

--- a/tests/Unit/Lifecycle/BudgetBlockerTest.php
+++ b/tests/Unit/Lifecycle/BudgetBlockerTest.php
@@ -367,4 +367,74 @@ class BudgetBlockerTest extends TestCase {
 		$this->assertFalse($this->guard->canCommit('PO-1', $this->commitment(1000000)));
 
 	}//end testFailClosedOnException()
+
+	/**
+	 * A regel whose amount cannot be read is DENIED, not treated as zero.
+	 *
+	 * The shipped code coalesced a missing amount to 0, and `fits()` is
+	 * `$bedrag <= freeRoom()`, so every unreadable regel fitted every budget
+	 * that was not already overcommitted — the commitment was approved against
+	 * a figure nothing had read (CWE-863).
+	 *
+	 * The amount here (EUR 5.000.000) is far beyond the free room, so the
+	 * ONLY way this can return true is the coalesce-to-zero path. That makes
+	 * the assertion unable to pass for an unrelated reason.
+	 *
+	 * @return void
+	 */
+	public function testRegelWithUnreadableAmountIsDenied(): void {
+		$this->withObjectService(
+			$this->buildObjectServiceStub(['Budget' => [$this->budget()], 'Mandaat' => []])
+		);
+
+		$commitment = $this->commitment(500000000);
+		// The amount arrives under a key this guard does not read — exactly what
+		// a vocabulary drift on either side of the flow produces.
+		$commitment['regels'][0]['bedrag_excl_btw'] = $commitment['regels'][0]['amount_excl_vat'];
+		unset($commitment['regels'][0]['amount_excl_vat']);
+
+		$this->assertFalse(
+			$this->guard->canCommit('PO-1', $commitment),
+			'an unreadable amount must deny, not coalesce to a zero that fits every budget'
+		);
+
+	}//end testRegelWithUnreadableAmountIsDenied()
+
+	/**
+	 * A non-numeric amount is DENIED for the same reason.
+	 *
+	 * `array_key_exists()` alone would accept `'onbekend'`, which `(int)` casts
+	 * to 0 — the same fail-open through a different door.
+	 *
+	 * @return void
+	 */
+	public function testRegelWithNonNumericAmountIsDenied(): void {
+		$this->withObjectService(
+			$this->buildObjectServiceStub(['Budget' => [$this->budget()], 'Mandaat' => []])
+		);
+
+		$commitment = $this->commitment(500000000);
+		$commitment['regels'][0]['amount_excl_vat'] = 'onbekend';
+
+		$this->assertFalse($this->guard->canCommit('PO-1', $commitment));
+
+	}//end testRegelWithNonNumericAmountIsDenied()
+
+	/**
+	 * POSITIVE CONTROL: a readable amount within free room is still allowed.
+	 *
+	 * Without this, the two denials above would also be satisfied by a guard
+	 * that had started denying everything — which is precisely how a
+	 * fail-closed repair goes wrong.
+	 *
+	 * @return void
+	 */
+	public function testReadableAmountWithinBudgetIsStillAllowed(): void {
+		$this->withObjectService(
+			$this->buildObjectServiceStub(['Budget' => [$this->budget()], 'Mandaat' => []])
+		);
+
+		$this->assertTrue($this->guard->canCommit('PO-1', $this->commitment(10000000)));
+
+	}//end testReadableAmountWithinBudgetIsStillAllowed()
 }//end class


### PR DESCRIPTION
Refs #498 — this is that PR's security half, **ported rather than merged**, and
the reason for porting it is itself a finding.

## The defect, and it is still live on `development`

`BudgetBlocker::regelFitsBudget()` coalesced a missing regel amount to zero, and
`fits()` compares that amount against the budget's free room. **Zero fits every
budget that is not already overcommitted.** So a regel whose amount the guard
could not read was not rejected and was not flagged — it was approved, against a
figure nothing had ever looked at. A budget control that passes for the wrong
reason (CWE-863).

An unreadable amount is not a zero amount. It now denies, which is the posture
the rest of the method already takes: a missing Budget row above it denies too.
Both doors are closed — the key being absent, and the key being present but not
numeric, because a non-numeric string also casts to zero.

## Why this is not just a merge of #498

⚠️ **#498 guards a key that no longer exists.** It was written against
`bedrag_excl_btw`. The vocabulary renames have since moved this field, and both
the fail-open and every surrounding lookup on `development` are on the new
spelling. Merging #498's fix as written would have been worse than doing
nothing twice over: it would not have closed the fail-open, and its new
fail-closed branch — testing for a key that is never present — would have denied
every commitment in the app.

The defect #498 describes is real and was unfixed. Only its address had changed.

## The controls

The two denial tests use an amount far beyond the free room, so the only way
either can pass is through the coalesce-to-zero path. They cannot go green for
an unrelated reason.

The third test is the one that keeps the other two honest: it asserts that a
readable, in-budget commitment is **still allowed**. The characteristic way a
fail-closed repair goes wrong is by denying everything, and two denial
assertions cannot tell a fix apart from that.

Negative control, predicted before it was run: restoring the coalesce fails
exactly the two denial tests and leaves the positive control green. That is what
happened.

## Verified

Unit suite 4117 tests, exit 0. PHPCS exit 0.

⚠️ **Two cells are red on this branch and were already red on `development`
before it existed** — the static-analysis debt the vocabulary renames left
behind, in files this branch does not touch. They are fixed by a separate PR
that is in flight; once that lands, a rebase clears them here. The counts on
this branch are identical to the counts on the base, which is how I know this
change contributes none of them.
