### PR TITLE
feat(format): adopt Nextcloud's prettier config, so styles are tabs too

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,18 @@
+# Build output, vendored trees and the separate Docusaurus site.
+js/
+dist/
+build/
+node_modules/
+vendor/
+coverage/
+coverage-frontend/
+coverage-vitest/
+docs/
+docusaurus/
+website/
+playwright-report/
+test-results/
+*.min.*
+# Written by the translation workflow — a formatter here would fight its own
+# generator on every run.
+l10n/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,12 +1,8 @@
-const {
-	defineConfig,
-} = require('@eslint/config-helpers')
+const { defineConfig } = require('@eslint/config-helpers')
 
 const js = require('@eslint/js')
 
-const {
-	FlatCompat,
-} = require('@eslint/eslintrc')
+const { FlatCompat } = require('@eslint/eslintrc')
 
 // The `@nextcloud` v8 base is Vue-2 era: on its own it activates ZERO
 // `vue/no-deprecated-*` rules, so Vue-2 idioms (`beforeDestroy`, `.sync`,
@@ -20,9 +16,7 @@ const {
 //
 // CJS: the extensionless subpath works because the package ships no `exports`
 // map. From ESM this would need `/eslint/index.js`.
-const {
-	conductionVue3Fixes,
-} = require('@conduction/nextcloud-vue/eslint')
+const { conductionVue3Fixes } = require('@conduction/nextcloud-vue/eslint')
 
 const compat = new FlatCompat({
 	baseDirectory: __dirname,
@@ -30,37 +24,60 @@ const compat = new FlatCompat({
 	allConfig: js.configs.all,
 })
 
-module.exports = defineConfig([{
-	extends: compat.extends('@nextcloud'),
+module.exports = defineConfig([
+	{
+		extends: compat.extends('@nextcloud'),
 
-	settings: {
-		'import/resolver': {
-			alias: {
-				map: [
-					['@', './src'],
-					['@floating-ui/dom-actual', './node_modules/@floating-ui/dom'],
-				],
-				extensions: ['.js', '.ts', '.vue', '.json', '.css'],
+		settings: {
+			'import/resolver': {
+				alias: {
+					map: [
+						['@', './src'],
+						[
+							'@floating-ui/dom-actual',
+							'./node_modules/@floating-ui/dom',
+						],
+					],
+					extensions: ['.js', '.ts', '.vue', '.json', '.css'],
+				},
 			},
 		},
-	},
 
-	rules: {
-		// Allow unused i18n functions (t, n) — imported for future translation wiring
-		'no-unused-vars': ['error', { varsIgnorePattern: '^(t|n)$', argsIgnorePattern: '^_' }],
-		'jsdoc/require-jsdoc': 'off',
-		'jsdoc/check-tag-names': ['warn', { definedTags: ['spec'] }],
-		'jsdoc/escape-inline-tags': 'off',
-		'vue/first-attribute-linebreak': 'off',
-		'@typescript-eslint/no-explicit-any': 'off',
-		'n/no-missing-import': 'off',
-		'import/namespace': 'off',
-		'import/default': 'off',
-		'import/no-named-as-default': 'off',
-		'import/no-named-as-default-member': 'off',
-		'import/no-unresolved': ['error', { ignore: ['^@conduction/nextcloud-vue'] }],
+		rules: {
+			// Allow unused i18n functions (t, n) — imported for future translation wiring
+			'no-unused-vars': [
+				'error',
+				{ varsIgnorePattern: '^(t|n)$', argsIgnorePattern: '^_' },
+			],
+			'jsdoc/require-jsdoc': 'off',
+			'jsdoc/check-tag-names': ['warn', { definedTags: ['spec'] }],
+			'jsdoc/escape-inline-tags': 'off',
+			'vue/first-attribute-linebreak': 'off',
+			'@typescript-eslint/no-explicit-any': 'off',
+			'n/no-missing-import': 'off',
+			'import/namespace': 'off',
+			'import/default': 'off',
+			'import/no-named-as-default': 'off',
+			'import/no-named-as-default-member': 'off',
+			'import/no-unresolved': [
+				'error',
+				{ ignore: ['^@conduction/nextcloud-vue'] },
+			],
+		},
 	},
-},
-// Spread LAST so the Vue-3 rules win over the Vue-2 @nextcloud base.
-...conductionVue3Fixes,
+	// Spread LAST so the Vue-3 rules win over the Vue-2 @nextcloud base.
+	...conductionVue3Fixes,
+	// eslint-config-prettier LAST OF ALL, and it has to be: it only turns rules
+	// OFF — every stylistic rule prettier now owns (indent, quotes,
+	// operator-linebreak, comma-dangle…). Anything spread after it would switch
+	// some of them back on, and eslint and prettier would then demand opposite
+	// things — the unfixable state this fleet already hit once with php-cs-fixer
+	// and PHPCS.
+	//
+	// It disables no CORRECTNESS rule: the whole `vue/no-deprecated-*` family
+	// stays present and ON, because prettier has no opinion about them.
+	// `indent` is now off HERE and enforced by prettier's `useTabs: true`
+	// instead — the same tab, from the tool that also covers CSS and SCSS,
+	// which @nextcloud/stylelint-config no longer does.
+	require('eslint-config-prettier'),
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@nextcloud/browserslist-config": "^3.0.1",
         "@nextcloud/eslint-config": "^8.4.1",
         "@nextcloud/eslint-plugin": "^2.0.0",
+        "@nextcloud/prettier-config": "^1.2.0",
         "@nextcloud/stylelint-config": "^2.4.0",
         "@nextcloud/webpack-vue-config": "^7.0.2",
         "@playwright/test": "^1.49.0",
@@ -59,6 +60,7 @@
         "babel-loader": "^10.1.1",
         "css-loader": "~7.1.1",
         "eslint": "^8.56.0",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-config-standard": "^17.1.0",
         "eslint-import-resolver-alias": "^1.1.2",
         "eslint-import-resolver-exports": "^1.0.0-beta.5",
@@ -70,6 +72,7 @@
         "eslint-plugin-vue": "^9.21.1",
         "node-polyfill-webpack-plugin": "^4.0.0",
         "postcss-html": "^1.8.1",
+        "prettier": "^3.9.6",
         "sass": "^1.99.0",
         "sass-loader": "^16.0.8",
         "style-loader": "~4.0.0",
@@ -2903,6 +2906,19 @@
       "license": "GPL-3.0-or-later",
       "engines": {
         "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+      }
+    },
+    "node_modules/@nextcloud/prettier-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/prettier-config/-/prettier-config-1.2.0.tgz",
+      "integrity": "sha512-6XPGOy3X0ZHw5Yho7ti7F8TguI68/uq55UtwhRbTRMmdO/uGLAHn9BA0nzwlGPbs0xFPwUoYPSuPJDA6rcAXlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-plugin-packagejson": "^2.5.10"
+      },
+      "peerDependencies": {
+        "prettier": ">=3.5.0"
       }
     },
     "node_modules/@nextcloud/router": {
@@ -8302,6 +8318,19 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "node_modules/detect-indent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.2.tgz",
+      "integrity": "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -8311,6 +8340,19 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-4.0.1.tgz",
+      "integrity": "sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/devlop": {
@@ -9077,6 +9119,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-config-standard": {
@@ -10574,6 +10632,16 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/git-hooks-list": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-4.2.1.tgz",
+      "integrity": "sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
       }
     },
     "node_modules/github-from-package": {
@@ -15554,6 +15622,40 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-packagejson": {
+      "version": "2.5.22",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.22.tgz",
+      "integrity": "sha512-G6WalmoUssKF8ZXkni0+n4324K+gG143KPysSQNW+FrR0XyNb3BdRxchGC/Q1FE/F702p7/6KU7r4mv0WSWbzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sort-package-json": "3.6.0"
+      },
+      "peerDependencies": {
+        "prettier": ">= 1.16.0"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/proc-log": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
@@ -17491,6 +17593,61 @@
       "optional": true,
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/sort-object-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-2.1.0.tgz",
+      "integrity": "sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sort-package-json": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.6.0.tgz",
+      "integrity": "sha512-fyJsPLhWvY7u2KsKPZn1PixbXp+1m7V8NWqU8CvgFRbMEX41Ffw1kD8n0CfJiGoaSfoAvbrqRRl/DcHO8omQOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-indent": "^7.0.2",
+        "detect-newline": "^4.0.1",
+        "git-hooks-list": "^4.1.1",
+        "is-plain-obj": "^4.1.0",
+        "semver": "^7.7.3",
+        "sort-object-keys": "^2.0.1",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "sort-package-json": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/sort-package-json/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sort-package-json/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/sortablejs": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "test:e2e:docs": "playwright test --project docs-capture",
     "test:e2e:install": "playwright install chromium",
     "stylelint": "stylelint \"src/**/*.{vue,scss,css}\"",
+    "format": "prettier --check \"**/*.{js,ts,vue,css,scss}\"",
+    "format:fix": "prettier --write \"**/*.{js,ts,vue,css,scss}\"",
     "stylelint-fix": "stylelint \"src/**/*.vue\" \"src/**/*.scss\" \"src/**/*.css\" --fix",
     "prepare": "git config core.hooksPath .githooks || true"
   },
@@ -78,6 +80,7 @@
     "@nextcloud/browserslist-config": "^3.0.1",
     "@nextcloud/eslint-config": "^8.4.1",
     "@nextcloud/eslint-plugin": "^2.0.0",
+    "@nextcloud/prettier-config": "^1.2.0",
     "@nextcloud/stylelint-config": "^2.4.0",
     "@nextcloud/webpack-vue-config": "^7.0.2",
     "@playwright/test": "^1.49.0",
@@ -94,6 +97,7 @@
     "babel-loader": "^10.1.1",
     "css-loader": "~7.1.1",
     "eslint": "^8.56.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-config-standard": "^17.1.0",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-exports": "^1.0.0-beta.5",
@@ -105,6 +109,7 @@
     "eslint-plugin-vue": "^9.21.1",
     "node-polyfill-webpack-plugin": "^4.0.0",
     "postcss-html": "^1.8.1",
+    "prettier": "^3.9.6",
     "sass": "^1.99.0",
     "sass-loader": "^16.0.8",
     "style-loader": "~4.0.0",
@@ -119,5 +124,6 @@
     "webpack": "^5.94.0",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^6.0.0"
-  }
+  },
+  "prettier": "@nextcloud/prettier-config"
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -59,7 +59,11 @@ export default defineConfig({
 		// PR pipelines don't reshoot screenshots on every push.
 		{
 			name: 'chromium',
-			testIgnore: ['**/docs-screenshots.spec.ts', '**/bookings-screenshots.spec.ts', '**/visual/**'],
+			testIgnore: [
+				'**/docs-screenshots.spec.ts',
+				'**/bookings-screenshots.spec.ts',
+				'**/visual/**',
+			],
 			use: {
 				...devices['Desktop Chrome'],
 				// Pick up the authenticated storage state globalSetup wrote.

--- a/public/inventoryServiceWorker.js
+++ b/public/inventoryServiceWorker.js
@@ -36,24 +36,32 @@ const STATIC_ASSETS = [
 
 self.addEventListener('install', (event) => {
 	event.waitUntil(
-		caches.open(CACHE_STATIC).then((cache) => cache.addAll(STATIC_ASSETS).catch(() => null)),
+		caches
+			.open(CACHE_STATIC)
+			.then((cache) => cache.addAll(STATIC_ASSETS).catch(() => null)),
 	)
 	self.skipWaiting()
 })
 
 self.addEventListener('activate', (event) => {
 	event.waitUntil(
-		caches.keys().then((keys) => Promise.all(
-			keys
-				.filter((key) => !key.startsWith(VERSION))
-				.map((key) => caches.delete(key)),
-		)),
+		caches
+			.keys()
+			.then((keys) =>
+				Promise.all(
+					keys
+						.filter((key) => !key.startsWith(VERSION))
+						.map((key) => caches.delete(key)),
+				),
+			),
 	)
 	self.clients.claim()
 })
 
-const isApiRequest = (url) => url.pathname.includes('/apps/shillinq/api/v1/inventory/')
-const isImageRequest = (req) => req.destination === 'image' || /\.(png|jpg|jpeg|svg|webp)$/i.test(req.url)
+const isApiRequest = (url) =>
+	url.pathname.includes('/apps/shillinq/api/v1/inventory/')
+const isImageRequest = (req) =>
+	req.destination === 'image' || /\.(png|jpg|jpeg|svg|webp)$/i.test(req.url)
 
 self.addEventListener('fetch', (event) => {
 	const req = event.request
@@ -97,7 +105,7 @@ async function cacheFirstWithExpiry(req, cacheName, maxAgeMs) {
 	const cached = await cache.match(req)
 	if (cached) {
 		const stored = cached.headers.get('x-sw-cached-at')
-		const age = stored ? (Date.now() - Number(stored)) : Infinity
+		const age = stored ? Date.now() - Number(stored) : Infinity
 		if (Number.isFinite(age) && age < maxAgeMs) {
 			return cached
 		}
@@ -108,7 +116,11 @@ async function cacheFirstWithExpiry(req, cacheName, maxAgeMs) {
 			const headers = new Headers(response.headers)
 			headers.set('x-sw-cached-at', String(Date.now()))
 			const body = await response.clone().blob()
-			const stamped = new Response(body, { status: response.status, statusText: response.statusText, headers })
+			const stamped = new Response(body, {
+				status: response.status,
+				statusText: response.statusText,
+				headers,
+			})
 			cache.put(req, stamped)
 		}
 		return response

--- a/scripts/generate-manifest-shell.js
+++ b/scripts/generate-manifest-shell.js
@@ -111,7 +111,8 @@ function buildShellFragment(fragment, fragmentStem) {
  * @return {{fragments: Array<object>}} The shell document.
  */
 function generateShellDocument(dir = MANIFEST_D_DIR) {
-	const files = fs.readdirSync(dir)
+	const files = fs
+		.readdirSync(dir)
 		.filter((name) => name.endsWith('.json'))
 		.sort()
 
@@ -137,8 +138,8 @@ function main() {
 	// eslint-disable-next-line no-console
 	console.log(
 		`[generate-manifest-shell] wrote ${SHELL_OUTPUT_PATH} `
-		+ `(${shell.fragments.length} fragments, `
-		+ `${shell.fragments.reduce((n, f) => n + f.pages.length, 0)} pages)`,
+			+ `(${shell.fragments.length} fragments, `
+			+ `${shell.fragments.reduce((n, f) => n + f.pages.length, 0)} pages)`,
 	)
 }
 
@@ -146,4 +147,9 @@ if (require.main === module) {
 	main()
 }
 
-module.exports = { generateShellDocument, buildShellFragment, slimPages, SHELL_PAGE_KEYS }
+module.exports = {
+	generateShellDocument,
+	buildShellFragment,
+	slimPages,
+	SHELL_PAGE_KEYS,
+}

--- a/src/api/accountantApi.js
+++ b/src/api/accountantApi.js
@@ -36,7 +36,9 @@ export async function fetchAccountantDashboard() {
  * @return {void}
  */
 export function downloadHandoverPack(administrationId, period) {
-	let url = generateUrl(`/apps/shillinq/api/accountant/administrations/${encodeURIComponent(administrationId)}/handover-pack`)
+	let url = generateUrl(
+		`/apps/shillinq/api/accountant/administrations/${encodeURIComponent(administrationId)}/handover-pack`,
+	)
 	if (period) {
 		url += `?period=${encodeURIComponent(period)}`
 	}

--- a/src/api/invoiceApi.js
+++ b/src/api/invoiceApi.js
@@ -42,7 +42,9 @@ async function get(invoiceId) {
  * @return {Promise<object>} The posted invoice.
  */
 async function post(invoiceId) {
-	const { data } = await axios.post(base('/' + encodeURIComponent(invoiceId) + '/post'))
+	const { data } = await axios.post(
+		base('/' + encodeURIComponent(invoiceId) + '/post'),
+	)
 	return data
 }
 
@@ -69,7 +71,7 @@ async function exportPdf(invoiceId) {
  */
 async function list(filters = {}) {
 	const { data } = await axios.get(base(''), { params: filters })
-	return Array.isArray(data) ? data : (data?.invoices || [])
+	return Array.isArray(data) ? data : data?.invoices || []
 }
 
 export default { generate, get, post, exportPdf, list }

--- a/src/components/AdministratieSwitcher.vue
+++ b/src/components/AdministratieSwitcher.vue
@@ -46,7 +46,9 @@
 				:close-after-click="true"
 				@click="onSelect(administration.administrationId)">
 				<template #icon>
-					<CheckBold v-if="administration.administrationId === activeId" :size="18" />
+					<CheckBold
+						v-if="administration.administrationId === activeId"
+						:size="18" />
 					<OfficeBuildingOutline v-else :size="18" />
 				</template>
 				{{ formatLabel(administration) }}
@@ -205,7 +207,11 @@ export default {
 				const response = await switchAdministration(administrationId)
 				this.activeId = response.activeAdministrationId
 				this.$emit('switched', this.activeId)
-				if (this.reloadAfterSwitch && typeof window !== 'undefined' && window.location) {
+				if (
+					this.reloadAfterSwitch
+					&& typeof window !== 'undefined'
+					&& window.location
+				) {
 					window.location.reload()
 				}
 			} catch (error) {
@@ -215,7 +221,10 @@ export default {
 				} else if (status === 401) {
 					this.errorMessage = t('shillinq', 'Not authenticated')
 				} else {
-					this.errorMessage = t('shillinq', 'Failed to switch administration')
+					this.errorMessage = t(
+						'shillinq',
+						'Failed to switch administration',
+					)
 				}
 				this.$emit('error', error)
 			} finally {

--- a/src/components/BudgetBBVMapping/BBVProgrammePicker.vue
+++ b/src/components/BudgetBBVMapping/BBVProgrammePicker.vue
@@ -105,11 +105,17 @@ export default {
 			if (!this.modelValue) {
 				return null
 			}
-			const match = this.options.find((o) => o.value === String(this.modelValue))
+			const match = this.options.find(
+				(o) => o.value === String(this.modelValue),
+			)
 			if (match) {
 				return match
 			}
-			return { value: String(this.modelValue), display: String(this.modelValue), programme: null }
+			return {
+				value: String(this.modelValue),
+				display: String(this.modelValue),
+				programme: null,
+			}
 		},
 	},
 	watch: {
@@ -162,21 +168,31 @@ export default {
 					params.administrationId = this.administrationId
 				}
 				const response = await axios.get(
-					generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}`),
+					generateUrl(
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}`,
+					),
 					{ params },
 				)
-				const rows = response.data?.results ?? response.data?.objects ?? response.data ?? []
+				const rows =
+					response.data?.results
+					?? response.data?.objects
+					?? response.data
+					?? []
 				this.programmes = Array.isArray(rows) ? rows : []
 				if (this.modelValue) {
-					const match = this.programmes.find((p) =>
-						String(p.programmeCode || p.id) === String(this.modelValue))
+					const match = this.programmes.find(
+						(p) =>
+							String(p.programmeCode || p.id)
+							=== String(this.modelValue),
+					)
 					if (match) {
 						this.$emit('selected', match)
 					}
 				}
 			} catch (e) {
 				this.programmes = []
-				this.fetchError = e?.response?.data?.error
+				this.fetchError =
+					e?.response?.data?.error
 					|| this.t('shillinq', 'Failed to load BBV programmes.')
 			} finally {
 				this.loading = false

--- a/src/components/BudgetBBVMapping/BudgetBBVMappingDetail.vue
+++ b/src/components/BudgetBBVMapping/BudgetBBVMappingDetail.vue
@@ -51,7 +51,11 @@
 			:sidebar-open="false"
 			object-type="bbv-budget-mapping"
 			:object-id="recordId || ''"
-			:sidebar-props="{ register: 'shillinq', schema: 'BudgetBBVMapping', title: t('shillinq', 'Mapping audit trail') }">
+			:sidebar-props="{
+				register: 'shillinq',
+				schema: 'BudgetBBVMapping',
+				title: t('shillinq', 'Mapping audit trail'),
+			}">
 			<template #actions>
 				<button
 					type="button"
@@ -90,7 +94,10 @@
 							:administration-id="form.administrationId"
 							data-testid="bbv-mapping-detail-gl"
 							@selected="onGlAccountSelected" />
-						<p v-if="selectedAccount" class="bbv-mapping-detail__hint" data-testid="bbv-mapping-detail-gl-hint">
+						<p
+							v-if="selectedAccount"
+							class="bbv-mapping-detail__hint"
+							data-testid="bbv-mapping-detail-gl-hint">
 							{{ glAccountSummary }}
 						</p>
 					</div>
@@ -102,12 +109,16 @@
 							:fiscal-year="fiscalYearOfMapping"
 							data-testid="bbv-mapping-detail-programme"
 							@selected="onProgrammeSelected" />
-						<p v-if="selectedProgramme" class="bbv-mapping-detail__hint" data-testid="bbv-mapping-detail-programme-hint">
+						<p
+							v-if="selectedProgramme"
+							class="bbv-mapping-detail__hint"
+							data-testid="bbv-mapping-detail-programme-hint">
 							{{ programmeSummary }}
 						</p>
 					</div>
 
-					<div class="bbv-mapping-detail__row bbv-mapping-detail__row--inline">
+					<div
+						class="bbv-mapping-detail__row bbv-mapping-detail__row--inline">
 						<label class="bbv-mapping-detail__field">
 							<span>{{ t('shillinq', 'Allocation (%)') }}</span>
 							<input
@@ -118,7 +129,7 @@
 								step="0.01"
 								data-testid="bbv-mapping-detail-allocation"
 								class="bbv-mapping-detail__input"
-								@input="scheduleAllocationCheck">
+								@input="scheduleAllocationCheck" />
 						</label>
 						<label class="bbv-mapping-detail__field">
 							<span>{{ t('shillinq', 'Effective from') }}</span>
@@ -127,7 +138,7 @@
 								type="date"
 								data-testid="bbv-mapping-detail-effective-from"
 								class="bbv-mapping-detail__input"
-								@change="scheduleAllocationCheck">
+								@change="scheduleAllocationCheck" />
 						</label>
 						<label class="bbv-mapping-detail__field">
 							<span>{{ t('shillinq', 'Effective to') }}</span>
@@ -135,7 +146,7 @@
 								v-model="form.effectiveTo"
 								type="date"
 								data-testid="bbv-mapping-detail-effective-to"
-								class="bbv-mapping-detail__input">
+								class="bbv-mapping-detail__input" />
 						</label>
 						<label class="bbv-mapping-detail__field">
 							<span>{{ t('shillinq', 'Status') }}</span>
@@ -143,8 +154,12 @@
 								v-model="form.status"
 								class="bbv-mapping-detail__input"
 								data-testid="bbv-mapping-detail-status">
-								<option value="active">{{ t('shillinq', 'Active') }}</option>
-								<option value="archived">{{ t('shillinq', 'Archived') }}</option>
+								<option value="active">
+									{{ t('shillinq', 'Active') }}
+								</option>
+								<option value="archived">
+									{{ t('shillinq', 'Archived') }}
+								</option>
 							</select>
 						</label>
 					</div>
@@ -152,9 +167,11 @@
 					<div
 						v-if="allocationFeedback.message"
 						class="bbv-mapping-detail__alloc"
-						:class="allocationFeedback.severity === 'error'
-							? 'bbv-mapping-detail__alloc--error'
-							: 'bbv-mapping-detail__alloc--info'"
+						:class="
+							allocationFeedback.severity === 'error'
+								? 'bbv-mapping-detail__alloc--error'
+								: 'bbv-mapping-detail__alloc--info'
+						"
 						data-testid="bbv-mapping-detail-alloc-feedback"
 						role="status"
 						aria-live="polite">
@@ -289,17 +306,22 @@ export default {
 			if (!this.form.glAccountNumber || !this.form.programmeCode) {
 				return false
 			}
-			if (this.form.allocationPercentage === null
+			if (
+				this.form.allocationPercentage === null
 				|| this.form.allocationPercentage === undefined
 				|| this.form.allocationPercentage === ''
 				|| Number(this.form.allocationPercentage) < 0
-				|| Number(this.form.allocationPercentage) > 100) {
+				|| Number(this.form.allocationPercentage) > 100
+			) {
 				return false
 			}
 			if (!this.form.effectiveFrom) {
 				return false
 			}
-			if (this.form.effectiveTo && this.form.effectiveTo < this.form.effectiveFrom) {
+			if (
+				this.form.effectiveTo
+				&& this.form.effectiveTo < this.form.effectiveFrom
+			) {
 				return false
 			}
 			if (this.allocationFeedback.severity === 'error') {
@@ -325,9 +347,10 @@ export default {
 			const name = a.accountName || a.name || a.title || ''
 			const type = a.accountType || a.type || ''
 			const balanceCents = a.balance ?? a.balanceCents
-			const balance = balanceCents !== null && balanceCents !== undefined
-				? this.formatEuro(balanceCents)
-				: ''
+			const balance =
+				balanceCents !== null && balanceCents !== undefined
+					? this.formatEuro(balanceCents)
+					: ''
 			const parts = [name, type, balance].filter(Boolean)
 			return parts.join(' · ')
 		},
@@ -369,9 +392,15 @@ export default {
 			this.loadError = ''
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}/${this.recordId}`),
+					generateUrl(
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}/${this.recordId}`,
+					),
 				)
-				const body = response.data?.object ?? response.data?.result ?? response.data ?? null
+				const body =
+					response.data?.object
+					?? response.data?.result
+					?? response.data
+					?? null
 				if (!body || typeof body !== 'object') {
 					throw new Error('Empty response')
 				}
@@ -379,13 +408,16 @@ export default {
 				this.form.glAccountNumber = body.glAccountNumber ?? ''
 				this.form.programmeCode = body.programmeCode ?? ''
 				this.form.allocationPercentage = body.allocationPercentage ?? 0
-				this.form.effectiveFrom = body.effectiveFrom ?? this.defaultEffectiveFrom()
+				this.form.effectiveFrom =
+					body.effectiveFrom ?? this.defaultEffectiveFrom()
 				this.form.effectiveTo = body.effectiveTo ?? ''
 				this.form.status = body.status ?? 'active'
-				this.form.administrationId = body.administrationId ?? this.administrationId ?? ''
+				this.form.administrationId =
+					body.administrationId ?? this.administrationId ?? ''
 				await this.refreshAllocationProjection()
 			} catch (e) {
-				this.loadError = e?.response?.data?.error
+				this.loadError =
+					e?.response?.data?.error
 					|| this.t('shillinq', 'Failed to load mapping.')
 			} finally {
 				this.loading = false
@@ -430,16 +462,26 @@ export default {
 					params.administrationId = adminId
 				}
 				const response = await axios.get(
-					generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}`),
+					generateUrl(
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}`,
+					),
 					{ params },
 				)
-				const rows = response.data?.results ?? response.data?.objects ?? response.data ?? []
+				const rows =
+					response.data?.results
+					?? response.data?.objects
+					?? response.data
+					?? []
 				const others = Array.isArray(rows) ? rows : []
 				const sumOthers = others.reduce((acc, row) => {
 					if (!row || typeof row !== 'object') {
 						return acc
 					}
-					if (!this.isCreate && this.recordId && String(row.id) === this.recordId) {
+					if (
+						!this.isCreate
+						&& this.recordId
+						&& String(row.id) === this.recordId
+					) {
 						return acc
 					}
 					if (!this.overlapsFiscalYear(row, fiscalYear)) {
@@ -450,26 +492,35 @@ export default {
 				}, 0)
 				this.existingAllocationTotal = sumOthers
 				const current = Number(this.form.allocationPercentage ?? 0)
-				const projected = sumOthers + (Number.isFinite(current) ? current : 0)
+				const projected =
+					sumOthers + (Number.isFinite(current) ? current : 0)
 				if (projected > ALLOCATION_OVER_THRESHOLD) {
 					const over = (projected - 100).toFixed(2)
 					this.allocationFeedback = {
 						severity: 'error',
-						message: this.t('shillinq', 'GL {gl} total would be {pct} % — {over} % over 100 %. Reduce the allocation before saving.', {
-							gl,
-							pct: projected.toFixed(2),
-							over,
-						}),
+						message: this.t(
+							'shillinq',
+							'GL {gl} total would be {pct} % — {over} % over 100 %. Reduce the allocation before saving.',
+							{
+								gl,
+								pct: projected.toFixed(2),
+								over,
+							},
+						),
 					}
 				} else {
 					const remaining = Math.max(0, 100 - sumOthers)
 					this.allocationFeedback = {
 						severity: 'info',
-						message: this.t('shillinq', 'GL {gl} total: {sum} % — you can add up to {remaining} %.', {
-							gl,
-							sum: sumOthers.toFixed(2),
-							remaining: remaining.toFixed(2),
-						}),
+						message: this.t(
+							'shillinq',
+							'GL {gl} total: {sum} % — you can add up to {remaining} %.',
+							{
+								gl,
+								sum: sumOthers.toFixed(2),
+								remaining: remaining.toFixed(2),
+							},
+						),
 					}
 				}
 			} catch (e) {
@@ -516,13 +567,17 @@ export default {
 			try {
 				if (this.isCreate) {
 					await axios.post(
-						generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}`),
+						generateUrl(
+							`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}`,
+						),
 						payload,
 					)
 					showSuccess(this.t('shillinq', 'Mapping created.'))
 				} else {
 					await axios.put(
-						generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}/${this.recordId}`),
+						generateUrl(
+							`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}/${this.recordId}`,
+						),
 						payload,
 					)
 					showSuccess(this.t('shillinq', 'Mapping saved.'))
@@ -530,7 +585,8 @@ export default {
 				this.returnToIndex()
 			} catch (e) {
 				const responseError = e?.response?.data
-				this.saveError = (responseError && (responseError.error || responseError.message))
+				this.saveError =
+					(responseError && (responseError.error || responseError.message))
 					|| e?.message
 					|| this.t('shillinq', 'Failed to save mapping.')
 				showError(this.saveError)
@@ -555,14 +611,17 @@ export default {
 			this.deleting = true
 			try {
 				await axios.delete(
-					generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}/${this.recordId}`),
+					generateUrl(
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}/${this.recordId}`,
+					),
 				)
 				showSuccess(this.t('shillinq', 'Mapping deleted.'))
 				this.deleteDialogOpen = false
 				this.returnToIndex()
 			} catch (e) {
 				const responseError = e?.response?.data
-				const message = (responseError && (responseError.error || responseError.message))
+				const message =
+					(responseError && (responseError.error || responseError.message))
 					|| e?.message
 					|| this.t('shillinq', 'Failed to delete mapping.')
 				showError(message)

--- a/src/components/BudgetBBVMapping/BudgetBBVMappingIndex.vue
+++ b/src/components/BudgetBBVMapping/BudgetBBVMappingIndex.vue
@@ -39,7 +39,12 @@
 	<div class="bbv-mapping-index" data-testid="bbv-mapping-index">
 		<CnIndexPage
 			:title="t('shillinq', 'Budget Mapping')"
-			:description="t('shillinq', 'Allocations of GL accounts to BBV programmes (REQ-BBVW-002 / REQ-BBVW-004).')"
+			:description="
+				t(
+					'shillinq',
+					'Allocations of GL accounts to BBV programmes (REQ-BBVW-002 / REQ-BBVW-004).',
+				)
+			"
 			:objects="filteredObjects"
 			:loading="loading"
 			:pagination="pagination"
@@ -56,7 +61,9 @@
 			@row-click="onRowClick"
 			@page-changed="onPageChange">
 			<template #header-actions>
-				<div class="bbv-mapping-index__filters" data-testid="bbv-mapping-index-filters">
+				<div
+					class="bbv-mapping-index__filters"
+					data-testid="bbv-mapping-index-filters">
 					<span
 						v-if="scope.fiscalYear"
 						class="bbv-mapping-index__fy"
@@ -68,9 +75,13 @@
 						type="search"
 						class="bbv-mapping-index__search"
 						data-testid="bbv-mapping-search"
-						:aria-label="t('shillinq', 'Search by GL account or programme code')"
-						:placeholder="t('shillinq', 'Search account or programme...')"
-						@input="onSearchInput">
+						:aria-label="
+							t('shillinq', 'Search by GL account or programme code')
+						"
+						:placeholder="
+							t('shillinq', 'Search account or programme...')
+						"
+						@input="onSearchInput" />
 					<select
 						v-model="fiscalYearFilter"
 						class="bbv-mapping-index__filter"
@@ -94,18 +105,10 @@
 						<option value="">
 							{{ t('shillinq', 'All allocations') }}
 						</option>
-						<option value="0-25">
-							0-25 %
-						</option>
-						<option value="25-50">
-							25-50 %
-						</option>
-						<option value="50-75">
-							50-75 %
-						</option>
-						<option value="75-100">
-							75-100 %
-						</option>
+						<option value="0-25">0-25 %</option>
+						<option value="25-50">25-50 %</option>
+						<option value="50-75">50-75 %</option>
+						<option value="75-100">75-100 %</option>
 					</select>
 					<label class="bbv-mapping-index__date-label">
 						{{ t('shillinq', 'Effective on or after') }}
@@ -113,7 +116,7 @@
 							v-model="effectiveFromAfter"
 							type="date"
 							class="bbv-mapping-index__date"
-							data-testid="bbv-mapping-effective-from-after">
+							data-testid="bbv-mapping-effective-from-after" />
 					</label>
 					<label class="bbv-mapping-index__date-label">
 						{{ t('shillinq', 'Effective on or before') }}
@@ -121,7 +124,7 @@
 							v-model="effectiveFromBefore"
 							type="date"
 							class="bbv-mapping-index__date"
-							data-testid="bbv-mapping-effective-from-before">
+							data-testid="bbv-mapping-effective-from-before" />
 					</label>
 				</div>
 			</template>
@@ -156,7 +159,10 @@
 			</template>
 		</CnIndexPage>
 
-		<p v-if="error" class="bbv-mapping-index__error" data-testid="bbv-mapping-index-error">
+		<p
+			v-if="error"
+			class="bbv-mapping-index__error"
+			data-testid="bbv-mapping-index-error">
 			{{ error }}
 		</p>
 	</div>
@@ -237,12 +243,30 @@ export default {
 		 */
 		columnOverrides() {
 			return {
-				glAccountNumber: { label: this.t('shillinq', 'GL Account'), sortable: true },
-				programmeCode: { label: this.t('shillinq', 'Programme'), sortable: true },
-				allocationPercentage: { label: this.t('shillinq', 'Allocation %'), sortable: true },
-				effectiveFrom: { label: this.t('shillinq', 'Effective From'), sortable: true },
-				effectiveTo: { label: this.t('shillinq', 'Effective To'), sortable: true },
-				lifecycleState: { label: this.t('shillinq', 'Status'), sortable: true },
+				glAccountNumber: {
+					label: this.t('shillinq', 'GL Account'),
+					sortable: true,
+				},
+				programmeCode: {
+					label: this.t('shillinq', 'Programme'),
+					sortable: true,
+				},
+				allocationPercentage: {
+					label: this.t('shillinq', 'Allocation %'),
+					sortable: true,
+				},
+				effectiveFrom: {
+					label: this.t('shillinq', 'Effective From'),
+					sortable: true,
+				},
+				effectiveTo: {
+					label: this.t('shillinq', 'Effective To'),
+					sortable: true,
+				},
+				lifecycleState: {
+					label: this.t('shillinq', 'Status'),
+					sortable: true,
+				},
 			}
 		},
 		/**
@@ -284,10 +308,16 @@ export default {
 		 */
 		filteredObjects() {
 			const term = (this.searchTermApplied || '').trim().toLowerCase()
-			const after = this.effectiveFromAfter ? new Date(this.effectiveFromAfter) : null
-			const before = this.effectiveFromBefore ? new Date(this.effectiveFromBefore) : null
+			const after = this.effectiveFromAfter
+				? new Date(this.effectiveFromAfter)
+				: null
+			const before = this.effectiveFromBefore
+				? new Date(this.effectiveFromBefore)
+				: null
 			const allocation = this.parseAllocationBucket(this.allocationBucket)
-			const yearFilter = this.fiscalYearFilter ? Number(this.fiscalYearFilter) : null
+			const yearFilter = this.fiscalYearFilter
+				? Number(this.fiscalYearFilter)
+				: null
 
 			return (this.objects || []).filter((row) => {
 				if (term) {
@@ -298,8 +328,12 @@ export default {
 					}
 				}
 				if (yearFilter !== null) {
-					const startYear = row.effectiveFrom ? new Date(row.effectiveFrom).getFullYear() : null
-					const endYear = row.effectiveTo ? new Date(row.effectiveTo).getFullYear() : null
+					const startYear = row.effectiveFrom
+						? new Date(row.effectiveFrom).getFullYear()
+						: null
+					const endYear = row.effectiveTo
+						? new Date(row.effectiveTo).getFullYear()
+						: null
 					// A mapping matches the fiscal year if its effective
 					// window overlaps Jan 1 → Dec 31 of that year.
 					if (startYear !== null && startYear > yearFilter) {
@@ -319,7 +353,9 @@ export default {
 					}
 				}
 				if (after || before) {
-					const eff = row.effectiveFrom ? new Date(row.effectiveFrom) : null
+					const eff = row.effectiveFrom
+						? new Date(row.effectiveFrom)
+						: null
 					if (!eff) {
 						return false
 					}
@@ -360,7 +396,11 @@ export default {
 		 * @spec openspec/specs/realtime-updates/spec.md
 		 */
 		async syncLiveSubscription() {
-			if (typeof this.store.subscribe !== 'function' || this.liveHandle || this.livePending) {
+			if (
+				typeof this.store.subscribe !== 'function'
+				|| this.liveHandle
+				|| this.livePending
+			) {
 				return
 			}
 			this.livePending = true
@@ -382,7 +422,8 @@ export default {
 					(fresh) => {
 						if (Array.isArray(fresh) && this.liveHandle) {
 							this.objects = fresh
-							this.pagination = this.store.pagination?.[TYPE_SLUG] || null
+							this.pagination =
+								this.store.pagination?.[TYPE_SLUG] || null
 						}
 					},
 				)
@@ -390,7 +431,10 @@ export default {
 				this.livePending = false
 				this.liveHandle = null
 				// eslint-disable-next-line no-console
-				console.warn('[BudgetBBVMappingIndex] live subscription failed:', e?.message ?? e)
+				console.warn(
+					'[BudgetBBVMappingIndex] live subscription failed:',
+					e?.message ?? e,
+				)
 			}
 		},
 		/**
@@ -430,7 +474,9 @@ export default {
 				// from axios via the same generateUrl helper.
 				const axios = (await import('@nextcloud/axios')).default
 				const { generateUrl } = await import('@nextcloud/router')
-				const response = await axios.get(generateUrl('/apps/shillinq/budget-mappings'))
+				const response = await axios.get(
+					generateUrl('/apps/shillinq/budget-mappings'),
+				)
 				const data = response?.data?.scope || {}
 				this.scope = {
 					administrationId: data.administrationId || null,
@@ -473,12 +519,14 @@ export default {
 				this.pagination = this.store.pagination?.[TYPE_SLUG] || null
 				const storeError = this.store.errors?.[TYPE_SLUG]
 				if (storeError) {
-					this.error = storeError.message
+					this.error =
+						storeError.message
 						|| this.t('shillinq', 'Failed to load budget mappings')
 				}
 			} catch (e) {
 				this.objects = []
-				this.error = e?.response?.data?.error
+				this.error =
+					e?.response?.data?.error
 					|| this.t('shillinq', 'Failed to load budget mappings')
 			} finally {
 				this.loading = false
@@ -544,7 +592,8 @@ export default {
 				this.objects = rows
 				this.pagination = this.store.pagination?.[TYPE_SLUG] || null
 			} catch (e) {
-				this.error = e?.response?.data?.error
+				this.error =
+					e?.response?.data?.error
 					|| this.t('shillinq', 'Failed to load budget mappings')
 			} finally {
 				this.loading = false

--- a/src/components/BudgetBBVMapping/GlAccountPicker.vue
+++ b/src/components/BudgetBBVMapping/GlAccountPicker.vue
@@ -87,7 +87,11 @@ export default {
 			}
 			return this.options.filter((o) => {
 				const num = String(o.value || '').toLowerCase()
-				const name = (o.account?.accountName || o.account?.name || '').toLowerCase()
+				const name = (
+					o.account?.accountName
+					|| o.account?.name
+					|| ''
+				).toLowerCase()
 				return num.includes(q) || name.includes(q)
 			})
 		},
@@ -95,13 +99,19 @@ export default {
 			if (!this.modelValue) {
 				return null
 			}
-			const match = this.options.find((o) => o.value === String(this.modelValue))
+			const match = this.options.find(
+				(o) => o.value === String(this.modelValue),
+			)
 			if (match) {
 				return match
 			}
 			// Account list may not have arrived yet — surface the raw value
 			// so the form still shows the number while the fetch completes.
-			return { value: String(this.modelValue), display: String(this.modelValue), account: null }
+			return {
+				value: String(this.modelValue),
+				display: String(this.modelValue),
+				account: null,
+			}
 		},
 	},
 	watch: {
@@ -125,9 +135,12 @@ export default {
 			const name = account.accountName || account.name || account.title || ''
 			const type = account.accountType || account.type || ''
 			const balanceCents = account.balance ?? account.balanceCents
-			const balance = balanceCents !== null && balanceCents !== undefined && Number.isFinite(Number(balanceCents))
-				? this.formatEuro(balanceCents)
-				: ''
+			const balance =
+				balanceCents !== null
+				&& balanceCents !== undefined
+				&& Number.isFinite(Number(balanceCents))
+					? this.formatEuro(balanceCents)
+					: ''
 			const parts = [number, name, type, balance].filter(Boolean)
 			return parts.join(' · ')
 		},
@@ -167,22 +180,32 @@ export default {
 					params.administrationId = this.administrationId
 				}
 				const response = await axios.get(
-					generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}`),
+					generateUrl(
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}`,
+					),
 					{ params },
 				)
-				const rows = response.data?.results ?? response.data?.objects ?? response.data ?? []
+				const rows =
+					response.data?.results
+					?? response.data?.objects
+					?? response.data
+					?? []
 				this.accounts = Array.isArray(rows) ? rows : []
 				// Surface the selected account once data lands.
 				if (this.modelValue) {
-					const match = this.accounts.find((a) =>
-						String(a.accountNumber || a.id) === String(this.modelValue))
+					const match = this.accounts.find(
+						(a) =>
+							String(a.accountNumber || a.id)
+							=== String(this.modelValue),
+					)
 					if (match) {
 						this.$emit('selected', match)
 					}
 				}
 			} catch (e) {
 				this.accounts = []
-				this.fetchError = e?.response?.data?.error
+				this.fetchError =
+					e?.response?.data?.error
 					|| this.t('shillinq', 'Failed to load chart of accounts.')
 			} finally {
 				this.loading = false

--- a/src/components/Dashboard/BBVComplianceDashboard.vue
+++ b/src/components/Dashboard/BBVComplianceDashboard.vue
@@ -95,7 +95,10 @@
 			</template>
 		</CnDashboardPage>
 
-		<p v-if="error" class="bbv-dashboard__error" data-testid="bbv-dashboard-error">
+		<p
+			v-if="error"
+			class="bbv-dashboard__error"
+			data-testid="bbv-dashboard-error">
 			{{ error }}
 		</p>
 	</div>
@@ -141,18 +144,63 @@ export default {
 	computed: {
 		widgets() {
 			return [
-				{ id: 'bbv-kpis', title: this.t('shillinq', 'Key compliance metrics'), type: 'custom' },
-				{ id: 'bbv-pie', title: this.t('shillinq', 'Compliance status distribution'), type: 'custom' },
-				{ id: 'bbv-trend', title: this.t('shillinq', 'YTD cumulative spend per programme'), type: 'custom' },
-				{ id: 'bbv-table', title: this.t('shillinq', 'Programme utilization'), type: 'custom' },
+				{
+					id: 'bbv-kpis',
+					title: this.t('shillinq', 'Key compliance metrics'),
+					type: 'custom',
+				},
+				{
+					id: 'bbv-pie',
+					title: this.t('shillinq', 'Compliance status distribution'),
+					type: 'custom',
+				},
+				{
+					id: 'bbv-trend',
+					title: this.t('shillinq', 'YTD cumulative spend per programme'),
+					type: 'custom',
+				},
+				{
+					id: 'bbv-table',
+					title: this.t('shillinq', 'Programme utilization'),
+					type: 'custom',
+				},
 			]
 		},
 		layout() {
 			return [
-				{ id: 'layout-kpis', widgetId: 'bbv-kpis', gridX: 0, gridY: 0, gridWidth: 12, gridHeight: 2, showTitle: false },
-				{ id: 'layout-pie', widgetId: 'bbv-pie', gridX: 0, gridY: 2, gridWidth: 6, gridHeight: 4 },
-				{ id: 'layout-trend', widgetId: 'bbv-trend', gridX: 6, gridY: 2, gridWidth: 6, gridHeight: 4 },
-				{ id: 'layout-table', widgetId: 'bbv-table', gridX: 0, gridY: 6, gridWidth: 12, gridHeight: 5 },
+				{
+					id: 'layout-kpis',
+					widgetId: 'bbv-kpis',
+					gridX: 0,
+					gridY: 0,
+					gridWidth: 12,
+					gridHeight: 2,
+					showTitle: false,
+				},
+				{
+					id: 'layout-pie',
+					widgetId: 'bbv-pie',
+					gridX: 0,
+					gridY: 2,
+					gridWidth: 6,
+					gridHeight: 4,
+				},
+				{
+					id: 'layout-trend',
+					widgetId: 'bbv-trend',
+					gridX: 6,
+					gridY: 2,
+					gridWidth: 6,
+					gridHeight: 4,
+				},
+				{
+					id: 'layout-table',
+					widgetId: 'bbv-table',
+					gridX: 0,
+					gridY: 6,
+					gridWidth: 12,
+					gridHeight: 5,
+				},
 			]
 		},
 		fyLabel() {
@@ -163,7 +211,10 @@ export default {
 		},
 		scopeDescription() {
 			if (!this.scope.fiscalYear) {
-				return this.t('shillinq', 'Fiscal-year overview of programme utilization and compliance status.')
+				return this.t(
+					'shillinq',
+					'Fiscal-year overview of programme utilization and compliance status.',
+				)
 			}
 			return this.t(
 				'shillinq',
@@ -180,7 +231,9 @@ export default {
 		t,
 		async loadAdministrationContext() {
 			try {
-				const response = await axios.get(generateUrl('/apps/shillinq/api/administrations/context'))
+				const response = await axios.get(
+					generateUrl('/apps/shillinq/api/administrations/context'),
+				)
 				const admins = response.data?.administrations || []
 				this.administrationOptions = admins.map((a) => ({
 					value: a.administrationId,
@@ -191,7 +244,10 @@ export default {
 				}
 			} catch (e) {
 				// Inline error; the dashboard still renders an empty envelope.
-				this.error = this.t('shillinq', 'Failed to load administration context')
+				this.error = this.t(
+					'shillinq',
+					'Failed to load administration context',
+				)
 			}
 		},
 		async onAdministrationChange() {
@@ -213,7 +269,9 @@ export default {
 					{ params },
 				)
 				const data = response.data || {}
-				this.programmes = Array.isArray(data.programmes) ? data.programmes : []
+				this.programmes = Array.isArray(data.programmes)
+					? data.programmes
+					: []
 				this.mappings = Array.isArray(data.mappings) ? data.mappings : []
 				this.timeline = Array.isArray(data.timeline) ? data.timeline : []
 				this.scope = data.scope || {
@@ -226,8 +284,14 @@ export default {
 				this.programmes = []
 				this.timeline = []
 				this.mappings = []
-				this.scope = { administrationId: null, fiscalYear: null, startDate: null, endDate: null }
-				this.error = e?.response?.data?.error
+				this.scope = {
+					administrationId: null,
+					fiscalYear: null,
+					startDate: null,
+					endDate: null,
+				}
+				this.error =
+					e?.response?.data?.error
 					|| this.t('shillinq', 'Failed to load BBV programmes')
 			} finally {
 				this.loading = false

--- a/src/components/Dashboard/BBVKPICards.vue
+++ b/src/components/Dashboard/BBVKPICards.vue
@@ -78,13 +78,17 @@ export default {
 			return this.programmes.length
 		},
 		onTrackCount() {
-			return this.programmes.filter(p => p.complianceStatus === 'on-track').length
+			return this.programmes.filter((p) => p.complianceStatus === 'on-track')
+				.length
 		},
 		atRiskCount() {
-			return this.programmes.filter(p => p.complianceStatus === 'at-risk').length
+			return this.programmes.filter((p) => p.complianceStatus === 'at-risk')
+				.length
 		},
 		nonCompliantCount() {
-			return this.programmes.filter(p => p.complianceStatus === 'non-compliant').length
+			return this.programmes.filter(
+				(p) => p.complianceStatus === 'non-compliant',
+			).length
 		},
 	},
 	methods: { t },

--- a/src/components/Dashboard/BBVProgrammeTable.vue
+++ b/src/components/Dashboard/BBVProgrammeTable.vue
@@ -37,19 +37,27 @@
 			:loading="loading"
 			row-key="rowKey"
 			:loading-text="t('shillinq', 'Loading programmes…')"
-			:empty-text="t('shillinq', 'No active programmes found for this fiscal year.')"
+			:empty-text="
+				t('shillinq', 'No active programmes found for this fiscal year.')
+			"
 			@sort="onSort">
 			<template #column-budget="{ row }">
-				<span class="bbv-programme-table__money">{{ formatEuro(row.totalBudget) }}</span>
+				<span class="bbv-programme-table__money">{{
+					formatEuro(row.totalBudget)
+				}}</span>
 			</template>
 			<template #column-ytd="{ row }">
-				<span class="bbv-programme-table__money">{{ formatEuro(row.ytdSpend) }}</span>
+				<span class="bbv-programme-table__money">{{
+					formatEuro(row.ytdSpend)
+				}}</span>
 			</template>
 			<template #column-utilization="{ row }">
 				<span
 					class="bbv-programme-table__util"
 					:class="utilizationClass(row.complianceStatus)">
-					{{ formatPercentage(row.utilizationPercentage, row.utilization) }}
+					{{
+						formatPercentage(row.utilizationPercentage, row.utilization)
+					}}
 				</span>
 			</template>
 			<template #column-status="{ row }">
@@ -58,7 +66,9 @@
 					:class="badgeClass(row.complianceStatus)"
 					:title="badgeTooltip(row.complianceStatus)"
 					:data-testid="`bbv-status-${row.programmeCode}`">
-					<span aria-hidden="true">{{ badgeEmoji(row.complianceStatus) }}</span>
+					<span aria-hidden="true">{{
+						badgeEmoji(row.complianceStatus)
+					}}</span>
 					<span>{{ badgeLabel(row.complianceStatus) }}</span>
 				</span>
 			</template>
@@ -102,12 +112,32 @@ export default {
 	computed: {
 		columns() {
 			return [
-				{ key: 'programmeCode', label: this.t('shillinq', 'Code'), sortable: true },
-				{ key: 'programmeName', label: this.t('shillinq', 'Name'), sortable: true },
-				{ key: 'budget', label: this.t('shillinq', 'Budget'), sortable: true },
+				{
+					key: 'programmeCode',
+					label: this.t('shillinq', 'Code'),
+					sortable: true,
+				},
+				{
+					key: 'programmeName',
+					label: this.t('shillinq', 'Name'),
+					sortable: true,
+				},
+				{
+					key: 'budget',
+					label: this.t('shillinq', 'Budget'),
+					sortable: true,
+				},
 				{ key: 'ytd', label: this.t('shillinq', 'YTD'), sortable: true },
-				{ key: 'utilization', label: this.t('shillinq', 'Utilization %'), sortable: true },
-				{ key: 'status', label: this.t('shillinq', 'Status'), sortable: true },
+				{
+					key: 'utilization',
+					label: this.t('shillinq', 'Utilization %'),
+					sortable: true,
+				},
+				{
+					key: 'status',
+					label: this.t('shillinq', 'Status'),
+					sortable: true,
+				},
 			]
 		},
 		rows() {
@@ -151,7 +181,12 @@ export default {
 				return Number(row.utilization || 0)
 			}
 			if (key === 'status') {
-				const order = { 'non-compliant': 0, 'at-risk': 1, 'on-track': 2, unconfigured: 3 }
+				const order = {
+					'non-compliant': 0,
+					'at-risk': 1,
+					'on-track': 2,
+					unconfigured: 3,
+				}
 				return order[row.complianceStatus] ?? 4
 			}
 			return row[key] ?? ''
@@ -171,7 +206,11 @@ export default {
 			}
 		},
 		formatEuro(cents) {
-			if (cents === null || cents === undefined || !Number.isFinite(Number(cents))) {
+			if (
+				cents === null
+				|| cents === undefined
+				|| !Number.isFinite(Number(cents))
+			) {
 				return '—'
 			}
 			return new Intl.NumberFormat('nl-NL', {
@@ -195,13 +234,15 @@ export default {
 			return `${numeric.toFixed(1)} %`
 		},
 		utilizationClass(status) {
-			if (status === 'non-compliant') return 'bbv-programme-table__util--danger'
+			if (status === 'non-compliant')
+				return 'bbv-programme-table__util--danger'
 			if (status === 'at-risk') return 'bbv-programme-table__util--warning'
 			if (status === 'on-track') return 'bbv-programme-table__util--ok'
 			return 'bbv-programme-table__util--muted'
 		},
 		badgeClass(status) {
-			if (status === 'non-compliant') return 'bbv-programme-table__badge--danger'
+			if (status === 'non-compliant')
+				return 'bbv-programme-table__badge--danger'
 			if (status === 'at-risk') return 'bbv-programme-table__badge--warning'
 			if (status === 'on-track') return 'bbv-programme-table__badge--ok'
 			return 'bbv-programme-table__badge--muted'
@@ -213,20 +254,30 @@ export default {
 			return '⚪'
 		},
 		badgeLabel(status) {
-			if (status === 'non-compliant') return this.t('shillinq', 'Non-compliant')
+			if (status === 'non-compliant')
+				return this.t('shillinq', 'Non-compliant')
 			if (status === 'at-risk') return this.t('shillinq', 'At-risk')
 			if (status === 'on-track') return this.t('shillinq', 'On-track')
 			return this.t('shillinq', 'Unconfigured')
 		},
 		badgeTooltip(status) {
 			if (status === 'at-risk') {
-				return this.t('shillinq', 'Projected to exceed budget — review allocations')
+				return this.t(
+					'shillinq',
+					'Projected to exceed budget — review allocations',
+				)
 			}
 			if (status === 'non-compliant') {
-				return this.t('shillinq', 'Spend already exceeds the on-track threshold')
+				return this.t(
+					'shillinq',
+					'Spend already exceeds the on-track threshold',
+				)
 			}
 			if (status === 'unconfigured') {
-				return this.t('shillinq', 'No GL allocations configured for this programme')
+				return this.t(
+					'shillinq',
+					'No GL allocations configured for this programme',
+				)
 			}
 			return this.t('shillinq', 'Programme spend is within the on-track band')
 		},

--- a/src/components/Dashboard/BBVTrendChart.vue
+++ b/src/components/Dashboard/BBVTrendChart.vue
@@ -37,8 +37,20 @@
 import { CnChartWidget } from '@conduction/nextcloud-vue'
 import { translate as t } from '@nextcloud/l10n'
 
-const MONTH_KEYS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-	'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+const MONTH_KEYS = [
+	'Jan',
+	'Feb',
+	'Mar',
+	'Apr',
+	'May',
+	'Jun',
+	'Jul',
+	'Aug',
+	'Sep',
+	'Oct',
+	'Nov',
+	'Dec',
+]
 
 export default {
 	name: 'BBVTrendChart',
@@ -62,7 +74,7 @@ export default {
 	},
 	computed: {
 		categories() {
-			return MONTH_KEYS.map(key => this.t('shillinq', key))
+			return MONTH_KEYS.map((key) => this.t('shillinq', key))
 		},
 		series() {
 			if (this.timeline.length > 0) {
@@ -99,9 +111,14 @@ export default {
 				if (!grouped.has(code)) {
 					grouped.set(code, new Array(12).fill(0))
 				}
-				const monthIndex = Math.max(0, Math.min(11, Number(row.month || 1) - 1))
+				const monthIndex = Math.max(
+					0,
+					Math.min(11, Number(row.month || 1) - 1),
+				)
 				const cents = Number(row.cumulativeSpendCents || 0)
-				grouped.get(code)[monthIndex] = Number.isFinite(cents) ? cents / 100 : 0
+				grouped.get(code)[monthIndex] = Number.isFinite(cents)
+					? cents / 100
+					: 0
 			}
 			const out = []
 			for (const programme of this.programmes) {
@@ -143,7 +160,11 @@ export default {
 			return out
 		},
 		formatEuro(cents) {
-			if (cents === null || cents === undefined || !Number.isFinite(Number(cents))) {
+			if (
+				cents === null
+				|| cents === undefined
+				|| !Number.isFinite(Number(cents))
+			) {
 				return '—'
 			}
 			return new Intl.NumberFormat('nl-NL', {

--- a/src/components/FieldConfidenceBadge.vue
+++ b/src/components/FieldConfidenceBadge.vue
@@ -14,11 +14,7 @@
 -->
 
 <template>
-	<span
-		class="fcb"
-		:class="badgeClass"
-		:data-testid="testId"
-		:title="label">
+	<span class="fcb" :class="badgeClass" :data-testid="testId" :title="label">
 		<span class="fcb__pct">{{ percentLabel }}</span>
 		<span class="fcb__label">{{ label }}</span>
 	</span>
@@ -61,7 +57,10 @@ export default {
 	},
 	computed: {
 		hasConfidence() {
-			return typeof this.confidence === 'number' && Number.isFinite(this.confidence)
+			return (
+				typeof this.confidence === 'number'
+				&& Number.isFinite(this.confidence)
+			)
 		},
 		needsReview() {
 			return this.hasConfidence && this.confidence < this.reviewThreshold

--- a/src/components/ar-invoice/AREInvoiceActions.vue
+++ b/src/components/ar-invoice/AREInvoiceActions.vue
@@ -26,12 +26,22 @@
 			:disabled="!canSend || sending"
 			data-testid="ar-einvoice-send"
 			@click="onSend">
-			{{ sending ? t('shillinq', 'Sending...') : t('shillinq', 'Send e-invoice') }}
+			{{
+				sending
+					? t('shillinq', 'Sending...')
+					: t('shillinq', 'Send e-invoice')
+			}}
 		</NcButton>
-		<p v-if="sendError" class="ar-einvoice-actions__error" data-testid="ar-einvoice-send-error">
+		<p
+			v-if="sendError"
+			class="ar-einvoice-actions__error"
+			data-testid="ar-einvoice-send-error">
 			{{ sendError }}
 		</p>
-		<p v-if="fallbackNotice" class="ar-einvoice-actions__notice" data-testid="ar-einvoice-fallback-notice">
+		<p
+			v-if="fallbackNotice"
+			class="ar-einvoice-actions__notice"
+			data-testid="ar-einvoice-fallback-notice">
 			{{ fallbackNotice }}
 		</p>
 	</div>
@@ -105,11 +115,16 @@ export default {
 					generateUrl(sendEInvoiceEndpoint(this.invoiceNumber)),
 					{ administrationId: this.administrationId },
 				)
-				const { deliveryStatus, fallbackNotice } = mapSendResult(response.data || {}, this.t)
+				const { deliveryStatus, fallbackNotice } = mapSendResult(
+					response.data || {},
+					this.t,
+				)
 				this.localDeliveryStatus = deliveryStatus
 				this.fallbackNotice = fallbackNotice
 				if (fallbackNotice === '') {
-					showSuccess(this.t('shillinq', 'Invoice queued for Peppol delivery.'))
+					showSuccess(
+						this.t('shillinq', 'Invoice queued for Peppol delivery.'),
+					)
 				}
 			} catch (e) {
 				this.sendError = extractSendErrorMessage(e, this.t)

--- a/src/components/ar-invoice/arEInvoiceActions.js
+++ b/src/components/ar-invoice/arEInvoiceActions.js
@@ -57,9 +57,13 @@ export function sendEInvoiceEndpoint(invoiceNumber) {
  */
 export function mapSendResult(result, t) {
 	const deliveryStatus = result?.deliveryStatus || 'queued'
-	const fallbackNotice = result?.fallback === true
-		? t('shillinq', 'No Peppol participant found for this debtor — use PDF + email instead.')
-		: ''
+	const fallbackNotice =
+		result?.fallback === true
+			? t(
+					'shillinq',
+					'No Peppol participant found for this debtor — use PDF + email instead.',
+				)
+			: ''
 	return { deliveryStatus, fallbackNotice }
 }
 

--- a/src/components/cashflow/CashflowDashboard.vue
+++ b/src/components/cashflow/CashflowDashboard.vue
@@ -15,8 +15,16 @@
 -->
 <template>
 	<div class="cashflow-dashboard">
-		<div v-if="crisisActive" class="cashflow-dashboard__crisis-banner" role="alert">
-			{{ t('shillinq', 'CRISIS ACTIVE: predicted negative saldo within 4 weeks. Review action suggestions below.') }}
+		<div
+			v-if="crisisActive"
+			class="cashflow-dashboard__crisis-banner"
+			role="alert">
+			{{
+				t(
+					'shillinq',
+					'CRISIS ACTIVE: predicted negative saldo within 4 weeks. Review action suggestions below.',
+				)
+			}}
 		</div>
 
 		<div class="cashflow-dashboard__header">
@@ -46,17 +54,30 @@
 		</div>
 
 		<!-- The chart itself is rendered by the manifest widget; this is a placeholder slot. -->
-		<div class="cashflow-dashboard__chart-slot" data-widget="cashflow-13week-chart">
+		<div
+			class="cashflow-dashboard__chart-slot"
+			data-widget="cashflow-13week-chart">
 			<slot name="chart" />
 		</div>
 
 		<div v-if="selectedWeek" class="cashflow-dashboard__week-detail">
 			<h3>{{ t('shillinq', 'Week') }} {{ selectedWeek.weeknummer }}</h3>
 			<ul>
-				<li>{{ t('shillinq', 'Inflows AR') }}: {{ selectedWeek.inflows_ar_geprognosticeerd }}</li>
-				<li>{{ t('shillinq', 'Outflows AP') }}: {{ selectedWeek.outflows_ap_geprognosticeerd }}</li>
-				<li>{{ t('shillinq', 'Net Mutatie') }}: {{ selectedWeek.nettoMutatie }}</li>
-				<li>{{ t('shillinq', 'Eind Saldo') }}: {{ selectedWeek.eindSaldo }}</li>
+				<li>
+					{{ t('shillinq', 'Inflows AR') }}:
+					{{ selectedWeek.inflows_ar_geprognosticeerd }}
+				</li>
+				<li>
+					{{ t('shillinq', 'Outflows AP') }}:
+					{{ selectedWeek.outflows_ap_geprognosticeerd }}
+				</li>
+				<li>
+					{{ t('shillinq', 'Net Mutatie') }}:
+					{{ selectedWeek.nettoMutatie }}
+				</li>
+				<li>
+					{{ t('shillinq', 'Eind Saldo') }}: {{ selectedWeek.eindSaldo }}
+				</li>
 			</ul>
 		</div>
 	</div>
@@ -96,7 +117,7 @@ export default {
 				return false
 			}
 			const leading = this.weeks.slice(0, 4)
-			return leading.some(w => Number(w.eindSaldo) < 0)
+			return leading.some((w) => Number(w.eindSaldo) < 0)
 		},
 	},
 

--- a/src/components/cashflow/ScenarioCreator.vue
+++ b/src/components/cashflow/ScenarioCreator.vue
@@ -20,7 +20,7 @@
 				v-model="scenario.naam"
 				type="text"
 				required
-				:placeholder="t('shillinq', 'e.g. Acme pays late by 4 weeks')">
+				:placeholder="t('shillinq', 'e.g. Acme pays late by 4 weeks')" />
 		</label>
 
 		<label class="scenario-creator__field">
@@ -57,13 +57,13 @@
 					v-model="adjustment.arInvoiceId"
 					type="text"
 					:aria-label="t('shillinq', 'AR invoice ID')"
-					:placeholder="t('shillinq', 'AR invoice ID')">
+					:placeholder="t('shillinq', 'AR invoice ID')" />
 				<input
 					v-if="adjustment.type === 'AR_PROJECTION_OVERRIDE'"
 					v-model.number="adjustment.weekShift"
 					type="number"
 					:aria-label="t('shillinq', 'Week shift')"
-					:placeholder="t('shillinq', 'Week shift')">
+					:placeholder="t('shillinq', 'Week shift')" />
 				<input
 					v-if="adjustment.type === 'AR_PROJECTION_OVERRIDE'"
 					v-model.number="adjustment.kansVanBetaling"
@@ -72,14 +72,14 @@
 					max="1"
 					step="0.05"
 					:aria-label="t('shillinq', 'Probability (0-1)')"
-					:placeholder="t('shillinq', 'Probability (0-1)')">
+					:placeholder="t('shillinq', 'Probability (0-1)')" />
 
 				<input
 					v-if="adjustment.type === 'RECURRING_COST_ADJUSTMENT'"
 					v-model="adjustment.recurId"
 					type="text"
 					:aria-label="t('shillinq', 'Recurring ID')"
-					:placeholder="t('shillinq', 'Recurring ID')">
+					:placeholder="t('shillinq', 'Recurring ID')" />
 				<select
 					v-if="adjustment.type === 'RECURRING_COST_ADJUSTMENT'"
 					v-model="adjustment.adjustmentType"
@@ -100,14 +100,14 @@
 					v-model="adjustment.name"
 					type="text"
 					:aria-label="t('shillinq', 'Deal name')"
-					:placeholder="t('shillinq', 'Deal name')">
+					:placeholder="t('shillinq', 'Deal name')" />
 				<input
 					v-if="adjustment.type === 'NEW_REVENUE'"
 					v-model.number="adjustment.amount"
 					type="number"
 					step="0.01"
 					:aria-label="t('shillinq', 'Amount EUR')"
-					:placeholder="t('shillinq', 'Amount EUR')">
+					:placeholder="t('shillinq', 'Amount EUR')" />
 				<input
 					v-if="adjustment.type === 'NEW_REVENUE'"
 					v-model.number="adjustment.probability"
@@ -116,13 +116,13 @@
 					max="1"
 					step="0.05"
 					:aria-label="t('shillinq', 'Probability')"
-					:placeholder="t('shillinq', 'Probability')">
+					:placeholder="t('shillinq', 'Probability')" />
 				<input
 					v-if="adjustment.type === 'NEW_REVENUE'"
 					v-model.number="adjustment.expectedReceiptWeek"
 					type="number"
 					:aria-label="t('shillinq', 'Expected week')"
-					:placeholder="t('shillinq', 'Expected week')">
+					:placeholder="t('shillinq', 'Expected week')" />
 
 				<input
 					v-if="adjustment.type === 'BUFFER_POLICY_OVERRIDE'"
@@ -130,7 +130,7 @@
 					type="number"
 					step="0.01"
 					:aria-label="t('shillinq', 'Buffer EUR')"
-					:placeholder="t('shillinq', 'Buffer EUR')">
+					:placeholder="t('shillinq', 'Buffer EUR')" />
 
 				<button type="button" @click="removeAdjustment(index)">
 					{{ t('shillinq', 'Remove') }}
@@ -190,7 +190,10 @@ export default {
 			this.scenario.aanpassingen.splice(index, 1)
 		},
 		handleSubmit() {
-			this.$emit('create-scenario', { ...this.scenario, createdAt: new Date().toISOString() })
+			this.$emit('create-scenario', {
+				...this.scenario,
+				createdAt: new Date().toISOString(),
+			})
 		},
 	},
 }

--- a/src/components/dashboard/financial/CashflowChartWidget.vue
+++ b/src/components/dashboard/financial/CashflowChartWidget.vue
@@ -34,7 +34,8 @@ export default {
 
 	computed: {
 		forecast() {
-			if (!this.financialData) return { months: [], cashIn: [], cashOut: [], cashNet: [] }
+			if (!this.financialData)
+				return { months: [], cashIn: [], cashOut: [], cashNet: [] }
 			const lastRealized = this.months[this.months.length - 1]
 			return forecastByMonth(this.financialData.cashflowWeeks, lastRealized)
 		},
@@ -45,31 +46,67 @@ export default {
 			if (!this.glSeries) return []
 			const realizedCount = this.months.length
 			const forecastCount = this.forecast.months.length
-			const padRealized = (data) => [...data, ...Array(forecastCount).fill(null)]
-			const padForecast = (data) => [...Array(realizedCount).fill(null), ...data]
+			const padRealized = (data) => [
+				...data,
+				...Array(forecastCount).fill(null),
+			]
+			const padForecast = (data) => [
+				...Array(realizedCount).fill(null),
+				...data,
+			]
 			const series = [
-				{ name: t('shillinq', 'Money in'), type: 'column', data: padRealized(this.glSeries.cashIn) },
-				{ name: t('shillinq', 'Money out'), type: 'column', data: padRealized(this.glSeries.cashOut) },
-				{ name: t('shillinq', 'Net'), type: 'line', data: [...this.glSeries.cashNet, ...this.forecast.cashNet] },
+				{
+					name: t('shillinq', 'Money in'),
+					type: 'column',
+					data: padRealized(this.glSeries.cashIn),
+				},
+				{
+					name: t('shillinq', 'Money out'),
+					type: 'column',
+					data: padRealized(this.glSeries.cashOut),
+				},
+				{
+					name: t('shillinq', 'Net'),
+					type: 'line',
+					data: [...this.glSeries.cashNet, ...this.forecast.cashNet],
+				},
 			]
 			if (forecastCount > 0) {
-				series.splice(2, 0,
-					{ name: t('shillinq', 'Forecast in'), type: 'column', data: padForecast(this.forecast.cashIn) },
-					{ name: t('shillinq', 'Forecast out'), type: 'column', data: padForecast(this.forecast.cashOut) },
+				series.splice(
+					2,
+					0,
+					{
+						name: t('shillinq', 'Forecast in'),
+						type: 'column',
+						data: padForecast(this.forecast.cashIn),
+					},
+					{
+						name: t('shillinq', 'Forecast out'),
+						type: 'column',
+						data: padForecast(this.forecast.cashOut),
+					},
 				)
 			}
 			return series
 		},
 		options() {
 			const colors = ['#46ba61', '#e04224']
-			if (this.forecast.months.length > 0) colors.push('#46ba6155', '#e0422455')
+			if (this.forecast.months.length > 0)
+				colors.push('#46ba6155', '#e0422455')
 			colors.push('var(--color-primary-element, #0082c9)')
 			return {
 				colors,
-				stroke: { width: this.series.map((s) => (s.type === 'line' ? 3 : 0)) },
+				stroke: {
+					width: this.series.map((s) => (s.type === 'line' ? 3 : 0)),
+				},
 				plotOptions: { bar: { columnWidth: '60%', borderRadius: 2 } },
 				yaxis: { labels: { formatter: (value) => formatEur(value) } },
-				tooltip: { y: { formatter: (value) => (value === null ? '—' : formatEur(value, 2)) } },
+				tooltip: {
+					y: {
+						formatter: (value) =>
+							value === null ? '—' : formatEur(value, 2),
+					},
+				},
 			}
 		},
 	},

--- a/src/components/dashboard/financial/chartWidgetMixin.js
+++ b/src/components/dashboard/financial/chartWidgetMixin.js
@@ -8,7 +8,12 @@
 import { ref } from 'vue'
 import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { useFinancialData } from './useFinancialData.js'
-import { lastMonths, monthLabel, monthlyFinancialSeries, monthsInRange } from './financialSeries.js'
+import {
+	lastMonths,
+	monthLabel,
+	monthlyFinancialSeries,
+	monthsInRange,
+} from './financialSeries.js'
 
 export const TRAILING_MONTHS = 12
 
@@ -57,9 +62,10 @@ export default {
 		months() {
 			// Unwrap ref (Vue 2.7 options-API inject may give either shape).
 			const injected = this.cnDashboardDateRange
-			const range = (injected && typeof injected === 'object' && 'value' in injected)
-				? injected.value
-				: injected
+			const range =
+				injected && typeof injected === 'object' && 'value' in injected
+					? injected.value
+					: injected
 			if (range && range.from && range.to) {
 				const ms = monthsInRange(range.from, range.to)
 				if (ms.length > 0) return ms
@@ -74,7 +80,12 @@ export default {
 		glSeries() {
 			if (!this.financialData) return null
 			const { accounts, transactions, lines } = this.financialData
-			return monthlyFinancialSeries({ accounts, transactions, lines, months: this.months })
+			return monthlyFinancialSeries({
+				accounts,
+				transactions,
+				lines,
+				months: this.months,
+			})
 		},
 	},
 

--- a/src/components/dashboard/financial/financialSeries.js
+++ b/src/components/dashboard/financial/financialSeries.js
@@ -37,7 +37,9 @@ export function lastMonths(count, now = new Date()) {
 	const months = []
 	for (let i = count - 1; i >= 0; i--) {
 		const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
-		months.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`)
+		months.push(
+			`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`,
+		)
 	}
 	return months
 }
@@ -58,7 +60,9 @@ export function monthsInRange(from, to) {
 	const months = []
 	let d = new Date(start.getFullYear(), start.getMonth(), 1)
 	while (d <= end && months.length < 60) {
-		months.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`)
+		months.push(
+			`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`,
+		)
 		d = new Date(d.getFullYear(), d.getMonth() + 1, 1)
 	}
 	return months
@@ -74,7 +78,10 @@ export function monthsInRange(from, to) {
  */
 export function monthLabel(key) {
 	const [y, m] = key.split('-').map(Number)
-	return new Date(y, m - 1, 1).toLocaleDateString(undefined, { month: 'short', year: '2-digit' })
+	return new Date(y, m - 1, 1).toLocaleDateString(undefined, {
+		month: 'short',
+		year: '2-digit',
+	})
 }
 
 /**
@@ -96,8 +103,11 @@ export function classifyAccounts(accounts) {
 		if (!number) continue
 		if (account.accountType === 'revenue') revenue.add(number)
 		else if (account.accountType === 'expenses') expenses.add(number)
-		else if (account.accountType === 'assets'
-			&& (/^10/.test(number) || /\b(bank|kas|cash)\b/i.test(String(account.name ?? '')))) {
+		else if (
+			account.accountType === 'assets'
+			&& (/^10/.test(number)
+				|| /\b(bank|kas|cash)\b/i.test(String(account.name ?? '')))
+		) {
 			liquid.add(number)
 		}
 	}
@@ -178,11 +188,15 @@ export function monthlyFinancialSeries({ accounts, transactions, lines, months }
 		cashNet: [],
 	}
 	for (const key of months) {
-		let revenue = 0; let costs = 0; let cashIn = 0; let cashOut = 0
+		let revenue = 0
+		let costs = 0
+		let cashIn = 0
+		let cashOut = 0
 		for (const line of buckets.get(key) || []) {
 			const number = String(line.accountNumber ?? '')
 			if (classes.revenue.has(number)) revenue += signedAmount(line, 'revenue')
-			else if (classes.expenses.has(number)) costs += signedAmount(line, 'expenses')
+			else if (classes.expenses.has(number))
+				costs += signedAmount(line, 'expenses')
 			if (classes.liquid.has(number)) {
 				const movement = signedAmount(line, 'liquid')
 				if (movement >= 0) cashIn += movement
@@ -260,7 +274,9 @@ export function forecastByMonth(weeks, afterMonth) {
 		months,
 		cashIn: months.map((key) => round2(byMonth.get(key).cashIn)),
 		cashOut: months.map((key) => round2(byMonth.get(key).cashOut)),
-		cashNet: months.map((key) => round2(byMonth.get(key).cashIn - byMonth.get(key).cashOut)),
+		cashNet: months.map((key) =>
+			round2(byMonth.get(key).cashIn - byMonth.get(key).cashOut),
+		),
 	}
 }
 
@@ -276,7 +292,12 @@ export function forecastByMonth(weeks, afterMonth) {
  * @return {object[]}
  */
 export function openArRows(invoices, customers, now = new Date()) {
-	const names = new Map((customers || []).map((c) => [String(c.customerId ?? c['@self']?.id ?? ''), c.legalName || c.tradeName || '']))
+	const names = new Map(
+		(customers || []).map((c) => [
+			String(c.customerId ?? c['@self']?.id ?? ''),
+			c.legalName || c.tradeName || '',
+		]),
+	)
 	return (invoices || [])
 		.filter((inv) => OPEN_AR_STATES.includes(inv.lifecycleState))
 		.map((inv) => ({
@@ -303,7 +324,12 @@ export function openArRows(invoices, customers, now = new Date()) {
  * @return {object[]}
  */
 export function openApRows(transactions, vendors, now = new Date()) {
-	const names = new Map((vendors || []).map((v) => [String(v.vendorNumber ?? v['@self']?.id ?? ''), v.name || v.tradingName || '']))
+	const names = new Map(
+		(vendors || []).map((v) => [
+			String(v.vendorNumber ?? v['@self']?.id ?? ''),
+			v.name || v.tradingName || '',
+		]),
+	)
 	return (transactions || [])
 		.filter((tx) => OPEN_AP_STATES.includes(tx.state))
 		.map((tx) => ({
@@ -333,13 +359,21 @@ export function openApRows(transactions, vendors, now = new Date()) {
  * @param {Date} now Reference date (YTD window + current month).
  * @return {object}
  */
-export function computeKpis({ accounts, transactions, lines, arInvoices, apTransactions, hourEntries }, now = new Date()) {
+export function computeKpis(
+	{ accounts, transactions, lines, arInvoices, apTransactions, hourEntries },
+	now = new Date(),
+) {
 	const year = now.getFullYear()
 	const ytdMonths = []
 	for (let m = 0; m <= now.getMonth(); m++) {
 		ytdMonths.push(`${year}-${String(m + 1).padStart(2, '0')}`)
 	}
-	const series = monthlyFinancialSeries({ accounts, transactions, lines, months: ytdMonths })
+	const series = monthlyFinancialSeries({
+		accounts,
+		transactions,
+		lines,
+		months: ytdMonths,
+	})
 	const turnoverYtd = round2(sum(series.revenue))
 	const marginYtd = round2(sum(series.margin))
 
@@ -364,7 +398,8 @@ export function computeKpis({ accounts, transactions, lines, arInvoices, apTrans
 	return {
 		turnoverYtd,
 		marginYtd,
-		marginPctYtd: turnoverYtd > 0 ? round2((marginYtd / turnoverYtd) * 100) : null,
+		marginPctYtd:
+			turnoverYtd > 0 ? round2((marginYtd / turnoverYtd) * 100) : null,
 		openArAmount: round2(sum(openAr.map((r) => r.amount))),
 		openArCount: openAr.length,
 		openApAmount: round2(sum(openAp.map((r) => r.amount))),
@@ -384,8 +419,13 @@ export function computeKpis({ accounts, transactions, lines, arInvoices, apTrans
  * @return {string}
  */
 export function formatEur(value, maximumFractionDigits = 0) {
-	if (value === null || value === undefined || Number.isNaN(Number(value))) return '—'
-	return new Intl.NumberFormat(undefined, { style: 'currency', currency: 'EUR', maximumFractionDigits }).format(Number(value))
+	if (value === null || value === undefined || Number.isNaN(Number(value)))
+		return '—'
+	return new Intl.NumberFormat(undefined, {
+		style: 'currency',
+		currency: 'EUR',
+		maximumFractionDigits,
+	}).format(Number(value))
 }
 
 /**
@@ -425,7 +465,10 @@ function round2(value) {
  * @return {{ turnover: number, margin: number, marginPct: (number|null),
  *   billableHours: number, billablePct: (number|null) }}
  */
-export function computeRangeKpis({ accounts, transactions, lines, hourEntries }, months) {
+export function computeRangeKpis(
+	{ accounts, transactions, lines, hourEntries },
+	months,
+) {
 	const series = monthlyFinancialSeries({ accounts, transactions, lines, months })
 	const turnover = round2(sum(series.revenue))
 	const margin = round2(sum(series.margin))
@@ -439,6 +482,7 @@ export function computeRangeKpis({ accounts, transactions, lines, hourEntries },
 		margin,
 		marginPct: turnover > 0 ? round2((margin / turnover) * 100) : null,
 		billableHours: round2(billableHours),
-		billablePct: totalHours > 0 ? round2((billableHours / totalHours) * 100) : null,
+		billablePct:
+			totalHours > 0 ? round2((billableHours / totalHours) * 100) : null,
 	}
 }

--- a/src/components/dashboard/financial/useFinancialData.js
+++ b/src/components/dashboard/financial/useFinancialData.js
@@ -52,14 +52,16 @@ async function fetchSchema(schema) {
 /** @return {Promise<object>} */
 async function fetchAll() {
 	const entries = Object.entries(SCHEMAS)
-	const settled = await Promise.all(entries.map(async ([key, schema]) => {
-		try {
-			return [key, await fetchSchema(schema)]
-		} catch (e) {
-			error.value = e
-			return [key, []]
-		}
-	}))
+	const settled = await Promise.all(
+		entries.map(async ([key, schema]) => {
+			try {
+				return [key, await fetchSchema(schema)]
+			} catch (e) {
+				error.value = e
+				return [key, []]
+			}
+		}),
+	)
 	return Object.fromEntries(settled)
 }
 
@@ -79,8 +81,12 @@ export function useFinancialData() {
 			loading.value = true
 			error.value = null
 			inflight = fetchAll()
-				.then((result) => { data.value = result })
-				.finally(() => { loading.value = false })
+				.then((result) => {
+					data.value = result
+				})
+				.finally(() => {
+					loading.value = false
+				})
 		}
 		return inflight
 	}

--- a/src/components/goods-receipt-note/GoodsReceiptNoteDetail.vue
+++ b/src/components/goods-receipt-note/GoodsReceiptNoteDetail.vue
@@ -26,7 +26,10 @@
 			{{ t('shillinq', 'Loading goods receipt note...') }}
 		</div>
 
-		<div v-else-if="error" class="grn-detail__error" data-testid="grn-detail-error">
+		<div
+			v-else-if="error"
+			class="grn-detail__error"
+			data-testid="grn-detail-error">
 			{{ error }}
 		</div>
 
@@ -34,16 +37,22 @@
 			<header class="grn-detail__header" data-testid="grn-detail-header">
 				<h2>{{ grn.grnNumber }}</h2>
 				<p>
-					<span class="grn-detail__pill" :class="`grn-detail__pill--${grn.statusCode}`">
+					<span
+						class="grn-detail__pill"
+						:class="`grn-detail__pill--${grn.statusCode}`">
 						{{ statusLabel(grn.statusCode) }}
 					</span>
-					<span v-if="grn.carrier">{{ t('shillinq', 'Carrier') }}: {{ grn.carrier }}</span>
+					<span v-if="grn.carrier"
+						>{{ t('shillinq', 'Carrier') }}: {{ grn.carrier }}</span
+					>
 					<span v-if="grn.deliveryNoteReference">
-						{{ t('shillinq', 'Delivery note') }}: {{ grn.deliveryNoteReference }}
+						{{ t('shillinq', 'Delivery note') }}:
+						{{ grn.deliveryNoteReference }}
 					</span>
 				</p>
 				<p>
-					{{ t('shillinq', 'Received') }}: {{ formatTimestamp(grn.receivedAt) }}
+					{{ t('shillinq', 'Received') }}:
+					{{ formatTimestamp(grn.receivedAt) }}
 					<template v-if="grn.receivedBy">
 						— {{ grn.receivedBy }}
 					</template>
@@ -96,7 +105,10 @@
 
 			<section class="grn-detail__photos">
 				<h3>{{ t('shillinq', 'Delivery photos') }}</h3>
-				<ul v-if="(grn.photos || []).length > 0" class="grn-detail__photo-grid" data-testid="grn-detail-photos">
+				<ul
+					v-if="(grn.photos || []).length > 0"
+					class="grn-detail__photo-grid"
+					data-testid="grn-detail-photos">
 					<li v-for="photoId in grn.photos" :key="photoId">
 						<a :href="photoUrl(photoId)" target="_blank" rel="noopener">
 							{{ photoId }}
@@ -112,13 +124,22 @@
 				<h3>{{ t('shillinq', 'Three-way matches') }}</h3>
 				<ul v-if="matches.length > 0" data-testid="grn-detail-matches">
 					<li v-for="match in matches" :key="match.id">
-						<router-link :to="{ name: 'ThreeWayMatchDetail', params: { id: match.id } }">
+						<router-link
+							:to="{
+								name: 'ThreeWayMatchDetail',
+								params: { id: match.id },
+							}">
 							{{ match.matchReference || match.id }}
 						</router-link>
 					</li>
 				</ul>
 				<p v-else class="grn-detail__matches-empty">
-					{{ t('shillinq', 'No matches yet — invoices will populate them.') }}
+					{{
+						t(
+							'shillinq',
+							'No matches yet — invoices will populate them.',
+						)
+					}}
 				</p>
 			</section>
 
@@ -129,7 +150,11 @@
 					:disabled="transitioning"
 					data-testid="grn-detail-quality-check"
 					@click="onQualityCheck">
-					{{ transitioning ? t('shillinq', 'Working...') : t('shillinq', 'Quality check passed') }}
+					{{
+						transitioning
+							? t('shillinq', 'Working...')
+							: t('shillinq', 'Quality check passed')
+					}}
 				</NcButton>
 				<NcButton
 					v-if="canAccept"
@@ -137,9 +162,16 @@
 					:disabled="transitioning"
 					data-testid="grn-detail-accept"
 					@click="onAccept">
-					{{ transitioning ? t('shillinq', 'Working...') : t('shillinq', 'Accept goods') }}
+					{{
+						transitioning
+							? t('shillinq', 'Working...')
+							: t('shillinq', 'Accept goods')
+					}}
 				</NcButton>
-				<p v-if="transitionError" class="grn-detail__error" data-testid="grn-detail-transition-error">
+				<p
+					v-if="transitionError"
+					class="grn-detail__error"
+					data-testid="grn-detail-transition-error">
 					{{ transitionError }}
 				</p>
 			</footer>
@@ -194,7 +226,9 @@ export default {
 			this.loading = true
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/shillinq/api/openregister/objects/GoodsReceiptNote/${this.id}`),
+					generateUrl(
+						`/apps/shillinq/api/openregister/objects/GoodsReceiptNote/${this.id}`,
+					),
 				)
 				this.grn = response.data || null
 				if (this.grn) {
@@ -203,7 +237,9 @@ export default {
 					await this.loadMatches()
 				}
 			} catch (e) {
-				this.error = e?.response?.data?.error || this.t('shillinq', 'Failed to load goods receipt note')
+				this.error =
+					e?.response?.data?.error
+					|| this.t('shillinq', 'Failed to load goods receipt note')
 			} finally {
 				this.loading = false
 			}
@@ -211,7 +247,9 @@ export default {
 		async loadLines() {
 			try {
 				const response = await axios.get(
-					generateUrl('/apps/shillinq/api/openregister/objects/GoodsReceiptLine'),
+					generateUrl(
+						'/apps/shillinq/api/openregister/objects/GoodsReceiptLine',
+					),
 					{ params: { filter: { grnId: this.id } } },
 				)
 				this.lines = response.data?.results || response.data || []
@@ -224,7 +262,9 @@ export default {
 			for (const poId of this.grn.poIds || []) {
 				try {
 					const response = await axios.get(
-						generateUrl(`/apps/shillinq/api/openregister/objects/PurchaseOrder/${poId}`),
+						generateUrl(
+							`/apps/shillinq/api/openregister/objects/PurchaseOrder/${poId}`,
+						),
 					)
 					map[poId] = response.data || null
 				} catch (e) {
@@ -236,7 +276,9 @@ export default {
 		async loadMatches() {
 			try {
 				const response = await axios.get(
-					generateUrl('/apps/shillinq/api/openregister/objects/ThreeWayMatch'),
+					generateUrl(
+						'/apps/shillinq/api/openregister/objects/ThreeWayMatch',
+					),
 					{ params: { filter: { grnIds: this.id } } },
 				)
 				this.matches = response.data?.results || response.data || []
@@ -256,12 +298,16 @@ export default {
 			this.transitioning = true
 			try {
 				const response = await axios.post(
-					generateUrl(`/apps/shillinq/api/goods-receipt-notes/${this.id}/quality-check`),
+					generateUrl(
+						`/apps/shillinq/api/goods-receipt-notes/${this.id}/quality-check`,
+					),
 					{ administrationId: this.grn?.administrationId },
 				)
 				this.grn = response.data || this.grn
 			} catch (e) {
-				this.transitionError = e?.response?.data?.error || this.t('shillinq', 'Quality check failed')
+				this.transitionError =
+					e?.response?.data?.error
+					|| this.t('shillinq', 'Quality check failed')
 			} finally {
 				this.transitioning = false
 			}
@@ -271,13 +317,16 @@ export default {
 			this.transitioning = true
 			try {
 				const response = await axios.post(
-					generateUrl(`/apps/shillinq/api/goods-receipt-notes/${this.id}/accept`),
+					generateUrl(
+						`/apps/shillinq/api/goods-receipt-notes/${this.id}/accept`,
+					),
 					{ administrationId: this.grn?.administrationId },
 				)
 				this.grn = response.data || this.grn
 				await this.loadLines()
 			} catch (e) {
-				this.transitionError = e?.response?.data?.error || this.t('shillinq', 'Accept failed')
+				this.transitionError =
+					e?.response?.data?.error || this.t('shillinq', 'Accept failed')
 			} finally {
 				this.transitioning = false
 			}

--- a/src/components/goods-receipt-note/GoodsReceiptNoteForm.vue
+++ b/src/components/goods-receipt-note/GoodsReceiptNoteForm.vue
@@ -53,7 +53,12 @@
 			<fieldset class="grn-form__lines">
 				<legend>{{ t('shillinq', 'Line items') }}</legend>
 				<p v-if="availableLines.length === 0" class="grn-form__lines-empty">
-					{{ t('shillinq', 'Pick at least one purchase order to load lines.') }}
+					{{
+						t(
+							'shillinq',
+							'Pick at least one purchase order to load lines.',
+						)
+					}}
 				</p>
 				<ul v-else class="grn-form__lines-list">
 					<li
@@ -62,9 +67,14 @@
 						class="grn-form__line"
 						:data-testid="`grn-form-line-${line.id}`">
 						<header class="grn-form__line-header">
-							<strong>{{ line.description || line.productOrServiceCode || line.id }}</strong>
+							<strong>{{
+								line.description
+								|| line.productOrServiceCode
+								|| line.id
+							}}</strong>
 							<span class="grn-form__line-ordered">
-								{{ t('shillinq', 'Ordered') }}: {{ formatQty(line.quantityOrdered) }}
+								{{ t('shillinq', 'Ordered') }}:
+								{{ formatQty(line.quantityOrdered) }}
 								{{ line.unitOfMeasure || '' }}
 							</span>
 						</header>
@@ -73,7 +83,9 @@
 							<label class="grn-form__field">
 								<span>{{ t('shillinq', 'Received') }}</span>
 								<NcInputField
-									v-model.number="lineState[line.id].quantityReceived"
+									v-model.number="
+										lineState[line.id].quantityReceived
+									"
 									type="number"
 									step="0.001"
 									min="0"
@@ -83,7 +95,9 @@
 							<label class="grn-form__field">
 								<span>{{ t('shillinq', 'Accepted') }}</span>
 								<NcInputField
-									v-model.number="lineState[line.id].quantityAccepted"
+									v-model.number="
+										lineState[line.id].quantityAccepted
+									"
 									type="number"
 									step="0.001"
 									min="0"
@@ -93,7 +107,9 @@
 							<label class="grn-form__field">
 								<span>{{ t('shillinq', 'Rejected') }}</span>
 								<NcInputField
-									v-model.number="lineState[line.id].quantityRejected"
+									v-model.number="
+										lineState[line.id].quantityRejected
+									"
 									type="number"
 									step="0.001"
 									min="0"
@@ -115,7 +131,9 @@
 								<span>{{ t('shillinq', 'Batch / lot') }}</span>
 								<NcTextField
 									v-model="lineState[line.id].batchReference"
-									:label="t('shillinq', 'Batch reference (optional)')"
+									:label="
+										t('shillinq', 'Batch reference (optional)')
+									"
 									:show-trailing-button="false" />
 							</label>
 						</div>
@@ -132,8 +150,11 @@
 					multiple
 					:aria-label="t('shillinq', 'Choose delivery photos to attach')"
 					data-testid="grn-form-photo-input"
-					@change="onPhotoSelected">
-				<ul v-if="photos.length > 0" class="grn-form__photo-list" data-testid="grn-form-photo-list">
+					@change="onPhotoSelected" />
+				<ul
+					v-if="photos.length > 0"
+					class="grn-form__photo-list"
+					data-testid="grn-form-photo-list">
 					<li v-for="photo in photos" :key="photo.id">
 						{{ photo.name }}
 					</li>
@@ -153,7 +174,11 @@
 					type="submit"
 					:disabled="submitting || !canSubmit"
 					data-testid="grn-form-submit">
-					{{ submitting ? t('shillinq', 'Saving...') : t('shillinq', 'Save goods receipt') }}
+					{{
+						submitting
+							? t('shillinq', 'Saving...')
+							: t('shillinq', 'Save goods receipt')
+					}}
 				</NcButton>
 			</div>
 		</form>
@@ -198,15 +223,23 @@ export default {
 				return false
 			}
 			// At least one line must report a received quantity.
-			return Object.values(this.lineState).some((entry) => Number(entry.quantityReceived) > 0)
+			return Object.values(this.lineState).some(
+				(entry) => Number(entry.quantityReceived) > 0,
+			)
 		},
 		rejectionReasonOptions() {
 			return [
 				{ value: 'schade', label: this.t('shillinq', 'Damage') },
-				{ value: 'verkeerd_product', label: this.t('shillinq', 'Wrong product') },
+				{
+					value: 'verkeerd_product',
+					label: this.t('shillinq', 'Wrong product'),
+				},
 				{ value: 'expired', label: this.t('shillinq', 'Expired') },
 				{ value: 'niet_besteld', label: this.t('shillinq', 'Not ordered') },
-				{ value: 'short_shipped', label: this.t('shillinq', 'Short shipped') },
+				{
+					value: 'short_shipped',
+					label: this.t('shillinq', 'Short shipped'),
+				},
 				{ value: 'other', label: this.t('shillinq', 'Other') },
 			]
 		},
@@ -226,7 +259,9 @@ export default {
 	methods: {
 		async loadAdministrationContext() {
 			try {
-				const response = await axios.get(generateUrl('/apps/shillinq/api/administrations/context'))
+				const response = await axios.get(
+					generateUrl('/apps/shillinq/api/administrations/context'),
+				)
 				const admins = response.data?.administrations || []
 				this.administrationOptions = admins.map((a) => ({
 					value: a.administrationId,
@@ -236,20 +271,27 @@ export default {
 					this.administrationId = response.data.activeAdministrationId
 				}
 			} catch (e) {
-				this.error = this.t('shillinq', 'Failed to load administration context')
+				this.error = this.t(
+					'shillinq',
+					'Failed to load administration context',
+				)
 			}
 		},
 		async loadOpenPurchaseOrders() {
 			try {
 				const response = await axios.get(
-					generateUrl('/apps/shillinq/api/openregister/objects/PurchaseOrder'),
+					generateUrl(
+						'/apps/shillinq/api/openregister/objects/PurchaseOrder',
+					),
 				)
 				const records = response.data?.results || response.data || []
 				const open = records.filter((row) => {
 					const state = row.lifecycleState || ''
 					return state !== 'draft' && state !== 'cancelled'
 				})
-				this.openPurchaseOrders = Object.fromEntries(open.map((row) => [row.id || row.poNumber, row]))
+				this.openPurchaseOrders = Object.fromEntries(
+					open.map((row) => [row.id || row.poNumber, row]),
+				)
 				this.poOptions = open.map((row) => ({
 					value: row.id || row.poNumber,
 					label: row.poNumber || row.id,
@@ -270,7 +312,9 @@ export default {
 			for (const poId of this.selectedPoIds) {
 				try {
 					const response = await axios.get(
-						generateUrl('/apps/shillinq/api/openregister/objects/PurchaseOrderLine'),
+						generateUrl(
+							'/apps/shillinq/api/openregister/objects/PurchaseOrderLine',
+						),
 						{ params: { filter: { poId } } },
 					)
 					const records = response.data?.results || response.data || []
@@ -301,7 +345,11 @@ export default {
 			// File-id resolution is delegated to docudesk on submit; here we
 			// stash a preview-friendly name so the operator sees the list.
 			for (const file of files) {
-				this.photos.push({ id: `${file.name}-${file.size}`, name: file.name, file })
+				this.photos.push({
+					id: `${file.name}-${file.size}`,
+					name: file.name,
+					file,
+				})
 			}
 		},
 		formatQty(qty) {
@@ -335,7 +383,10 @@ export default {
 		async onSubmit() {
 			this.error = ''
 			if (!this.canSubmit) {
-				this.error = this.t('shillinq', 'Pick at least one PO and one line with a received quantity')
+				this.error = this.t(
+					'shillinq',
+					'Pick at least one PO and one line with a received quantity',
+				)
 				return
 			}
 
@@ -353,7 +404,8 @@ export default {
 					},
 				)
 				const grn = grnResponse.data || {}
-				const grnId = grn.id || (grn['@self'] && grn['@self'].id) || grn.grnNumber
+				const grnId =
+					grn.id || (grn['@self'] && grn['@self'].id) || grn.grnNumber
 				if (!grnId) {
 					throw new Error('Missing GRN id in response')
 				}
@@ -364,12 +416,15 @@ export default {
 						continue
 					}
 					await axios.post(
-						generateUrl(`/apps/shillinq/api/goods-receipt-notes/${grnId}/lines`),
+						generateUrl(
+							`/apps/shillinq/api/goods-receipt-notes/${grnId}/lines`,
+						),
 						{
 							administrationId: this.administrationId,
 							poLineId: line.id,
 							quantityReceived: state.quantityReceived,
-							quantityAccepted: state.quantityAccepted || state.quantityReceived,
+							quantityAccepted:
+								state.quantityAccepted || state.quantityReceived,
 							quantityRejected: state.quantityRejected || 0,
 							rejectionReason: state.rejectionReason,
 							batchReference: state.batchReference,
@@ -377,9 +432,14 @@ export default {
 					)
 				}
 
-				this.$router.push({ name: 'GoodsReceiptNoteDetail', params: { id: grnId } })
+				this.$router.push({
+					name: 'GoodsReceiptNoteDetail',
+					params: { id: grnId },
+				})
 			} catch (e) {
-				this.error = e?.response?.data?.error || this.t('shillinq', 'Failed to save goods receipt')
+				this.error =
+					e?.response?.data?.error
+					|| this.t('shillinq', 'Failed to save goods receipt')
 			} finally {
 				this.submitting = false
 			}

--- a/src/components/inventory/BarcodeScanner.vue
+++ b/src/components/inventory/BarcodeScanner.vue
@@ -28,7 +28,9 @@
 				autoplay
 				playsinline
 				muted
-				:aria-label="t('shillinq', 'Live camera preview for barcode scanning')" />
+				:aria-label="
+					t('shillinq', 'Live camera preview for barcode scanning')
+				" />
 			<p class="barcode-scanner__hint">
 				{{ t('shillinq', 'Point the camera at the barcode') }}
 			</p>
@@ -43,7 +45,7 @@
 					:placeholder="t('shillinq', 'Enter barcode or SKU')"
 					autocomplete="off"
 					inputmode="search"
-					:aria-label="t('shillinq', 'Manual barcode or SKU entry')">
+					:aria-label="t('shillinq', 'Manual barcode or SKU entry')" />
 			</label>
 			<button type="submit" :disabled="!manualValue">
 				{{ t('shillinq', 'Use this code') }}
@@ -91,7 +93,10 @@ export default {
 	async mounted() {
 		const available = await nativeDetectorAvailable(this.formats)
 		if (!available) {
-			this.cameraError = this.t('shillinq', 'No barcode decoder available; use manual entry.')
+			this.cameraError = this.t(
+				'shillinq',
+				'No barcode decoder available; use manual entry.',
+			)
 			return
 		}
 		try {
@@ -109,7 +114,10 @@ export default {
 				}
 			}
 		} catch (e) {
-			this.cameraError = this.t('shillinq', 'Camera unavailable; use manual entry.')
+			this.cameraError = this.t(
+				'shillinq',
+				'Camera unavailable; use manual entry.',
+			)
 		}
 	},
 	beforeUnmount() {

--- a/src/components/inventory/CountOp.vue
+++ b/src/components/inventory/CountOp.vue
@@ -15,9 +15,17 @@
 		<form class="count-op__form" @submit.prevent="handleConfirm">
 			<label>
 				<span>{{ t('shillinq', 'Location') }}</span>
-				<select v-model="location" required :aria-label="t('shillinq', 'Count location')">
-					<option value="">{{ t('shillinq', 'Select a location') }}</option>
-					<option v-for="loc in store.locations" :key="loc.code" :value="loc.code">
+				<select
+					v-model="location"
+					required
+					:aria-label="t('shillinq', 'Count location')">
+					<option value="">
+						{{ t('shillinq', 'Select a location') }}
+					</option>
+					<option
+						v-for="loc in store.locations"
+						:key="loc.code"
+						:value="loc.code">
 						{{ loc.name }} ({{ loc.code }})
 					</option>
 				</select>
@@ -31,7 +39,7 @@
 						type="text"
 						required
 						:placeholder="t('shillinq', 'Tap scan or type SKU')"
-						:aria-label="t('shillinq', 'Stock keeping unit')">
+						:aria-label="t('shillinq', 'Stock keeping unit')" />
 					<button type="button" @click="scanning = true">
 						{{ t('shillinq', 'Scan') }}
 					</button>
@@ -47,18 +55,26 @@
 					step="0.01"
 					required
 					:aria-label="t('shillinq', 'Physical count')"
-					@input="recomputeVariance">
+					@input="recomputeVariance" />
 			</label>
 
-			<div v-if="systemQuantity !== null" class="count-op__variance" role="status">
+			<div
+				v-if="systemQuantity !== null"
+				class="count-op__variance"
+				role="status">
 				{{ t('shillinq', 'System qty: {sys}', { sys: systemQuantity }) }}
 				—
 				{{ t('shillinq', 'Variance: {variance}', { variance: variance }) }}
 			</div>
 
 			<label>
-				<input v-model="reconcile" type="checkbox">
-				{{ t('shillinq', 'Update InventoryStock to physical count (reconcile)') }}
+				<input v-model="reconcile" type="checkbox" />
+				{{
+					t(
+						'shillinq',
+						'Update InventoryStock to physical count (reconcile)',
+					)
+				}}
 			</label>
 
 			<div v-if="error" class="count-op__error" role="alert">
@@ -135,7 +151,11 @@ export default {
 				return
 			}
 			try {
-				this.systemQuantity = await readStockQuantity(this.store.db, this.sku, this.location)
+				this.systemQuantity = await readStockQuantity(
+					this.store.db,
+					this.sku,
+					this.location,
+				)
 			} catch (e) {
 				this.systemQuantity = 0
 			}
@@ -144,14 +164,25 @@ export default {
 			this.error = null
 			this.successMessage = null
 
-			if (!this.location || !this.sku || this.physicalQuantity === null || this.physicalQuantity < 0) {
-				this.error = this.t('shillinq', 'Location, SKU and a non-negative physical count are required.')
+			if (
+				!this.location
+				|| !this.sku
+				|| this.physicalQuantity === null
+				|| this.physicalQuantity < 0
+			) {
+				this.error = this.t(
+					'shillinq',
+					'Location, SKU and a non-negative physical count are required.',
+				)
 				return
 			}
 
 			const now = Date.now()
 			if (now - this.lastSubmittedAt < 5000) {
-				this.error = this.t('shillinq', 'Already submitted; waiting for server ACK.')
+				this.error = this.t(
+					'shillinq',
+					'Already submitted; waiting for server ACK.',
+				)
 				return
 			}
 			this.lastSubmittedAt = now
@@ -175,7 +206,10 @@ export default {
 				this.systemQuantity = null
 				this.reconcile = false
 			} catch (e) {
-				this.error = e && e.message ? e.message : this.t('shillinq', 'Could not record count.')
+				this.error =
+					e && e.message
+						? e.message
+						: this.t('shillinq', 'Could not record count.')
 			} finally {
 				this.submitting = false
 			}
@@ -185,19 +219,42 @@ export default {
 </script>
 
 <style scoped>
-.count-op { display: flex; flex-direction: column; gap: var(--default-grid-baseline, 4px); padding: var(--default-grid-baseline, 4px); }
+.count-op {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline, 4px);
+	padding: var(--default-grid-baseline, 4px);
+}
 
-.count-op__form label { display: flex; flex-direction: column; margin-bottom: var(--default-grid-baseline, 4px); }
+.count-op__form label {
+	display: flex;
+	flex-direction: column;
+	margin-bottom: var(--default-grid-baseline, 4px);
+}
 
-.count-op__sku-row { display: flex; gap: var(--default-grid-baseline, 4px); }
+.count-op__sku-row {
+	display: flex;
+	gap: var(--default-grid-baseline, 4px);
+}
 
-.count-op__sku-row input { flex: 1; }
+.count-op__sku-row input {
+	flex: 1;
+}
 
-.count-op__variance { color: var(--color-text-maxcontrast); }
+.count-op__variance {
+	color: var(--color-text-maxcontrast);
+}
 
-.count-op__error { color: var(--color-error); }
+.count-op__error {
+	color: var(--color-error);
+}
 
-.count-op__success { color: var(--color-success); }
+.count-op__success {
+	color: var(--color-success);
+}
 
-.count-op__actions { display: flex; justify-content: flex-end; }
+.count-op__actions {
+	display: flex;
+	justify-content: flex-end;
+}
 </style>

--- a/src/components/inventory/PickOp.vue
+++ b/src/components/inventory/PickOp.vue
@@ -15,9 +15,17 @@
 		<form class="pick-op__form" @submit.prevent="handleConfirm">
 			<label>
 				<span>{{ t('shillinq', 'Location') }}</span>
-				<select v-model="location" required :aria-label="t('shillinq', 'Pick location')">
-					<option value="">{{ t('shillinq', 'Select a location') }}</option>
-					<option v-for="loc in store.locations" :key="loc.code" :value="loc.code">
+				<select
+					v-model="location"
+					required
+					:aria-label="t('shillinq', 'Pick location')">
+					<option value="">
+						{{ t('shillinq', 'Select a location') }}
+					</option>
+					<option
+						v-for="loc in store.locations"
+						:key="loc.code"
+						:value="loc.code">
 						{{ loc.name }} ({{ loc.code }})
 					</option>
 				</select>
@@ -31,7 +39,7 @@
 						type="text"
 						required
 						:placeholder="t('shillinq', 'Tap scan or type SKU')"
-						:aria-label="t('shillinq', 'Stock keeping unit')">
+						:aria-label="t('shillinq', 'Stock keeping unit')" />
 					<button type="button" @click="scanning = true">
 						{{ t('shillinq', 'Scan') }}
 					</button>
@@ -40,7 +48,10 @@
 
 			<label>
 				<span>{{ t('shillinq', 'Order line id (optional)') }}</span>
-				<input v-model="orderLineId" type="text" :aria-label="t('shillinq', 'Order line id')">
+				<input
+					v-model="orderLineId"
+					type="text"
+					:aria-label="t('shillinq', 'Order line id')" />
 			</label>
 
 			<label>
@@ -51,7 +62,7 @@
 					min="0.01"
 					step="0.01"
 					required
-					:aria-label="t('shillinq', 'Quantity to pick')">
+					:aria-label="t('shillinq', 'Quantity to pick')" />
 			</label>
 
 			<div v-if="error" class="pick-op__error" role="alert">
@@ -115,14 +126,26 @@ export default {
 			this.warning = null
 			this.successMessage = null
 
-			if (!this.location || !this.sku || !this.quantity || this.quantity <= 0) {
-				this.error = this.t('shillinq', 'Location, SKU and a positive quantity are required.')
+			if (
+				!this.location
+				|| !this.sku
+				|| !this.quantity
+				|| this.quantity <= 0
+			) {
+				this.error = this.t(
+					'shillinq',
+					'Location, SKU and a positive quantity are required.',
+				)
 				return
 			}
 
 			try {
 				if (this.store.db) {
-					const onHand = await readStockQuantity(this.store.db, this.sku, this.location)
+					const onHand = await readStockQuantity(
+						this.store.db,
+						this.sku,
+						this.location,
+					)
 					if (onHand < this.quantity) {
 						this.warning = this.t(
 							'shillinq',
@@ -138,7 +161,10 @@ export default {
 
 			const now = Date.now()
 			if (now - this.lastSubmittedAt < 5000) {
-				this.error = this.t('shillinq', 'Already submitted; waiting for server ACK.')
+				this.error = this.t(
+					'shillinq',
+					'Already submitted; waiting for server ACK.',
+				)
 				return
 			}
 			this.lastSubmittedAt = now
@@ -161,7 +187,10 @@ export default {
 				this.quantity = null
 				this.orderLineId = ''
 			} catch (e) {
-				this.error = e && e.message ? e.message : this.t('shillinq', 'Could not record pick.')
+				this.error =
+					e && e.message
+						? e.message
+						: this.t('shillinq', 'Could not record pick.')
 			} finally {
 				this.submitting = false
 			}
@@ -171,19 +200,42 @@ export default {
 </script>
 
 <style scoped>
-.pick-op { display: flex; flex-direction: column; gap: var(--default-grid-baseline, 4px); padding: var(--default-grid-baseline, 4px); }
+.pick-op {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline, 4px);
+	padding: var(--default-grid-baseline, 4px);
+}
 
-.pick-op__form label { display: flex; flex-direction: column; margin-bottom: var(--default-grid-baseline, 4px); }
+.pick-op__form label {
+	display: flex;
+	flex-direction: column;
+	margin-bottom: var(--default-grid-baseline, 4px);
+}
 
-.pick-op__sku-row { display: flex; gap: var(--default-grid-baseline, 4px); }
+.pick-op__sku-row {
+	display: flex;
+	gap: var(--default-grid-baseline, 4px);
+}
 
-.pick-op__sku-row input { flex: 1; }
+.pick-op__sku-row input {
+	flex: 1;
+}
 
-.pick-op__error { color: var(--color-error); }
+.pick-op__error {
+	color: var(--color-error);
+}
 
-.pick-op__warning { color: var(--color-warning); }
+.pick-op__warning {
+	color: var(--color-warning);
+}
 
-.pick-op__success { color: var(--color-success); }
+.pick-op__success {
+	color: var(--color-success);
+}
 
-.pick-op__actions { display: flex; justify-content: flex-end; }
+.pick-op__actions {
+	display: flex;
+	justify-content: flex-end;
+}
 </style>

--- a/src/components/inventory/ReceiveOp.vue
+++ b/src/components/inventory/ReceiveOp.vue
@@ -15,9 +15,17 @@
 		<form class="receive-op__form" @submit.prevent="handleConfirm">
 			<label>
 				<span>{{ t('shillinq', 'Location') }}</span>
-				<select v-model="location" required :aria-label="t('shillinq', 'Receiving location')">
-					<option value="">{{ t('shillinq', 'Select a location') }}</option>
-					<option v-for="loc in store.locations" :key="loc.code" :value="loc.code">
+				<select
+					v-model="location"
+					required
+					:aria-label="t('shillinq', 'Receiving location')">
+					<option value="">
+						{{ t('shillinq', 'Select a location') }}
+					</option>
+					<option
+						v-for="loc in store.locations"
+						:key="loc.code"
+						:value="loc.code">
 						{{ loc.name }} ({{ loc.code }})
 					</option>
 				</select>
@@ -31,7 +39,7 @@
 						type="text"
 						required
 						:placeholder="t('shillinq', 'Tap scan or type SKU')"
-						:aria-label="t('shillinq', 'Stock keeping unit')">
+						:aria-label="t('shillinq', 'Stock keeping unit')" />
 					<button type="button" @click="scanning = true">
 						{{ t('shillinq', 'Scan') }}
 					</button>
@@ -46,7 +54,7 @@
 					min="0.01"
 					step="0.01"
 					required
-					:aria-label="t('shillinq', 'Quantity received')">
+					:aria-label="t('shillinq', 'Quantity received')" />
 			</label>
 
 			<div v-if="error" class="receive-op__error" role="alert">
@@ -103,15 +111,26 @@ export default {
 			this.error = null
 			this.successMessage = null
 
-			if (!this.location || !this.sku || !this.quantity || this.quantity <= 0) {
-				this.error = this.t('shillinq', 'Location, SKU and a positive quantity are required.')
+			if (
+				!this.location
+				|| !this.sku
+				|| !this.quantity
+				|| this.quantity <= 0
+			) {
+				this.error = this.t(
+					'shillinq',
+					'Location, SKU and a positive quantity are required.',
+				)
 				return
 			}
 
 			// REQ-SYNC-002 idempotency guard — reject duplicate confirms within 5s.
 			const now = Date.now()
 			if (now - this.lastSubmittedAt < 5000) {
-				this.error = this.t('shillinq', 'Already submitted; waiting for server ACK.')
+				this.error = this.t(
+					'shillinq',
+					'Already submitted; waiting for server ACK.',
+				)
 				return
 			}
 			this.lastSubmittedAt = now
@@ -133,7 +152,10 @@ export default {
 				this.quantity = null
 				this.lastTransactionId = result.transactionId
 			} catch (e) {
-				this.error = e && e.message ? e.message : this.t('shillinq', 'Could not record receipt.')
+				this.error =
+					e && e.message
+						? e.message
+						: this.t('shillinq', 'Could not record receipt.')
 			} finally {
 				this.submitting = false
 			}
@@ -143,17 +165,38 @@ export default {
 </script>
 
 <style scoped>
-.receive-op { display: flex; flex-direction: column; gap: var(--default-grid-baseline, 4px); padding: var(--default-grid-baseline, 4px); }
+.receive-op {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline, 4px);
+	padding: var(--default-grid-baseline, 4px);
+}
 
-.receive-op__form label { display: flex; flex-direction: column; margin-bottom: var(--default-grid-baseline, 4px); }
+.receive-op__form label {
+	display: flex;
+	flex-direction: column;
+	margin-bottom: var(--default-grid-baseline, 4px);
+}
 
-.receive-op__sku-row { display: flex; gap: var(--default-grid-baseline, 4px); }
+.receive-op__sku-row {
+	display: flex;
+	gap: var(--default-grid-baseline, 4px);
+}
 
-.receive-op__sku-row input { flex: 1; }
+.receive-op__sku-row input {
+	flex: 1;
+}
 
-.receive-op__error { color: var(--color-error); }
+.receive-op__error {
+	color: var(--color-error);
+}
 
-.receive-op__success { color: var(--color-success); }
+.receive-op__success {
+	color: var(--color-success);
+}
 
-.receive-op__actions { display: flex; justify-content: flex-end; }
+.receive-op__actions {
+	display: flex;
+	justify-content: flex-end;
+}
 </style>

--- a/src/components/inventory/SyncStatusBadge.vue
+++ b/src/components/inventory/SyncStatusBadge.vue
@@ -33,7 +33,13 @@
 				:key="conflict.at + index"
 				role="status">
 				<span>
-					{{ t('shillinq', 'Stock was updated by another user. {applied} record(s) merged at {at}.', { applied: conflict.applied, at: conflict.at }) }}
+					{{
+						t(
+							'shillinq',
+							'Stock was updated by another user. {applied} record(s) merged at {at}.',
+							{ applied: conflict.applied, at: conflict.at },
+						)
+					}}
 				</span>
 				<button type="button" @click="store.dismissConflict(index)">
 					{{ t('shillinq', 'Dismiss') }}
@@ -61,7 +67,12 @@ export default {
 			return useInventoryMobileScannerStore()
 		},
 		badgeClass() {
-			if (this.store.syncState === 'syncing' || this.store.syncState === 'pending' || this.store.syncState === 'failed' || this.isStale) {
+			if (
+				this.store.syncState === 'syncing'
+				|| this.store.syncState === 'pending'
+				|| this.store.syncState === 'failed'
+				|| this.isStale
+			) {
 				return 'sync-status-badge__button--yellow'
 			}
 			if (this.store.syncState === 'offline') {
@@ -77,11 +88,13 @@ export default {
 			if (Number.isNaN(ts)) {
 				return false
 			}
-			return (this.now - ts) > STALE_THRESHOLD_MS
+			return this.now - ts > STALE_THRESHOLD_MS
 		},
 		humanLabel() {
 			if (this.store.syncState === 'failed') {
-				return this.t('shillinq', 'Sync failed; retry {sec}s', { sec: Math.ceil((this.store.retryInMs || 0) / 1000) })
+				return this.t('shillinq', 'Sync failed; retry {sec}s', {
+					sec: Math.ceil((this.store.retryInMs || 0) / 1000),
+				})
 			}
 			if (this.store.syncState === 'syncing') {
 				return this.t('shillinq', 'Syncing…')
@@ -90,10 +103,14 @@ export default {
 				return this.t('shillinq', 'Offline')
 			}
 			if (this.store.pendingCount > 0) {
-				return this.t('shillinq', 'Pending ({n})', { n: this.store.pendingCount })
+				return this.t('shillinq', 'Pending ({n})', {
+					n: this.store.pendingCount,
+				})
 			}
 			if (this.store.lastSyncedAt) {
-				return this.t('shillinq', 'Last synced {at}', { at: this.formatTime(this.store.lastSyncedAt) })
+				return this.t('shillinq', 'Last synced {at}', {
+					at: this.formatTime(this.store.lastSyncedAt),
+				})
 			}
 			return this.t('shillinq', 'Sync now')
 		},
@@ -129,7 +146,9 @@ export default {
 </script>
 
 <style scoped>
-.sync-status-badge { position: relative; }
+.sync-status-badge {
+	position: relative;
+}
 
 .sync-status-badge__button {
 	display: inline-flex;
@@ -141,20 +160,33 @@ export default {
 }
 
 .sync-status-badge__dot {
-	width: 8px; height: 8px; border-radius: 50%;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
 	background: var(--color-success);
 }
 
-.sync-status-badge__button--green .sync-status-badge__dot { background: var(--color-success); }
+.sync-status-badge__button--green .sync-status-badge__dot {
+	background: var(--color-success);
+}
 
-.sync-status-badge__button--yellow .sync-status-badge__dot { background: var(--color-warning); }
+.sync-status-badge__button--yellow .sync-status-badge__dot {
+	background: var(--color-warning);
+}
 
-.sync-status-badge__button--red .sync-status-badge__dot { background: var(--color-error); }
+.sync-status-badge__button--red .sync-status-badge__dot {
+	background: var(--color-error);
+}
 
-.sync-status-badge__conflicts { list-style: none; padding: 0; margin-top: var(--default-grid-baseline, 4px); }
+.sync-status-badge__conflicts {
+	list-style: none;
+	padding: 0;
+	margin-top: var(--default-grid-baseline, 4px);
+}
 
 .sync-status-badge__conflicts li {
-	display: flex; gap: var(--default-grid-baseline, 4px);
+	display: flex;
+	gap: var(--default-grid-baseline, 4px);
 	background: var(--color-background-hover);
 	padding: var(--default-grid-baseline, 4px);
 	border-radius: var(--border-radius, 4px);

--- a/src/components/inventory/TransferOp.vue
+++ b/src/components/inventory/TransferOp.vue
@@ -15,9 +15,15 @@
 		<form class="transfer-op__form" @submit.prevent="handleConfirm">
 			<label>
 				<span>{{ t('shillinq', 'From location') }}</span>
-				<select v-model="fromLocation" required :aria-label="t('shillinq', 'Source location')">
+				<select
+					v-model="fromLocation"
+					required
+					:aria-label="t('shillinq', 'Source location')">
 					<option value="">{{ t('shillinq', 'Select source') }}</option>
-					<option v-for="loc in store.locations" :key="loc.code" :value="loc.code">
+					<option
+						v-for="loc in store.locations"
+						:key="loc.code"
+						:value="loc.code">
 						{{ loc.name }} ({{ loc.code }})
 					</option>
 				</select>
@@ -31,7 +37,7 @@
 						type="text"
 						required
 						:placeholder="t('shillinq', 'Tap scan or type SKU')"
-						:aria-label="t('shillinq', 'Stock keeping unit')">
+						:aria-label="t('shillinq', 'Stock keeping unit')" />
 					<button type="button" @click="scanning = true">
 						{{ t('shillinq', 'Scan') }}
 					</button>
@@ -40,9 +46,17 @@
 
 			<label>
 				<span>{{ t('shillinq', 'To location') }}</span>
-				<select v-model="toLocation" required :aria-label="t('shillinq', 'Destination location')">
-					<option value="">{{ t('shillinq', 'Select destination') }}</option>
-					<option v-for="loc in availableDestinations" :key="loc.code" :value="loc.code">
+				<select
+					v-model="toLocation"
+					required
+					:aria-label="t('shillinq', 'Destination location')">
+					<option value="">
+						{{ t('shillinq', 'Select destination') }}
+					</option>
+					<option
+						v-for="loc in availableDestinations"
+						:key="loc.code"
+						:value="loc.code">
 						{{ loc.name }} ({{ loc.code }})
 					</option>
 				</select>
@@ -56,7 +70,7 @@
 					min="0.01"
 					step="0.01"
 					required
-					:aria-label="t('shillinq', 'Quantity to transfer')">
+					:aria-label="t('shillinq', 'Quantity to transfer')" />
 			</label>
 
 			<div v-if="error" class="transfer-op__error" role="alert">
@@ -106,7 +120,9 @@ export default {
 			return useInventoryMobileScannerStore()
 		},
 		availableDestinations() {
-			return this.store.locations.filter((loc) => loc.code !== this.fromLocation)
+			return this.store.locations.filter(
+				(loc) => loc.code !== this.fromLocation,
+			)
 		},
 	},
 	methods: {
@@ -118,19 +134,35 @@ export default {
 			this.error = null
 			this.successMessage = null
 
-			if (!this.fromLocation || !this.toLocation || !this.sku || !this.quantity || this.quantity <= 0) {
-				this.error = this.t('shillinq', 'Source, destination, SKU and a positive quantity are required.')
+			if (
+				!this.fromLocation
+				|| !this.toLocation
+				|| !this.sku
+				|| !this.quantity
+				|| this.quantity <= 0
+			) {
+				this.error = this.t(
+					'shillinq',
+					'Source, destination, SKU and a positive quantity are required.',
+				)
 				return
 			}
 			if (this.fromLocation === this.toLocation) {
-				this.error = this.t('shillinq', 'Source and destination must differ.')
+				this.error = this.t(
+					'shillinq',
+					'Source and destination must differ.',
+				)
 				return
 			}
 
 			// Validate source has enough stock — REQ-INVENTORY-002 acceptance.
 			try {
 				if (this.store.db) {
-					const onHand = await readStockQuantity(this.store.db, this.sku, this.fromLocation)
+					const onHand = await readStockQuantity(
+						this.store.db,
+						this.sku,
+						this.fromLocation,
+					)
 					if (onHand < this.quantity) {
 						this.error = this.t(
 							'shillinq',
@@ -146,7 +178,10 @@ export default {
 
 			const now = Date.now()
 			if (now - this.lastSubmittedAt < 5000) {
-				this.error = this.t('shillinq', 'Already submitted; waiting for server ACK.')
+				this.error = this.t(
+					'shillinq',
+					'Already submitted; waiting for server ACK.',
+				)
 				return
 			}
 			this.lastSubmittedAt = now
@@ -163,12 +198,19 @@ export default {
 				this.successMessage = this.t(
 					'shillinq',
 					'Transferred {qty} units {from} → {to} (pending sync)',
-					{ qty: this.quantity, from: this.fromLocation, to: this.toLocation },
+					{
+						qty: this.quantity,
+						from: this.fromLocation,
+						to: this.toLocation,
+					},
 				)
 				this.sku = ''
 				this.quantity = null
 			} catch (e) {
-				this.error = e && e.message ? e.message : this.t('shillinq', 'Could not record transfer.')
+				this.error =
+					e && e.message
+						? e.message
+						: this.t('shillinq', 'Could not record transfer.')
 			} finally {
 				this.submitting = false
 			}
@@ -178,17 +220,38 @@ export default {
 </script>
 
 <style scoped>
-.transfer-op { display: flex; flex-direction: column; gap: var(--default-grid-baseline, 4px); padding: var(--default-grid-baseline, 4px); }
+.transfer-op {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline, 4px);
+	padding: var(--default-grid-baseline, 4px);
+}
 
-.transfer-op__form label { display: flex; flex-direction: column; margin-bottom: var(--default-grid-baseline, 4px); }
+.transfer-op__form label {
+	display: flex;
+	flex-direction: column;
+	margin-bottom: var(--default-grid-baseline, 4px);
+}
 
-.transfer-op__sku-row { display: flex; gap: var(--default-grid-baseline, 4px); }
+.transfer-op__sku-row {
+	display: flex;
+	gap: var(--default-grid-baseline, 4px);
+}
 
-.transfer-op__sku-row input { flex: 1; }
+.transfer-op__sku-row input {
+	flex: 1;
+}
 
-.transfer-op__error { color: var(--color-error); }
+.transfer-op__error {
+	color: var(--color-error);
+}
 
-.transfer-op__success { color: var(--color-success); }
+.transfer-op__success {
+	color: var(--color-success);
+}
 
-.transfer-op__actions { display: flex; justify-content: flex-end; }
+.transfer-op__actions {
+	display: flex;
+	justify-content: flex-end;
+}
 </style>

--- a/src/components/invoice/InvoiceGenerator.vue
+++ b/src/components/invoice/InvoiceGenerator.vue
@@ -23,31 +23,39 @@
 				<label>
 					{{ t('shillinq', 'Billing model') }}
 					<select v-model="form.billingModel" required>
-						<option value="t_and_m">{{ t('shillinq', 'Time & Materials') }}</option>
-						<option value="fixed_fee">{{ t('shillinq', 'Fixed fee') }}</option>
-						<option value="milestone">{{ t('shillinq', 'Milestone') }}</option>
-						<option value="retainer">{{ t('shillinq', 'Retainer') }}</option>
+						<option value="t_and_m">
+							{{ t('shillinq', 'Time & Materials') }}
+						</option>
+						<option value="fixed_fee">
+							{{ t('shillinq', 'Fixed fee') }}
+						</option>
+						<option value="milestone">
+							{{ t('shillinq', 'Milestone') }}
+						</option>
+						<option value="retainer">
+							{{ t('shillinq', 'Retainer') }}
+						</option>
 						<option value="mixed">{{ t('shillinq', 'Mixed') }}</option>
 					</select>
 				</label>
 				<label>
 					{{ t('shillinq', 'Customer') }}
-					<input v-model="form.customerId" type="text" required>
+					<input v-model="form.customerId" type="text" required />
 				</label>
 				<label>
 					{{ t('shillinq', 'Project (optional)') }}
-					<input v-model="form.projectId" type="text">
+					<input v-model="form.projectId" type="text" />
 				</label>
 			</div>
 
 			<div class="invoice-generator__row">
 				<label>
 					{{ t('shillinq', 'From') }}
-					<input v-model="form.fromDate" type="date" required>
+					<input v-model="form.fromDate" type="date" required />
 				</label>
 				<label>
 					{{ t('shillinq', 'To') }}
-					<input v-model="form.toDate" type="date" required>
+					<input v-model="form.toDate" type="date" required />
 				</label>
 			</div>
 
@@ -55,7 +63,10 @@
 				<label v-if="needsRateCard">
 					{{ t('shillinq', 'Rate card') }}
 					<select v-model="form.rateCardId">
-						<option v-for="card in rateCards" :key="card.id" :value="card.id">
+						<option
+							v-for="card in rateCards"
+							:key="card.id"
+							:value="card.id">
 							{{ card.label }}
 						</option>
 					</select>
@@ -70,14 +81,15 @@
 				</label>
 				<label v-if="needsFixedFee">
 					{{ t('shillinq', 'Fixed fee (€)') }}
-					<input v-model.number="fixedFeeEuros"
+					<input
+						v-model.number="fixedFeeEuros"
 						type="number"
 						min="0"
-						step="0.01">
+						step="0.01" />
 				</label>
 				<label v-if="needsMilestone">
 					{{ t('shillinq', 'Milestone ID') }}
-					<input v-model="form.milestoneId" type="text">
+					<input v-model="form.milestoneId" type="text" />
 				</label>
 			</div>
 
@@ -100,9 +112,18 @@
 			</div>
 
 			<div v-if="totals" class="invoice-generator__totals">
-				<p><strong>{{ t('shillinq', 'Net amount') }}:</strong> € {{ formatMoney(totals.netAmount) }}</p>
-				<p><strong>{{ t('shillinq', 'VAT/BTW') }}:</strong> € {{ formatMoney(totals.vatAmount) }}</p>
-				<p><strong>{{ t('shillinq', 'Gross amount') }}:</strong> € {{ formatMoney(totals.grossAmount) }}</p>
+				<p>
+					<strong>{{ t('shillinq', 'Net amount') }}:</strong> €
+					{{ formatMoney(totals.netAmount) }}
+				</p>
+				<p>
+					<strong>{{ t('shillinq', 'VAT/BTW') }}:</strong> €
+					{{ formatMoney(totals.vatAmount) }}
+				</p>
+				<p>
+					<strong>{{ t('shillinq', 'Gross amount') }}:</strong> €
+					{{ formatMoney(totals.grossAmount) }}
+				</p>
 			</div>
 
 			<div class="invoice-generator__actions">
@@ -194,11 +215,17 @@ export default {
 			if (typeof raw !== 'string' || raw.trim() === '') {
 				return []
 			}
-			return raw.split(',').map(s => s.trim()).filter(Boolean)
+			return raw
+				.split(',')
+				.map((s) => s.trim())
+				.filter(Boolean)
 		},
 		formatMoney(value) {
 			const n = Number(value || 0)
-			return n.toLocaleString('nl-NL', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+			return n.toLocaleString('nl-NL', {
+				minimumFractionDigits: 2,
+				maximumFractionDigits: 2,
+			})
 		},
 		async onSaveDraft() {
 			this.busy = true
@@ -213,7 +240,10 @@ export default {
 				}
 				this.$emit('draft-created', result)
 			} catch (e) {
-				this.error = (e && e.message) ? e.message : t('shillinq', 'Failed to draft invoice')
+				this.error =
+					e && e.message
+						? e.message
+						: t('shillinq', 'Failed to draft invoice')
 			} finally {
 				this.busy = false
 			}
@@ -237,7 +267,10 @@ export default {
 				const result = await invoiceApi.post(this.draftId)
 				this.$emit('posted', result)
 			} catch (e) {
-				this.error = (e && e.message) ? e.message : t('shillinq', 'Failed to post invoice')
+				this.error =
+					e && e.message
+						? e.message
+						: t('shillinq', 'Failed to post invoice')
 			} finally {
 				this.busy = false
 			}

--- a/src/components/invoice/InvoiceLineItemReview.vue
+++ b/src/components/invoice/InvoiceLineItemReview.vue
@@ -47,20 +47,24 @@
 					<td class="num">
 						{{ formatRate(line.rateApplied) }}
 					</td>
-					<td class="num">
-						€ {{ formatMoney(line.costAmount) }}
-					</td>
-					<td class="num">
-						{{ line.vatRate }}%
-					</td>
+					<td class="num">€ {{ formatMoney(line.costAmount) }}</td>
+					<td class="num">{{ line.vatRate }}%</td>
 				</tr>
 			</tbody>
 		</table>
 
 		<footer class="invoice-line-review__totals">
 			<p>{{ t('shillinq', 'Net') }}: € {{ formatMoney(summary.netAmount) }}</p>
-			<p>{{ t('shillinq', 'VAT/BTW') }}: € {{ formatMoney(summary.vatAmount) }}</p>
-			<p><strong>{{ t('shillinq', 'Gross') }}: € {{ formatMoney(summary.grossAmount) }}</strong></p>
+			<p>
+				{{ t('shillinq', 'VAT/BTW') }}: €
+				{{ formatMoney(summary.vatAmount) }}
+			</p>
+			<p>
+				<strong
+					>{{ t('shillinq', 'Gross') }}: €
+					{{ formatMoney(summary.grossAmount) }}</strong
+				>
+			</p>
 		</footer>
 	</section>
 </template>
@@ -96,7 +100,10 @@ export default {
 		},
 		formatMoney(value) {
 			const n = Number(value || 0)
-			return n.toLocaleString('nl-NL', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+			return n.toLocaleString('nl-NL', {
+				minimumFractionDigits: 2,
+				maximumFractionDigits: 2,
+			})
 		},
 		formatUnits(value) {
 			if (value === null || value === undefined) return ''

--- a/src/components/period-close/PeriodCloseDetail.vue
+++ b/src/components/period-close/PeriodCloseDetail.vue
@@ -33,56 +33,84 @@
 -->
 <template>
 	<div class="period-close-detail" data-testid="period-close-detail">
-		<div v-if="loading" class="period-close-detail__loading" data-testid="period-close-detail-loading">
+		<div
+			v-if="loading"
+			class="period-close-detail__loading"
+			data-testid="period-close-detail-loading">
 			{{ t('shillinq', 'Loading period…') }}
 		</div>
 
-		<div v-else-if="loadError" class="period-close-detail__error" data-testid="period-close-detail-error">
+		<div
+			v-else-if="loadError"
+			class="period-close-detail__error"
+			data-testid="period-close-detail-error">
 			{{ loadError }}
 		</div>
 
 		<div v-else-if="period" class="period-close-detail__body">
-			<header class="period-close-detail__header" data-testid="period-close-detail-header">
+			<header
+				class="period-close-detail__header"
+				data-testid="period-close-detail-header">
 				<h2>{{ period.name || period.periodId }}</h2>
 				<p class="period-close-detail__meta">
-					<span class="period-close-detail__pill" :class="`period-close-detail__pill--${stateSlug}`">
+					<span
+						class="period-close-detail__pill"
+						:class="`period-close-detail__pill--${stateSlug}`">
 						{{ stateLabel }}
 					</span>
 					<span class="period-close-detail__chip">
-						{{ t('shillinq', 'Period') }}: <strong>{{ period.periodId }}</strong>
+						{{ t('shillinq', 'Period') }}:
+						<strong>{{ period.periodId }}</strong>
 					</span>
-					<span v-if="period.administrationId" class="period-close-detail__chip">
-						{{ t('shillinq', 'Administration') }}: <strong>{{ period.administrationId }}</strong>
+					<span
+						v-if="period.administrationId"
+						class="period-close-detail__chip">
+						{{ t('shillinq', 'Administration') }}:
+						<strong>{{ period.administrationId }}</strong>
 					</span>
 					<span v-if="period.fiscalYear" class="period-close-detail__chip">
-						{{ t('shillinq', 'Fiscal year') }}: <strong>{{ period.fiscalYear }}</strong>
+						{{ t('shillinq', 'Fiscal year') }}:
+						<strong>{{ period.fiscalYear }}</strong>
 					</span>
 				</p>
 				<p class="period-close-detail__dates">
-					<span>{{ formatDate(period.startDate) }} – {{ formatDate(period.endDate) }}</span>
+					<span
+						>{{ formatDate(period.startDate) }} –
+						{{ formatDate(period.endDate) }}</span
+					>
 				</p>
 				<p v-if="period.closedAt" class="period-close-detail__close-info">
-					{{ t('shillinq', 'Closed at') }}: {{ formatTimestamp(period.closedAt) }}
+					{{ t('shillinq', 'Closed at') }}:
+					{{ formatTimestamp(period.closedAt) }}
 					<template v-if="period.closedBy">
 						— {{ period.closedBy }}
 					</template>
 				</p>
-				<p v-if="period.auditLockedAt" class="period-close-detail__lock-info">
-					{{ t('shillinq', 'Audit locked at') }}: {{ formatTimestamp(period.auditLockedAt) }}
+				<p
+					v-if="period.auditLockedAt"
+					class="period-close-detail__lock-info">
+					{{ t('shillinq', 'Audit locked at') }}:
+					{{ formatTimestamp(period.auditLockedAt) }}
 					<template v-if="period.auditLockedBy">
 						— {{ period.auditLockedBy }}
 					</template>
 				</p>
 			</header>
 
-			<section class="period-close-detail__actions" data-testid="period-close-detail-actions">
+			<section
+				class="period-close-detail__actions"
+				data-testid="period-close-detail-actions">
 				<NcButton
 					v-if="canStartClose"
 					variant="primary"
 					:disabled="transitioning"
 					data-testid="period-close-detail-start-close"
 					@click="onStartClose">
-					{{ transitioning ? t('shillinq', 'Working…') : t('shillinq', 'Start close') }}
+					{{
+						transitioning
+							? t('shillinq', 'Working…')
+							: t('shillinq', 'Start close')
+					}}
 				</NcButton>
 				<NcButton
 					v-if="canClose"
@@ -90,7 +118,11 @@
 					:disabled="transitioning"
 					data-testid="period-close-detail-close"
 					@click="onClose">
-					{{ transitioning ? t('shillinq', 'Working…') : t('shillinq', 'Close period') }}
+					{{
+						transitioning
+							? t('shillinq', 'Working…')
+							: t('shillinq', 'Close period')
+					}}
 				</NcButton>
 				<NcButton
 					v-if="canReopen"
@@ -106,19 +138,33 @@
 					:disabled="transitioning"
 					data-testid="period-close-detail-lock-audit"
 					@click="onLockAudit">
-					{{ transitioning ? t('shillinq', 'Working…') : t('shillinq', 'Lock for audit') }}
+					{{
+						transitioning
+							? t('shillinq', 'Working…')
+							: t('shillinq', 'Lock for audit')
+					}}
 				</NcButton>
-				<p v-if="transitionError" class="period-close-detail__error" data-testid="period-close-detail-transition-error">
+				<p
+					v-if="transitionError"
+					class="period-close-detail__error"
+					data-testid="period-close-detail-transition-error">
 					{{ transitionError }}
 				</p>
-				<p v-if="transitionNotice" class="period-close-detail__notice" data-testid="period-close-detail-transition-notice">
+				<p
+					v-if="transitionNotice"
+					class="period-close-detail__notice"
+					data-testid="period-close-detail-transition-notice">
 					{{ transitionNotice }}
 				</p>
 			</section>
 
-			<section class="period-close-detail__checklist" data-testid="period-close-detail-checklist">
+			<section
+				class="period-close-detail__checklist"
+				data-testid="period-close-detail-checklist">
 				<h3>{{ t('shillinq', 'Close checklist') }}</h3>
-				<table v-if="checklistItems.length > 0" class="period-close-detail__checklist-table">
+				<table
+					v-if="checklistItems.length > 0"
+					class="period-close-detail__checklist-table">
 					<thead>
 						<tr>
 							<th scope="col">{{ t('shillinq', 'Category') }}</th>
@@ -136,21 +182,37 @@
 							<td>{{ categoryLabel(item.category) }}</td>
 							<td>{{ item.description }}</td>
 							<td>
-								<span :class="`period-close-detail__pill period-close-detail__pill--${item.resolved ? 'closed' : 'open'}`">
-									{{ item.resolved ? t('shillinq', 'Resolved') : t('shillinq', 'Open') }}
+								<span
+									:class="`period-close-detail__pill period-close-detail__pill--${item.resolved ? 'closed' : 'open'}`">
+									{{
+										item.resolved
+											? t('shillinq', 'Resolved')
+											: t('shillinq', 'Open')
+									}}
 								</span>
 							</td>
-							<td>{{ item.resolvedAt ? formatTimestamp(item.resolvedAt) : '—' }}</td>
+							<td>
+								{{
+									item.resolvedAt
+										? formatTimestamp(item.resolvedAt)
+										: '—'
+								}}
+							</td>
 							<td>{{ item.resolvedBy || '—' }}</td>
 						</tr>
 					</tbody>
 				</table>
-				<p v-else class="period-close-detail__empty" data-testid="period-close-detail-checklist-empty">
+				<p
+					v-else
+					class="period-close-detail__empty"
+					data-testid="period-close-detail-checklist-empty">
 					{{ t('shillinq', 'No checklist items yet.') }}
 				</p>
 			</section>
 
-			<section class="period-close-detail__flags" data-testid="period-close-detail-flags">
+			<section
+				class="period-close-detail__flags"
+				data-testid="period-close-detail-flags">
 				<h3>{{ t('shillinq', 'AI close assistant') }}</h3>
 				<ul v-if="aiFlags.length > 0" class="period-close-detail__flag-list">
 					<li
@@ -160,18 +222,28 @@
 						:class="`period-close-detail__flag--${flag.severity || 'warning'}`"
 						:data-testid="`period-close-detail-flag-${flag.id || flag.code}`">
 						<strong>{{ flag.title || flag.code }}</strong>
-						<span v-if="flag.description"> — {{ flag.description }}</span>
-						<span v-if="flag.count !== undefined" class="period-close-detail__flag-count">
+						<span v-if="flag.description">
+							— {{ flag.description }}</span
+						>
+						<span
+							v-if="flag.count !== undefined"
+							class="period-close-detail__flag-count">
 							({{ flag.count }})
 						</span>
 					</li>
 				</ul>
-				<p v-else class="period-close-detail__empty" data-testid="period-close-detail-flags-empty">
+				<p
+					v-else
+					class="period-close-detail__empty"
+					data-testid="period-close-detail-flags-empty">
 					{{ t('shillinq', 'No close assistant flags raised.') }}
 				</p>
 			</section>
 
-			<section v-if="reopenedHistory.length > 0" class="period-close-detail__history" data-testid="period-close-detail-history">
+			<section
+				v-if="reopenedHistory.length > 0"
+				class="period-close-detail__history"
+				data-testid="period-close-detail-history">
 				<h3>{{ t('shillinq', 'Reopen history') }}</h3>
 				<ol>
 					<li
@@ -179,12 +251,20 @@
 						:key="`reopen-${idx}`"
 						:data-testid="`period-close-detail-history-${idx}`">
 						<strong>{{ formatTimestamp(entry.reopenedAt) }}</strong>
-						<span v-if="entry.reopenedBy"> — {{ entry.reopenedBy }}</span>
-						<p v-if="entry.closeReason" class="period-close-detail__history-reason">
-							{{ t('shillinq', 'Close reason') }}: {{ entry.closeReason }}
+						<span v-if="entry.reopenedBy">
+							— {{ entry.reopenedBy }}</span
+						>
+						<p
+							v-if="entry.closeReason"
+							class="period-close-detail__history-reason">
+							{{ t('shillinq', 'Close reason') }}:
+							{{ entry.closeReason }}
 						</p>
-						<p v-if="entry.originalClosedAt" class="period-close-detail__history-orig">
-							{{ t('shillinq', 'Original close') }}: {{ formatTimestamp(entry.originalClosedAt) }}
+						<p
+							v-if="entry.originalClosedAt"
+							class="period-close-detail__history-orig">
+							{{ t('shillinq', 'Original close') }}:
+							{{ formatTimestamp(entry.originalClosedAt) }}
 							<template v-if="entry.originalClosedBy">
 								— {{ entry.originalClosedBy }}
 							</template>
@@ -193,7 +273,9 @@
 				</ol>
 			</section>
 
-			<section class="period-close-detail__links" data-testid="period-close-detail-links">
+			<section
+				class="period-close-detail__links"
+				data-testid="period-close-detail-links">
 				<h3>{{ t('shillinq', 'Related views') }}</h3>
 				<ul>
 					<li>
@@ -272,16 +354,16 @@ export default {
 		stateLabel() {
 			const state = (this.period && this.period.state) || STATE_OPEN
 			switch (state) {
-			case STATE_OPEN:
-				return t('shillinq', 'Open')
-			case STATE_CLOSING:
-				return t('shillinq', 'Closing')
-			case STATE_CLOSED:
-				return t('shillinq', 'Closed')
-			case STATE_AUDIT_LOCKED:
-				return t('shillinq', 'Audit locked')
-			default:
-				return state
+				case STATE_OPEN:
+					return t('shillinq', 'Open')
+				case STATE_CLOSING:
+					return t('shillinq', 'Closing')
+				case STATE_CLOSED:
+					return t('shillinq', 'Closed')
+				case STATE_AUDIT_LOCKED:
+					return t('shillinq', 'Audit locked')
+				default:
+					return state
 			}
 		},
 		canStartClose() {
@@ -297,13 +379,17 @@ export default {
 			return this.period && this.period.state === STATE_CLOSED
 		},
 		checklistItems() {
-			return Array.isArray(this.period?.taskChecklistItems) ? this.period.taskChecklistItems : []
+			return Array.isArray(this.period?.taskChecklistItems)
+				? this.period.taskChecklistItems
+				: []
 		},
 		aiFlags() {
 			return Array.isArray(this.period?.aiFlags) ? this.period.aiFlags : []
 		},
 		reopenedHistory() {
-			return Array.isArray(this.period?.reopenedHistory) ? this.period.reopenedHistory : []
+			return Array.isArray(this.period?.reopenedHistory)
+				? this.period.reopenedHistory
+				: []
 		},
 		reopenDialogPeriodName() {
 			if (!this.period) {
@@ -336,7 +422,9 @@ export default {
 			this.loading = true
 			this.loadError = ''
 			try {
-				const url = generateUrl(`/apps/shillinq/api/period-close/${encodeURIComponent(this.recordId)}`)
+				const url = generateUrl(
+					`/apps/shillinq/api/period-close/${encodeURIComponent(this.recordId)}`,
+				)
 				const response = await axios.get(url)
 				const data = response?.data?.data
 				if (!data || typeof data !== 'object') {
@@ -346,7 +434,10 @@ export default {
 					this.period = data
 				}
 			} catch (err) {
-				this.loadError = this.extractErrorMessage(err, t('shillinq', 'Failed to load period.'))
+				this.loadError = this.extractErrorMessage(
+					err,
+					t('shillinq', 'Failed to load period.'),
+				)
 			} finally {
 				this.loading = false
 			}
@@ -381,26 +472,32 @@ export default {
 		},
 		categoryLabel(category) {
 			switch (category) {
-			case 'ap':
-				return t('shillinq', 'Accounts payable')
-			case 'ar':
-				return t('shillinq', 'Accounts receivable')
-			case 'bank':
-				return t('shillinq', 'Bank reconciliation')
-			case 'expense':
-				return t('shillinq', 'Expense claims')
-			default:
-				return category || t('shillinq', 'Other')
+				case 'ap':
+					return t('shillinq', 'Accounts payable')
+				case 'ar':
+					return t('shillinq', 'Accounts receivable')
+				case 'bank':
+					return t('shillinq', 'Bank reconciliation')
+				case 'expense':
+					return t('shillinq', 'Expense claims')
+				default:
+					return category || t('shillinq', 'Other')
 			}
 		},
 		async onStartClose() {
-			await this.transition('start-close', t('shillinq', 'Period close initiated.'))
+			await this.transition(
+				'start-close',
+				t('shillinq', 'Period close initiated.'),
+			)
 		},
 		async onClose() {
 			await this.transition('close', t('shillinq', 'Period closed.'))
 		},
 		async onLockAudit() {
-			await this.transition('lock-audit', t('shillinq', 'Period locked for audit.'))
+			await this.transition(
+				'lock-audit',
+				t('shillinq', 'Period locked for audit.'),
+			)
 		},
 		async transition(action, successMessage, body = {}) {
 			if (!this.recordId) {
@@ -410,7 +507,9 @@ export default {
 			this.transitionError = ''
 			this.transitionNotice = ''
 			try {
-				const url = generateUrl(`/apps/shillinq/api/period-close/${encodeURIComponent(this.recordId)}/${action}`)
+				const url = generateUrl(
+					`/apps/shillinq/api/period-close/${encodeURIComponent(this.recordId)}/${action}`,
+				)
 				const response = await axios.post(url, body || {})
 				const next = response?.data?.data
 				if (next && typeof next === 'object') {
@@ -420,7 +519,10 @@ export default {
 				}
 				this.transitionNotice = successMessage
 			} catch (err) {
-				this.transitionError = this.extractErrorMessage(err, t('shillinq', 'Transition failed.'))
+				this.transitionError = this.extractErrorMessage(
+					err,
+					t('shillinq', 'Transition failed.'),
+				)
 			} finally {
 				this.transitioning = false
 			}
@@ -448,7 +550,9 @@ export default {
 			this.reopenSubmitting = true
 			this.reopenError = ''
 			try {
-				const url = generateUrl(`/apps/shillinq/api/period-close/${encodeURIComponent(this.recordId)}/reopen`)
+				const url = generateUrl(
+					`/apps/shillinq/api/period-close/${encodeURIComponent(this.recordId)}/reopen`,
+				)
 				const response = await axios.post(url, { closeReason: trimmed })
 				const next = response?.data?.data
 				if (next && typeof next === 'object') {
@@ -459,7 +563,10 @@ export default {
 				this.reopenDialogOpen = false
 				this.transitionNotice = t('shillinq', 'Period reopened.')
 			} catch (err) {
-				this.reopenError = this.extractErrorMessage(err, t('shillinq', 'Reopen failed.'))
+				this.reopenError = this.extractErrorMessage(
+					err,
+					t('shillinq', 'Reopen failed.'),
+				)
 			} finally {
 				this.reopenSubmitting = false
 			}
@@ -468,7 +575,10 @@ export default {
 			const status = err?.response?.status
 			const message = err?.response?.data?.message
 			if (status === 403) {
-				return t('shillinq', 'You do not have permission to perform this action.')
+				return t(
+					'shillinq',
+					'You do not have permission to perform this action.',
+				)
 			}
 			if (typeof message === 'string' && message.length > 0) {
 				return message

--- a/src/components/pipelinq/KlantbeeldTimeline.vue
+++ b/src/components/pipelinq/KlantbeeldTimeline.vue
@@ -63,20 +63,28 @@
 				class="klantbeeld-timeline__row"
 				:data-testid="`klantbeeld-row-${index}`"
 				:data-status="row.status || ''">
-				<div class="klantbeeld-timeline__row-date" :data-testid="`klantbeeld-row-${index}-date`">
+				<div
+					class="klantbeeld-timeline__row-date"
+					:data-testid="`klantbeeld-row-${index}-date`">
 					{{ formatDate(row.date) }}
 				</div>
-				<div class="klantbeeld-timeline__row-description" :data-testid="`klantbeeld-row-${index}-description`">
+				<div
+					class="klantbeeld-timeline__row-description"
+					:data-testid="`klantbeeld-row-${index}-description`">
 					{{ row.description || label('(no description)') }}
 				</div>
-				<div class="klantbeeld-timeline__row-amount" :data-testid="`klantbeeld-row-${index}-amount`">
+				<div
+					class="klantbeeld-timeline__row-amount"
+					:data-testid="`klantbeeld-row-${index}-amount`">
 					{{ formatAmount(row) }}
 				</div>
 				<div
 					v-if="row.status"
 					class="klantbeeld-timeline__row-status"
 					:data-testid="`klantbeeld-row-${index}-status`">
-					<span class="klantbeeld-timeline__pill" :class="`klantbeeld-timeline__pill--${row.status}`">
+					<span
+						class="klantbeeld-timeline__pill"
+						:class="`klantbeeld-timeline__pill--${row.status}`">
 						{{ label(row.status) }}
 					</span>
 				</div>

--- a/src/components/pipelinq/PipelinqProfileCard.vue
+++ b/src/components/pipelinq/PipelinqProfileCard.vue
@@ -29,7 +29,11 @@
 				v-if="state === 'ok'"
 				class="pipelinq-profile-card__kind"
 				data-testid="pipelinq-profile-kind">
-				{{ kind === 'organization' ? label('Organization') : label('Individual') }}
+				{{
+					kind === 'organization'
+						? label('Organization')
+						: label('Individual')
+				}}
 			</span>
 		</header>
 
@@ -46,7 +50,10 @@
 					</dt>
 					<dd
 						class="pipelinq-profile-card__value"
-						:class="{ 'pipelinq-profile-card__value--emphasis': field.emphasis === true }"
+						:class="{
+							'pipelinq-profile-card__value--emphasis':
+								field.emphasis === true,
+						}"
 						:data-testid="`pipelinq-profile-${field.key}`">
 						<a
 							v-if="field.href"
@@ -158,7 +165,10 @@ export default {
 			return String(this.booking?.pipelinqContactId || '').trim()
 		},
 		pipelinqLink() {
-			return buildPipelinqLink(this.pipelinqBaseUrl, this.payload?.contact?.externalId)
+			return buildPipelinqLink(
+				this.pipelinqBaseUrl,
+				this.payload?.contact?.externalId,
+			)
 		},
 	},
 	methods: {

--- a/src/components/purchase-order/PurchaseOrderDetail.vue
+++ b/src/components/purchase-order/PurchaseOrderDetail.vue
@@ -26,7 +26,10 @@
 			{{ t('shillinq', 'Loading purchase order...') }}
 		</div>
 
-		<div v-else-if="error" class="po-detail__error" data-testid="po-detail-error">
+		<div
+			v-else-if="error"
+			class="po-detail__error"
+			data-testid="po-detail-error">
 			{{ error }}
 		</div>
 
@@ -34,13 +37,25 @@
 			<header class="po-detail__header" data-testid="po-detail-header">
 				<h2>{{ purchaseOrder.poNumber }}</h2>
 				<p>
-					<span class="po-detail__pill">{{ purchaseOrder.lifecycleState }}</span>
-					<span>{{ t('shillinq', 'Supplier') }}: {{ purchaseOrder.supplierId }}</span>
-					<span>{{ t('shillinq', 'Cost center') }}: {{ purchaseOrder.costCenter }}</span>
-					<span v-if="purchaseOrder.projectCode">{{ t('shillinq', 'Project') }}: {{ purchaseOrder.projectCode }}</span>
+					<span class="po-detail__pill">{{
+						purchaseOrder.lifecycleState
+					}}</span>
+					<span
+						>{{ t('shillinq', 'Supplier') }}:
+						{{ purchaseOrder.supplierId }}</span
+					>
+					<span
+						>{{ t('shillinq', 'Cost center') }}:
+						{{ purchaseOrder.costCenter }}</span
+					>
+					<span v-if="purchaseOrder.projectCode"
+						>{{ t('shillinq', 'Project') }}:
+						{{ purchaseOrder.projectCode }}</span
+					>
 				</p>
 				<p>
-					{{ t('shillinq', 'Total') }}: <strong>{{ formatMoney(purchaseOrder.totalAmount) }}</strong>
+					{{ t('shillinq', 'Total') }}:
+					<strong>{{ formatMoney(purchaseOrder.totalAmount) }}</strong>
 				</p>
 			</header>
 
@@ -86,11 +101,15 @@
 							{{ roleLabel(entry.role) }}
 						</div>
 						<div class="po-detail__chain-status">
-							<span :class="`po-detail__pill po-detail__pill--${entry.status}`">
+							<span
+								:class="`po-detail__pill po-detail__pill--${entry.status}`">
 								{{ entry.status }}
 							</span>
-							<span v-if="entry.signedAt" class="po-detail__chain-timestamp">
-								{{ t('shillinq', 'Signed') }}: {{ formatTimestamp(entry.signedAt) }}
+							<span
+								v-if="entry.signedAt"
+								class="po-detail__chain-timestamp">
+								{{ t('shillinq', 'Signed') }}:
+								{{ formatTimestamp(entry.signedAt) }}
 								<template v-if="entry.signedBy">
 									— {{ entry.signedBy }}
 								</template>
@@ -98,7 +117,9 @@
 						</div>
 					</li>
 				</ol>
-				<p v-if="!(purchaseOrder.approvalChain || []).length" class="po-detail__chain-empty">
+				<p
+					v-if="!(purchaseOrder.approvalChain || []).length"
+					class="po-detail__chain-empty">
 					{{ t('shillinq', 'No approval chain required.') }}
 				</p>
 			</section>
@@ -110,18 +131,28 @@
 					<dd data-testid="po-detail-grns">
 						<ul v-if="grns.length > 0">
 							<li v-for="grn in grns" :key="grn.id">
-								<router-link :to="{ name: 'GoodsReceiptNoteDetail', params: { id: grn.id } }">
+								<router-link
+									:to="{
+										name: 'GoodsReceiptNoteDetail',
+										params: { id: grn.id },
+									}">
 									{{ grn.grnNumber || grn.id }}
 								</router-link>
 							</li>
 						</ul>
-						<span v-else>{{ t('shillinq', 'No goods receipt notes yet') }}</span>
+						<span v-else>{{
+							t('shillinq', 'No goods receipt notes yet')
+						}}</span>
 					</dd>
 					<dt>{{ t('shillinq', '3-way matches') }}</dt>
 					<dd data-testid="po-detail-matches">
 						<ul v-if="matches.length > 0">
 							<li v-for="match in matches" :key="match.id">
-								<router-link :to="{ name: 'ThreeWayMatchDetail', params: { id: match.id } }">
+								<router-link
+									:to="{
+										name: 'ThreeWayMatchDetail',
+										params: { id: match.id },
+									}">
 									{{ match.matchReference || match.id }}
 								</router-link>
 							</li>
@@ -131,16 +162,25 @@
 				</dl>
 			</section>
 
-			<section class="po-detail__transmission" data-testid="po-detail-transmission">
+			<section
+				class="po-detail__transmission"
+				data-testid="po-detail-transmission">
 				<h3>{{ t('shillinq', 'Transmission') }}</h3>
 				<dl>
 					<dt>{{ t('shillinq', 'Peppol message id') }}</dt>
 					<dd data-testid="po-detail-peppol-message-id">
-						{{ purchaseOrder.peppolMessageId || t('shillinq', 'Not yet transmitted') }}
+						{{
+							purchaseOrder.peppolMessageId
+							|| t('shillinq', 'Not yet transmitted')
+						}}
 					</dd>
 					<dt>{{ t('shillinq', 'Peppol sent at') }}</dt>
 					<dd data-testid="po-detail-peppol-sent-at">
-						{{ purchaseOrder.peppolSentAt ? formatTimestamp(purchaseOrder.peppolSentAt) : '—' }}
+						{{
+							purchaseOrder.peppolSentAt
+								? formatTimestamp(purchaseOrder.peppolSentAt)
+								: '—'
+						}}
 					</dd>
 					<template v-if="purchaseOrder.peppolFallbackReason">
 						<dt>{{ t('shillinq', 'Fallback reason') }}</dt>
@@ -157,22 +197,45 @@
 					:disabled="!canSend || sending"
 					data-testid="po-detail-send-peppol"
 					@click="onSendPeppol">
-					{{ sending && sendingChannel === 'peppol' ? t('shillinq', 'Sending Peppol...') : t('shillinq', 'Send via Peppol') }}
+					{{
+						sending && sendingChannel === 'peppol'
+							? t('shillinq', 'Sending Peppol...')
+							: t('shillinq', 'Send via Peppol')
+					}}
 				</NcButton>
 				<NcButton
 					variant="secondary"
 					:disabled="!canSend || sending"
 					data-testid="po-detail-send-email"
 					@click="onSendEmail">
-					{{ sending && sendingChannel === 'email' ? t('shillinq', 'Sending PDF...') : t('shillinq', 'Send via PDF+email') }}
+					{{
+						sending && sendingChannel === 'email'
+							? t('shillinq', 'Sending PDF...')
+							: t('shillinq', 'Send via PDF+email')
+					}}
 				</NcButton>
-				<p v-if="!canSend && purchaseOrder.lifecycleState !== 'sent'" class="po-detail__send-hint">
-					{{ t('shillinq', 'Sending is blocked until every approver signs.') }}
+				<p
+					v-if="!canSend && purchaseOrder.lifecycleState !== 'sent'"
+					class="po-detail__send-hint">
+					{{
+						t(
+							'shillinq',
+							'Sending is blocked until every approver signs.',
+						)
+					}}
 				</p>
-				<p v-else-if="purchaseOrder.lifecycleState === 'sent'" class="po-detail__send-hint" data-testid="po-detail-already-sent">
-					{{ t('shillinq', 'Purchase order has already been transmitted.') }}
+				<p
+					v-else-if="purchaseOrder.lifecycleState === 'sent'"
+					class="po-detail__send-hint"
+					data-testid="po-detail-already-sent">
+					{{
+						t('shillinq', 'Purchase order has already been transmitted.')
+					}}
 				</p>
-				<p v-if="sendError" class="po-detail__error" data-testid="po-detail-send-error">
+				<p
+					v-if="sendError"
+					class="po-detail__error"
+					data-testid="po-detail-send-error">
 					{{ sendError }}
 				</p>
 			</footer>
@@ -230,7 +293,9 @@ export default {
 			if (chain.length === 0) {
 				return false
 			}
-			return chain.every((entry) => entry.status === 'approved' && !!entry.signedAt)
+			return chain.every(
+				(entry) => entry.status === 'approved' && !!entry.signedAt,
+			)
 		},
 	},
 	async created() {
@@ -241,14 +306,18 @@ export default {
 			this.loading = true
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/shillinq/api/openregister/objects/PurchaseOrder/${this.id}`),
+					generateUrl(
+						`/apps/shillinq/api/openregister/objects/PurchaseOrder/${this.id}`,
+					),
 				)
 				this.purchaseOrder = response.data || null
 				if (this.purchaseOrder) {
 					await this.loadRelated()
 				}
 			} catch (e) {
-				this.error = e?.response?.data?.error || this.t('shillinq', 'Failed to load purchase order')
+				this.error =
+					e?.response?.data?.error
+					|| this.t('shillinq', 'Failed to load purchase order')
 			} finally {
 				this.loading = false
 			}
@@ -259,7 +328,9 @@ export default {
 			// simply render the empty-state placeholders.
 			try {
 				const grnResponse = await axios.get(
-					generateUrl('/apps/shillinq/api/openregister/objects/GoodsReceiptNote'),
+					generateUrl(
+						'/apps/shillinq/api/openregister/objects/GoodsReceiptNote',
+					),
 					{ params: { filter: { poIds: this.id } } },
 				)
 				this.grns = grnResponse.data?.results || grnResponse.data || []
@@ -268,37 +339,46 @@ export default {
 			}
 			try {
 				const matchResponse = await axios.get(
-					generateUrl('/apps/shillinq/api/openregister/objects/ThreeWayMatch'),
+					generateUrl(
+						'/apps/shillinq/api/openregister/objects/ThreeWayMatch',
+					),
 					{ params: { filter: { matchedPoIds: this.id } } },
 				)
-				this.matches = matchResponse.data?.results || matchResponse.data || []
+				this.matches =
+					matchResponse.data?.results || matchResponse.data || []
 			} catch (e) {
 				this.matches = []
 			}
 		},
 		async onSendPeppol() {
-			await this.transmit('peppol', `/apps/shillinq/api/purchase-orders/${this.id}/transmit/peppol`)
+			await this.transmit(
+				'peppol',
+				`/apps/shillinq/api/purchase-orders/${this.id}/transmit/peppol`,
+			)
 		},
 		async onSendEmail() {
-			await this.transmit('email', `/apps/shillinq/api/purchase-orders/${this.id}/transmit/email`, {
-				fallbackReason: 'manual_pdf_email_fallback',
-			})
+			await this.transmit(
+				'email',
+				`/apps/shillinq/api/purchase-orders/${this.id}/transmit/email`,
+				{
+					fallbackReason: 'manual_pdf_email_fallback',
+				},
+			)
 		},
 		async transmit(channel, path, extraBody = {}) {
 			this.sendError = ''
 			this.sending = true
 			this.sendingChannel = channel
 			try {
-				const response = await axios.post(
-					generateUrl(path),
-					{
-						administrationId: this.purchaseOrder?.administrationId,
-						...extraBody,
-					},
-				)
+				const response = await axios.post(generateUrl(path), {
+					administrationId: this.purchaseOrder?.administrationId,
+					...extraBody,
+				})
 				this.purchaseOrder = response.data || this.purchaseOrder
 			} catch (e) {
-				this.sendError = e?.response?.data?.error || this.t('shillinq', 'Failed to send purchase order')
+				this.sendError =
+					e?.response?.data?.error
+					|| this.t('shillinq', 'Failed to send purchase order')
 			} finally {
 				this.sending = false
 				this.sendingChannel = ''

--- a/src/components/purchase-order/PurchaseOrderForm.vue
+++ b/src/components/purchase-order/PurchaseOrderForm.vue
@@ -72,7 +72,9 @@
 							<th scope="col">{{ t('shillinq', 'GL account') }}</th>
 							<th scope="col">{{ t('shillinq', 'Line total') }}</th>
 							<th scope="col">
-								<span class="po-form__sr-only">{{ t('shillinq', 'Actions') }}</span>
+								<span class="po-form__sr-only">{{
+									t('shillinq', 'Actions')
+								}}</span>
 							</th>
 						</tr>
 					</thead>
@@ -126,21 +128,35 @@
 						</tr>
 					</tbody>
 				</table>
-				<NcButton variant="secondary" data-testid="po-form-add-line" @click="addLine">
+				<NcButton
+					variant="secondary"
+					data-testid="po-form-add-line"
+					@click="addLine">
 					{{ t('shillinq', 'Add line') }}
 				</NcButton>
 			</fieldset>
 
 			<fieldset class="po-form__chain">
-				<legend>{{ t('shillinq', 'Approval chain (server-determined)') }}</legend>
+				<legend>
+					{{ t('shillinq', 'Approval chain (server-determined)') }}
+				</legend>
 				<p class="po-form__total" data-testid="po-form-total">
-					{{ t('shillinq', 'Total') }}: <strong>{{ formatMoney(total) }}</strong>
+					{{ t('shillinq', 'Total') }}:
+					<strong>{{ formatMoney(total) }}</strong>
 				</p>
-				<ul v-if="approvalChain.length > 0" class="po-form__chain-list" data-testid="po-form-chain">
+				<ul
+					v-if="approvalChain.length > 0"
+					class="po-form__chain-list"
+					data-testid="po-form-chain">
 					<li v-for="entry in approvalChain" :key="entry.role">
 						<span class="po-form__chain-order">#{{ entry.order }}</span>
-						<span class="po-form__chain-role">{{ roleLabel(entry.role) }}</span>
-						<span class="po-form__chain-status po-form__chain-status--pending">{{ t('shillinq', 'pending') }}</span>
+						<span class="po-form__chain-role">{{
+							roleLabel(entry.role)
+						}}</span>
+						<span
+							class="po-form__chain-status po-form__chain-status--pending"
+							>{{ t('shillinq', 'pending') }}</span
+						>
 					</li>
 				</ul>
 				<p v-else class="po-form__chain-empty">
@@ -152,8 +168,15 @@
 				{{ error }}
 			</div>
 
-			<p class="po-form__transmission-hint" data-testid="po-form-transmission-hint">
-				{{ t('shillinq', 'Once the approval chain is complete you can send this PO via Peppol or PDF+email from the detail view.') }}
+			<p
+				class="po-form__transmission-hint"
+				data-testid="po-form-transmission-hint">
+				{{
+					t(
+						'shillinq',
+						'Once the approval chain is complete you can send this PO via Peppol or PDF+email from the detail view.',
+					)
+				}}
 			</p>
 
 			<div class="po-form__actions">
@@ -162,7 +185,11 @@
 					type="submit"
 					:disabled="submitting"
 					data-testid="po-form-submit">
-					{{ submitting ? t('shillinq', 'Creating...') : t('shillinq', 'Create purchase order') }}
+					{{
+						submitting
+							? t('shillinq', 'Creating...')
+							: t('shillinq', 'Create purchase order')
+					}}
 				</NcButton>
 			</div>
 		</form>
@@ -170,7 +197,13 @@
 </template>
 
 <script>
-import { NcButton, NcInputField, NcSelect, NcTextArea, NcTextField } from '@nextcloud/vue'
+import {
+	NcButton,
+	NcInputField,
+	NcSelect,
+	NcTextArea,
+	NcTextField,
+} from '@nextcloud/vue'
 import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 
@@ -263,7 +296,9 @@ export default {
 		},
 		async loadAdministrationContext() {
 			try {
-				const response = await axios.get(generateUrl('/apps/shillinq/api/administrations/context'))
+				const response = await axios.get(
+					generateUrl('/apps/shillinq/api/administrations/context'),
+				)
 				const admins = response.data?.administrations || []
 				this.administrationOptions = admins.map((a) => ({
 					value: a.administrationId,
@@ -274,7 +309,10 @@ export default {
 				}
 			} catch (e) {
 				// Surface as an inline error rather than crashing the form.
-				this.error = this.t('shillinq', 'Failed to load administration context')
+				this.error = this.t(
+					'shillinq',
+					'Failed to load administration context',
+				)
 			}
 		},
 		async refreshApprovalChain(amount) {
@@ -307,7 +345,10 @@ export default {
 				return
 			}
 			if (this.total <= 0) {
-				this.error = this.t('shillinq', 'Purchase order total must be positive')
+				this.error = this.t(
+					'shillinq',
+					'Purchase order total must be positive',
+				)
 				return
 			}
 
@@ -328,10 +369,15 @@ export default {
 				const po = response.data || {}
 				const id = po.id || (po['@self'] && po['@self'].id) || po.poNumber
 				if (id) {
-					this.$router.push({ name: 'PurchaseOrderDetail', params: { id } })
+					this.$router.push({
+						name: 'PurchaseOrderDetail',
+						params: { id },
+					})
 				}
 			} catch (e) {
-				const message = e?.response?.data?.error || this.t('shillinq', 'Failed to create purchase order')
+				const message =
+					e?.response?.data?.error
+					|| this.t('shillinq', 'Failed to create purchase order')
 				this.error = message
 			} finally {
 				this.submitting = false

--- a/src/components/reporting/GeneratedReportsIndex.vue
+++ b/src/components/reporting/GeneratedReportsIndex.vue
@@ -43,7 +43,12 @@
 					{{ t('shillinq', 'Generated reports') }}
 				</h2>
 				<p class="generated-reports__hint">
-					{{ t('shillinq', 'Every report generated from the Reporting & Compliance overview is archived here with a download link to the stored file.') }}
+					{{
+						t(
+							'shillinq',
+							'Every report generated from the Reporting & Compliance overview is archived here with a download link to the stored file.',
+						)
+					}}
 				</p>
 			</div>
 			<router-link
@@ -54,9 +59,13 @@
 			</router-link>
 		</header>
 
-		<div class="generated-reports__filters" data-testid="generated-reports-filters">
+		<div
+			class="generated-reports__filters"
+			data-testid="generated-reports-filters">
 			<div class="generated-reports__filter">
-				<label class="generated-reports__filter-label" for="generated-category-filter">
+				<label
+					class="generated-reports__filter-label"
+					for="generated-category-filter">
 					{{ t('shillinq', 'Category') }}
 				</label>
 				<select
@@ -75,7 +84,9 @@
 				</select>
 			</div>
 			<div class="generated-reports__filter">
-				<label class="generated-reports__filter-label" for="generated-period-filter">
+				<label
+					class="generated-reports__filter-label"
+					for="generated-period-filter">
 					{{ t('shillinq', 'Period') }}
 				</label>
 				<select
@@ -94,7 +105,9 @@
 				</select>
 			</div>
 			<div class="generated-reports__filter">
-				<label class="generated-reports__filter-label" for="generated-administration-filter">
+				<label
+					class="generated-reports__filter-label"
+					for="generated-administration-filter">
 					{{ t('shillinq', 'Administration') }}
 				</label>
 				<select
@@ -114,11 +127,17 @@
 			</div>
 		</div>
 
-		<div v-if="loading" class="generated-reports__loading" data-testid="generated-reports-loading">
+		<div
+			v-if="loading"
+			class="generated-reports__loading"
+			data-testid="generated-reports-loading">
 			{{ t('shillinq', 'Loading generated reports…') }}
 		</div>
 
-		<div v-else-if="error" class="generated-reports__error" data-testid="generated-reports-error">
+		<div
+			v-else-if="error"
+			class="generated-reports__error"
+			data-testid="generated-reports-error">
 			{{ error }}
 		</div>
 
@@ -127,7 +146,9 @@
 			data-testid="generated-reports-table"
 			:columns="columns"
 			:rows="filteredRows"
-			:empty-label="t('shillinq', 'No generated reports match the current filters.')">
+			:empty-label="
+				t('shillinq', 'No generated reports match the current filters.')
+			">
 			<template #cell-reportType="{ row }">
 				{{ reportLabel(row) }}
 			</template>
@@ -138,7 +159,9 @@
 				{{ formatDate(row.generatedAt) }}
 			</template>
 			<template #cell-format="{ row }">
-				<span class="generated-reports__format">{{ (row.format || '').toUpperCase() }}</span>
+				<span class="generated-reports__format">{{
+					(row.format || '').toUpperCase()
+				}}</span>
 			</template>
 			<template #cell-administrationId="{ row }">
 				{{ administrationLabel(row.administrationId) }}
@@ -183,24 +206,61 @@ export default {
 	computed: {
 		columns() {
 			return [
-				{ key: 'reportType', label: this.t('shillinq', 'Report'), sortable: true },
-				{ key: 'category', label: this.t('shillinq', 'Category'), sortable: true },
-				{ key: 'period', label: this.t('shillinq', 'Period'), sortable: true },
-				{ key: 'administrationId', label: this.t('shillinq', 'Administration'), sortable: true },
-				{ key: 'format', label: this.t('shillinq', 'Format'), sortable: true },
-				{ key: 'generatedAt', label: this.t('shillinq', 'Generated at'), sortable: true },
-				{ key: 'download', label: this.t('shillinq', 'File'), sortable: false },
+				{
+					key: 'reportType',
+					label: this.t('shillinq', 'Report'),
+					sortable: true,
+				},
+				{
+					key: 'category',
+					label: this.t('shillinq', 'Category'),
+					sortable: true,
+				},
+				{
+					key: 'period',
+					label: this.t('shillinq', 'Period'),
+					sortable: true,
+				},
+				{
+					key: 'administrationId',
+					label: this.t('shillinq', 'Administration'),
+					sortable: true,
+				},
+				{
+					key: 'format',
+					label: this.t('shillinq', 'Format'),
+					sortable: true,
+				},
+				{
+					key: 'generatedAt',
+					label: this.t('shillinq', 'Generated at'),
+					sortable: true,
+				},
+				{
+					key: 'download',
+					label: this.t('shillinq', 'File'),
+					sortable: false,
+				},
 			]
 		},
 		categoryOptions() {
-			const present = [...new Set(this.rows.map(r => r.category).filter(Boolean))]
-			return present.map(key => ({ value: key, label: this.categories[key] || key }))
+			const present = [
+				...new Set(this.rows.map((r) => r.category).filter(Boolean)),
+			]
+			return present.map((key) => ({
+				value: key,
+				label: this.categories[key] || key,
+			}))
 		},
 		periodOptions() {
-			return [...new Set(this.rows.map(r => r.period).filter(Boolean))].sort().reverse()
+			return [...new Set(this.rows.map((r) => r.period).filter(Boolean))]
+				.sort()
+				.reverse()
 		},
 		administrationOptions() {
-			return [...new Set(this.rows.map(r => r.administrationId).filter(Boolean))]
+			return [
+				...new Set(this.rows.map((r) => r.administrationId).filter(Boolean)),
+			]
 		},
 		filteredRows() {
 			return this.rows.filter((row) => {
@@ -210,7 +270,10 @@ export default {
 				if (this.periodFilter && row.period !== this.periodFilter) {
 					return false
 				}
-				if (this.administrationFilter && row.administrationId !== this.administrationFilter) {
+				if (
+					this.administrationFilter
+					&& row.administrationId !== this.administrationFilter
+				) {
 					return false
 				}
 				return true
@@ -227,15 +290,22 @@ export default {
 			this.loading = true
 			this.error = ''
 			try {
-				const response = await axios.get(generateUrl('/apps/shillinq/api/reporting/generated'))
+				const response = await axios.get(
+					generateUrl('/apps/shillinq/api/reporting/generated'),
+				)
 				const data = response.data || {}
 				const rows = Array.isArray(data.generated)
 					? data.generated
-					: (Array.isArray(data.results) ? data.results : (Array.isArray(data) ? data : []))
+					: Array.isArray(data.results)
+						? data.results
+						: Array.isArray(data)
+							? data
+							: []
 				this.rows = rows
 				this.categories = data.categories || {}
 			} catch (e) {
-				this.error = e?.response?.data?.error
+				this.error =
+					e?.response?.data?.error
 					|| this.t('shillinq', 'Failed to load generated reports')
 			} finally {
 				this.loading = false
@@ -248,11 +318,14 @@ export default {
 		 */
 		async loadAdministrationContext() {
 			try {
-				const response = await axios.get(generateUrl('/apps/shillinq/api/administrations/context'))
+				const response = await axios.get(
+					generateUrl('/apps/shillinq/api/administrations/context'),
+				)
 				const admins = response.data?.administrations || []
 				const names = {}
 				for (const a of admins) {
-					names[a.administrationId] = a.name || a.administrationCode || a.administrationId
+					names[a.administrationId] =
+						a.name || a.administrationCode || a.administrationId
 				}
 				this.administrationNames = names
 			} catch (e) {

--- a/src/components/reporting/ReportingComplianceOverview.vue
+++ b/src/components/reporting/ReportingComplianceOverview.vue
@@ -60,7 +60,12 @@
 					{{ t('shillinq', 'Reporting & Compliance') }}
 				</h2>
 				<p class="reporting-overview__hint">
-					{{ t('shillinq', 'Generate every statutory, tax and public-sector report shillinq supports from one place. Pick a report, choose a period and format, and generate the file.') }}
+					{{
+						t(
+							'shillinq',
+							'Generate every statutory, tax and public-sector report shillinq supports from one place. Pick a report, choose a period and format, and generate the file.',
+						)
+					}}
 				</p>
 			</div>
 
@@ -81,9 +86,13 @@
 			</div>
 		</header>
 
-		<div class="reporting-overview__filters" data-testid="reporting-overview-filters">
+		<div
+			class="reporting-overview__filters"
+			data-testid="reporting-overview-filters">
 			<div class="reporting-overview__filter">
-				<label class="reporting-overview__filter-label" for="reporting-category-filter">
+				<label
+					class="reporting-overview__filter-label"
+					for="reporting-category-filter">
 					{{ t('shillinq', 'Category') }}
 				</label>
 				<select
@@ -102,7 +111,9 @@
 				</select>
 			</div>
 			<div class="reporting-overview__filter">
-				<label class="reporting-overview__filter-label" for="reporting-search">
+				<label
+					class="reporting-overview__filter-label"
+					for="reporting-search">
 					{{ t('shillinq', 'Search') }}
 				</label>
 				<input
@@ -110,15 +121,21 @@
 					v-model="search"
 					type="search"
 					data-testid="reporting-search"
-					:placeholder="t('shillinq', 'Search reports…')">
+					:placeholder="t('shillinq', 'Search reports…')" />
 			</div>
 		</div>
 
-		<div v-if="loading" class="reporting-overview__loading" data-testid="reporting-overview-loading">
+		<div
+			v-if="loading"
+			class="reporting-overview__loading"
+			data-testid="reporting-overview-loading">
 			{{ t('shillinq', 'Loading report catalogue…') }}
 		</div>
 
-		<div v-else-if="error" class="reporting-overview__error" data-testid="reporting-overview-error">
+		<div
+			v-else-if="error"
+			class="reporting-overview__error"
+			data-testid="reporting-overview-error">
 			{{ error }}
 		</div>
 
@@ -157,7 +174,9 @@
 						<p class="reporting-overview__card-desc">
 							{{ report.description }}
 						</p>
-						<div v-if="report.kind !== 'view'" class="reporting-overview__card-format">
+						<div
+							v-if="report.kind !== 'view'"
+							class="reporting-overview__card-format">
 							<label
 								class="reporting-overview__filter-label"
 								:for="`reporting-format-${report.id}`">
@@ -168,7 +187,7 @@
 								v-model="selectedFormat[report.id]"
 								:data-testid="`reporting-format-${report.id}`">
 								<option
-									v-for="format in (report.formats || [])"
+									v-for="format in report.formats || []"
 									:key="format"
 									:value="format">
 									{{ format.toUpperCase() }}
@@ -244,10 +263,10 @@ export default {
 		 * categories that actually have a report in the loaded catalogue.
 		 */
 		categoryOptions() {
-			const present = new Set(this.reports.map(r => r.category))
+			const present = new Set(this.reports.map((r) => r.category))
 			return Object.keys(this.categories)
-				.filter(key => present.has(key))
-				.map(key => ({ value: key, label: this.categories[key] }))
+				.filter((key) => present.has(key))
+				.map((key) => ({ value: key, label: this.categories[key] }))
 		},
 		/**
 		 * The catalogue filtered by the category select + the free-text
@@ -264,7 +283,8 @@ export default {
 				if (!term) {
 					return true
 				}
-				const haystack = `${report.label} ${report.description} ${report.id}`.toLowerCase()
+				const haystack =
+					`${report.label} ${report.description} ${report.id}`.toLowerCase()
 				return haystack.includes(term)
 			})
 
@@ -279,10 +299,10 @@ export default {
 
 			// Keep catalogue order; append any unknown categories last.
 			const orderedKeys = [
-				...order.filter(key => byCategory[key]),
-				...Object.keys(byCategory).filter(key => !order.includes(key)),
+				...order.filter((key) => byCategory[key]),
+				...Object.keys(byCategory).filter((key) => !order.includes(key)),
 			]
-			return orderedKeys.map(key => ({
+			return orderedKeys.map((key) => ({
 				category: key,
 				label: this.categories[key] || key,
 				reports: byCategory[key],
@@ -304,22 +324,29 @@ export default {
 			this.loading = true
 			this.error = ''
 			try {
-				const response = await axios.get(generateUrl('/apps/shillinq/api/reporting/types'))
+				const response = await axios.get(
+					generateUrl('/apps/shillinq/api/reporting/types'),
+				)
 				const data = response.data || {}
 				const rows = Array.isArray(data.types)
 					? data.types
-					: (Array.isArray(data) ? data : [])
+					: Array.isArray(data)
+						? data
+						: []
 				// Merge the existing report VIEW pages (navigate-cards) so the one
 				// overview holds every report — generate-to-file and on-screen
 				// views alike — instead of leaving them as scattered menu items.
-				const views = reportViews.map(v => ({
+				const views = reportViews.map((v) => ({
 					...v,
 					kind: 'view',
 					formats: [],
 					description: this.t('shillinq', 'Open this report.'),
 				}))
 				this.reports = [...rows, ...views]
-				this.categories = { ...(data.categories || {}), ...reportViewCategories }
+				this.categories = {
+					...(data.categories || {}),
+					...reportViewCategories,
+				}
 
 				// Seed each card's format picker with the first offered format.
 				const seed = {}
@@ -328,7 +355,8 @@ export default {
 				}
 				this.selectedFormat = seed
 			} catch (e) {
-				this.error = e?.response?.data?.error
+				this.error =
+					e?.response?.data?.error
 					|| this.t('shillinq', 'Failed to load the report catalogue')
 			} finally {
 				this.loading = false
@@ -342,14 +370,17 @@ export default {
 		 */
 		async loadAdministrationContext() {
 			try {
-				const response = await axios.get(generateUrl('/apps/shillinq/api/administrations/context'))
+				const response = await axios.get(
+					generateUrl('/apps/shillinq/api/administrations/context'),
+				)
 				const admins = response.data?.administrations || []
-				this.administrationOptions = admins.map(a => ({
+				this.administrationOptions = admins.map((a) => ({
 					value: a.administrationId,
 					label: a.name || a.administrationCode || a.administrationId,
 				}))
 				if (response.data?.activeAdministrationId) {
-					this.activeAdministrationId = response.data.activeAdministrationId
+					this.activeAdministrationId =
+						response.data.activeAdministrationId
 				}
 			} catch (e) {
 				this.administrationOptions = []
@@ -366,8 +397,13 @@ export default {
 		 */
 		onGenerated(result) {
 			this.dialogReport = null
-			const downloadUrl = result?.downloadUrl
-				|| (result?.id ? generateUrl(`/apps/shillinq/api/reporting/download/${result.id}`) : null)
+			const downloadUrl =
+				result?.downloadUrl
+				|| (result?.id
+					? generateUrl(
+							`/apps/shillinq/api/reporting/download/${result.id}`,
+						)
+					: null)
 			if (downloadUrl) {
 				showSuccess(
 					this.t('shillinq', 'Report generated — {link}', {

--- a/src/components/settings/BankImportPage.vue
+++ b/src/components/settings/BankImportPage.vue
@@ -13,11 +13,19 @@
 		<header class="bank-import-page__header">
 			<h2>{{ t('shillinq', 'Import bank statements') }}</h2>
 			<p class="bank-import-page__hint">
-				{{ t('shillinq', 'Upload a bank statement (CAMT.053 / MT940 / CSV) to import its transactions and reconcile them against your invoices and bills.') }}
+				{{
+					t(
+						'shillinq',
+						'Upload a bank statement (CAMT.053 / MT940 / CSV) to import its transactions and reconcile them against your invoices and bills.',
+					)
+				}}
 			</p>
 		</header>
 
-		<NcButton variant="primary" data-testid="bank-import-launch" @click="showBankStatementWizard = true">
+		<NcButton
+			variant="primary"
+			data-testid="bank-import-launch"
+			@click="showBankStatementWizard = true">
 			<template #icon>
 				<BankTransferIn :size="20" />
 			</template>

--- a/src/components/supplier-invoice/SupplierInvoiceDetail.vue
+++ b/src/components/supplier-invoice/SupplierInvoiceDetail.vue
@@ -21,11 +21,17 @@
 -->
 <template>
 	<div class="si-detail">
-		<div v-if="loading" class="si-detail__loading" data-testid="si-detail-loading">
+		<div
+			v-if="loading"
+			class="si-detail__loading"
+			data-testid="si-detail-loading">
 			{{ t('shillinq', 'Loading supplier invoice...') }}
 		</div>
 
-		<div v-else-if="error" class="si-detail__error" data-testid="si-detail-error">
+		<div
+			v-else-if="error"
+			class="si-detail__error"
+			data-testid="si-detail-error">
 			{{ error }}
 		</div>
 
@@ -33,12 +39,18 @@
 			<header class="si-detail__header" data-testid="si-detail-header">
 				<h2>{{ invoice.invoiceNumber }}</h2>
 				<p>
-					<span class="si-detail__pill" :class="`si-detail__pill--${invoice.statusCode}`">
+					<span
+						class="si-detail__pill"
+						:class="`si-detail__pill--${invoice.statusCode}`">
 						{{ statusLabel(invoice.statusCode) }}
 					</span>
-					<span>{{ t('shillinq', 'Supplier') }}: {{ invoice.supplierId }}</span>
+					<span
+						>{{ t('shillinq', 'Supplier') }}:
+						{{ invoice.supplierId }}</span
+					>
 					<span v-if="invoice.invoiceDate">
-						{{ t('shillinq', 'Invoice date') }}: {{ formatDate(invoice.invoiceDate) }}
+						{{ t('shillinq', 'Invoice date') }}:
+						{{ formatDate(invoice.invoiceDate) }}
 					</span>
 					<span v-if="invoice.dueDate">
 						{{ t('shillinq', 'Due') }}: {{ formatDate(invoice.dueDate) }}
@@ -47,9 +59,15 @@
 				<p>
 					{{ t('shillinq', 'Total (incl. VAT)') }}:
 					<strong>{{ formatMoney(invoice.totalInclVat) }}</strong>
-					<span v-if="invoice.totalExclVat !== null && invoice.totalExclVat !== undefined">
-						({{ t('shillinq', 'excl.') }} {{ formatMoney(invoice.totalExclVat) }} ·
-						{{ t('shillinq', 'VAT') }} {{ formatMoney(invoice.totalVat) }})
+					<span
+						v-if="
+							invoice.totalExclVat !== null
+							&& invoice.totalExclVat !== undefined
+						">
+						({{ t('shillinq', 'excl.') }}
+						{{ formatMoney(invoice.totalExclVat) }} ·
+						{{ t('shillinq', 'VAT') }}
+						{{ formatMoney(invoice.totalVat) }})
 					</span>
 				</p>
 			</header>
@@ -67,10 +85,20 @@
 							:style="{ width: ocrPercent }" />
 					</div>
 					<span class="si-detail__ocr-value">{{ ocrPercent }}</span>
-					<span class="si-detail__ocr-tier">{{ ocrConfidenceTierLabel }}</span>
+					<span class="si-detail__ocr-tier">{{
+						ocrConfidenceTierLabel
+					}}</span>
 				</div>
-				<p v-if="isLowConfidence" class="si-detail__ocr-hint" data-testid="si-detail-ocr-low">
-					{{ t('shillinq', 'Low OCR confidence — lines will route to manual confirmation downstream.') }}
+				<p
+					v-if="isLowConfidence"
+					class="si-detail__ocr-hint"
+					data-testid="si-detail-ocr-low">
+					{{
+						t(
+							'shillinq',
+							'Low OCR confidence — lines will route to manual confirmation downstream.',
+						)
+					}}
 				</p>
 			</section>
 
@@ -81,7 +109,9 @@
 				<h3>{{ t('shillinq', 'Peppol / UBL provenance') }}</h3>
 				<dl>
 					<dt>{{ t('shillinq', 'UBL source') }}</dt>
-					<dd>{{ invoice.ublSourceUri || t('shillinq', '(not recorded)') }}</dd>
+					<dd>
+						{{ invoice.ublSourceUri || t('shillinq', '(not recorded)') }}
+					</dd>
 					<dt>{{ t('shillinq', 'Received via Peppol') }}</dt>
 					<dd>{{ formatTimestamp(invoice.peppolReceivedAt) }}</dd>
 				</dl>
@@ -125,14 +155,22 @@
 				<h3>{{ t('shillinq', '3-way match status') }}</h3>
 				<ul v-if="matches.length > 0">
 					<li v-for="match in matches" :key="match.id">
-						<router-link :to="{ name: 'ThreeWayMatchDetail', params: { id: match.id } }">
+						<router-link
+							:to="{
+								name: 'ThreeWayMatchDetail',
+								params: { id: match.id },
+							}">
 							{{ match.matchReference || match.id }}
 						</router-link>
-						<span class="si-detail__match-status">{{ match.matchStatus || '—' }}</span>
+						<span class="si-detail__match-status">{{
+							match.matchStatus || '—'
+						}}</span>
 					</li>
 				</ul>
 				<p v-else class="si-detail__matches-empty">
-					{{ t('shillinq', 'No match yet — awaiting the matching engine.') }}
+					{{
+						t('shillinq', 'No match yet — awaiting the matching engine.')
+					}}
 				</p>
 			</section>
 		</div>
@@ -172,7 +210,10 @@ export default {
 			}
 			// Defensive: a non-null ocrConfidenceScore implies the PDF/OCR path
 			// even when sourceFormat is absent (older ingestion runs).
-			return this.invoice.ocrConfidenceScore !== null && this.invoice.ocrConfidenceScore !== undefined
+			return (
+				this.invoice.ocrConfidenceScore !== null
+				&& this.invoice.ocrConfidenceScore !== undefined
+			)
 		},
 		isUblIngestion() {
 			if (!this.invoice) {
@@ -217,14 +258,18 @@ export default {
 			this.loading = true
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/shillinq/api/openregister/objects/SupplierInvoice/${this.id}`),
+					generateUrl(
+						`/apps/shillinq/api/openregister/objects/SupplierInvoice/${this.id}`,
+					),
 				)
 				this.invoice = response.data || null
 				if (this.invoice) {
 					await this.loadMatches()
 				}
 			} catch (e) {
-				this.error = e?.response?.data?.error || this.t('shillinq', 'Failed to load supplier invoice')
+				this.error =
+					e?.response?.data?.error
+					|| this.t('shillinq', 'Failed to load supplier invoice')
 			} finally {
 				this.loading = false
 			}
@@ -234,7 +279,9 @@ export default {
 			// through to the empty state when the lookup isn't available yet.
 			try {
 				const response = await axios.get(
-					generateUrl('/apps/shillinq/api/openregister/objects/ThreeWayMatch'),
+					generateUrl(
+						'/apps/shillinq/api/openregister/objects/ThreeWayMatch',
+					),
 					{ params: { filter: { invoiceId: this.id } } },
 				)
 				this.matches = response.data?.results || response.data || []

--- a/src/components/three-way-match/AuditTrailDetail.vue
+++ b/src/components/three-way-match/AuditTrailDetail.vue
@@ -28,41 +28,74 @@
 				{{ t('shillinq', 'Audit trail') }}
 			</h2>
 			<p class="audit-trail__hint">
-				{{ t('shillinq', 'Complete lifecycle history for this supplier invoice. Exportable as an immutable ZIP for external auditors (BW2 art 2:10, 7-year retention).') }}
+				{{
+					t(
+						'shillinq',
+						'Complete lifecycle history for this supplier invoice. Exportable as an immutable ZIP for external auditors (BW2 art 2:10, 7-year retention).',
+					)
+				}}
 			</p>
 		</header>
 
-		<div v-if="loading" class="audit-trail__loading" data-testid="audit-trail-loading">
+		<div
+			v-if="loading"
+			class="audit-trail__loading"
+			data-testid="audit-trail-loading">
 			{{ t('shillinq', 'Loading audit trail…') }}
 		</div>
 
-		<div v-else-if="error" class="audit-trail__error" data-testid="audit-trail-error">
+		<div
+			v-else-if="error"
+			class="audit-trail__error"
+			data-testid="audit-trail-error">
 			{{ error }}
 		</div>
 
 		<div v-else-if="ledger" class="audit-trail__body">
 			<section class="audit-trail__summary" data-testid="audit-trail-summary">
 				<div class="audit-trail__field">
-					<span class="audit-trail__label">{{ t('shillinq', 'Invoice') }}</span>
-					<span class="audit-trail__value" data-testid="audit-trail-invoice-number">{{ summaryInvoiceNumber }}</span>
+					<span class="audit-trail__label">{{
+						t('shillinq', 'Invoice')
+					}}</span>
+					<span
+						class="audit-trail__value"
+						data-testid="audit-trail-invoice-number"
+						>{{ summaryInvoiceNumber }}</span
+					>
 				</div>
 				<div class="audit-trail__field">
-					<span class="audit-trail__label">{{ t('shillinq', 'Supplier') }}</span>
-					<span class="audit-trail__value" data-testid="audit-trail-supplier">{{ summarySupplierId }}</span>
+					<span class="audit-trail__label">{{
+						t('shillinq', 'Supplier')
+					}}</span>
+					<span
+						class="audit-trail__value"
+						data-testid="audit-trail-supplier"
+						>{{ summarySupplierId }}</span
+					>
 				</div>
 				<div class="audit-trail__field">
-					<span class="audit-trail__label">{{ t('shillinq', 'Total (incl. VAT)') }}</span>
+					<span class="audit-trail__label">{{
+						t('shillinq', 'Total (incl. VAT)')
+					}}</span>
 					<span class="audit-trail__value" data-testid="audit-trail-total">
 						{{ formatMoney(summaryTotal) }} {{ summaryCurrency }}
 					</span>
 				</div>
 				<div class="audit-trail__field">
-					<span class="audit-trail__label">{{ t('shillinq', 'Lifecycle events') }}</span>
-					<span class="audit-trail__value" data-testid="audit-trail-event-count">{{ events.length }}</span>
+					<span class="audit-trail__label">{{
+						t('shillinq', 'Lifecycle events')
+					}}</span>
+					<span
+						class="audit-trail__value"
+						data-testid="audit-trail-event-count"
+						>{{ events.length }}</span
+					>
 				</div>
 			</section>
 
-			<section class="audit-trail__timeline" data-testid="audit-trail-timeline">
+			<section
+				class="audit-trail__timeline"
+				data-testid="audit-trail-timeline">
 				<ol class="audit-trail__events">
 					<li
 						v-for="(event, index) in events"
@@ -73,16 +106,21 @@
 						<div class="audit-trail__event-marker" />
 						<div class="audit-trail__event-body">
 							<div class="audit-trail__event-row">
-								<span class="audit-trail__event-time" data-testid="audit-trail-event-time">
+								<span
+									class="audit-trail__event-time"
+									data-testid="audit-trail-event-time">
 									{{ formatTimestamp(event.timestamp) }}
 								</span>
-								<span class="audit-trail__event-name" data-testid="audit-trail-event-name">
+								<span
+									class="audit-trail__event-name"
+									data-testid="audit-trail-event-name">
 									{{ eventLabel(event.event) }}
 								</span>
 							</div>
 							<div class="audit-trail__event-meta">
 								<span data-testid="audit-trail-event-actor">
-									{{ t('shillinq', 'Actor') }}: {{ event.actor || '—' }}
+									{{ t('shillinq', 'Actor') }}:
+									{{ event.actor || '—' }}
 								</span>
 								<span data-testid="audit-trail-event-object">
 									{{ event.objectType }} #{{ event.objectId }}
@@ -94,7 +132,11 @@
 								data-testid="audit-trail-event-details">
 								<dl>
 									<!-- Vue 3 requires the v-for key on the <template> itself. -->
-									<template v-for="(detailValue, detailKey) in event.details" :key="detailKey">
+									<template
+										v-for="(
+											detailValue, detailKey
+										) in event.details"
+										:key="detailKey">
 										<dt>
 											{{ detailKey }}
 										</dt>
@@ -116,7 +158,11 @@
 					:disabled="exporting"
 					data-testid="audit-trail-export-button"
 					@click="exportPackage">
-					{{ exporting ? t('shillinq', 'Exporting…') : t('shillinq', 'Export audit package (ZIP)') }}
+					{{
+						exporting
+							? t('shillinq', 'Exporting…')
+							: t('shillinq', 'Export audit package (ZIP)')
+					}}
 				</button>
 				<div
 					v-if="exportError"
@@ -129,33 +175,58 @@
 					class="audit-trail__export-envelope"
 					data-testid="audit-trail-export-envelope">
 					<div class="audit-trail__field">
-						<span class="audit-trail__label">{{ t('shillinq', 'Package id') }}</span>
-						<span class="audit-trail__value" data-testid="audit-trail-export-package-id">
+						<span class="audit-trail__label">{{
+							t('shillinq', 'Package id')
+						}}</span>
+						<span
+							class="audit-trail__value"
+							data-testid="audit-trail-export-package-id">
 							{{ exportEnvelope.packageId }}
 						</span>
 					</div>
 					<div class="audit-trail__field">
-						<span class="audit-trail__label">{{ t('shillinq', 'SHA-256 (ledger)') }}</span>
-						<code class="audit-trail__value" data-testid="audit-trail-export-sha256">
+						<span class="audit-trail__label">{{
+							t('shillinq', 'SHA-256 (ledger)')
+						}}</span>
+						<code
+							class="audit-trail__value"
+							data-testid="audit-trail-export-sha256">
 							{{ exportEnvelope.sha256 }}
 						</code>
 					</div>
 					<div class="audit-trail__field">
-						<span class="audit-trail__label">{{ t('shillinq', 'Retention') }}</span>
-						<span class="audit-trail__value" data-testid="audit-trail-export-retention">
-							{{ exportEnvelope.retentionYears }} {{ t('shillinq', 'years (BW2 art 2:10)') }}
+						<span class="audit-trail__label">{{
+							t('shillinq', 'Retention')
+						}}</span>
+						<span
+							class="audit-trail__value"
+							data-testid="audit-trail-export-retention">
+							{{ exportEnvelope.retentionYears }}
+							{{ t('shillinq', 'years (BW2 art 2:10)') }}
 						</span>
 					</div>
 					<div class="audit-trail__field">
-						<span class="audit-trail__label">{{ t('shillinq', 'Events recorded') }}</span>
-						<span class="audit-trail__value" data-testid="audit-trail-export-event-count">
+						<span class="audit-trail__label">{{
+							t('shillinq', 'Events recorded')
+						}}</span>
+						<span
+							class="audit-trail__value"
+							data-testid="audit-trail-export-event-count">
 							{{ exportEnvelope.eventCount }}
 						</span>
 					</div>
 					<div class="audit-trail__field">
-						<span class="audit-trail__label">{{ t('shillinq', 'Archived to docudesk') }}</span>
-						<span class="audit-trail__value" data-testid="audit-trail-export-archived">
-							{{ exportEnvelope.archived ? t('shillinq', 'Yes') : t('shillinq', 'Pending') }}
+						<span class="audit-trail__label">{{
+							t('shillinq', 'Archived to docudesk')
+						}}</span>
+						<span
+							class="audit-trail__value"
+							data-testid="audit-trail-export-archived">
+							{{
+								exportEnvelope.archived
+									? t('shillinq', 'Yes')
+									: t('shillinq', 'Pending')
+							}}
 						</span>
 					</div>
 				</div>
@@ -216,16 +287,34 @@ export default {
 			return this.ledger.events
 		},
 		summaryInvoiceNumber() {
-			return (this.ledger && this.ledger.summary && this.ledger.summary.invoiceNumber) || '—'
+			return (
+				(this.ledger
+					&& this.ledger.summary
+					&& this.ledger.summary.invoiceNumber)
+				|| '—'
+			)
 		},
 		summarySupplierId() {
-			return (this.ledger && this.ledger.summary && this.ledger.summary.supplierId) || '—'
+			return (
+				(this.ledger
+					&& this.ledger.summary
+					&& this.ledger.summary.supplierId)
+				|| '—'
+			)
 		},
 		summaryTotal() {
-			return (this.ledger && this.ledger.summary && this.ledger.summary.totalInclVat) || 0
+			return (
+				(this.ledger
+					&& this.ledger.summary
+					&& this.ledger.summary.totalInclVat)
+				|| 0
+			)
 		},
 		summaryCurrency() {
-			return (this.ledger && this.ledger.summary && this.ledger.summary.currency) || 'EUR'
+			return (
+				(this.ledger && this.ledger.summary && this.ledger.summary.currency)
+				|| 'EUR'
+			)
 		},
 	},
 	async created() {
@@ -247,7 +336,8 @@ export default {
 				)
 				this.ledger = response.data || null
 			} catch (e) {
-				this.error = (e && e.response && e.response.data && e.response.data.error)
+				this.error =
+					(e && e.response && e.response.data && e.response.data.error)
 					|| this.t('shillinq', 'Failed to load audit trail')
 			} finally {
 				this.loading = false
@@ -258,7 +348,9 @@ export default {
 			this.exportError = ''
 			try {
 				const response = await axios.post(
-					generateUrl('/apps/shillinq/api/three-way-match/audit-trail/export'),
+					generateUrl(
+						'/apps/shillinq/api/three-way-match/audit-trail/export',
+					),
 					{
 						administrationId: this.administrationId,
 						invoiceId: this.invoiceId,
@@ -266,7 +358,8 @@ export default {
 				)
 				this.exportEnvelope = response.data || null
 			} catch (e) {
-				this.exportError = (e && e.response && e.response.data && e.response.data.error)
+				this.exportError =
+					(e && e.response && e.response.data && e.response.data.error)
 					|| this.t('shillinq', 'Failed to export audit package')
 			} finally {
 				this.exporting = false
@@ -301,7 +394,10 @@ export default {
 		},
 		formatMoney(cents) {
 			const value = Number(cents || 0) / 100
-			return value.toLocaleString('nl-NL', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+			return value.toLocaleString('nl-NL', {
+				minimumFractionDigits: 2,
+				maximumFractionDigits: 2,
+			})
 		},
 		formatDetailValue(value) {
 			if (value === null || value === undefined) {

--- a/src/components/three-way-match/ThreeWayMatchExceptionPanel.vue
+++ b/src/components/three-way-match/ThreeWayMatchExceptionPanel.vue
@@ -30,11 +30,17 @@
 -->
 <template>
 	<div class="twm-exception" data-testid="twm-exception-panel">
-		<div v-if="loading" class="twm-exception__loading" data-testid="twm-exception-loading">
+		<div
+			v-if="loading"
+			class="twm-exception__loading"
+			data-testid="twm-exception-loading">
 			{{ t('shillinq', 'Loading match...') }}
 		</div>
 
-		<div v-else-if="error" class="twm-exception__error" data-testid="twm-exception-error">
+		<div
+			v-else-if="error"
+			class="twm-exception__error"
+			data-testid="twm-exception-error">
 			{{ error }}
 		</div>
 
@@ -49,7 +55,8 @@
 						{{ t('shillinq', 'Invoice') }}: {{ invoice.invoiceNumber }}
 					</span>
 					<span v-if="match.createdAt">
-						{{ t('shillinq', 'Created') }}: {{ formatTimestamp(match.createdAt) }}
+						{{ t('shillinq', 'Created') }}:
+						{{ formatTimestamp(match.createdAt) }}
 					</span>
 				</p>
 			</header>
@@ -63,13 +70,18 @@
 					<thead>
 						<tr>
 							<th scope="col">{{ t('shillinq', 'Field') }}</th>
-							<th scope="col">{{ t('shillinq', 'Purchase Order') }}</th>
+							<th scope="col">
+								{{ t('shillinq', 'Purchase Order') }}
+							</th>
 							<th scope="col">{{ t('shillinq', 'Goods Receipt') }}</th>
 							<th scope="col">{{ t('shillinq', 'Invoice') }}</th>
 						</tr>
 					</thead>
 					<tbody>
-						<tr v-for="row in comparisonRows" :key="row.field" :data-testid="`twm-exception-row-${row.field}`">
+						<tr
+							v-for="row in comparisonRows"
+							:key="row.field"
+							:data-testid="`twm-exception-row-${row.field}`">
 							<td>{{ row.label }}</td>
 							<td>{{ row.po }}</td>
 							<td>{{ row.grn }}</td>
@@ -86,14 +98,26 @@
 				data-testid="twm-exception-divergence">
 				<h3>{{ t('shillinq', 'Divergence details') }}</h3>
 				<ul>
-					<li v-for="(entry, index) in divergenceRows" :key="index" :data-testid="`twm-exception-div-${index}`">
-						<strong>{{ entry.field }}</strong>:
-						{{ t('shillinq', 'expected') }} {{ entry.expected }} ·
+					<li
+						v-for="(entry, index) in divergenceRows"
+						:key="index"
+						:data-testid="`twm-exception-div-${index}`">
+						<strong>{{ entry.field }}</strong
+						>: {{ t('shillinq', 'expected') }} {{ entry.expected }} ·
 						{{ t('shillinq', 'actual') }} {{ entry.actual }}
-						<span v-if="entry.deltaCents !== null && entry.deltaCents !== undefined">
-							· {{ t('shillinq', 'Δ') }} {{ formatMoney(entry.deltaCents) }}
+						<span
+							v-if="
+								entry.deltaCents !== null
+								&& entry.deltaCents !== undefined
+							">
+							· {{ t('shillinq', 'Δ') }}
+							{{ formatMoney(entry.deltaCents) }}
 						</span>
-						<span v-if="entry.deltaPercentage !== null && entry.deltaPercentage !== undefined">
+						<span
+							v-if="
+								entry.deltaPercentage !== null
+								&& entry.deltaPercentage !== undefined
+							">
 							· {{ formatBasisPoints(entry.deltaPercentage) }}
 						</span>
 					</li>
@@ -116,8 +140,11 @@
 					<dt>{{ t('shillinq', 'Notes') }}</dt>
 					<dd>{{ match.resolutionNotes || '—' }}</dd>
 				</dl>
-				<p v-if="dispatch && dispatch.dispatchId" data-testid="twm-exception-dispatch-id">
-					{{ t('shillinq', 'CreditNote dispatch') }}: {{ dispatch.dispatchId }}
+				<p
+					v-if="dispatch && dispatch.dispatchId"
+					data-testid="twm-exception-dispatch-id">
+					{{ t('shillinq', 'CreditNote dispatch') }}:
+					{{ dispatch.dispatchId }}
 				</p>
 			</section>
 
@@ -128,7 +155,12 @@
 				data-testid="twm-exception-actions">
 				<h3>{{ t('shillinq', 'Resolution') }}</h3>
 				<p class="twm-exception__hint">
-					{{ t('shillinq', 'Payment is blocked until this exception is resolved.') }}
+					{{
+						t(
+							'shillinq',
+							'Payment is blocked until this exception is resolved.',
+						)
+					}}
 				</p>
 				<label class="twm-exception__notes-label" for="twm-exception-notes">
 					{{ t('shillinq', 'Motivation / reason') }}
@@ -139,9 +171,17 @@
 					data-testid="twm-exception-notes"
 					rows="3"
 					maxlength="2000"
-					:placeholder="t('shillinq', 'Document the motivation, dispute reason or rejection reason.')" />
+					:placeholder="
+						t(
+							'shillinq',
+							'Document the motivation, dispute reason or rejection reason.',
+						)
+					" />
 
-				<div v-if="actionError" class="twm-exception__action-error" data-testid="twm-exception-action-error">
+				<div
+					v-if="actionError"
+					class="twm-exception__action-error"
+					data-testid="twm-exception-action-error">
 					{{ actionError }}
 				</div>
 
@@ -279,14 +319,18 @@ export default {
 			this.loading = true
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/shillinq/api/openregister/objects/ThreeWayMatch/${this.id}`),
+					generateUrl(
+						`/apps/shillinq/api/openregister/objects/ThreeWayMatch/${this.id}`,
+					),
 				)
 				this.match = response.data || null
 				if (this.match) {
 					await this.loadRelated()
 				}
 			} catch (e) {
-				this.error = e?.response?.data?.error || this.t('shillinq', 'Failed to load match')
+				this.error =
+					e?.response?.data?.error
+					|| this.t('shillinq', 'Failed to load match')
 			} finally {
 				this.loading = false
 			}
@@ -299,11 +343,15 @@ export default {
 			if (this.match.invoiceId) {
 				tasks.push(this.loadInvoice())
 			}
-			const matchedPoIds = Array.isArray(this.match.matchedPoIds) ? this.match.matchedPoIds : []
+			const matchedPoIds = Array.isArray(this.match.matchedPoIds)
+				? this.match.matchedPoIds
+				: []
 			if (matchedPoIds.length > 0) {
 				tasks.push(this.loadPo(matchedPoIds[0]))
 			}
-			const matchedGrnIds = Array.isArray(this.match.matchedGrnIds) ? this.match.matchedGrnIds : []
+			const matchedGrnIds = Array.isArray(this.match.matchedGrnIds)
+				? this.match.matchedGrnIds
+				: []
 			if (matchedGrnIds.length > 0) {
 				tasks.push(this.loadGrn(matchedGrnIds[0]))
 			}
@@ -312,7 +360,9 @@ export default {
 		async loadInvoice() {
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/shillinq/api/openregister/objects/SupplierInvoice/${this.match.invoiceId}`),
+					generateUrl(
+						`/apps/shillinq/api/openregister/objects/SupplierInvoice/${this.match.invoiceId}`,
+					),
 				)
 				this.invoice = response.data || null
 			} catch (e) {
@@ -322,7 +372,9 @@ export default {
 		async loadPo(poId) {
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/shillinq/api/openregister/objects/PurchaseOrder/${poId}`),
+					generateUrl(
+						`/apps/shillinq/api/openregister/objects/PurchaseOrder/${poId}`,
+					),
 				)
 				this.po = response.data || null
 			} catch (e) {
@@ -332,7 +384,9 @@ export default {
 		async loadGrn(grnId) {
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/shillinq/api/openregister/objects/GoodsReceiptNote/${grnId}`),
+					generateUrl(
+						`/apps/shillinq/api/openregister/objects/GoodsReceiptNote/${grnId}`,
+					),
 				)
 				this.grn = response.data || null
 			} catch (e) {
@@ -356,7 +410,10 @@ export default {
 		},
 		async submitResolution(path, extra) {
 			if (this.notes.trim() === '') {
-				this.actionError = this.t('shillinq', 'A motivation / reason is required.')
+				this.actionError = this.t(
+					'shillinq',
+					'A motivation / reason is required.',
+				)
 				return
 			}
 			this.submitting = true
@@ -380,7 +437,9 @@ export default {
 				}
 				this.notes = ''
 			} catch (e) {
-				this.actionError = e?.response?.data?.error || this.t('shillinq', 'Resolution failed')
+				this.actionError =
+					e?.response?.data?.error
+					|| this.t('shillinq', 'Resolution failed')
 			} finally {
 				this.submitting = false
 			}
@@ -401,7 +460,10 @@ export default {
 			const labels = {
 				accepted: this.t('shillinq', 'Accepted with motivation'),
 				rejected: this.t('shillinq', 'Rejected — payment blocked'),
-				credit_note_requested: this.t('shillinq', 'Dispute filed (UBL CreditNote)'),
+				credit_note_requested: this.t(
+					'shillinq',
+					'Dispute filed (UBL CreditNote)',
+				),
 				supplier_contacted: this.t('shillinq', 'Supplier contacted'),
 				po_adjusted: this.t('shillinq', 'PO adjusted'),
 				tolerance_override: this.t('shillinq', 'Tolerance override'),

--- a/src/components/three-way-match/ThreeWayMatchIndex.vue
+++ b/src/components/three-way-match/ThreeWayMatchIndex.vue
@@ -31,7 +31,12 @@
 				{{ t('shillinq', 'Three-way matches') }}
 			</h2>
 			<p class="twm-index__hint">
-				{{ t('shillinq', 'Every supplier invoice scored against its purchase order(s) and goods receipt note(s) by the matching engine.') }}
+				{{
+					t(
+						'shillinq',
+						'Every supplier invoice scored against its purchase order(s) and goods receipt note(s) by the matching engine.',
+					)
+				}}
 			</p>
 		</header>
 
@@ -46,17 +51,26 @@
 				<option value="">
 					{{ t('shillinq', 'All statuses') }}
 				</option>
-				<option v-for="opt in statusOptions" :key="opt.value" :value="opt.value">
+				<option
+					v-for="opt in statusOptions"
+					:key="opt.value"
+					:value="opt.value">
 					{{ opt.label }}
 				</option>
 			</select>
 		</div>
 
-		<div v-if="loading" class="twm-index__loading" data-testid="twm-index-loading">
+		<div
+			v-if="loading"
+			class="twm-index__loading"
+			data-testid="twm-index-loading">
 			{{ t('shillinq', 'Loading three-way matches...') }}
 		</div>
 
-		<div v-else-if="error" class="twm-index__error" data-testid="twm-index-error">
+		<div
+			v-else-if="error"
+			class="twm-index__error"
+			data-testid="twm-index-error">
 			{{ error }}
 		</div>
 
@@ -68,7 +82,11 @@
 			:rows="filteredMatches"
 			:empty-label="t('shillinq', 'No matches recorded yet.')">
 			<template #cell-invoice="{ row }">
-				<router-link :to="{ name: 'SupplierInvoiceDetail', params: { id: row.invoiceId } }">
+				<router-link
+					:to="{
+						name: 'SupplierInvoiceDetail',
+						params: { id: row.invoiceId },
+					}">
 					{{ supplierInvoiceLabel(row) }}
 				</router-link>
 			</template>
@@ -92,10 +110,12 @@
 			<template #cell-refs="{ row }">
 				<span class="twm-index__refs">
 					<span v-if="(row.matchedPoIds || []).length > 0">
-						{{ t('shillinq', 'PO') }}: {{ (row.matchedPoIds || []).join(', ') }}
+						{{ t('shillinq', 'PO') }}:
+						{{ (row.matchedPoIds || []).join(', ') }}
 					</span>
 					<span v-if="(row.matchedGrnIds || []).length > 0">
-						{{ t('shillinq', 'GRN') }}: {{ (row.matchedGrnIds || []).join(', ') }}
+						{{ t('shillinq', 'GRN') }}:
+						{{ (row.matchedGrnIds || []).join(', ') }}
 					</span>
 				</span>
 			</template>
@@ -106,9 +126,11 @@
 					:data-testid="`twm-reevaluate-${row.id}`"
 					:disabled="reevaluating === row.id"
 					@click="reevaluate(row)">
-					{{ reevaluating === row.id
-						? t('shillinq', 'Evaluating...')
-						: t('shillinq', 'Re-evaluate') }}
+					{{
+						reevaluating === row.id
+							? t('shillinq', 'Evaluating...')
+							: t('shillinq', 'Re-evaluate')
+					}}
 				</button>
 			</template>
 		</CnDataTable>
@@ -156,23 +178,65 @@ export default {
 		 */
 		columns() {
 			return [
-				{ key: 'invoice', label: this.t('shillinq', 'Invoice'), sortable: false },
-				{ key: 'supplier', label: this.t('shillinq', 'Supplier'), sortable: false },
-				{ key: 'amount', label: this.t('shillinq', 'Amount'), sortable: false },
-				{ key: 'matchDate', label: this.t('shillinq', 'Match date'), sortable: false },
-				{ key: 'matchStatus', label: this.t('shillinq', 'Status'), sortable: true },
-				{ key: 'refs', label: this.t('shillinq', 'Linked PO / GRN'), sortable: false },
+				{
+					key: 'invoice',
+					label: this.t('shillinq', 'Invoice'),
+					sortable: false,
+				},
+				{
+					key: 'supplier',
+					label: this.t('shillinq', 'Supplier'),
+					sortable: false,
+				},
+				{
+					key: 'amount',
+					label: this.t('shillinq', 'Amount'),
+					sortable: false,
+				},
+				{
+					key: 'matchDate',
+					label: this.t('shillinq', 'Match date'),
+					sortable: false,
+				},
+				{
+					key: 'matchStatus',
+					label: this.t('shillinq', 'Status'),
+					sortable: true,
+				},
+				{
+					key: 'refs',
+					label: this.t('shillinq', 'Linked PO / GRN'),
+					sortable: false,
+				},
 				{ key: 'actions', label: '', sortable: false },
 			]
 		},
 		statusOptions() {
 			return [
-				{ value: 'auto_approved', label: this.t('shillinq', 'Auto-approved') },
-				{ value: 'within_tolerance', label: this.t('shillinq', 'Within tolerance') },
-				{ value: 'exception_price', label: this.t('shillinq', 'Price exception') },
-				{ value: 'exception_quantity', label: this.t('shillinq', 'Quantity exception') },
-				{ value: 'exception_missing_grn', label: this.t('shillinq', 'Missing GRN') },
-				{ value: 'exception_missing_po', label: this.t('shillinq', 'Missing PO') },
+				{
+					value: 'auto_approved',
+					label: this.t('shillinq', 'Auto-approved'),
+				},
+				{
+					value: 'within_tolerance',
+					label: this.t('shillinq', 'Within tolerance'),
+				},
+				{
+					value: 'exception_price',
+					label: this.t('shillinq', 'Price exception'),
+				},
+				{
+					value: 'exception_quantity',
+					label: this.t('shillinq', 'Quantity exception'),
+				},
+				{
+					value: 'exception_missing_grn',
+					label: this.t('shillinq', 'Missing GRN'),
+				},
+				{
+					value: 'exception_missing_po',
+					label: this.t('shillinq', 'Missing PO'),
+				},
 				{ value: 'fraud_alert', label: this.t('shillinq', 'Fraud alert') },
 			]
 		},
@@ -180,7 +244,9 @@ export default {
 			if (!this.statusFilter) {
 				return this.matches
 			}
-			return this.matches.filter(match => match.matchStatus === this.statusFilter)
+			return this.matches.filter(
+				(match) => match.matchStatus === this.statusFilter,
+			)
 		},
 	},
 	async created() {
@@ -192,7 +258,9 @@ export default {
 			this.error = ''
 			try {
 				const response = await axios.get(
-					generateUrl('/apps/shillinq/api/openregister/objects/ThreeWayMatch'),
+					generateUrl(
+						'/apps/shillinq/api/openregister/objects/ThreeWayMatch',
+					),
 				)
 				const rows = response.data?.results || response.data || []
 				this.matches = Array.isArray(rows) ? rows : []
@@ -200,11 +268,15 @@ export default {
 				// Pre-fetch invoice headers for the supplier + amount columns.
 				// One bulk call when the OR API supports an `id IN (..)` filter;
 				// otherwise we fall back to silent best-effort.
-				const invoiceIds = [...new Set(this.matches.map(m => m.invoiceId).filter(Boolean))]
+				const invoiceIds = [
+					...new Set(this.matches.map((m) => m.invoiceId).filter(Boolean)),
+				]
 				for (const id of invoiceIds) {
 					try {
 						const inv = await axios.get(
-							generateUrl(`/apps/shillinq/api/openregister/objects/SupplierInvoice/${id}`),
+							generateUrl(
+								`/apps/shillinq/api/openregister/objects/SupplierInvoice/${id}`,
+							),
 						)
 						this.invoices[id] = inv.data || null
 					} catch (e) {
@@ -212,7 +284,9 @@ export default {
 					}
 				}
 			} catch (e) {
-				this.error = e?.response?.data?.error || this.t('shillinq', 'Failed to load three-way matches')
+				this.error =
+					e?.response?.data?.error
+					|| this.t('shillinq', 'Failed to load three-way matches')
 			} finally {
 				this.loading = false
 			}
@@ -226,7 +300,8 @@ export default {
 				const response = await axios.post(
 					generateUrl('/apps/shillinq/api/three-way-matches/evaluate'),
 					{
-						administrationId: this.administrationId || match.administrationId,
+						administrationId:
+							this.administrationId || match.administrationId,
 						invoiceId: match.invoiceId,
 					},
 				)
@@ -234,7 +309,9 @@ export default {
 				// record; otherwise reload the whole list as a safety net.
 				const updated = response.data
 				if (updated && updated.id) {
-					const i = this.matches.findIndex(m => m.id === match.id || m.id === updated.id)
+					const i = this.matches.findIndex(
+						(m) => m.id === match.id || m.id === updated.id,
+					)
 					if (i >= 0) {
 						this.matches.splice(i, 1, updated)
 					} else {
@@ -244,7 +321,9 @@ export default {
 					await this.loadMatches()
 				}
 			} catch (e) {
-				this.error = e?.response?.data?.error || this.t('shillinq', 'Re-evaluation failed')
+				this.error =
+					e?.response?.data?.error
+					|| this.t('shillinq', 'Re-evaluation failed')
 			} finally {
 				this.reevaluating = ''
 			}
@@ -262,7 +341,11 @@ export default {
 		},
 		amountLabel(match) {
 			const invoice = this.invoices[match.invoiceId]
-			if (!invoice || invoice.totalInclVat === null || invoice.totalInclVat === undefined) {
+			if (
+				!invoice
+				|| invoice.totalInclVat === null
+				|| invoice.totalInclVat === undefined
+			) {
 				return '—'
 			}
 			const currency = invoice.currency || 'EUR'

--- a/src/components/vendor-performance/VendorPerformanceDetail.vue
+++ b/src/components/vendor-performance/VendorPerformanceDetail.vue
@@ -29,30 +29,51 @@
 				{{ t('shillinq', 'Vendor performance') }}
 			</h2>
 			<p class="vp-detail__hint">
-				{{ t('shillinq', 'Monthly scorecard computed by the vendor performance aggregation cron.') }}
+				{{
+					t(
+						'shillinq',
+						'Monthly scorecard computed by the vendor performance aggregation cron.',
+					)
+				}}
 			</p>
 		</header>
 
-		<div v-if="loading" class="vp-detail__loading" data-testid="vp-detail-loading">
+		<div
+			v-if="loading"
+			class="vp-detail__loading"
+			data-testid="vp-detail-loading">
 			{{ t('shillinq', 'Loading scorecard...') }}
 		</div>
 
-		<div v-else-if="error" class="vp-detail__error" data-testid="vp-detail-error">
+		<div
+			v-else-if="error"
+			class="vp-detail__error"
+			data-testid="vp-detail-error">
 			{{ error }}
 		</div>
 
 		<div v-else-if="scorecard" class="vp-detail__body">
 			<section class="vp-detail__summary" data-testid="vp-detail-summary">
 				<div class="vp-detail__field">
-					<span class="vp-detail__label">{{ t('shillinq', 'Supplier') }}</span>
-					<span class="vp-detail__value" data-testid="vp-supplier">{{ scorecard.supplierId || '—' }}</span>
+					<span class="vp-detail__label">{{
+						t('shillinq', 'Supplier')
+					}}</span>
+					<span class="vp-detail__value" data-testid="vp-supplier">{{
+						scorecard.supplierId || '—'
+					}}</span>
 				</div>
 				<div class="vp-detail__field">
-					<span class="vp-detail__label">{{ t('shillinq', 'Period') }}</span>
-					<span class="vp-detail__value" data-testid="vp-period">{{ scorecard.period || '—' }}</span>
+					<span class="vp-detail__label">{{
+						t('shillinq', 'Period')
+					}}</span>
+					<span class="vp-detail__value" data-testid="vp-period">{{
+						scorecard.period || '—'
+					}}</span>
 				</div>
 				<div class="vp-detail__field">
-					<span class="vp-detail__label">{{ t('shillinq', 'Overall score') }}</span>
+					<span class="vp-detail__label">{{
+						t('shillinq', 'Overall score')
+					}}</span>
 					<span
 						class="vp-detail__score"
 						:class="scoreClass(scorecard.overallScore)"
@@ -61,7 +82,9 @@
 					</span>
 				</div>
 				<div class="vp-detail__field">
-					<span class="vp-detail__label">{{ t('shillinq', 'Trend') }}</span>
+					<span class="vp-detail__label">{{
+						t('shillinq', 'Trend')
+					}}</span>
 					<span
 						class="vp-detail__pill"
 						:class="`vp-detail__pill--${scorecard.scoreTrend || 'stable'}`"
@@ -70,14 +93,22 @@
 					</span>
 				</div>
 				<div class="vp-detail__field">
-					<span class="vp-detail__label">{{ t('shillinq', 'Auto-review eligible') }}</span>
+					<span class="vp-detail__label">{{
+						t('shillinq', 'Auto-review eligible')
+					}}</span>
 					<span
 						class="vp-detail__pill"
-						:class="scorecard.automatedReviewEligible ? 'vp-detail__pill--eligible' : 'vp-detail__pill--ineligible'"
+						:class="
+							scorecard.automatedReviewEligible
+								? 'vp-detail__pill--eligible'
+								: 'vp-detail__pill--ineligible'
+						"
 						data-testid="vp-eligible-badge">
-						{{ scorecard.automatedReviewEligible
-							? t('shillinq', 'Yes')
-							: t('shillinq', 'No') }}
+						{{
+							scorecard.automatedReviewEligible
+								? t('shillinq', 'Yes')
+								: t('shillinq', 'No')
+						}}
 					</span>
 				</div>
 			</section>
@@ -137,7 +168,10 @@
 					<li>
 						<router-link
 							v-if="scorecard.supplierId"
-							:to="{ name: 'PurchaseOrderIndex', query: { supplierId: scorecard.supplierId } }"
+							:to="{
+								name: 'PurchaseOrderIndex',
+								query: { supplierId: scorecard.supplierId },
+							}"
 							data-testid="vp-link-pos">
 							{{ t('shillinq', 'Purchase orders for this supplier') }}
 						</router-link>
@@ -145,7 +179,10 @@
 					<li>
 						<router-link
 							v-if="scorecard.supplierId"
-							:to="{ name: 'SupplierInvoiceIndex', query: { supplierId: scorecard.supplierId } }"
+							:to="{
+								name: 'SupplierInvoiceIndex',
+								query: { supplierId: scorecard.supplierId },
+							}"
 							data-testid="vp-link-invoices">
 							{{ t('shillinq', 'Supplier invoices') }}
 						</router-link>
@@ -212,11 +249,15 @@ export default {
 			}
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/shillinq/api/openregister/objects/VendorPerformance/${id}`),
+					generateUrl(
+						`/apps/shillinq/api/openregister/objects/VendorPerformance/${id}`,
+					),
 				)
 				this.scorecard = response.data || null
 			} catch (e) {
-				this.error = e?.response?.data?.error || this.t('shillinq', 'Failed to load scorecard')
+				this.error =
+					e?.response?.data?.error
+					|| this.t('shillinq', 'Failed to load scorecard')
 			} finally {
 				this.loading = false
 			}

--- a/src/components/vendor-performance/VendorPerformanceIndex.vue
+++ b/src/components/vendor-performance/VendorPerformanceIndex.vue
@@ -26,7 +26,12 @@
 				{{ t('shillinq', 'Vendor performance') }}
 			</h2>
 			<p class="vp-index__hint">
-				{{ t('shillinq', 'Latest monthly scorecard per supplier. Suppliers above 96 % are flagged for auto-review once the 90-day bootstrap window has passed.') }}
+				{{
+					t(
+						'shillinq',
+						'Latest monthly scorecard per supplier. Suppliers above 96 % are flagged for auto-review once the 90-day bootstrap window has passed.',
+					)
+				}}
 			</p>
 		</header>
 
@@ -93,11 +98,17 @@
 			<template #cell-automatedReviewEligible="{ row }">
 				<span
 					class="vp-index__pill"
-					:class="row.automatedReviewEligible ? 'vp-index__pill--eligible' : 'vp-index__pill--ineligible'"
+					:class="
+						row.automatedReviewEligible
+							? 'vp-index__pill--eligible'
+							: 'vp-index__pill--ineligible'
+					"
 					:data-testid="`vp-eligible-${row.id}`">
-					{{ row.automatedReviewEligible
-						? t('shillinq', 'Yes')
-						: t('shillinq', 'No') }}
+					{{
+						row.automatedReviewEligible
+							? t('shillinq', 'Yes')
+							: t('shillinq', 'No')
+					}}
 				</span>
 			</template>
 			<template #cell-actions="{ row }">
@@ -139,12 +150,36 @@ export default {
 		 */
 		columns() {
 			return [
-				{ key: 'supplierId', label: this.t('shillinq', 'Supplier'), sortable: true },
-				{ key: 'period', label: this.t('shillinq', 'Period'), sortable: true },
-				{ key: 'overallScore', label: this.t('shillinq', 'Overall score'), sortable: true },
-				{ key: 'scoreTrend', label: this.t('shillinq', 'Trend'), sortable: true },
-				{ key: 'disputeCount', label: this.t('shillinq', 'Disputes'), sortable: true },
-				{ key: 'automatedReviewEligible', label: this.t('shillinq', 'Auto-review eligible'), sortable: true },
+				{
+					key: 'supplierId',
+					label: this.t('shillinq', 'Supplier'),
+					sortable: true,
+				},
+				{
+					key: 'period',
+					label: this.t('shillinq', 'Period'),
+					sortable: true,
+				},
+				{
+					key: 'overallScore',
+					label: this.t('shillinq', 'Overall score'),
+					sortable: true,
+				},
+				{
+					key: 'scoreTrend',
+					label: this.t('shillinq', 'Trend'),
+					sortable: true,
+				},
+				{
+					key: 'disputeCount',
+					label: this.t('shillinq', 'Disputes'),
+					sortable: true,
+				},
+				{
+					key: 'automatedReviewEligible',
+					label: this.t('shillinq', 'Auto-review eligible'),
+					sortable: true,
+				},
 				{ key: 'actions', label: '', sortable: false },
 			]
 		},
@@ -164,15 +199,21 @@ export default {
 				}
 			}
 			const list = [...map.values()]
-			list.sort((a, b) => Number(b.overallScore || 0) - Number(a.overallScore || 0))
+			list.sort(
+				(a, b) => Number(b.overallScore || 0) - Number(a.overallScore || 0),
+			)
 			return list
 		},
 		filteredRows() {
 			if (this.eligibilityFilter === 'eligible') {
-				return this.latestPerSupplier.filter(r => r.automatedReviewEligible === true)
+				return this.latestPerSupplier.filter(
+					(r) => r.automatedReviewEligible === true,
+				)
 			}
 			if (this.eligibilityFilter === 'ineligible') {
-				return this.latestPerSupplier.filter(r => r.automatedReviewEligible !== true)
+				return this.latestPerSupplier.filter(
+					(r) => r.automatedReviewEligible !== true,
+				)
 			}
 			return this.latestPerSupplier
 		},
@@ -186,12 +227,16 @@ export default {
 			this.error = ''
 			try {
 				const response = await axios.get(
-					generateUrl('/apps/shillinq/api/openregister/objects/VendorPerformance'),
+					generateUrl(
+						'/apps/shillinq/api/openregister/objects/VendorPerformance',
+					),
 				)
 				const rows = response.data?.results || response.data || []
 				this.rows = Array.isArray(rows) ? rows : []
 			} catch (e) {
-				this.error = e?.response?.data?.error || this.t('shillinq', 'Failed to load vendor scorecards')
+				this.error =
+					e?.response?.data?.error
+					|| this.t('shillinq', 'Failed to load vendor scorecards')
 			} finally {
 				this.loading = false
 			}

--- a/src/components/wbso/AccountNode.vue
+++ b/src/components/wbso/AccountNode.vue
@@ -9,23 +9,39 @@
  @spec openspec/changes/bookkeeping-wbso-sno-administratie/tasks.md#task-20
 -->
 <template>
-	<li role="treeitem" class="wbso-account-node" :aria-expanded="hasChildren ? expanded : null">
+	<li
+		role="treeitem"
+		class="wbso-account-node"
+		:aria-expanded="hasChildren ? expanded : null">
 		<div class="wbso-account-node__row" :style="{ paddingLeft: indent }">
-			<button v-if="hasChildren"
+			<button
+				v-if="hasChildren"
 				type="button"
 				class="wbso-account-node__toggle"
-				:aria-label="expanded ? t('shillinq', 'Collapse') : t('shillinq', 'Expand')"
+				:aria-label="
+					expanded ? t('shillinq', 'Collapse') : t('shillinq', 'Expand')
+				"
 				@click="expanded = !expanded">
 				{{ expanded ? '▾' : '▸' }}
 			</button>
 			<span v-else class="wbso-account-node__leaf-bullet">•</span>
-			<span class="wbso-account-node__number">{{ account.accountNumber }}</span>
+			<span class="wbso-account-node__number">{{
+				account.accountNumber
+			}}</span>
 			<span class="wbso-account-node__name">{{ account.name }}</span>
-			<span class="wbso-account-node__type">{{ translateType(account.accountType) }}</span>
-			<span class="wbso-account-node__status" :data-status="account.status">{{ translateStatus(account.status) }}</span>
+			<span class="wbso-account-node__type">{{
+				translateType(account.accountType)
+			}}</span>
+			<span class="wbso-account-node__status" :data-status="account.status">{{
+				translateStatus(account.status)
+			}}</span>
 		</div>
-		<ul v-if="hasChildren && expanded" class="wbso-account-node__children" role="group">
-			<AccountNode v-for="child in account.children"
+		<ul
+			v-if="hasChildren && expanded"
+			class="wbso-account-node__children"
+			role="group">
+			<AccountNode
+				v-for="child in account.children"
 				:key="child.accountNumber"
 				:account="child"
 				:depth="depth + 1" />
@@ -56,7 +72,10 @@ export default {
 
 	computed: {
 		hasChildren() {
-			return Array.isArray(this.account.children) && this.account.children.length > 0
+			return (
+				Array.isArray(this.account.children)
+				&& this.account.children.length > 0
+			)
 		},
 		indent() {
 			return `${this.depth * 1.25}rem`

--- a/src/components/widget/SelfServiceWidget.vue
+++ b/src/components/widget/SelfServiceWidget.vue
@@ -23,7 +23,8 @@
 -->
 
 <template>
-	<div :class="rootClass"
+	<div
+		:class="rootClass"
 		:lang="lang"
 		role="form"
 		:aria-label="t('Book an appointment')">
@@ -38,7 +39,9 @@
 
 		<!-- STEP 1 — Service -->
 		<section v-if="step === 'service'">
-			<label class="wsw-widget__label" :for="ids.service">{{ t('Select a service') }}</label>
+			<label class="wsw-widget__label" :for="ids.service">{{
+				t('Select a service')
+			}}</label>
 			<select
 				:id="ids.service"
 				v-model="selectedServiceId"
@@ -48,7 +51,10 @@
 				<option value="">
 					{{ t('Select a service') }}
 				</option>
-				<option v-for="service in services" :key="service.serviceId" :value="service.serviceId">
+				<option
+					v-for="service in services"
+					:key="service.serviceId"
+					:value="service.serviceId">
 					{{ service.name }} ({{ service.duration }} {{ t('minutes') }})
 				</option>
 			</select>
@@ -57,7 +63,8 @@
 			</p>
 
 			<div class="wsw-widget__actions">
-				<button type="button"
+				<button
+					type="button"
 					class="wsw-widget__button"
 					:disabled="!selectedServiceId"
 					@click="goToDateStep">
@@ -68,17 +75,22 @@
 
 		<!-- STEP 2 — Date + time -->
 		<section v-if="step === 'datetime'">
-			<label class="wsw-widget__label" :for="ids.date">{{ t('Select a date') }}</label>
+			<label class="wsw-widget__label" :for="ids.date">{{
+				t('Select a date')
+			}}</label>
 			<input
 				:id="ids.date"
 				v-model="selectedDate"
 				class="wsw-widget__input"
 				type="date"
 				:min="todayIso"
-				@change="loadSlots">
+				@change="loadSlots" />
 
-			<label class="wsw-widget__label" :for="ids.slot">{{ t('Select a time') }}</label>
-			<div :id="ids.slot"
+			<label class="wsw-widget__label" :for="ids.slot">{{
+				t('Select a time')
+			}}</label>
+			<div
+				:id="ids.slot"
 				class="wsw-widget__slot-grid"
 				role="radiogroup"
 				:aria-label="t('Select a time')">
@@ -87,7 +99,11 @@
 					:key="slot.startTime"
 					type="button"
 					role="radio"
-					:aria-checked="selectedSlot && selectedSlot.startTime === slot.startTime ? 'true' : 'false'"
+					:aria-checked="
+						selectedSlot && selectedSlot.startTime === slot.startTime
+							? 'true'
+							: 'false'
+					"
 					:class="slotClasses(slot)"
 					@click="selectedSlot = slot">
 					{{ formatTime(slot.startTime) }}
@@ -98,10 +114,14 @@
 			</p>
 
 			<div class="wsw-widget__actions">
-				<button type="button" class="wsw-widget__button wsw-widget__button--secondary" @click="step = 'service'">
+				<button
+					type="button"
+					class="wsw-widget__button wsw-widget__button--secondary"
+					@click="step = 'service'">
 					{{ t('Back') }}
 				</button>
-				<button type="button"
+				<button
+					type="button"
 					class="wsw-widget__button"
 					:disabled="!selectedSlot"
 					@click="step = 'details'">
@@ -112,40 +132,52 @@
 
 		<!-- STEP 3 — Customer details -->
 		<section v-if="step === 'details'">
-			<label class="wsw-widget__label" :for="ids.name">{{ t('Your name') }}</label>
-			<input :id="ids.name"
+			<label class="wsw-widget__label" :for="ids.name">{{
+				t('Your name')
+			}}</label>
+			<input
+				:id="ids.name"
 				v-model="customerName"
 				class="wsw-widget__input"
 				type="text"
 				required
-				maxlength="255">
+				maxlength="255" />
 			<p class="wsw-widget__error" role="alert">
 				{{ errors.name }}
 			</p>
 
-			<label class="wsw-widget__label" :for="ids.email">{{ t('Email address') }}</label>
-			<input :id="ids.email"
+			<label class="wsw-widget__label" :for="ids.email">{{
+				t('Email address')
+			}}</label>
+			<input
+				:id="ids.email"
 				v-model="email"
 				class="wsw-widget__input"
 				type="email"
 				autocomplete="email"
-				required>
+				required />
 			<p class="wsw-widget__error" role="alert">
 				{{ errors.email }}
 			</p>
 
-			<label class="wsw-widget__label" :for="ids.phone">{{ t('Phone (optional)') }}</label>
-			<input :id="ids.phone"
+			<label class="wsw-widget__label" :for="ids.phone">{{
+				t('Phone (optional)')
+			}}</label>
+			<input
+				:id="ids.phone"
 				v-model="phone"
 				class="wsw-widget__input"
 				type="tel"
-				autocomplete="tel">
+				autocomplete="tel" />
 			<p class="wsw-widget__error" role="alert">
 				{{ errors.phone }}
 			</p>
 
-			<label class="wsw-widget__label" :for="ids.notes">{{ t('Notes (optional)') }}</label>
-			<textarea :id="ids.notes"
+			<label class="wsw-widget__label" :for="ids.notes">{{
+				t('Notes (optional)')
+			}}</label>
+			<textarea
+				:id="ids.notes"
 				v-model="notes"
 				class="wsw-widget__textarea"
 				maxlength="500"
@@ -155,10 +187,14 @@
 			</p>
 
 			<div class="wsw-widget__actions">
-				<button type="button" class="wsw-widget__button wsw-widget__button--secondary" @click="step = 'datetime'">
+				<button
+					type="button"
+					class="wsw-widget__button wsw-widget__button--secondary"
+					@click="step = 'datetime'">
 					{{ t('Back') }}
 				</button>
-				<button type="button"
+				<button
+					type="button"
 					class="wsw-widget__button"
 					:disabled="!detailsValid"
 					@click="step = 'review'">
@@ -187,10 +223,14 @@
 			</p>
 
 			<div class="wsw-widget__actions">
-				<button type="button" class="wsw-widget__button wsw-widget__button--secondary" @click="step = 'details'">
+				<button
+					type="button"
+					class="wsw-widget__button wsw-widget__button--secondary"
+					@click="step = 'details'">
 					{{ t('Back') }}
 				</button>
-				<button type="button"
+				<button
+					type="button"
 					class="wsw-widget__button"
 					:disabled="submitting"
 					@click="submit">
@@ -200,7 +240,10 @@
 		</section>
 
 		<!-- STEP 5 — Result -->
-		<section v-if="step === 'confirmed'" class="wsw-widget__status wsw-widget__status--success" role="status">
+		<section
+			v-if="step === 'confirmed'"
+			class="wsw-widget__status wsw-widget__status--success"
+			role="status">
 			<strong>{{ t('Booking confirmed') }}</strong>
 			<p>{{ confirmationMessage }}</p>
 		</section>
@@ -301,12 +344,19 @@ export default {
 			return steps[this.step] || ''
 		},
 		selectedServiceName() {
-			const found = this.services.find(s => s.serviceId === this.selectedServiceId)
+			const found = this.services.find(
+				(s) => s.serviceId === this.selectedServiceId,
+			)
 			return found ? found.name : ''
 		},
 		detailsValid() {
 			this.validateDetails()
-			return !this.errors.name && !this.errors.email && !this.errors.phone && !this.errors.notes
+			return (
+				!this.errors.name
+				&& !this.errors.email
+				&& !this.errors.phone
+				&& !this.errors.notes
+			)
 		},
 	},
 	mounted() {
@@ -333,13 +383,20 @@ export default {
 		slotClasses(slot) {
 			return [
 				'wsw-widget__slot',
-				{ 'wsw-widget__slot--selected': this.selectedSlot && this.selectedSlot.startTime === slot.startTime },
+				{
+					'wsw-widget__slot--selected':
+						this.selectedSlot
+						&& this.selectedSlot.startTime === slot.startTime,
+				},
 			]
 		},
 		formatTime(iso) {
 			try {
 				const date = new Date(iso)
-				return date.toLocaleTimeString(this.lang, { hour: '2-digit', minute: '2-digit' })
+				return date.toLocaleTimeString(this.lang, {
+					hour: '2-digit',
+					minute: '2-digit',
+				})
 			} catch (e) {
 				return iso
 			}
@@ -351,10 +408,15 @@ export default {
 			}
 		},
 		buildUrl(path, params) {
-			const url = new URL(this.apiBase.replace(/\/$/, '') + path, window.location.origin)
+			const url = new URL(
+				this.apiBase.replace(/\/$/, '') + path,
+				window.location.origin,
+			)
 			url.searchParams.set('businessId', this.businessId)
 			if (params) {
-				Object.keys(params).forEach(k => url.searchParams.set(k, params[k]))
+				Object.keys(params).forEach((k) =>
+					url.searchParams.set(k, params[k]),
+				)
 			}
 			return url.toString()
 		},
@@ -367,17 +429,23 @@ export default {
 					headers: this.authHeaders(),
 				})
 				if (response.status === 401 || response.status === 403) {
-					this.servicesError = this.t('Configuration error. Please contact the website owner.')
+					this.servicesError = this.t(
+						'Configuration error. Please contact the website owner.',
+					)
 					return
 				}
 				if (!response.ok) {
-					this.servicesError = this.t('We could not load the available services. Please try again later.')
+					this.servicesError = this.t(
+						'We could not load the available services. Please try again later.',
+					)
 					return
 				}
 				const payload = await response.json()
-				this.services = (payload && payload.services) ? payload.services : []
+				this.services = payload && payload.services ? payload.services : []
 			} catch (e) {
-				this.servicesError = this.t('Network error. Please check your connection and try again.')
+				this.servicesError = this.t(
+					'Network error. Please check your connection and try again.',
+				)
 			} finally {
 				this.loadingServices = false
 			}
@@ -406,38 +474,56 @@ export default {
 					{ method: 'GET', headers: this.authHeaders() },
 				)
 				if (response.status === 401 || response.status === 403) {
-					this.slotsError = this.t('Configuration error. Please contact the website owner.')
+					this.slotsError = this.t(
+						'Configuration error. Please contact the website owner.',
+					)
 					return
 				}
 				if (response.status === 404) {
-					this.slotsError = this.t('This service is no longer available. Please refresh the page.')
+					this.slotsError = this.t(
+						'This service is no longer available. Please refresh the page.',
+					)
 					return
 				}
 				if (!response.ok) {
-					this.slotsError = this.t('We could not load available times. Please try another date.')
+					this.slotsError = this.t(
+						'We could not load available times. Please try another date.',
+					)
 					return
 				}
 				const payload = await response.json()
-				this.slots = (payload && payload.slots) ? payload.slots : []
+				this.slots = payload && payload.slots ? payload.slots : []
 			} catch (e) {
-				this.slotsError = this.t('Network error. Please check your connection and try again.')
+				this.slotsError = this.t(
+					'Network error. Please check your connection and try again.',
+				)
 			}
 		},
 		validateDetails() {
 			const nameLength = (this.customerName || '').trim().length
-			this.errors.name = nameLength >= 1 ? '' : this.t('Please enter your name')
+			this.errors.name =
+				nameLength >= 1 ? '' : this.t('Please enter your name')
 
 			// Simple RFC-5322-light email check; the server re-validates strictly.
 			const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-			this.errors.email = emailRe.test(this.email || '') ? '' : this.t('Please enter a valid email address')
+			this.errors.email = emailRe.test(this.email || '')
+				? ''
+				: this.t('Please enter a valid email address')
 
 			this.errors.phone = ''
 			if (this.phone) {
 				const phoneRe = /^\+?[1-9]\d{1,14}$/
-				this.errors.phone = phoneRe.test(this.phone) ? '' : this.t('Phone number must be in international format (e.g. +31612345678)')
+				this.errors.phone = phoneRe.test(this.phone)
+					? ''
+					: this.t(
+							'Phone number must be in international format (e.g. +31612345678)',
+						)
 			}
 
-			this.errors.notes = (this.notes || '').length <= 500 ? '' : this.t('Notes must be at most 500 characters')
+			this.errors.notes =
+				(this.notes || '').length <= 500
+					? ''
+					: this.t('Notes must be at most 500 characters')
 		},
 		async submit() {
 			if (!this.selectedSlot) {
@@ -446,48 +532,69 @@ export default {
 			this.submitting = true
 			this.submitError = ''
 			try {
-				const response = await fetch(this.buildUrl('/api/widget/appointments'), {
-					method: 'POST',
-					headers: this.authHeaders(),
-					body: JSON.stringify({
-						serviceId: this.selectedServiceId,
-						resourceId: this.resourceId,
-						startTime: this.selectedSlot.startTime,
-						endTime: this.selectedSlot.endTime,
-						customerName: this.customerName,
-						email: this.email,
-						phone: this.phone || null,
-						notes: this.notes || null,
-					}),
-				})
+				const response = await fetch(
+					this.buildUrl('/api/widget/appointments'),
+					{
+						method: 'POST',
+						headers: this.authHeaders(),
+						body: JSON.stringify({
+							serviceId: this.selectedServiceId,
+							resourceId: this.resourceId,
+							startTime: this.selectedSlot.startTime,
+							endTime: this.selectedSlot.endTime,
+							customerName: this.customerName,
+							email: this.email,
+							phone: this.phone || null,
+							notes: this.notes || null,
+						}),
+					},
+				)
 				if (response.status === 409) {
-					this.submitError = this.t('This slot was just booked. Please select another time.')
+					this.submitError = this.t(
+						'This slot was just booked. Please select another time.',
+					)
 					await this.loadSlots()
 					this.step = 'datetime'
 					return
 				}
 				if (response.status === 401 || response.status === 403) {
-					this.submitError = this.t('Configuration error. Please contact the website owner.')
+					this.submitError = this.t(
+						'Configuration error. Please contact the website owner.',
+					)
 					return
 				}
 				if (response.status === 404) {
-					this.submitError = this.t('This service is no longer available. Please refresh the page.')
+					this.submitError = this.t(
+						'This service is no longer available. Please refresh the page.',
+					)
 					return
 				}
 				if (response.status >= 500) {
-					this.submitError = this.t('Something went wrong. Our team has been notified. Please try again later.')
+					this.submitError = this.t(
+						'Something went wrong. Our team has been notified. Please try again later.',
+					)
 					return
 				}
 				if (!response.ok) {
 					const payload = await response.json().catch(() => ({}))
-					this.submitError = (payload && payload.message) ? payload.message : this.t('Network error. Please check your connection and try again.')
+					this.submitError =
+						payload && payload.message
+							? payload.message
+							: this.t(
+									'Network error. Please check your connection and try again.',
+								)
 					return
 				}
 				const payload = await response.json()
-				this.confirmationMessage = (payload && payload.confirmationMessage) ? payload.confirmationMessage : this.t('Booking confirmed')
+				this.confirmationMessage =
+					payload && payload.confirmationMessage
+						? payload.confirmationMessage
+						: this.t('Booking confirmed')
 				this.step = 'confirmed'
 			} catch (e) {
-				this.submitError = this.t('Network error. Please check your connection and try again.')
+				this.submitError = this.t(
+					'Network error. Please check your connection and try again.',
+				)
 			} finally {
 				this.submitting = false
 			}

--- a/src/components/widget/WidgetEmbed.js
+++ b/src/components/widget/WidgetEmbed.js
@@ -123,7 +123,9 @@ export const BookingWidget = {
 	 * @return {string} Iframe src URL.
 	 */
 	iframeUrl(config) {
-		const error = validateConfig(Object.assign({}, config, { containerId: 'iframe' }))
+		const error = validateConfig(
+			Object.assign({}, config, { containerId: 'iframe' }),
+		)
 		if (error) {
 			// eslint-disable-next-line no-console
 			console.error('[BookingWidget] ' + error)
@@ -138,7 +140,9 @@ export const BookingWidget = {
 		if (config.primaryColor) {
 			params.set('primaryColor', config.primaryColor)
 		}
-		return config.apiBase.replace(/\/$/, '') + '/widget/iframe?' + params.toString()
+		return (
+			config.apiBase.replace(/\/$/, '') + '/widget/iframe?' + params.toString()
+		)
 	},
 }
 

--- a/src/composables/useBarcodeScanner.js
+++ b/src/composables/useBarcodeScanner.js
@@ -32,7 +32,10 @@ const DEFAULT_FORMATS = ['qr_code', 'ean_13', 'code_128', 'code_39', 'code_93']
  * @return {Promise<boolean>} True when a native decoder is available.
  */
 export async function nativeDetectorAvailable(formats = DEFAULT_FORMATS) {
-	if (typeof window === 'undefined' || typeof window.BarcodeDetector !== 'function') {
+	if (
+		typeof window === 'undefined'
+		|| typeof window.BarcodeDetector !== 'function'
+	) {
 		return false
 	}
 	try {
@@ -54,7 +57,11 @@ export async function nativeDetectorAvailable(formats = DEFAULT_FORMATS) {
  * @return {Promise<MediaStream>} The live camera stream.
  */
 export async function requestCameraStream() {
-	if (typeof navigator === 'undefined' || !navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+	if (
+		typeof navigator === 'undefined'
+		|| !navigator.mediaDevices
+		|| !navigator.mediaDevices.getUserMedia
+	) {
 		throw new Error('Camera not supported by this browser')
 	}
 	return navigator.mediaDevices.getUserMedia({
@@ -89,14 +96,20 @@ export function releaseStream(stream) {
  * @return {Promise<{rawValue:string, format:string}|null>} Decoded result.
  */
 export async function decodeFrame(source, formats = DEFAULT_FORMATS) {
-	if (typeof window === 'undefined' || typeof window.BarcodeDetector !== 'function') {
+	if (
+		typeof window === 'undefined'
+		|| typeof window.BarcodeDetector !== 'function'
+	) {
 		return null
 	}
 	try {
 		const detector = new window.BarcodeDetector({ formats })
 		const codes = await detector.detect(source)
 		if (Array.isArray(codes) && codes.length > 0) {
-			return { rawValue: codes[0].rawValue, format: codes[0].format || 'unknown' }
+			return {
+				rawValue: codes[0].rawValue,
+				format: codes[0].format || 'unknown',
+			}
 		}
 	} catch (e) {
 		// Returning null lets the caller try the next frame / format / fallback.
@@ -118,7 +131,7 @@ export async function decodeWithJsQrFallback(imageData) {
 	try {
 		// eslint-disable-next-line import/no-unresolved
 		const mod = await import(/* webpackIgnore: true */ 'jsqr')
-		const jsQR = (mod && mod.default) ? mod.default : mod
+		const jsQR = mod && mod.default ? mod.default : mod
 		if (typeof jsQR !== 'function') {
 			return null
 		}

--- a/src/composables/useInventoryDb.js
+++ b/src/composables/useInventoryDb.js
@@ -69,7 +69,9 @@ export function initDB() {
 		req.onupgradeneeded = (event) => {
 			const db = event.target.result
 			if (!db.objectStoreNames.contains(STORE_STOCK)) {
-				const stock = db.createObjectStore(STORE_STOCK, { keyPath: 'skuLocation' })
+				const stock = db.createObjectStore(STORE_STOCK, {
+					keyPath: 'skuLocation',
+				})
 				stock.createIndex('sku', 'sku', { unique: false })
 				stock.createIndex('location', 'location', { unique: false })
 				stock.createIndex('lastModified', 'lastModified', { unique: false })
@@ -82,14 +84,19 @@ export function initDB() {
 				db.createObjectStore(STORE_LOCATION, { keyPath: 'code' })
 			}
 			if (!db.objectStoreNames.contains(STORE_PENDING)) {
-				const pending = db.createObjectStore(STORE_PENDING, { keyPath: 'id' })
+				const pending = db.createObjectStore(STORE_PENDING, {
+					keyPath: 'id',
+				})
 				pending.createIndex('synced', 'synced', { unique: false })
-				pending.createIndex('transactionId', 'transactionId', { unique: true })
+				pending.createIndex('transactionId', 'transactionId', {
+					unique: true,
+				})
 			}
 		}
 
 		req.onsuccess = () => resolve(req.result)
-		req.onerror = () => reject(req.error || new Error('Failed to open IndexedDB'))
+		req.onerror = () =>
+			reject(req.error || new Error('Failed to open IndexedDB'))
 	})
 }
 
@@ -319,7 +326,10 @@ export async function mergeServerDelta(db, row) {
 	const existing = await promisify(store.get(key))
 
 	let decision = 'applied-server'
-	if (existing && isStrictlyLater(existing.lastModified, row.lastModified) === true) {
+	if (
+		existing
+		&& isStrictlyLater(existing.lastModified, row.lastModified) === true
+	) {
 		decision = 'kept-local'
 	} else {
 		store.put({

--- a/src/composables/useInventorySync.js
+++ b/src/composables/useInventorySync.js
@@ -23,7 +23,12 @@
 
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
-import { mergeServerDelta, markOpSynced, deletePendingOp, readUnsyncedOps } from './useInventoryDb.js'
+import {
+	mergeServerDelta,
+	markOpSynced,
+	deletePendingOp,
+	readUnsyncedOps,
+} from './useInventoryDb.js'
 
 const URL_SYNC = '/apps/shillinq/api/v1/inventory/sync'
 const URL_LOCATIONS = '/apps/shillinq/api/v1/inventory/locations'
@@ -123,11 +128,23 @@ export async function syncUpload(db) {
 			continue
 		}
 		if (ack.status === 'accepted') {
-			await markOpSynced(db, op.id, ack.serverAckedAt || data.serverTimestamp || new Date().toISOString())
+			await markOpSynced(
+				db,
+				op.id,
+				ack.serverAckedAt
+					|| data.serverTimestamp
+					|| new Date().toISOString(),
+			)
 			await deletePendingOp(db, op.id)
 			accepted += 1
 		} else if (ack.status === 'duplicate') {
-			await markOpSynced(db, op.id, ack.serverAckedAt || data.serverTimestamp || new Date().toISOString())
+			await markOpSynced(
+				db,
+				op.id,
+				ack.serverAckedAt
+					|| data.serverTimestamp
+					|| new Date().toISOString(),
+			)
 			await deletePendingOp(db, op.id)
 			duplicates += 1
 		} else {
@@ -167,15 +184,20 @@ export async function fetchLocations() {
 export function createSyncScheduler(db, opts = {}) {
 	const intervalMs = opts.intervalMs || DEFAULT_INTERVAL_MS
 	const onStatus = typeof opts.onStatus === 'function' ? opts.onStatus : () => {}
-	const getCursor = typeof opts.getLastSyncedAt === 'function' ? opts.getLastSyncedAt : () => null
-	const setCursor = typeof opts.setLastSyncedAt === 'function' ? opts.setLastSyncedAt : () => {}
+	const getCursor =
+		typeof opts.getLastSyncedAt === 'function'
+			? opts.getLastSyncedAt
+			: () => null
+	const setCursor =
+		typeof opts.setLastSyncedAt === 'function' ? opts.setLastSyncedAt : () => {}
 
 	let timerId = null
 	let stopped = true
 	let inFlight = false
 	let backoffIndex = 0
 
-	const isOnline = () => typeof navigator === 'undefined' || navigator.onLine !== false
+	const isOnline = () =>
+		typeof navigator === 'undefined' || navigator.onLine !== false
 
 	async function runOnce() {
 		if (inFlight) {
@@ -184,7 +206,11 @@ export function createSyncScheduler(db, opts = {}) {
 		inFlight = true
 		try {
 			if (!isOnline()) {
-				onStatus({ state: 'offline', lastSyncedAt: getCursor(), error: null })
+				onStatus({
+					state: 'offline',
+					lastSyncedAt: getCursor(),
+					error: null,
+				})
 				return
 			}
 			onStatus({ state: 'syncing', lastSyncedAt: getCursor(), error: null })
@@ -195,13 +221,25 @@ export function createSyncScheduler(db, opts = {}) {
 			onStatus({
 				state: 'synced',
 				lastSyncedAt: dl.serverTimestamp,
-				summary: { applied: dl.applied, kept: dl.kept, accepted: up.accepted, duplicates: up.duplicates, rejected: up.rejected },
+				summary: {
+					applied: dl.applied,
+					kept: dl.kept,
+					accepted: up.accepted,
+					duplicates: up.duplicates,
+					rejected: up.rejected,
+				},
 				error: null,
 			})
 		} catch (e) {
-			const delay = BACKOFF_STEPS_MS[Math.min(backoffIndex, BACKOFF_STEPS_MS.length - 1)]
+			const delay =
+				BACKOFF_STEPS_MS[Math.min(backoffIndex, BACKOFF_STEPS_MS.length - 1)]
 			backoffIndex = Math.min(backoffIndex + 1, BACKOFF_STEPS_MS.length - 1)
-			onStatus({ state: 'failed', lastSyncedAt: getCursor(), error: e && e.message ? e.message : String(e), retryInMs: delay })
+			onStatus({
+				state: 'failed',
+				lastSyncedAt: getCursor(),
+				error: e && e.message ? e.message : String(e),
+				retryInMs: delay,
+			})
 		} finally {
 			inFlight = false
 		}
@@ -256,9 +294,9 @@ export function newTransactionId() {
 		} else if (i === 14) {
 			out += '4'
 		} else if (i === 19) {
-			out += hex[(Math.random() * 4 | 0) + 8]
+			out += hex[((Math.random() * 4) | 0) + 8]
 		} else {
-			out += hex[Math.random() * 16 | 0]
+			out += hex[(Math.random() * 16) | 0]
 		}
 	}
 	return out

--- a/src/composables/usePipelinqProfile.js
+++ b/src/composables/usePipelinqProfile.js
@@ -59,7 +59,12 @@ export function buildProfileFields(contact) {
 	const fields = []
 	const legalName = trimmed(contact.legalName)
 	if (legalName) {
-		fields.push({ key: 'legalName', label: 'Name', value: legalName, emphasis: true })
+		fields.push({
+			key: 'legalName',
+			label: 'Name',
+			value: legalName,
+			emphasis: true,
+		})
 	}
 	const kvk = trimmed(contact.kvkNumber)
 	if (kvk) {
@@ -67,11 +72,21 @@ export function buildProfileFields(contact) {
 	}
 	const email = trimmed(contact.email)
 	if (email) {
-		fields.push({ key: 'email', label: 'Email', value: email, href: `mailto:${email}` })
+		fields.push({
+			key: 'email',
+			label: 'Email',
+			value: email,
+			href: `mailto:${email}`,
+		})
 	}
 	const phone = trimmed(contact.phone)
 	if (phone) {
-		fields.push({ key: 'phone', label: 'Phone', value: phone, href: `tel:${phone.replace(/\s+/g, '')}` })
+		fields.push({
+			key: 'phone',
+			label: 'Phone',
+			value: phone,
+			href: `tel:${phone.replace(/\s+/g, '')}`,
+		})
 	}
 	const address = trimmed(contact.address)
 	if (address) {
@@ -99,7 +114,10 @@ export function selectProfileState(payload) {
 	if (payload.notLinkedToPipelinq === true) {
 		return 'unlinked'
 	}
-	if (typeof payload.contactError === 'string' && payload.contactError.length > 0) {
+	if (
+		typeof payload.contactError === 'string'
+		&& payload.contactError.length > 0
+	) {
 		return 'error'
 	}
 	if (!payload.contact || payload.contact.found === false) {
@@ -133,7 +151,9 @@ export function selectHistoryState(payload) {
 	if (k.unavailable === true) {
 		return 'unavailable'
 	}
-	const empty = (k.empty === true) || (Array.isArray(k.transactions) && k.transactions.length === 0)
+	const empty =
+		k.empty === true
+		|| (Array.isArray(k.transactions) && k.transactions.length === 0)
 	if (empty) {
 		return 'empty'
 	}
@@ -184,8 +204,12 @@ export function formatTransactionDate(iso) {
  * @return {{ limit: number, offset: number }}
  */
 export function nextPageParams(klantbeeld, defaultLimit = 5) {
-	const limit = Number.isFinite(Number(klantbeeld?.limit)) ? Number(klantbeeld.limit) : defaultLimit
-	const offset = Number.isFinite(Number(klantbeeld?.offset)) ? Number(klantbeeld.offset) : 0
+	const limit = Number.isFinite(Number(klantbeeld?.limit))
+		? Number(klantbeeld.limit)
+		: defaultLimit
+	const offset = Number.isFinite(Number(klantbeeld?.offset))
+		? Number(klantbeeld.offset)
+		: 0
 	return {
 		limit: Math.max(1, limit),
 		offset: Math.max(0, offset) + Math.max(1, limit),

--- a/src/composables/useServiceWorker.js
+++ b/src/composables/useServiceWorker.js
@@ -50,7 +50,7 @@ export async function unregisterInventoryServiceWorker() {
 	for (const reg of registrations) {
 		if (reg.scope && reg.scope.endsWith(SW_SCOPE)) {
 			// eslint-disable-next-line no-await-in-loop
-			unregistered = await reg.unregister() || unregistered
+			unregistered = (await reg.unregister()) || unregistered
 		}
 	}
 	return unregistered

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,11 @@ import './setPublicPath.js'
 
 import { createApp, h, reactive } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router'
-import { translate as t, translatePlural as n, loadTranslations } from '@nextcloud/l10n'
+import {
+	translate as t,
+	translatePlural as n,
+	loadTranslations,
+} from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
 import {
 	buildManifest,
@@ -27,7 +31,10 @@ import manifestShell from './manifest.d.shell.json'
 import menuLayout from './menu-layout.json'
 import registry from './registry.js'
 import appIcons from './icons.js'
-import { mergeFullFragmentIntoManifest, buildPageFragmentIndex } from './utils/mergeFragmentIntoManifest.js'
+import {
+	mergeFullFragmentIntoManifest,
+	buildPageFragmentIndex,
+} from './utils/mergeFragmentIntoManifest.js'
 
 // Library CSS — must be explicit import (webpack tree-shakes side-effect imports from aliased packages)
 import '@conduction/nextcloud-vue/css/index.css'
@@ -74,7 +81,10 @@ try {
 } catch (e) {
 	// Non-fatal — lib translations fall back to English source.
 	// eslint-disable-next-line no-console
-	console.warn('[shillinq] registerTranslations failed; falling back to English', e)
+	console.warn(
+		'[shillinq] registerTranslations failed; falling back to English',
+		e,
+	)
 }
 
 // Fire-and-forget translation load. Some Nextcloud installs (including
@@ -89,7 +99,10 @@ function tryLoadTranslations() {
 	try {
 		const result = loadTranslations('shillinq', () => {})
 		if (result && typeof result.then === 'function') {
-			result.then(() => {}, () => {})
+			result.then(
+				() => {},
+				() => {},
+			)
 		}
 	} catch {
 		// no-op
@@ -117,7 +130,9 @@ const RoutePageRenderer = { ...CnPageRenderer }
 // CnPageRenderer's reactive `resolvedProps` computed (it reads
 // `currentPage.config`; Vue 3's Proxy tracks the brand-new key too — see
 // src/utils/mergeFragmentIntoManifest.js for the full contract).
-const mergedManifest = reactive(buildManifest(bundledManifest, manifestShell.fragments, menuLayout))
+const mergedManifest = reactive(
+	buildManifest(bundledManifest, manifestShell.fragments, menuLayout),
+)
 
 // pageId → fragment filename stem, built once from the shell-derived slim
 // pages (each carries `_fragment`; base-manifest pages carry none and are
@@ -154,12 +169,18 @@ async function loadFragment(fragmentStem) {
 		// resolve to either the plain object or an ES module namespace
 		// wrapping it in `.default`, depending on loader/mode configuration.
 		// Unwrap defensively rather than assume one shape.
-		const fullFragment = (imported && typeof imported === 'object' && Array.isArray(imported.pages)) ? imported : imported?.default
+		const fullFragment =
+			imported && typeof imported === 'object' && Array.isArray(imported.pages)
+				? imported
+				: imported?.default
 		mergeFullFragmentIntoManifest(mergedManifest, fullFragment)
 		loadedFragments.add(fragmentStem)
 	} catch (e) {
 		// eslint-disable-next-line no-console
-		console.warn(`[shillinq] failed to lazy-load manifest fragment "${fragmentStem}"; navigating with slim page data.`, e)
+		console.warn(
+			`[shillinq] failed to lazy-load manifest fragment "${fragmentStem}"; navigating with slim page data.`,
+			e,
+		)
 	}
 }
 
@@ -246,12 +267,13 @@ const customComponentsProp = Object.fromEntries(
 // renamed to `#shillinq-app` (templates/index.php) rather than reasoning
 // about which of the two divs wins.
 const app = createApp({
-	render: () => h(App, {
-		manifest: mergedManifest,
-		pageTypes: pageTypesProp,
-		registry: registryProp,
-		customComponents: customComponentsProp,
-	}),
+	render: () =>
+		h(App, {
+			manifest: mergedManifest,
+			pageTypes: pageTypesProp,
+			registry: registryProp,
+			customComponents: customComponentsProp,
+		}),
 })
 
 // Vue 3 has no global `Vue.mixin` / `Vue.use` — everything is per-app.

--- a/src/modals/BankStatementWizard.vue
+++ b/src/modals/BankStatementWizard.vue
@@ -35,7 +35,9 @@
 		<div class="bsw">
 			<!-- Step 1: format selection + file upload -->
 			<div v-if="step === 1" class="bsw__step" data-testid="bsw-step-1">
-				<p class="bsw__heading">{{ t('shillinq', 'How does your bank export statements?') }}</p>
+				<p class="bsw__heading">
+					{{ t('shillinq', 'How does your bank export statements?') }}
+				</p>
 				<NcSelect
 					:model-value="selectedFormatOption"
 					:options="formatSelectOptions"
@@ -46,12 +48,17 @@
 					data-testid="bsw-format"
 					@update:model-value="onFormatSelected" />
 
-				<p v-if="form.format" class="bsw__hint" data-testid="bsw-format-hint">
+				<p
+					v-if="form.format"
+					class="bsw__hint"
+					data-testid="bsw-format-hint">
 					{{ formatInstructions }}
 				</p>
 
 				<div v-if="form.format" class="bsw__field">
-					<label class="bsw__label" for="bsw-file">{{ t('shillinq', 'Statement file') }}</label>
+					<label class="bsw__label" for="bsw-file">{{
+						t('shillinq', 'Statement file')
+					}}</label>
 					<input
 						id="bsw-file"
 						ref="file"
@@ -59,12 +66,18 @@
 						:accept="acceptFor(form.format)"
 						class="bsw__input"
 						data-testid="bsw-file"
-						@change="onFileChosen">
+						@change="onFileChosen" />
 				</div>
 
 				<p class="bsw__psd2">
-					{{ t('shillinq', 'Or connect your bank directly and skip manual uploads:') }}
-					<a href="#"
+					{{
+						t(
+							'shillinq',
+							'Or connect your bank directly and skip manual uploads:',
+						)
+					}}
+					<a
+						href="#"
 						class="bsw__link"
 						data-testid="bsw-psd2"
 						@click.prevent="goToBankConnections">
@@ -75,10 +88,14 @@
 
 			<!-- Step 2: account mapping -->
 			<div v-else-if="step === 2" class="bsw__step" data-testid="bsw-step-2">
-				<p class="bsw__heading">{{ t('shillinq', 'Map to Shillinq account') }}</p>
+				<p class="bsw__heading">
+					{{ t('shillinq', 'Map to Shillinq account') }}
+				</p>
 				<dl class="bsw__meta">
 					<dt>{{ t('shillinq', 'Statement IBAN') }}</dt>
-					<dd data-testid="bsw-iban">{{ statementIban || t('shillinq', 'Unknown') }}</dd>
+					<dd data-testid="bsw-iban">
+						{{ statementIban || t('shillinq', 'Unknown') }}
+					</dd>
 					<dt>{{ t('shillinq', 'Statement name') }}</dt>
 					<dd>{{ statementName || '—' }}</dd>
 				</dl>
@@ -90,22 +107,34 @@
 			<!-- Step 3: import summary -->
 			<div v-else class="bsw__step" data-testid="bsw-step-3">
 				<p v-if="importing" class="bsw__heading" data-testid="bsw-importing">
-					{{ t('shillinq', 'Importing {count} transactions', { count: result ? result.transactionCount : '…' }) }}
+					{{
+						t('shillinq', 'Importing {count} transactions', {
+							count: result ? result.transactionCount : '…',
+						})
+					}}
 				</p>
 				<template v-else-if="result">
 					<p class="bsw__heading" data-testid="bsw-summary">
-						{{ t('shillinq', 'Importing {count} transactions', { count: result.transactionCount }) }}
+						{{
+							t('shillinq', 'Importing {count} transactions', {
+								count: result.transactionCount,
+							})
+						}}
 					</p>
 					<ul class="bsw__counts">
 						<li data-testid="bsw-matched">
-							{{ result.matchedCount }} {{ t('shillinq', 'automatically matched') }}
+							{{ result.matchedCount }}
+							{{ t('shillinq', 'automatically matched') }}
 						</li>
 						<li data-testid="bsw-unmatched">
-							{{ result.unmatchedCount }} {{ t('shillinq', 'unmatched — require manual review') }}
+							{{ result.unmatchedCount }}
+							{{ t('shillinq', 'unmatched — require manual review') }}
 						</li>
 					</ul>
 				</template>
-				<p v-if="error" class="bsw__error" data-testid="bsw-error">{{ error }}</p>
+				<p v-if="error" class="bsw__error" data-testid="bsw-error">
+					{{ error }}
+				</p>
 			</div>
 		</div>
 
@@ -194,14 +223,26 @@ export default {
 		},
 		/** @spec openspec/specs/shillinq-bank-statement-wizard/spec.md */
 		selectedFormatOption() {
-			return this.formatSelectOptions.find((o) => o.value === this.form.format) || null
+			return (
+				this.formatSelectOptions.find((o) => o.value === this.form.format)
+				|| null
+			)
 		},
 		/** @spec openspec/specs/shillinq-bank-statement-wizard/spec.md */
 		formatInstructions() {
 			const map = {
-				camt053: t('shillinq', 'Most Dutch banks (ING, Rabobank, ABN AMRO, SNS). Export from your bank: Downloads → Account overview → Format: CAMT.053 → Date range: last 30 days.'),
-				mt940: t('shillinq', 'Older SWIFT format (Triodos, some ING accounts). Export the MT940 / .STA file from your bank portal.'),
-				csv: t('shillinq', 'Custom export with a header row (valueDate, amount, currency, remittanceInfo, counterpartyName, counterpartyIban).'),
+				camt053: t(
+					'shillinq',
+					'Most Dutch banks (ING, Rabobank, ABN AMRO, SNS). Export from your bank: Downloads → Account overview → Format: CAMT.053 → Date range: last 30 days.',
+				),
+				mt940: t(
+					'shillinq',
+					'Older SWIFT format (Triodos, some ING accounts). Export the MT940 / .STA file from your bank portal.',
+				),
+				csv: t(
+					'shillinq',
+					'Custom export with a header row (valueDate, amount, currency, remittanceInfo, counterpartyName, counterpartyIban).',
+				),
 			}
 			return map[this.form.format] || ''
 		},
@@ -259,7 +300,9 @@ export default {
 		extractStatementMeta() {
 			// Lightweight pre-parse: pull the first IBAN-shaped token so the
 			// account-mapping step can show it and consult the IBAN memory.
-			const m = String(this.form.contents).match(/\b([A-Z]{2}\d{2}[A-Z0-9]{10,30})\b/)
+			const m = String(this.form.contents).match(
+				/\b([A-Z]{2}\d{2}[A-Z0-9]{10,30})\b/,
+			)
 			this.statementIban = m ? m[1] : ''
 		},
 		/** @spec openspec/specs/shillinq-bank-statement-wizard/spec.md */
@@ -297,7 +340,8 @@ export default {
 				}
 				this.$emit('imported', this.result)
 			} catch (e) {
-				this.error = e?.response?.data?.error
+				this.error =
+					e?.response?.data?.error
 					|| e?.message
 					|| t('shillinq', 'Failed to import the bank statement.')
 				showError(this.error)

--- a/src/modals/BillImportModal.vue
+++ b/src/modals/BillImportModal.vue
@@ -56,7 +56,10 @@
 		@closing="onClose">
 		<div class="bim">
 			<!-- Step 1 — Upload -->
-			<div v-if="step === 'upload'" class="bim__step" data-testid="bim-upload-step">
+			<div
+				v-if="step === 'upload'"
+				class="bim__step"
+				data-testid="bim-upload-step">
 				<p class="bim__intro">
 					{{ t('shillinq', 'Upload supplier invoice') }}
 				</p>
@@ -65,23 +68,43 @@
 					data-testid="bim-dropzone"
 					@dragover.prevent
 					@drop.prevent="onDrop">
-					<span>{{ t('shillinq', 'Drag and drop a UBL XML or CSV file') }}</span>
+					<span>{{
+						t('shillinq', 'Drag and drop a UBL XML or CSV file')
+					}}</span>
 					<input
 						ref="fileInput"
 						type="file"
 						accept=".xml,.ubl,.csv,.pdf,application/xml,text/csv,application/pdf"
 						class="bim__file"
-						:aria-label="t('shillinq', 'Choose a UBL XML, CSV or PDF bill to import')"
+						:aria-label="
+							t(
+								'shillinq',
+								'Choose a UBL XML, CSV or PDF bill to import',
+							)
+						"
 						data-testid="bim-file-input"
-						@change="onFileSelected">
+						@change="onFileSelected" />
 				</div>
 
 				<p class="bim__hint" data-testid="bim-pdf-hint">
-					{{ t('shillinq', 'PDF OCR extraction is not yet available. Please upload a UBL/e-invoice XML or CSV.') }}
+					{{
+						t(
+							'shillinq',
+							'PDF OCR extraction is not yet available. Please upload a UBL/e-invoice XML or CSV.',
+						)
+					}}
 				</p>
 
-				<p v-if="pdfDeferred" class="bim__deferred" data-testid="bim-pdf-deferred">
-					{{ t('shillinq', 'PDF OCR extraction is not yet available. Please upload a UBL/e-invoice XML or CSV.') }}
+				<p
+					v-if="pdfDeferred"
+					class="bim__deferred"
+					data-testid="bim-pdf-deferred">
+					{{
+						t(
+							'shillinq',
+							'PDF OCR extraction is not yet available. Please upload a UBL/e-invoice XML or CSV.',
+						)
+					}}
 				</p>
 
 				<p v-if="error" class="bim__error" data-testid="bim-upload-error">
@@ -90,7 +113,10 @@
 
 				<!-- receipt-extraction-consume (REQ-RXC-001/002) — pending
 				     extraction drafts awaiting operator review. -->
-				<div v-if="pendingDrafts.length > 0" class="bim__pending" data-testid="bim-pending-drafts">
+				<div
+					v-if="pendingDrafts.length > 0"
+					class="bim__pending"
+					data-testid="bim-pending-drafts">
 					<p class="bim__intro">
 						{{ t('shillinq', 'Extracted fields') }}
 					</p>
@@ -104,8 +130,12 @@
 								type="button"
 								class="bim__pending-button"
 								@click="openDraft(draft.id)">
-								<span>{{ draft.label || t('shillinq', '(no invoice number)') }}</span>
-								<FieldConfidenceBadge :confidence="draft.overallConfidence" />
+								<span>{{
+									draft.label
+									|| t('shillinq', '(no invoice number)')
+								}}</span>
+								<FieldConfidenceBadge
+									:confidence="draft.overallConfidence" />
 							</button>
 						</li>
 					</ul>
@@ -118,21 +148,34 @@
 					{{ t('shillinq', 'Review and confirm') }}
 				</p>
 
-				<p v-if="isDraftReview" class="bim__hint" data-testid="bim-review-hint">
-					{{ requiresReview
-						? t('shillinq', 'Some fields have low confidence — please review before confirming.')
-						: t('shillinq', 'Extraction confidence is high. Review and confirm.') }}
+				<p
+					v-if="isDraftReview"
+					class="bim__hint"
+					data-testid="bim-review-hint">
+					{{
+						requiresReview
+							? t(
+									'shillinq',
+									'Some fields have low confidence — please review before confirming.',
+								)
+							: t(
+									'shillinq',
+									'Extraction confidence is high. Review and confirm.',
+								)
+					}}
 				</p>
 
 				<div class="bim__field">
-					<label class="bim__label" for="bim-supplier">{{ t('shillinq', 'Supplier') }}</label>
+					<label class="bim__label" for="bim-supplier">{{
+						t('shillinq', 'Supplier')
+					}}</label>
 					<div class="bim__field-row">
 						<input
 							id="bim-supplier"
 							v-model="form.supplier"
 							type="text"
 							class="bim__input"
-							data-testid="bim-supplier">
+							data-testid="bim-supplier" />
 						<FieldConfidenceBadge
 							v-if="isDraftReview"
 							field="supplierId"
@@ -142,14 +185,16 @@
 				</div>
 
 				<div class="bim__field">
-					<label class="bim__label" for="bim-invoice-number">{{ t('shillinq', 'Invoice number') }}</label>
+					<label class="bim__label" for="bim-invoice-number">{{
+						t('shillinq', 'Invoice number')
+					}}</label>
 					<div class="bim__field-row">
 						<input
 							id="bim-invoice-number"
 							v-model="form.invoiceNumber"
 							type="text"
 							class="bim__input"
-							data-testid="bim-invoice-number">
+							data-testid="bim-invoice-number" />
 						<FieldConfidenceBadge
 							v-if="isDraftReview"
 							field="invoiceNumber"
@@ -160,14 +205,16 @@
 
 				<div class="bim__row">
 					<div class="bim__field">
-						<label class="bim__label" for="bim-invoice-date">{{ t('shillinq', 'Invoice date') }}</label>
+						<label class="bim__label" for="bim-invoice-date">{{
+							t('shillinq', 'Invoice date')
+						}}</label>
 						<div class="bim__field-row">
 							<input
 								id="bim-invoice-date"
 								v-model="form.invoiceDate"
 								type="date"
 								class="bim__input"
-								data-testid="bim-invoice-date">
+								data-testid="bim-invoice-date" />
 							<FieldConfidenceBadge
 								v-if="isDraftReview"
 								field="invoiceDate"
@@ -176,7 +223,9 @@
 						</div>
 					</div>
 					<div class="bim__field">
-						<label class="bim__label" for="bim-amount">{{ t('shillinq', 'Amount') }}</label>
+						<label class="bim__label" for="bim-amount">{{
+							t('shillinq', 'Amount')
+						}}</label>
 						<div class="bim__field-row">
 							<input
 								id="bim-amount"
@@ -184,7 +233,7 @@
 								type="number"
 								step="0.01"
 								class="bim__input"
-								data-testid="bim-amount">
+								data-testid="bim-amount" />
 							<FieldConfidenceBadge
 								v-if="isDraftReview"
 								field="totalInclVat"
@@ -193,14 +242,16 @@
 						</div>
 					</div>
 					<div class="bim__field">
-						<label class="bim__label" for="bim-vat-amount">{{ t('shillinq', 'VAT amount') }}</label>
+						<label class="bim__label" for="bim-vat-amount">{{
+							t('shillinq', 'VAT amount')
+						}}</label>
 						<input
 							id="bim-vat-amount"
 							v-model.number="form.vatAmount"
 							type="number"
 							step="0.01"
 							class="bim__input"
-							data-testid="bim-vat-amount">
+							data-testid="bim-vat-amount" />
 					</div>
 				</div>
 
@@ -221,13 +272,21 @@
 				     suggested booking account, reusing FieldConfidenceBadge; the
 				     operator must still click "Use suggestion" AND Save — never
 				     auto-filled/auto-booked (REQ-GAC-004/REQ-RXC-006). -->
-				<div v-if="glSuggestion" class="bim__suggestion" data-testid="bim-gl-suggestion">
+				<div
+					v-if="glSuggestion"
+					class="bim__suggestion"
+					data-testid="bim-gl-suggestion">
 					<div class="bim__field-row">
 						<FieldConfidenceBadge
 							field="suggestedGlAccount"
 							:confidence="glSuggestion.confidence" />
 						<span class="bim__suggestion-text">
-							{{ t('shillinq', 'Suggested: {code} {label}', { code: glSuggestion.code, label: glSuggestion.label }) }}
+							{{
+								t('shillinq', 'Suggested: {code} {label}', {
+									code: glSuggestion.code,
+									label: glSuggestion.label,
+								})
+							}}
 						</span>
 						<NcButton
 							variant="tertiary"
@@ -237,7 +296,9 @@
 							{{ t('shillinq', 'Use suggestion') }}
 						</NcButton>
 					</div>
-					<p class="bim__suggestion-rationale" data-testid="bim-gl-suggestion-rationale">
+					<p
+						class="bim__suggestion-rationale"
+						data-testid="bim-gl-suggestion-rationale">
 						{{ glSuggestion.rationale }}
 					</p>
 				</div>
@@ -258,10 +319,7 @@
 		</div>
 
 		<template #actions>
-			<NcButton
-				:disabled="busy"
-				data-testid="bim-cancel"
-				@click="onClose">
+			<NcButton :disabled="busy" data-testid="bim-cancel" @click="onClose">
 				{{ t('shillinq', 'Cancel') }}
 			</NcButton>
 			<NcButton
@@ -401,10 +459,16 @@ export default {
 		async loadPendingDrafts() {
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SUPPLIER_INVOICE_SCHEMA}`),
+					generateUrl(
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/${SUPPLIER_INVOICE_SCHEMA}`,
+					),
 					{ params: { extractionStatus: 'pending-review' } },
 				)
-				const rows = response.data?.results ?? response.data?.objects ?? response.data ?? []
+				const rows =
+					response.data?.results
+					?? response.data?.objects
+					?? response.data
+					?? []
 				this.pendingDraftRows = Array.isArray(rows) ? rows : []
 			} catch (e) {
 				// Non-blocking — the upload path still works without the list.
@@ -425,7 +489,9 @@ export default {
 			this.busy = true
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SUPPLIER_INVOICE_SCHEMA}/${id}`),
+					generateUrl(
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/${SUPPLIER_INVOICE_SCHEMA}/${id}`,
+					),
 				)
 				const record = response.data?.object ?? response.data ?? {}
 				this.importedRecord = record
@@ -456,7 +522,9 @@ export default {
 
 			try {
 				const response = await axios.post(
-					generateUrl(`/apps/shillinq/api/v1/extraction/drafts/${this.importedRecord.id}/suggest-account?schema=${SUPPLIER_INVOICE_SCHEMA}`),
+					generateUrl(
+						`/apps/shillinq/api/v1/extraction/drafts/${this.importedRecord.id}/suggest-account?schema=${SUPPLIER_INVOICE_SCHEMA}`,
+					),
 				)
 				this.glSuggestion = glAccountSuggestionSummary(response.data)
 			} catch (e) {
@@ -492,7 +560,12 @@ export default {
 						id: this.importedRecord.id ?? '',
 					},
 				)
-				showSuccess(t('shillinq', 'Extraction requested. The draft will update once docudesk responds.'))
+				showSuccess(
+					t(
+						'shillinq',
+						'Extraction requested. The draft will update once docudesk responds.',
+					),
+				)
 			} catch (e) {
 				this.error = importErrorMessage(e)
 				showError(this.error)
@@ -525,7 +598,10 @@ export default {
 			}
 
 			if (format !== 'ubl' && format !== 'csv') {
-				this.error = t('shillinq', 'Unsupported file. Upload a UBL/e-invoice XML or CSV.')
+				this.error = t(
+					'shillinq',
+					'Unsupported file. Upload a UBL/e-invoice XML or CSV.',
+				)
 				return
 			}
 
@@ -537,12 +613,18 @@ export default {
 					body,
 				)
 				const data = response.data ?? {}
-				const record = data.record ?? (Array.isArray(data.records) ? data.records[0] : null) ?? {}
+				const record =
+					data.record
+					?? (Array.isArray(data.records) ? data.records[0] : null)
+					?? {}
 				this.importedRecord = record
 				this.form = reviewFormFromRecord(record)
 				this.step = 'review'
 			} catch (e) {
-				if (e?.response?.status === 422 && e?.response?.data?.deferred === 'pdf-ocr') {
+				if (
+					e?.response?.status === 422
+					&& e?.response?.data?.deferred === 'pdf-ocr'
+				) {
 					this.pdfDeferred = true
 				}
 				this.error = importErrorMessage(e)
@@ -571,8 +653,12 @@ export default {
 				record.invoiceNumber = this.form.invoiceNumber
 				record.invoiceDate = this.form.invoiceDate
 				record.glAccount = this.form.glAccount
-				record.totalInclVat = Math.round((Number(this.form.amount) || 0) * 100)
-				record.totalVat = Math.round((Number(this.form.vatAmount) || 0) * 100)
+				record.totalInclVat = Math.round(
+					(Number(this.form.amount) || 0) * 100,
+				)
+				record.totalVat = Math.round(
+					(Number(this.form.vatAmount) || 0) * 100,
+				)
 				record.statusCode = record.statusCode || 'received'
 
 				let created
@@ -580,7 +666,9 @@ export default {
 					// REQ-RXC-004: commit the correction on the existing draft —
 					// never fabricates a duplicate SupplierInvoice.
 					const response = await axios.put(
-						generateUrl(`/apps/shillinq/api/v1/extraction/drafts/${record.id}?schema=${SUPPLIER_INVOICE_SCHEMA}`),
+						generateUrl(
+							`/apps/shillinq/api/v1/extraction/drafts/${record.id}?schema=${SUPPLIER_INVOICE_SCHEMA}`,
+						),
 						{
 							supplierId: record.supplierId,
 							invoiceNumber: record.invoiceNumber,
@@ -593,7 +681,9 @@ export default {
 					created = response.data?.record ?? response.data ?? {}
 				} else {
 					const response = await axios.post(
-						generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SUPPLIER_INVOICE_SCHEMA}`),
+						generateUrl(
+							`/apps/openregister/api/objects/${REGISTER_SLUG}/${SUPPLIER_INVOICE_SCHEMA}`,
+						),
 						record,
 					)
 					created = response.data?.object ?? response.data ?? {}

--- a/src/modals/BookingConflictDialog.vue
+++ b/src/modals/BookingConflictDialog.vue
@@ -29,7 +29,9 @@
 				</h2>
 			</header>
 			<section class="bk-conflict-dialog__body">
-				<p>{{ label('The proposed booking overlaps existing bookings:') }}</p>
+				<p>
+					{{ label('The proposed booking overlaps existing bookings:') }}
+				</p>
 				<ul class="bk-conflict-dialog__list" data-testid="bk-conflict-list">
 					<li
 						v-for="c in conflicts"
@@ -37,11 +39,18 @@
 						class="bk-conflict-dialog__item"
 						:data-testid="`bk-conflict-${c.bookingId}`">
 						<strong>{{ c.title || c.bookingId }}</strong>
-						<span>{{ formatTime(c.startTime) }} – {{ formatTime(c.endTime) }}</span>
+						<span
+							>{{ formatTime(c.startTime) }} –
+							{{ formatTime(c.endTime) }}</span
+						>
 					</li>
 				</ul>
 				<p class="bk-conflict-dialog__warn">
-					{{ label('Confirm to create the booking anyway, or cancel to adjust the times.') }}
+					{{
+						label(
+							'Confirm to create the booking anyway, or cancel to adjust the times.',
+						)
+					}}
 				</p>
 			</section>
 			<footer class="bk-conflict-dialog__footer">
@@ -139,15 +148,31 @@ export default {
 	padding: 12px 16px;
 }
 
-.bk-conflict-dialog__header { border-bottom: 1px solid var(--color-border, #ddd); }
+.bk-conflict-dialog__header {
+	border-bottom: 1px solid var(--color-border, #ddd);
+}
 
-.bk-conflict-dialog__footer { display: flex; justify-content: flex-end; gap: 8px; border-top: 1px solid var(--color-border, #ddd); }
+.bk-conflict-dialog__footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	border-top: 1px solid var(--color-border, #ddd);
+}
 
-.bk-conflict-dialog__list { list-style: disc; padding-left: 20px; }
+.bk-conflict-dialog__list {
+	list-style: disc;
+	padding-left: 20px;
+}
 
-.bk-conflict-dialog__item { display: flex; flex-direction: column; padding: 4px 0; }
+.bk-conflict-dialog__item {
+	display: flex;
+	flex-direction: column;
+	padding: 4px 0;
+}
 
-.bk-conflict-dialog__warn { color: var(--color-error, #c62828); }
+.bk-conflict-dialog__warn {
+	color: var(--color-error, #c62828);
+}
 
 .bk-conflict-dialog__btn {
 	padding: 6px 14px;

--- a/src/modals/BookingNotificationConfigModal.vue
+++ b/src/modals/BookingNotificationConfigModal.vue
@@ -34,7 +34,11 @@
 					{{ label('Notifications') }}
 				</h2>
 				<p class="bk-notification-modal__subtitle">
-					{{ label('Configure how this booking notifies customers, organizers and administrators.') }}
+					{{
+						label(
+							'Configure how this booking notifies customers, organizers and administrators.',
+						)
+					}}
 				</p>
 			</header>
 
@@ -42,7 +46,10 @@
 				<p v-if="loading" data-testid="bk-notification-loading">
 					{{ label('Loading triggers…') }}
 				</p>
-				<p v-else-if="error" class="bk-notification-modal__error" data-testid="bk-notification-error">
+				<p
+					v-else-if="error"
+					class="bk-notification-modal__error"
+					data-testid="bk-notification-error">
 					{{ error }}
 				</p>
 				<ul
@@ -60,10 +67,12 @@
 									type="checkbox"
 									:checked="t.status === 'enabled'"
 									:data-testid="`bk-notification-${t.slug}-enabled`"
-									@change="setEnabled(t, $event.target.checked)">
+									@change="setEnabled(t, $event.target.checked)" />
 								<span>{{ t.name }}</span>
 							</label>
-							<span class="bk-notification-modal__type">{{ t.triggerType }}</span>
+							<span class="bk-notification-modal__type">{{
+								t.triggerType
+							}}</span>
 						</header>
 						<div class="bk-notification-modal__channels">
 							<label
@@ -74,7 +83,9 @@
 									type="checkbox"
 									:checked="t.channels.includes(c)"
 									:data-testid="`bk-notification-${t.slug}-channel-${c}`"
-									@change="toggleChannel(t, c, $event.target.checked)">
+									@change="
+										toggleChannel(t, c, $event.target.checked)
+									" />
 								<span>{{ label(channelLabel(c)) }}</span>
 							</label>
 						</div>
@@ -170,8 +181,14 @@ export default {
 		 * @return {string} Capitalised label.
 		 */
 		channelLabel(channel) {
-			const map = { email: 'Email', sms: 'SMS', chat: 'Chat', teams: 'Teams', slack: 'Slack' }
-			return (map[channel] || channel)
+			const map = {
+				email: 'Email',
+				sms: 'SMS',
+				chat: 'Chat',
+				teams: 'Teams',
+				slack: 'Slack',
+			}
+			return map[channel] || channel
 		},
 		/**
 		 * Reset the editable copy from the incoming triggers prop.

--- a/src/modals/DeleteBudgetMappingDialog.vue
+++ b/src/modals/DeleteBudgetMappingDialog.vue
@@ -32,9 +32,16 @@
 			</header>
 			<section class="bbv-delete-dialog__body">
 				<p>
-					{{ label('This permanently removes the GL → programme allocation. Deletion is logged in the audit trail.') }}
+					{{
+						label(
+							'This permanently removes the GL → programme allocation. Deletion is logged in the audit trail.',
+						)
+					}}
 				</p>
-				<dl v-if="mapping" class="bbv-delete-dialog__summary" data-testid="bbv-delete-dialog-summary">
+				<dl
+					v-if="mapping"
+					class="bbv-delete-dialog__summary"
+					data-testid="bbv-delete-dialog-summary">
 					<dt>{{ label('GL account') }}</dt>
 					<dd>{{ mapping.glAccountNumber || '—' }}</dd>
 					<dt>{{ label('Programme') }}</dt>

--- a/src/modals/GenerateReportDialog.vue
+++ b/src/modals/GenerateReportDialog.vue
@@ -49,8 +49,11 @@
 
 			<section class="generate-report-dialog__body">
 				<div class="generate-report-dialog__field">
-					<label class="generate-report-dialog__label" for="generate-report-administration">
-						{{ t('shillinq', 'Administration') }} <span class="generate-report-dialog__required">*</span>
+					<label
+						class="generate-report-dialog__label"
+						for="generate-report-administration">
+						{{ t('shillinq', 'Administration') }}
+						<span class="generate-report-dialog__required">*</span>
 					</label>
 					<select
 						v-if="administrationOptions.length > 0"
@@ -77,12 +80,14 @@
 						class="generate-report-dialog__control"
 						:disabled="submitting"
 						data-testid="generate-report-administration"
-						:placeholder="t('shillinq', 'Administration id')">
+						:placeholder="t('shillinq', 'Administration id')" />
 				</div>
 
 				<div class="generate-report-dialog__row">
 					<div class="generate-report-dialog__field">
-						<label class="generate-report-dialog__label" for="generate-report-period-type">
+						<label
+							class="generate-report-dialog__label"
+							for="generate-report-period-type">
 							{{ t('shillinq', 'Period type') }}
 						</label>
 						<select
@@ -104,8 +109,11 @@
 					</div>
 
 					<div class="generate-report-dialog__field">
-						<label class="generate-report-dialog__label" for="generate-report-year">
-							{{ t('shillinq', 'Fiscal year') }} <span class="generate-report-dialog__required">*</span>
+						<label
+							class="generate-report-dialog__label"
+							for="generate-report-year">
+							{{ t('shillinq', 'Fiscal year') }}
+							<span class="generate-report-dialog__required">*</span>
 						</label>
 						<input
 							id="generate-report-year"
@@ -113,14 +121,17 @@
 							type="number"
 							class="generate-report-dialog__control"
 							:disabled="submitting"
-							data-testid="generate-report-year">
+							data-testid="generate-report-year" />
 					</div>
 
 					<div
 						v-if="form.periodType !== 'year'"
 						class="generate-report-dialog__field">
-						<label class="generate-report-dialog__label" for="generate-report-period-number">
-							{{ periodNumberLabel }} <span class="generate-report-dialog__required">*</span>
+						<label
+							class="generate-report-dialog__label"
+							for="generate-report-period-number">
+							{{ periodNumberLabel }}
+							<span class="generate-report-dialog__required">*</span>
 						</label>
 						<select
 							id="generate-report-period-number"
@@ -139,8 +150,11 @@
 				</div>
 
 				<div class="generate-report-dialog__field">
-					<label class="generate-report-dialog__label" for="generate-report-format">
-						{{ t('shillinq', 'Format') }} <span class="generate-report-dialog__required">*</span>
+					<label
+						class="generate-report-dialog__label"
+						for="generate-report-format">
+						{{ t('shillinq', 'Format') }}
+						<span class="generate-report-dialog__required">*</span>
 					</label>
 					<select
 						id="generate-report-format"
@@ -149,7 +163,7 @@
 						:disabled="submitting"
 						data-testid="generate-report-format">
 						<option
-							v-for="fmt in (report.formats || [])"
+							v-for="fmt in report.formats || []"
 							:key="fmt"
 							:value="fmt">
 							{{ fmt.toUpperCase() }}
@@ -180,7 +194,11 @@
 					:disabled="!canSubmit"
 					data-testid="generate-report-dialog-submit"
 					@click="onSubmit">
-					{{ submitting ? t('shillinq', 'Generating…') : t('shillinq', 'Generate') }}
+					{{
+						submitting
+							? t('shillinq', 'Generating…')
+							: t('shillinq', 'Generate')
+					}}
 				</button>
 			</footer>
 		</div>
@@ -230,7 +248,10 @@ export default {
 				periodType: 'year',
 				periodYear: new Date().getFullYear(),
 				periodNumber: 1,
-				format: this.format || (this.report.formats && this.report.formats[0]) || '',
+				format:
+					this.format
+					|| (this.report.formats && this.report.formats[0])
+					|| '',
 			},
 		}
 	},
@@ -293,13 +314,17 @@ export default {
 						format: this.form.format,
 						periodType: this.form.periodType,
 						periodYear: this.form.periodYear,
-						periodNumber: this.form.periodType === 'year' ? null : this.form.periodNumber,
+						periodNumber:
+							this.form.periodType === 'year'
+								? null
+								: this.form.periodNumber,
 						period: this.periodLabel(),
 					},
 				)
 				this.$emit('generated', response.data || {})
 			} catch (e) {
-				this.error = e?.response?.data?.error
+				this.error =
+					e?.response?.data?.error
 					|| this.t('shillinq', 'Report generation failed')
 			} finally {
 				this.submitting = false

--- a/src/modals/InvoiceQuickDraftModal.vue
+++ b/src/modals/InvoiceQuickDraftModal.vue
@@ -58,7 +58,7 @@
 						type="date"
 						class="iqd__input"
 						data-testid="iqd-invoice-date"
-						@change="recomputeDueDate">
+						@change="recomputeDueDate" />
 				</div>
 				<div class="iqd__field">
 					<label class="iqd__label" for="iqd-due-date">
@@ -69,7 +69,7 @@
 						v-model="form.dueDate"
 						type="date"
 						class="iqd__input"
-						data-testid="iqd-due-date">
+						data-testid="iqd-due-date" />
 				</div>
 			</div>
 
@@ -84,7 +84,7 @@
 					type="text"
 					class="iqd__input"
 					data-testid="iqd-reference"
-					:placeholder="t('shillinq', 'Optional')">
+					:placeholder="t('shillinq', 'Optional')" />
 			</div>
 
 			<!-- Line items -->
@@ -103,7 +103,7 @@
 						class="iqd__input iqd__input--desc"
 						:aria-label="t('shillinq', 'Line description')"
 						:placeholder="t('shillinq', 'Description')"
-						data-testid="iqd-line-description">
+						data-testid="iqd-line-description" />
 					<input
 						v-model.number="line.quantity"
 						type="number"
@@ -112,7 +112,7 @@
 						class="iqd__input iqd__input--qty"
 						:aria-label="t('shillinq', 'Line quantity')"
 						:placeholder="t('shillinq', 'Qty')"
-						data-testid="iqd-line-quantity">
+						data-testid="iqd-line-quantity" />
 					<input
 						v-model.number="line.unitPrice"
 						type="number"
@@ -121,7 +121,7 @@
 						class="iqd__input iqd__input--price"
 						:aria-label="t('shillinq', 'Line unit price')"
 						:placeholder="t('shillinq', 'Unit price')"
-						data-testid="iqd-line-unit-price">
+						data-testid="iqd-line-unit-price" />
 					<NcSelect
 						:model-value="vatOptionFor(line)"
 						:options="vatOptions"
@@ -162,7 +162,10 @@
 			<div class="iqd__totals" data-testid="iqd-totals">
 				<span>{{ t('shillinq', 'Net') }}: {{ formatEuro(netAmount) }}</span>
 				<span>{{ t('shillinq', 'VAT') }}: {{ formatEuro(vatAmount) }}</span>
-				<strong>{{ t('shillinq', 'Total') }}: {{ formatEuro(grossAmount) }}</strong>
+				<strong
+					>{{ t('shillinq', 'Total') }}:
+					{{ formatEuro(grossAmount) }}</strong
+				>
 			</div>
 
 			<p v-if="error" class="iqd__error" data-testid="iqd-error">
@@ -171,10 +174,7 @@
 		</div>
 
 		<template #actions>
-			<NcButton
-				:disabled="saving"
-				data-testid="iqd-cancel"
-				@click="onClose">
+			<NcButton :disabled="saving" data-testid="iqd-cancel" @click="onClose">
 				{{ t('shillinq', 'Cancel') }}
 			</NcButton>
 			<NcButton
@@ -266,9 +266,11 @@ export default {
 		canSave() {
 			if (this.saving) return false
 			if (!this.selectedCustomer || !this.selectedCustomer.value) return false
-			return this.form.lines.some((l) =>
-				(l.description || '').trim().length > 0
-				&& Number(l.unitPrice) > 0)
+			return this.form.lines.some(
+				(l) =>
+					(l.description || '').trim().length > 0
+					&& Number(l.unitPrice) > 0,
+			)
 		},
 	},
 	watch: {
@@ -301,8 +303,10 @@ export default {
 		},
 		/** @spec openspec/specs/shillinq-invoice-quick-draft/spec.md */
 		vatOptionFor(line) {
-			return this.vatOptions.find((o) => o.value === Number(line.btwRate))
+			return (
+				this.vatOptions.find((o) => o.value === Number(line.btwRate))
 				|| this.vatOptions[0]
+			)
 		},
 		/** @spec openspec/specs/shillinq-invoice-quick-draft/spec.md */
 		reset() {
@@ -321,10 +325,16 @@ export default {
 			this.loadingCustomers = true
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${CUSTOMER_SCHEMA}`),
+					generateUrl(
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/${CUSTOMER_SCHEMA}`,
+					),
 					{ params: { _limit: 500 } },
 				)
-				const rows = response.data?.results ?? response.data?.objects ?? response.data ?? []
+				const rows =
+					response.data?.results
+					?? response.data?.objects
+					?? response.data
+					?? []
 				this.customers = Array.isArray(rows) ? rows : []
 			} catch (e) {
 				this.customers = []
@@ -343,8 +353,11 @@ export default {
 		 */
 		async fetchAdministrationId() {
 			try {
-				const { data } = await axios.get(generateUrl('/apps/shillinq/api/settings'))
-				this.administrationId = data?.administration_id ?? data?.administrationId ?? ''
+				const { data } = await axios.get(
+					generateUrl('/apps/shillinq/api/settings'),
+				)
+				this.administrationId =
+					data?.administration_id ?? data?.administrationId ?? ''
 			} catch (e) {
 				this.administrationId = ''
 			}
@@ -364,18 +377,22 @@ export default {
 				if (prefs.glAccount) this.form.glAccount = String(prefs.glAccount)
 				const line = this.form.lines[0]
 				if (line) {
-					if (prefs.description && !line.description) line.description = prefs.description
-					if (prefs.unitPrice && !line.unitPrice) line.unitPrice = prefs.unitPrice
-					if (prefs.vatCode !== undefined && prefs.vatCode !== null) line.btwRate = prefs.vatCode
+					if (prefs.description && !line.description)
+						line.description = prefs.description
+					if (prefs.unitPrice && !line.unitPrice)
+						line.unitPrice = prefs.unitPrice
+					if (prefs.vatCode !== undefined && prefs.vatCode !== null)
+						line.btwRate = prefs.vatCode
 				}
 			}
 			this.recomputeDueDate(customer)
 		},
 		/** @spec openspec/specs/shillinq-invoice-quick-draft/spec.md */
 		recomputeDueDate(customerOrEvent) {
-			const customer = customerOrEvent && customerOrEvent.customerId
-				? customerOrEvent
-				: this.selectedCustomer?.customer
+			const customer =
+				customerOrEvent && customerOrEvent.customerId
+					? customerOrEvent
+					: this.selectedCustomer?.customer
 			const terms = customer?.paymentTerms || 'net30'
 			this.form.dueDate = dueDateFromTerms(this.form.invoiceDate, terms)
 		},
@@ -413,12 +430,15 @@ export default {
 					lines: this.form.lines,
 				})
 				const response = await axios.post(
-					generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${AR_SCHEMA}`),
+					generateUrl(
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/${AR_SCHEMA}`,
+					),
 					payload,
 				)
 				const created = response.data?.object ?? response.data ?? {}
 				const invoiceId = created.id ?? created.uuid ?? ''
-				const invoiceNumber = created.invoiceNumber || payload.invoiceNumber || ''
+				const invoiceNumber =
+					created.invoiceNumber || payload.invoiceNumber || ''
 
 				// Persist per-customer preferences for next time (REQ-IQD-004).
 				const firstLine = this.form.lines[0] || {}
@@ -430,14 +450,17 @@ export default {
 				})
 
 				showSuccess(
-					t('shillinq', 'Draft invoice {number} created.', { number: invoiceNumber || invoiceId }),
+					t('shillinq', 'Draft invoice {number} created.', {
+						number: invoiceNumber || invoiceId,
+					}),
 				)
 				// REQ-IQD-005: refresh the receivables widget without navigation.
 				emit('cn:widget:refresh', { widget: 'widget-open-debtors' })
 				this.$emit('created', { id: invoiceId, invoiceNumber })
 				this.$emit('close')
 			} catch (e) {
-				this.error = e?.response?.data?.error
+				this.error =
+					e?.response?.data?.error
 					|| e?.response?.data?.message
 					|| e?.message
 					|| t('shillinq', 'Failed to create draft invoice.')

--- a/src/modals/PaymentRunReconcileModal.vue
+++ b/src/modals/PaymentRunReconcileModal.vue
@@ -30,7 +30,12 @@
 		@closing="onClose">
 		<div class="prr">
 			<p class="prr__intro">
-				{{ t('shillinq', 'Import a CAMT.053 bank statement for this payment run. Its booked entries are matched to the run\'s payment lines; on a full match the run is reconciled.') }}
+				{{
+					t(
+						'shillinq',
+						"Import a CAMT.053 bank statement for this payment run. Its booked entries are matched to the run's payment lines; on a full match the run is reconciled.",
+					)
+				}}
 			</p>
 
 			<input
@@ -39,7 +44,7 @@
 				accept=".xml,application/xml,text/xml"
 				:aria-label="t('shillinq', 'Choose a CAMT.053 bank statement file')"
 				data-testid="payment-run-reconcile-file"
-				@change="onFileSelected">
+				@change="onFileSelected" />
 
 			<p v-if="fileName" class="prr__filename">
 				{{ t('shillinq', 'Selected') }}: {{ fileName }}
@@ -118,7 +123,9 @@ export default {
 			if (!this.result) {
 				return ''
 			}
-			return this.result.result === 'full' ? 'prr__result--ok' : 'prr__result--warn'
+			return this.result.result === 'full'
+				? 'prr__result--ok'
+				: 'prr__result--warn'
 		},
 	},
 	methods: {
@@ -145,7 +152,9 @@ export default {
 			this.result = null
 			try {
 				const response = await axios.post(
-					generateUrl(`/apps/shillinq/api/v1/payment-runs/${this.runId}/reconcile`),
+					generateUrl(
+						`/apps/shillinq/api/v1/payment-runs/${this.runId}/reconcile`,
+					),
 					{ contents: this.fileContents },
 				)
 				this.result = response.data
@@ -154,12 +163,17 @@ export default {
 					emit('cn:widget:refresh', { widget: 'PaymentRunDetail' })
 					this.$emit('reconciled', this.result)
 				} else {
-					showError(t('shillinq', 'Partial match — the run stays exported.'))
+					showError(
+						t('shillinq', 'Partial match — the run stays exported.'),
+					)
 				}
 			} catch (error) {
-				const message = error.response && error.response.data && error.response.data.error
-					? error.response.data.error
-					: t('shillinq', 'Could not reconcile the payment run.')
+				const message =
+					error.response
+					&& error.response.data
+					&& error.response.data.error
+						? error.response.data.error
+						: t('shillinq', 'Could not reconcile the payment run.')
 				showError(message)
 			} finally {
 				this.submitting = false

--- a/src/modals/RecurringInvoiceProfileModal.vue
+++ b/src/modals/RecurringInvoiceProfileModal.vue
@@ -31,24 +31,30 @@
 		<div class="rip">
 			<div class="rip__row">
 				<div class="rip__field">
-					<label class="rip__label" for="rip-name">{{ t('shillinq', 'Profile name') }}</label>
+					<label class="rip__label" for="rip-name">{{
+						t('shillinq', 'Profile name')
+					}}</label>
 					<input
 						id="rip-name"
 						v-model="form.name"
 						type="text"
 						class="rip__input"
 						data-testid="rip-name"
-						:placeholder="t('shillinq', 'e.g. Hosting Acme')">
+						:placeholder="t('shillinq', 'e.g. Hosting Acme')" />
 				</div>
 				<div class="rip__field">
-					<label class="rip__label" for="rip-customer">{{ t('shillinq', 'Customer') }}</label>
+					<label class="rip__label" for="rip-customer">{{
+						t('shillinq', 'Customer')
+					}}</label>
 					<input
 						id="rip-customer"
 						v-model="form.customerReference"
 						type="text"
 						class="rip__input"
 						data-testid="rip-customer"
-						:placeholder="t('shillinq', 'Nextcloud contact reference')">
+						:placeholder="
+							t('shillinq', 'Nextcloud contact reference')
+						" />
 				</div>
 			</div>
 
@@ -65,17 +71,21 @@
 						@update:model-value="(o) => onSelect('frequency', o)" />
 				</div>
 				<div class="rip__field">
-					<label class="rip__label" for="rip-interval">{{ t('shillinq', 'Interval') }}</label>
+					<label class="rip__label" for="rip-interval">{{
+						t('shillinq', 'Interval')
+					}}</label>
 					<input
 						id="rip-interval"
 						v-model.number="form.interval"
 						type="number"
 						min="1"
 						class="rip__input"
-						data-testid="rip-interval">
+						data-testid="rip-interval" />
 				</div>
 				<div class="rip__field">
-					<label class="rip__label" for="rip-invoice-day">{{ t('shillinq', 'Invoice day') }}</label>
+					<label class="rip__label" for="rip-invoice-day">{{
+						t('shillinq', 'Invoice day')
+					}}</label>
 					<input
 						id="rip-invoice-day"
 						v-model.number="form.invoiceDay"
@@ -83,29 +93,33 @@
 						min="1"
 						max="31"
 						class="rip__input"
-						data-testid="rip-invoice-day">
+						data-testid="rip-invoice-day" />
 				</div>
 			</div>
 
 			<div class="rip__row">
 				<div class="rip__field">
-					<label class="rip__label" for="rip-start-date">{{ t('shillinq', 'Start date') }}</label>
+					<label class="rip__label" for="rip-start-date">{{
+						t('shillinq', 'Start date')
+					}}</label>
 					<input
 						id="rip-start-date"
 						v-model="form.startDate"
 						type="date"
 						class="rip__input"
-						data-testid="rip-start-date">
+						data-testid="rip-start-date" />
 				</div>
 				<div class="rip__field">
-					<label class="rip__label" for="rip-payment-terms">{{ t('shillinq', 'Payment terms (days)') }}</label>
+					<label class="rip__label" for="rip-payment-terms">{{
+						t('shillinq', 'Payment terms (days)')
+					}}</label>
 					<input
 						id="rip-payment-terms"
 						v-model.number="form.paymentTermsDays"
 						type="number"
 						min="0"
 						class="rip__input"
-						data-testid="rip-payment-terms">
+						data-testid="rip-payment-terms" />
 				</div>
 				<div class="rip__field">
 					<NcSelect
@@ -124,7 +138,12 @@
 			<div class="rip__lines">
 				<span class="rip__label">{{ t('shillinq', 'Line items') }}</span>
 				<p class="rip__hint">
-					{{ t('shillinq', 'Use {period}, {month} and {year} tokens in the description — they expand per generated period.') }}
+					{{
+						t(
+							'shillinq',
+							'Use {period}, {month} and {year} tokens in the description — they expand per generated period.',
+						)
+					}}
 				</p>
 				<div
 					v-for="(line, idx) in form.lines"
@@ -136,8 +155,13 @@
 						type="text"
 						class="rip__input rip__input--desc"
 						:aria-label="t('shillinq', 'Line description')"
-						:placeholder="t('shillinq', 'Description (e.g. Hosting {month} {year})')"
-						data-testid="rip-line-description">
+						:placeholder="
+							t(
+								'shillinq',
+								'Description (e.g. Hosting {month} {year})',
+							)
+						"
+						data-testid="rip-line-description" />
 					<input
 						v-model.number="line.quantity"
 						type="number"
@@ -146,7 +170,7 @@
 						class="rip__input rip__input--qty"
 						:aria-label="t('shillinq', 'Line quantity')"
 						:placeholder="t('shillinq', 'Qty')"
-						data-testid="rip-line-quantity">
+						data-testid="rip-line-quantity" />
 					<input
 						v-model.number="line.unitPrice"
 						type="number"
@@ -155,7 +179,7 @@
 						class="rip__input rip__input--price"
 						:aria-label="t('shillinq', 'Line unit price')"
 						:placeholder="t('shillinq', 'Unit price')"
-						data-testid="rip-line-unit-price">
+						data-testid="rip-line-unit-price" />
 					<NcSelect
 						:model-value="vatOptionFor(line)"
 						:options="vatOptions"
@@ -176,7 +200,8 @@
 						×
 					</button>
 				</div>
-				<button type="button"
+				<button
+					type="button"
 					class="rip__add-line"
 					data-testid="rip-add-line"
 					@click="addLine">
@@ -186,12 +211,17 @@
 
 			<!-- Next-invoice preview (REQ-RIN-008) -->
 			<div class="rip__preview" data-testid="rip-preview">
-				<span class="rip__label">{{ t('shillinq', 'Next invoice preview') }}</span>
+				<span class="rip__label">{{
+					t('shillinq', 'Next invoice preview')
+				}}</span>
 				<ul class="rip__preview-list">
-					<li v-for="(desc, i) in previewDescriptions" :key="i">{{ desc }}</li>
+					<li v-for="(desc, i) in previewDescriptions" :key="i">
+						{{ desc }}
+					</li>
 				</ul>
 				<div class="rip__preview-total">
-					{{ t('shillinq', 'Per period (net)') }}: {{ formatEuro(perPeriodNetAmount) }}
+					{{ t('shillinq', 'Per period (net)') }}:
+					{{ formatEuro(perPeriodNetAmount) }}
 				</div>
 			</div>
 
@@ -209,7 +239,9 @@
 				:disabled="saving"
 				data-testid="rip-save"
 				@click="onSave">
-				{{ saving ? t('shillinq', 'Saving…') : t('shillinq', 'Save profile') }}
+				{{
+					saving ? t('shillinq', 'Saving…') : t('shillinq', 'Save profile')
+				}}
 			</NcButton>
 		</template>
 	</NcDialog>
@@ -231,8 +263,20 @@ import {
 const REGISTER_SLUG = 'shillinq'
 const SCHEMA_SLUG = 'RecurringInvoiceProfile'
 
-const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June',
-	'July', 'August', 'September', 'October', 'November', 'December']
+const MONTHS = [
+	'January',
+	'February',
+	'March',
+	'April',
+	'May',
+	'June',
+	'July',
+	'August',
+	'September',
+	'October',
+	'November',
+	'December',
+]
 
 export default {
 	name: 'RecurringInvoiceProfileModal',
@@ -260,7 +304,10 @@ export default {
 				{ value: 'annually', display: t('shillinq', 'Annually') },
 			],
 			issueModeOptions: [
-				{ value: 'draft-for-review', display: t('shillinq', 'Draft for review') },
+				{
+					value: 'draft-for-review',
+					display: t('shillinq', 'Draft for review'),
+				},
 				{ value: 'auto-issue', display: t('shillinq', 'Auto-issue') },
 			],
 			vatOptions: [
@@ -274,11 +321,17 @@ export default {
 	computed: {
 		/** @spec openspec/specs/recurring-invoicing/spec.md */
 		frequencyOption() {
-			return this.frequencyOptions.find((o) => o.value === this.form.frequency) || this.frequencyOptions[1]
+			return (
+				this.frequencyOptions.find((o) => o.value === this.form.frequency)
+				|| this.frequencyOptions[1]
+			)
 		},
 		/** @spec openspec/specs/recurring-invoicing/spec.md */
 		issueModeOption() {
-			return this.issueModeOptions.find((o) => o.value === this.form.issueMode) || this.issueModeOptions[0]
+			return (
+				this.issueModeOptions.find((o) => o.value === this.form.issueMode)
+				|| this.issueModeOptions[0]
+			)
 		},
 		/** @spec openspec/specs/recurring-invoicing/spec.md */
 		perPeriodNetAmount() {
@@ -290,10 +343,12 @@ export default {
 			const year = String(new Date().getFullYear())
 			return this.form.lines
 				.filter((l) => (l.description || '').trim().length > 0)
-				.map((l) => l.description
-					.replace(/\{period\}/g, `${month} ${year}`)
-					.replace(/\{month\}/g, month)
-					.replace(/\{year\}/g, year))
+				.map((l) =>
+					l.description
+						.replace(/\{period\}/g, `${month} ${year}`)
+						.replace(/\{month\}/g, month)
+						.replace(/\{year\}/g, year),
+				)
 		},
 	},
 	watch: {
@@ -329,11 +384,17 @@ export default {
 		},
 		/** @spec openspec/specs/recurring-invoicing/spec.md */
 		formatEuro(amount) {
-			return new Intl.NumberFormat('nl-NL', { style: 'currency', currency: 'EUR' }).format(Number(amount) || 0)
+			return new Intl.NumberFormat('nl-NL', {
+				style: 'currency',
+				currency: 'EUR',
+			}).format(Number(amount) || 0)
 		},
 		/** @spec openspec/specs/recurring-invoicing/spec.md */
 		vatOptionFor(line) {
-			return this.vatOptions.find((o) => o.value === Number(line.vatCode)) || this.vatOptions[0]
+			return (
+				this.vatOptions.find((o) => o.value === Number(line.vatCode))
+				|| this.vatOptions[0]
+			)
 		},
 		/** @spec openspec/specs/recurring-invoicing/spec.md */
 		onSelect(field, option) {
@@ -356,10 +417,19 @@ export default {
 		async fetchProfile() {
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}/${this.recordId}`),
+					generateUrl(
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}/${this.recordId}`,
+					),
 				)
 				const obj = response.data?.object ?? response.data ?? {}
-				this.form = { ...this.blankForm(), ...obj, lines: (obj.lines && obj.lines.length) ? obj.lines : [defaultRecurringLine()] }
+				this.form = {
+					...this.blankForm(),
+					...obj,
+					lines:
+						obj.lines && obj.lines.length
+							? obj.lines
+							: [defaultRecurringLine()],
+				}
 			} catch (e) {
 				showError(t('shillinq', 'Failed to load recurring profile.'))
 			}
@@ -378,13 +448,17 @@ export default {
 				const payload = buildProfilePayload(this.form)
 				if (this.recordId) {
 					await axios.put(
-						generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}/${this.recordId}`),
+						generateUrl(
+							`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}/${this.recordId}`,
+						),
 						payload,
 					)
 					showSuccess(t('shillinq', 'Recurring profile updated.'))
 				} else {
 					await axios.post(
-						generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}`),
+						generateUrl(
+							`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}`,
+						),
 						payload,
 					)
 					showSuccess(t('shillinq', 'Recurring profile created.'))
@@ -392,7 +466,10 @@ export default {
 				this.$emit('saved')
 				this.$emit('close')
 			} catch (e) {
-				const msg = e?.response?.data?.error || e?.message || t('shillinq', 'Failed to save recurring profile.')
+				const msg =
+					e?.response?.data?.error
+					|| e?.message
+					|| t('shillinq', 'Failed to save recurring profile.')
 				this.errors = [msg]
 				showError(msg)
 			} finally {
@@ -461,13 +538,24 @@ export default {
 	align-items: center;
 }
 
-.rip__input--desc { flex: 3; }
+.rip__input--desc {
+	flex: 3;
+}
 
-.rip__input--qty { flex: 1; max-width: 70px; }
+.rip__input--qty {
+	flex: 1;
+	max-width: 70px;
+}
 
-.rip__input--price { flex: 1; max-width: 110px; }
+.rip__input--price {
+	flex: 1;
+	max-width: 110px;
+}
 
-.rip__input--vat { flex: 1; min-width: 90px; }
+.rip__input--vat {
+	flex: 1;
+	min-width: 90px;
+}
 
 .rip__line-remove {
 	border: none;

--- a/src/modals/ReopenPeriodDialog.vue
+++ b/src/modals/ReopenPeriodDialog.vue
@@ -35,13 +35,22 @@
 			</header>
 			<section class="reopen-period-dialog__body">
 				<p v-if="periodName">
-					{{ t('shillinq', 'Reopening period:') }} <strong>{{ periodName }}</strong>
+					{{ t('shillinq', 'Reopening period:') }}
+					<strong>{{ periodName }}</strong>
 				</p>
 				<p class="reopen-period-dialog__hint">
-					{{ t('shillinq', 'Provide a close reason — the original close timestamp and actor are preserved in the audit history.') }}
+					{{
+						t(
+							'shillinq',
+							'Provide a close reason — the original close timestamp and actor are preserved in the audit history.',
+						)
+					}}
 				</p>
-				<label class="reopen-period-dialog__label" for="reopen-period-dialog-reason">
-					{{ t('shillinq', 'Close reason') }} <span class="reopen-period-dialog__required">*</span>
+				<label
+					class="reopen-period-dialog__label"
+					for="reopen-period-dialog-reason">
+					{{ t('shillinq', 'Close reason') }}
+					<span class="reopen-period-dialog__required">*</span>
 				</label>
 				<textarea
 					id="reopen-period-dialog-reason"
@@ -51,8 +60,16 @@
 					rows="3"
 					:disabled="submitting"
 					data-testid="reopen-period-dialog-reason"
-					:placeholder="t('shillinq', 'e.g. Adjusting journal for tax authority correction')" />
-				<p v-if="error" class="reopen-period-dialog__error" data-testid="reopen-period-dialog-error">
+					:placeholder="
+						t(
+							'shillinq',
+							'e.g. Adjusting journal for tax authority correction',
+						)
+					" />
+				<p
+					v-if="error"
+					class="reopen-period-dialog__error"
+					data-testid="reopen-period-dialog-error">
 					{{ error }}
 				</p>
 			</section>
@@ -71,7 +88,11 @@
 					:disabled="!canConfirm"
 					data-testid="reopen-period-dialog-confirm"
 					@click="onConfirm">
-					{{ submitting ? t('shillinq', 'Working…') : t('shillinq', 'Reopen') }}
+					{{
+						submitting
+							? t('shillinq', 'Working…')
+							: t('shillinq', 'Reopen')
+					}}
 				</button>
 			</footer>
 		</div>
@@ -115,7 +136,10 @@ export default {
 			if (next === true) {
 				this.closeReason = ''
 				this.$nextTick(() => {
-					if (this.$refs.reasonInput && typeof this.$refs.reasonInput.focus === 'function') {
+					if (
+						this.$refs.reasonInput
+						&& typeof this.$refs.reasonInput.focus === 'function'
+					) {
 						this.$refs.reasonInput.focus()
 					}
 				})

--- a/src/modals/bankStatementWizard.js
+++ b/src/modals/bankStatementWizard.js
@@ -32,7 +32,9 @@ export function formatOptions() {
  * @return {string} The normalised IBAN ('' when falsy).
  */
 export function normalizeIban(iban) {
-	return String(iban || '').replace(/\s+/g, '').toUpperCase()
+	return String(iban || '')
+		.replace(/\s+/g, '')
+		.toUpperCase()
 }
 
 /**
@@ -52,7 +54,7 @@ function readIbanStore() {
 			globalThis.localStorage?.removeItem(IBAN_MAP_KEY)
 			return {}
 		}
-		return (parsed.map && typeof parsed.map === 'object') ? parsed.map : {}
+		return parsed.map && typeof parsed.map === 'object' ? parsed.map : {}
 	} catch (e) {
 		return {}
 	}
@@ -70,7 +72,7 @@ export function loadIbanMapping(iban) {
 	const key = normalizeIban(iban)
 	if (!key) return null
 	const map = readIbanStore()
-	return (key in map && map[key]) ? String(map[key]) : null
+	return key in map && map[key] ? String(map[key]) : null
 }
 
 /**
@@ -132,7 +134,10 @@ export function setReturnBreadcrumb(statementId) {
 	try {
 		globalThis.sessionStorage?.setItem(
 			BREADCRUMB_FLAG,
-			JSON.stringify({ from: 'financial-overview', statementId: String(statementId || '') }),
+			JSON.stringify({
+				from: 'financial-overview',
+				statementId: String(statementId || ''),
+			}),
 		)
 	} catch (e) {
 		// Non-fatal.

--- a/src/modals/billImportModal.js
+++ b/src/modals/billImportModal.js
@@ -23,7 +23,8 @@ export const CREDITORS_WIDGET = 'widget-open-creditors'
  *
  * @type {string}
  */
-export const PDF_DEFERRAL_MESSAGE = 'PDF OCR extraction is not yet available. Please upload a UBL/e-invoice XML or CSV.'
+export const PDF_DEFERRAL_MESSAGE =
+	'PDF OCR extraction is not yet available. Please upload a UBL/e-invoice XML or CSV.'
 
 /**
  * Detect the import format from a file name (falling back to a content
@@ -35,7 +36,10 @@ export const PDF_DEFERRAL_MESSAGE = 'PDF OCR extraction is not yet available. Pl
  * @return {string} The detected format.
  */
 export function detectFormat(fileName, contents = '') {
-	const ext = String(fileName || '').split('.').pop().toLowerCase()
+	const ext = String(fileName || '')
+		.split('.')
+		.pop()
+		.toLowerCase()
 	if (ext === 'xml' || ext === 'ubl') return 'ubl'
 	if (ext === 'csv') return 'csv'
 	if (ext === 'pdf') return 'pdf'
@@ -125,8 +129,9 @@ function centsToEuro(cents) {
  */
 export function canSaveReview(form) {
 	const f = form || {}
-	return ['supplier', 'invoiceNumber', 'invoiceDate', 'glAccount']
-		.every((k) => String(f[k] ?? '').trim().length > 0)
+	return ['supplier', 'invoiceNumber', 'invoiceDate', 'glAccount'].every(
+		(k) => String(f[k] ?? '').trim().length > 0,
+	)
 }
 
 /**
@@ -140,13 +145,17 @@ export function canSaveReview(form) {
 export function importErrorMessage(error) {
 	const status = error?.response?.status
 	if (status === 409) {
-		return error?.response?.data?.error
+		return (
+			error?.response?.data?.error
 			|| 'This invoice number already exists for this supplier'
+		)
 	}
-	return error?.response?.data?.error
+	return (
+		error?.response?.data?.error
 		|| error?.response?.data?.message
 		|| error?.message
 		|| 'Import failed.'
+	)
 }
 
 /**
@@ -202,6 +211,7 @@ export function reviewFormFromDraft(record) {
 export function pendingDraftSummary(record) {
 	const r = record || {}
 	const label = String(r.invoiceNumber || r.supplierId || r.id || '')
-	const overall = typeof r.overallConfidence === 'number' ? r.overallConfidence : null
+	const overall =
+		typeof r.overallConfidence === 'number' ? r.overallConfidence : null
 	return { id: String(r.id ?? ''), label, overallConfidence: overall }
 }

--- a/src/modals/invoiceQuickDraft.js
+++ b/src/modals/invoiceQuickDraft.js
@@ -119,7 +119,10 @@ export function periodIdFromDate(invoiceDate) {
  * @return {string} A unique provisional invoice number.
  */
 export function provisionalInvoiceNumber(invoiceDate, now = new Date()) {
-	const datePart = String(invoiceDate || '').slice(0, 10).replace(/-/g, '') || 'DRAFT'
+	const datePart =
+		String(invoiceDate || '')
+			.slice(0, 10)
+			.replace(/-/g, '') || 'DRAFT'
 	const hh = String(now.getHours()).padStart(2, '0')
 	const mm = String(now.getMinutes()).padStart(2, '0')
 	const ss = String(now.getSeconds()).padStart(2, '0')
@@ -146,7 +149,10 @@ export function provisionalInvoiceNumber(invoiceDate, now = new Date()) {
 export function buildInvoicePayload(input) {
 	const totals = computeTotals(input.lines)
 	const lines = (input.lines || [])
-		.filter((l) => (l.description || '').trim().length > 0 || Number(l.unitPrice) > 0)
+		.filter(
+			(l) =>
+				(l.description || '').trim().length > 0 || Number(l.unitPrice) > 0,
+		)
 		.map((l, idx) => ({
 			lineNumber: idx + 1,
 			description: (l.description || '').trim(),
@@ -156,7 +162,8 @@ export function buildInvoicePayload(input) {
 			glAccount: input.glAccount || '',
 		}))
 	return {
-		invoiceNumber: input.invoiceNumber || provisionalInvoiceNumber(input.invoiceDate),
+		invoiceNumber:
+			input.invoiceNumber || provisionalInvoiceNumber(input.invoiceDate),
 		administrationId: String(input.administrationId || ''),
 		periodId: input.periodId || periodIdFromDate(input.invoiceDate),
 		customerId: String(input.customerId),

--- a/src/modals/recurringInvoiceProfile.js
+++ b/src/modals/recurringInvoiceProfile.js
@@ -54,8 +54,9 @@ export function validateProfile(form) {
 		errors.push('A customer is required.')
 	}
 	const lines = form.lines || []
-	const hasPricedLine = lines.some((l) =>
-		(l.description || '').trim().length > 0 && Number(l.unitPrice) > 0)
+	const hasPricedLine = lines.some(
+		(l) => (l.description || '').trim().length > 0 && Number(l.unitPrice) > 0,
+	)
 	if (!hasPricedLine) {
 		errors.push('At least one line with a description and a price is required.')
 	}
@@ -79,7 +80,10 @@ export function validateProfile(form) {
  */
 export function buildProfilePayload(form) {
 	const lines = (form.lines || [])
-		.filter((l) => (l.description || '').trim().length > 0 || Number(l.unitPrice) > 0)
+		.filter(
+			(l) =>
+				(l.description || '').trim().length > 0 || Number(l.unitPrice) > 0,
+		)
 		.map((l) => ({
 			description: (l.description || '').trim(),
 			quantity: Number(l.quantity) || 1,
@@ -103,7 +107,11 @@ export function buildProfilePayload(form) {
 		status: form.status || 'draft',
 	}
 
-	if (form.indexationPercent !== undefined && form.indexationPercent !== null && form.indexationPercent !== '') {
+	if (
+		form.indexationPercent !== undefined
+		&& form.indexationPercent !== null
+		&& form.indexationPercent !== ''
+	) {
 		payload.indexationPercent = Number(form.indexationPercent)
 	}
 	if (form.endDate) {

--- a/src/registry.js
+++ b/src/registry.js
@@ -336,7 +336,10 @@ import BankImportPage from './components/settings/BankImportPage.vue'
 import AccountantPortalDashboard from './views/AccountantPortalDashboard.vue'
 
 export default {
-	RecurringInvoiceProfileModal: { kind: 'modal', component: RecurringInvoiceProfileModal },
+	RecurringInvoiceProfileModal: {
+		kind: 'modal',
+		component: RecurringInvoiceProfileModal,
+	},
 
 	// ADR-049 Phase-4: modals launched by declarative headerActions (open-modal).
 	InvoiceQuickDraftModal: { kind: 'modal', component: InvoiceQuickDraftModal },
@@ -354,7 +357,10 @@ export default {
 	AdminInvoiceList: { kind: 'page', component: AdminInvoiceList },
 	AdminInvoiceDetail: { kind: 'page', component: AdminInvoiceDetail },
 
-	BookingsConfirmationPortal: { kind: 'page', component: BookingsConfirmationPortal },
+	BookingsConfirmationPortal: {
+		kind: 'page',
+		component: BookingsConfirmationPortal,
+	},
 	AfspraakDetail: { kind: 'page', component: AfspraakDetail },
 	ReceiptCapture: { kind: 'page', component: ReceiptCapture },
 
@@ -368,7 +374,10 @@ export default {
 
 	ThreeWayMatchIndex: { kind: 'page', component: ThreeWayMatchIndex },
 
-	ThreeWayMatchExceptionPanel: { kind: 'page', component: ThreeWayMatchExceptionPanel },
+	ThreeWayMatchExceptionPanel: {
+		kind: 'page',
+		component: ThreeWayMatchExceptionPanel,
+	},
 
 	VendorPerformanceIndex: { kind: 'page', component: VendorPerformanceIndex },
 	VendorPerformanceDetail: { kind: 'page', component: VendorPerformanceDetail },
@@ -379,7 +388,10 @@ export default {
 
 	BudgetBBVMappingDetail: { kind: 'page', component: BudgetBBVMappingDetail },
 	BudgetMappingDetail: { kind: 'page', component: BudgetBBVMappingDetail },
-	AdministrationSwitcherPage: { kind: 'page', component: AdministrationSwitcherPage },
+	AdministrationSwitcherPage: {
+		kind: 'page',
+		component: AdministrationSwitcherPage,
+	},
 
 	// bookings-resource-calendar custom pages (REQ-006/REQ-007).
 	BookingsCalendar: { kind: 'page', component: CalendarView },
@@ -429,10 +441,16 @@ export default {
 	},
 
 	// reporting-compliance-consolidation: Reporting & Compliance pages.
-	ReportingComplianceOverview: { kind: 'page', component: ReportingComplianceOverview },
+	ReportingComplianceOverview: {
+		kind: 'page',
+		component: ReportingComplianceOverview,
+	},
 	GeneratedReportsIndex: { kind: 'page', component: GeneratedReportsIndex },
 	BankImportPage: { kind: 'page', component: BankImportPage },
 
 	// accountant-portal: scoped multi-client dashboard + handover-pack export.
-	AccountantPortalDashboard: { kind: 'page', component: AccountantPortalDashboard },
+	AccountantPortalDashboard: {
+		kind: 'page',
+		component: AccountantPortalDashboard,
+	},
 }

--- a/src/settings.js
+++ b/src/settings.js
@@ -3,7 +3,11 @@
 import './setPublicPath.js'
 
 import { createApp, h } from 'vue'
-import { translate as t, translatePlural as n, loadTranslations } from '@nextcloud/l10n'
+import {
+	translate as t,
+	translatePlural as n,
+	loadTranslations,
+} from '@nextcloud/l10n'
 import pinia from './pinia.js'
 import AdminRoot from './views/settings/AdminRoot.vue'
 
@@ -28,7 +32,10 @@ app.mount('#shillinq-settings')
 try {
 	const result = loadTranslations('shillinq', () => {})
 	if (result && typeof result.then === 'function') {
-		result.then(() => {}, () => {})
+		result.then(
+			() => {},
+			() => {},
+		)
 	}
 } catch {
 	// no-op — English source strings are the fallback.

--- a/src/store/modules/budgetBBVMappingStore.js
+++ b/src/store/modules/budgetBBVMappingStore.js
@@ -51,10 +51,7 @@ const REGISTER_SLUG = 'shillinq'
 const SCHEMA_SLUG = 'BudgetBBVMapping'
 
 const useBaseStore = createObjectStore('budget-bbv-mapping', {
-	plugins: [
-		relationsPlugin(),
-		auditTrailsPlugin(),
-	],
+	plugins: [relationsPlugin(), auditTrailsPlugin()],
 	baseUrl: generateUrl('/apps/openregister/api/objects'),
 })
 
@@ -69,14 +66,14 @@ const useBaseStore = createObjectStore('budget-bbv-mapping', {
  */
 export function useBudgetBBVMappingStore() {
 	const store = useBaseStore()
-	if (typeof store.registerObjectType === 'function'
-		&& !store.objectTypeRegistry[TYPE_SLUG]) {
-		store.registerObjectType(
-			TYPE_SLUG,
-			SCHEMA_SLUG,
-			REGISTER_SLUG,
-			{ registerSlug: REGISTER_SLUG, schemaSlug: SCHEMA_SLUG },
-		)
+	if (
+		typeof store.registerObjectType === 'function'
+		&& !store.objectTypeRegistry[TYPE_SLUG]
+	) {
+		store.registerObjectType(TYPE_SLUG, SCHEMA_SLUG, REGISTER_SLUG, {
+			registerSlug: REGISTER_SLUG,
+			schemaSlug: SCHEMA_SLUG,
+		})
 	}
 	return store
 }

--- a/src/store/modules/inventoryMobileScanner.js
+++ b/src/store/modules/inventoryMobileScanner.js
@@ -30,7 +30,11 @@ import {
 	replaceLocations,
 	purgeOldPendingOps,
 } from '../../composables/useInventoryDb.js'
-import { createSyncScheduler, fetchLocations, newTransactionId } from '../../composables/useInventorySync.js'
+import {
+	createSyncScheduler,
+	fetchLocations,
+	newTransactionId,
+} from '../../composables/useInventorySync.js'
 
 const PURGE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
 
@@ -57,7 +61,8 @@ export const useInventoryMobileScannerStore = defineStore('inventoryMobileScanne
 	}),
 
 	getters: {
-		isOnline: () => typeof navigator === 'undefined' || navigator.onLine !== false,
+		isOnline: () =>
+			typeof navigator === 'undefined' || navigator.onLine !== false,
 		statusLabel: (state) => {
 			if (state.syncState === STATE_SYNCED) {
 				return state.lastSyncedAt ? `Synced ${state.lastSyncedAt}` : 'Synced'
@@ -66,7 +71,9 @@ export const useInventoryMobileScannerStore = defineStore('inventoryMobileScanne
 				return 'Syncing…'
 			}
 			if (state.syncState === STATE_PENDING) {
-				return state.pendingCount > 0 ? `Pending (${state.pendingCount})` : 'Pending'
+				return state.pendingCount > 0
+					? `Pending (${state.pendingCount})`
+					: 'Pending'
 			}
 			if (state.syncState === STATE_FAILED) {
 				return `Sync failed; retry in ${Math.ceil((state.retryInMs || 0) / 1000)}s`
@@ -198,14 +205,42 @@ export const useInventoryMobileScannerStore = defineStore('inventoryMobileScanne
 
 			let localQuantity = null
 			if (op.type === 'receive') {
-				localQuantity = await applyDelta(this.db, op.sku, op.location, Number(op.quantity), timestamp)
+				localQuantity = await applyDelta(
+					this.db,
+					op.sku,
+					op.location,
+					Number(op.quantity),
+					timestamp,
+				)
 			} else if (op.type === 'pick') {
-				localQuantity = await applyDelta(this.db, op.sku, op.location, -Math.abs(Number(op.quantity)), timestamp)
+				localQuantity = await applyDelta(
+					this.db,
+					op.sku,
+					op.location,
+					-Math.abs(Number(op.quantity)),
+					timestamp,
+				)
 			} else if (op.type === 'transfer') {
-				await applyDelta(this.db, op.sku, op.location, -Math.abs(Number(op.quantity)), timestamp)
-				localQuantity = await applyDelta(this.db, op.sku, op.toLocation, Math.abs(Number(op.quantity)), timestamp)
+				await applyDelta(
+					this.db,
+					op.sku,
+					op.location,
+					-Math.abs(Number(op.quantity)),
+					timestamp,
+				)
+				localQuantity = await applyDelta(
+					this.db,
+					op.sku,
+					op.toLocation,
+					Math.abs(Number(op.quantity)),
+					timestamp,
+				)
 			} else if (op.type === 'count') {
-				const systemQty = await readStockQuantity(this.db, op.sku, op.location)
+				const systemQty = await readStockQuantity(
+					this.db,
+					op.sku,
+					op.location,
+				)
 				if (op.reconcile === true) {
 					localQuantity = await applyDelta(
 						this.db,
@@ -228,7 +263,8 @@ export const useInventoryMobileScannerStore = defineStore('inventoryMobileScanne
 				toLocation: op.toLocation,
 				orderLineId: op.orderLineId,
 				quantity: op.quantity != null ? Number(op.quantity) : null,
-				physicalQuantity: op.physicalQuantity != null ? Number(op.physicalQuantity) : null,
+				physicalQuantity:
+					op.physicalQuantity != null ? Number(op.physicalQuantity) : null,
 				reconcile: op.reconcile === true,
 				timestamp,
 				synced: false,

--- a/src/store/modules/object.js
+++ b/src/store/modules/object.js
@@ -64,7 +64,9 @@ export const useObjectStore = defineStore('object', {
 				const url = new URL(this.baseUrl, window.location.origin)
 				url.searchParams.set('register', register)
 				url.searchParams.set('schema', schema)
-				Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v))
+				Object.entries(params).forEach(([k, v]) =>
+					url.searchParams.set(k, v),
+				)
 
 				const response = await fetch(url.toString(), {
 					headers: { requesttoken: OC.requestToken },

--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -25,9 +25,12 @@ export const useSettingsStore = defineStore('settings', {
 		async fetchSettings() {
 			this.loading = true
 			try {
-				const response = await fetch(generateUrl('/apps/shillinq/api/settings'), {
-					headers: { requesttoken: OC.requestToken },
-				})
+				const response = await fetch(
+					generateUrl('/apps/shillinq/api/settings'),
+					{
+						headers: { requesttoken: OC.requestToken },
+					},
+				)
 				if (response.ok) {
 					const data = await response.json()
 					this.settings = data
@@ -53,14 +56,17 @@ export const useSettingsStore = defineStore('settings', {
 		async saveSettings(settings) {
 			this.loading = true
 			try {
-				const response = await fetch(generateUrl('/apps/shillinq/api/settings'), {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-						requesttoken: OC.requestToken,
+				const response = await fetch(
+					generateUrl('/apps/shillinq/api/settings'),
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							requesttoken: OC.requestToken,
+						},
+						body: JSON.stringify(settings),
 					},
-					body: JSON.stringify(settings),
-				})
+				)
 				if (response.ok) {
 					const data = await response.json()
 					this.settings = data

--- a/src/styles/widget.css
+++ b/src/styles/widget.css
@@ -23,7 +23,8 @@
 	--wsw-border-color: #cccccc;
 	--wsw-success-color: #2d7500;
 	--wsw-error-color: #f83838;
-	--wsw-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+	--wsw-font-family:
+		-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 	--wsw-font-size-base: 16px;
 	--wsw-spacing-unit: 8px;
 	--wsw-border-radius: 4px;

--- a/src/utils/extractionConfidence.js
+++ b/src/utils/extractionConfidence.js
@@ -59,7 +59,10 @@ export function confidenceForField(record, field) {
  * @return {boolean}
  */
 export function isFieldCorrected(record, field) {
-	return Array.isArray(record?.humanCorrected) && record.humanCorrected.includes(field)
+	return (
+		Array.isArray(record?.humanCorrected)
+		&& record.humanCorrected.includes(field)
+	)
 }
 
 /**
@@ -90,7 +93,8 @@ export function requiresExplicitReview(record) {
 export function pendingDraftSummary(record, labelField = 'id') {
 	const r = record || {}
 	const label = String(r[labelField] || r.id || '')
-	const overall = typeof r.overallConfidence === 'number' ? r.overallConfidence : null
+	const overall =
+		typeof r.overallConfidence === 'number' ? r.overallConfidence : null
 	return { id: String(r.id ?? ''), label, overallConfidence: overall }
 }
 
@@ -111,7 +115,10 @@ export function pendingDraftSummary(record, labelField = 'id') {
  * @return {boolean}
  */
 export function hasKnownExtractionId(record) {
-	return typeof record?.docudeskExtractionId === 'string' && record.docudeskExtractionId.trim().length > 0
+	return (
+		typeof record?.docudeskExtractionId === 'string'
+		&& record.docudeskExtractionId.trim().length > 0
+	)
 }
 
 /**
@@ -137,7 +144,8 @@ export function glAccountSuggestionSummary(response) {
 	return {
 		code,
 		label: String(suggestion.label ?? ''),
-		confidence: typeof suggestion.confidence === 'number' ? suggestion.confidence : null,
+		confidence:
+			typeof suggestion.confidence === 'number' ? suggestion.confidence : null,
 		rationale: String(suggestion.rationale ?? ''),
 		source: String(suggestion.source ?? 'none'),
 	}

--- a/src/utils/mergeFragmentIntoManifest.js
+++ b/src/utils/mergeFragmentIntoManifest.js
@@ -44,7 +44,9 @@
  */
 export function mergeFullFragmentIntoManifest(manifest, fullFragment) {
 	const pages = Array.isArray(manifest && manifest.pages) ? manifest.pages : []
-	const fullPages = Array.isArray(fullFragment && fullFragment.pages) ? fullFragment.pages : []
+	const fullPages = Array.isArray(fullFragment && fullFragment.pages)
+		? fullFragment.pages
+		: []
 
 	let updated = 0
 	let appended = 0
@@ -87,7 +89,11 @@ export function buildPageFragmentIndex(pages) {
 	}
 
 	for (const page of pages) {
-		if (page && typeof page.id === 'string' && typeof page._fragment === 'string') {
+		if (
+			page
+			&& typeof page.id === 'string'
+			&& typeof page._fragment === 'string'
+		) {
 			index.set(page.id, page._fragment)
 		}
 	}

--- a/src/views/AccountantPortalDashboard.vue
+++ b/src/views/AccountantPortalDashboard.vue
@@ -28,26 +28,45 @@
 					{{ t('shillinq', 'Accountant portal') }}
 				</h2>
 				<p class="accountant-portal__description">
-					{{ t('shillinq', 'Status overview of every client administration you have access to. Only administrations you have a membership for are listed.') }}
+					{{
+						t(
+							'shillinq',
+							'Status overview of every client administration you have access to. Only administrations you have a membership for are listed.',
+						)
+					}}
 				</p>
 			</header>
 
-			<NcLoadingIcon v-if="loading"
+			<NcLoadingIcon
+				v-if="loading"
 				:size="32"
 				:name="t('shillinq', 'Loading client administrations')" />
-			<NcEmptyContent v-else-if="!administrations.length"
+			<NcEmptyContent
+				v-else-if="!administrations.length"
 				:name="t('shillinq', 'No client administrations')"
-				:description="t('shillinq', 'You have no administration memberships yet. Ask an administration owner to grant you access.')" />
+				:description="
+					t(
+						'shillinq',
+						'You have no administration memberships yet. Ask an administration owner to grant you access.',
+					)
+				" />
 			<div v-else class="accountant-portal__grid">
-				<article v-for="client in administrations"
+				<article
+					v-for="client in administrations"
 					:key="client.administrationId"
 					class="accountant-portal__card"
 					data-testid="accountant-client-card">
 					<header class="accountant-portal__card-header">
 						<h3 class="accountant-portal__card-title">
-							{{ client.name || client.administrationCode || client.administrationId }}
+							{{
+								client.name
+								|| client.administrationCode
+								|| client.administrationId
+							}}
 						</h3>
-						<span class="accountant-portal__role-badge">{{ client.role }}</span>
+						<span class="accountant-portal__role-badge">{{
+							client.role
+						}}</span>
 					</header>
 
 					<dl class="accountant-portal__status-list">
@@ -57,31 +76,48 @@
 						</div>
 						<div class="accountant-portal__status-row">
 							<dt>{{ t('shillinq', 'BTW filing') }}</dt>
-							<dd :class="{ 'accountant-portal__status-row--overdue': client.vatFiling && client.vatFiling.overdue }">
+							<dd
+								:class="{
+									'accountant-portal__status-row--overdue':
+										client.vatFiling && client.vatFiling.overdue,
+								}">
 								{{ vatFilingLabel(client.vatFiling) }}
 							</dd>
 						</div>
 						<div class="accountant-portal__status-row">
 							<dt>{{ t('shillinq', 'Missing documents') }}</dt>
-							<dd :class="{ 'accountant-portal__status-row--overdue': client.missingDocuments > 0 }">
+							<dd
+								:class="{
+									'accountant-portal__status-row--overdue':
+										client.missingDocuments > 0,
+								}">
 								{{ client.missingDocuments }}
 							</dd>
 						</div>
 						<div class="accountant-portal__status-row">
 							<dt>{{ t('shillinq', 'Needs attention') }}</dt>
-							<dd :class="{ 'accountant-portal__status-row--overdue': client.openItemsCount > 0 }">
+							<dd
+								:class="{
+									'accountant-portal__status-row--overdue':
+										client.openItemsCount > 0,
+								}">
 								{{ client.openItemsCount }}
 							</dd>
 						</div>
 					</dl>
 
-					<ul v-if="client.attentionItems && client.attentionItems.length" class="accountant-portal__attention-list">
-						<li v-for="item in client.attentionItems.slice(0, 3)" :key="item.id">
+					<ul
+						v-if="client.attentionItems && client.attentionItems.length"
+						class="accountant-portal__attention-list">
+						<li
+							v-for="item in client.attentionItems.slice(0, 3)"
+							:key="item.id">
 							{{ item.message }}
 						</li>
 					</ul>
 
-					<NcButton variant="secondary"
+					<NcButton
+						variant="secondary"
 						data-testid="accountant-handover-pack-button"
 						@click="downloadPack(client.administrationId)">
 						{{ t('shillinq', 'Download handover pack') }}
@@ -97,8 +133,16 @@
 </template>
 
 <script>
-import { NcAppContent, NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
-import { fetchAccountantDashboard, downloadHandoverPack } from '../api/accountantApi.js'
+import {
+	NcAppContent,
+	NcButton,
+	NcEmptyContent,
+	NcLoadingIcon,
+} from '@nextcloud/vue'
+import {
+	fetchAccountantDashboard,
+	downloadHandoverPack,
+} from '../api/accountantApi.js'
 
 export default {
 	name: 'AccountantPortalDashboard',
@@ -135,13 +179,21 @@ export default {
 
 			try {
 				const data = await fetchAccountantDashboard()
-				this.administrations = Array.isArray(data?.administrations) ? data.administrations : []
+				this.administrations = Array.isArray(data?.administrations)
+					? data.administrations
+					: []
 			} catch (error) {
 				const status = error?.response?.status
 				if (status === 401) {
-					this.errorMessage = this.t('shillinq', 'Please sign in to view the accountant portal.')
+					this.errorMessage = this.t(
+						'shillinq',
+						'Please sign in to view the accountant portal.',
+					)
 				} else {
-					this.errorMessage = this.t('shillinq', 'Failed to load the accountant dashboard.')
+					this.errorMessage = this.t(
+						'shillinq',
+						'Failed to load the accountant dashboard.',
+					)
 				}
 			} finally {
 				this.loading = false

--- a/src/views/AdministrationSwitcherPage.vue
+++ b/src/views/AdministrationSwitcherPage.vue
@@ -17,12 +17,18 @@
 				{{ t('shillinq', 'Switch administration') }}
 			</h2>
 			<p class="administratie-switcher-page__description">
-				{{ t('shillinq', 'Select which administration you want to work in. Only administrations you have a membership for are listed.') }}
+				{{
+					t(
+						'shillinq',
+						'Select which administration you want to work in. Only administrations you have a membership for are listed.',
+					)
+				}}
 			</p>
-			<AdministratieSwitcher
-				:reload-after-switch="true"
-				@error="onError" />
-			<p v-if="errorMessage" class="administratie-switcher-page__error" role="alert">
+			<AdministratieSwitcher :reload-after-switch="true" @error="onError" />
+			<p
+				v-if="errorMessage"
+				class="administratie-switcher-page__error"
+				role="alert">
 				{{ errorMessage }}
 			</p>
 		</div>
@@ -57,7 +63,10 @@ export default {
 		onError(error) {
 			const status = error?.response?.status
 			if (status === 401) {
-				this.errorMessage = t('shillinq', 'Please sign in to switch administrations.')
+				this.errorMessage = t(
+					'shillinq',
+					'Please sign in to switch administrations.',
+				)
 				return
 			}
 			this.errorMessage = t('shillinq', 'Failed to load administrations.')

--- a/src/views/BookingWidgetKeys.vue
+++ b/src/views/BookingWidgetKeys.vue
@@ -9,32 +9,45 @@
 				id="wsw-business-id"
 				v-model.trim="businessId"
 				type="text"
-				class="shillinq-widget-keys__input">
+				class="shillinq-widget-keys__input" />
 		</div>
 
 		<div class="shillinq-widget-keys__field">
-			<label for="wsw-administration-id">{{ t('shillinq', 'Administration ID') }}</label>
+			<label for="wsw-administration-id">{{
+				t('shillinq', 'Administration ID')
+			}}</label>
 			<input
 				id="wsw-administration-id"
 				v-model.trim="administrationId"
 				type="text"
-				class="shillinq-widget-keys__input">
+				class="shillinq-widget-keys__input" />
 		</div>
 
 		<div class="shillinq-widget-keys__actions">
-			<NcButton variant="primary" :disabled="!businessId || !administrationId || busy" @click="generate">
+			<NcButton
+				variant="primary"
+				:disabled="!businessId || !administrationId || busy"
+				@click="generate">
 				{{ t('shillinq', 'Generate key') }}
 			</NcButton>
-			<NcButton variant="secondary" :disabled="!businessId || busy" @click="rotate">
+			<NcButton
+				variant="secondary"
+				:disabled="!businessId || busy"
+				@click="rotate">
 				{{ t('shillinq', 'Rotate key') }}
 			</NcButton>
-			<NcButton variant="error" :disabled="!businessId || busy" @click="revoke">
+			<NcButton
+				variant="error"
+				:disabled="!businessId || busy"
+				@click="revoke">
 				{{ t('shillinq', 'Revoke key') }}
 			</NcButton>
 		</div>
 
 		<div v-if="plaintextKey" class="shillinq-widget-keys__key" role="status">
-			<strong>{{ t('shillinq', 'Copy this key now — it will not be shown again') }}</strong>
+			<strong>{{
+				t('shillinq', 'Copy this key now — it will not be shown again')
+			}}</strong>
 			<code>{{ plaintextKey }}</code>
 		</div>
 
@@ -69,14 +82,17 @@ export default {
 			this.busy = true
 			this.message = ''
 			try {
-				const response = await fetch(generateUrl(`/apps/shillinq/api/${path}`), {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-						requesttoken: OC.requestToken,
+				const response = await fetch(
+					generateUrl(`/apps/shillinq/api/${path}`),
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							requesttoken: OC.requestToken,
+						},
+						body: JSON.stringify(body),
 					},
-					body: JSON.stringify(body),
-				})
+				)
 				return await response.json()
 			} catch (error) {
 				console.error('Widget key request failed:', error)
@@ -126,7 +142,9 @@ export default {
 		},
 		async revoke() {
 			this.plaintextKey = ''
-			const result = await this.post('widget/admin/keys/revoke', { businessId: this.businessId })
+			const result = await this.post('widget/admin/keys/revoke', {
+				businessId: this.businessId,
+			})
 			this.message = result.message || ''
 		},
 	},

--- a/src/views/BudgetLineCommitments.vue
+++ b/src/views/BudgetLineCommitments.vue
@@ -22,17 +22,29 @@
 					{{ t('shillinq', 'Committed vs. realised per budget line') }}
 				</h2>
 				<p class="budget-line-commitments__description">
-					{{ t('shillinq', 'Per-budget-line breakdown of authorized, committed, realised and available budget, drilling down to the underlying commitments (Verplichtingen).') }}
+					{{
+						t(
+							'shillinq',
+							'Per-budget-line breakdown of authorized, committed, realised and available budget, drilling down to the underlying commitments (Verplichtingen).',
+						)
+					}}
 				</p>
 			</header>
 
 			<section class="budget-line-commitments__body">
-				<NcLoadingIcon v-if="loading"
+				<NcLoadingIcon
+					v-if="loading"
 					:size="32"
 					:name="t('shillinq', 'Loading budget lines')" />
-				<NcEmptyContent v-else-if="!rows.length"
+				<NcEmptyContent
+					v-else-if="!rows.length"
 					:name="t('shillinq', 'No budget lines')"
-					:description="t('shillinq', 'No Verplichtingsregel records exist yet. Approve a purchase order or sign a contract to materialise a commitment.')" />
+					:description="
+						t(
+							'shillinq',
+							'No Verplichtingsregel records exist yet. Approve a purchase order or sign a contract to materialise a commitment.',
+						)
+					" />
 				<table v-else class="budget-line-commitments__table">
 					<thead>
 						<tr>
@@ -48,16 +60,24 @@
 							<th scope="col">
 								{{ t('shillinq', 'GL account') }}
 							</th>
-							<th scope="col" class="budget-line-commitments__amount-col">
+							<th
+								scope="col"
+								class="budget-line-commitments__amount-col">
 								{{ t('shillinq', 'Authorized') }}
 							</th>
-							<th scope="col" class="budget-line-commitments__amount-col">
+							<th
+								scope="col"
+								class="budget-line-commitments__amount-col">
 								{{ t('shillinq', 'Committed') }}
 							</th>
-							<th scope="col" class="budget-line-commitments__amount-col">
+							<th
+								scope="col"
+								class="budget-line-commitments__amount-col">
 								{{ t('shillinq', 'Realised') }}
 							</th>
-							<th scope="col" class="budget-line-commitments__amount-col">
+							<th
+								scope="col"
+								class="budget-line-commitments__amount-col">
 								{{ t('shillinq', 'Available') }}
 							</th>
 						</tr>
@@ -66,7 +86,8 @@
 						<!-- Vue 3 requires the v-for key on the <template> itself; the
 						     Vue 2 spelling put one on each child and is a compile error. -->
 						<template v-for="row in rows" :key="row.key">
-							<tr class="budget-line-commitments__row"
+							<tr
+								class="budget-line-commitments__row"
 								data-testid="budget-line-row"
 								tabindex="0"
 								role="button"
@@ -88,21 +109,51 @@
 								<td class="budget-line-commitments__amount-cell">
 									{{ formatAmount(row.gerealiseerd) }}
 								</td>
-								<td class="budget-line-commitments__amount-cell"
-									:class="{ 'budget-line-commitments__amount-cell--negative': row.vrij < 0 }">
+								<td
+									class="budget-line-commitments__amount-cell"
+									:class="{
+										'budget-line-commitments__amount-cell--negative':
+											row.vrij < 0,
+									}">
 									{{ formatAmount(row.vrij) }}
 								</td>
 							</tr>
-							<tr v-if="expandedKey === row.key" class="budget-line-commitments__drilldown-row">
+							<tr
+								v-if="expandedKey === row.key"
+								class="budget-line-commitments__drilldown-row">
 								<td colspan="8">
-									<NcLoadingIcon v-if="drilldownLoading" :size="20" />
-									<p v-else-if="!drilldownItems.length" class="budget-line-commitments__drilldown-empty">
-										{{ t('shillinq', 'No underlying commitments found for this line.') }}
+									<NcLoadingIcon
+										v-if="drilldownLoading"
+										:size="20" />
+									<p
+										v-else-if="!drilldownItems.length"
+										class="budget-line-commitments__drilldown-empty">
+										{{
+											t(
+												'shillinq',
+												'No underlying commitments found for this line.',
+											)
+										}}
 									</p>
-									<ul v-else class="budget-line-commitments__drilldown-list" data-testid="budget-line-drilldown">
-										<li v-for="item in drilldownItems" :key="item.id || item.verplichting">
-											<span class="budget-line-commitments__drilldown-verplichting">{{ item.verplichting }}</span>
-											<span class="budget-line-commitments__drilldown-amount">{{ formatAmount(item.bedrag_excl_btw) }}</span>
+									<ul
+										v-else
+										class="budget-line-commitments__drilldown-list"
+										data-testid="budget-line-drilldown">
+										<li
+											v-for="item in drilldownItems"
+											:key="item.id || item.verplichting">
+											<span
+												class="budget-line-commitments__drilldown-verplichting"
+												>{{ item.verplichting }}</span
+											>
+											<span
+												class="budget-line-commitments__drilldown-amount"
+												>{{
+													formatAmount(
+														item.bedrag_excl_btw,
+													)
+												}}</span
+											>
 										</li>
 									</ul>
 								</td>
@@ -110,7 +161,10 @@
 						</template>
 					</tbody>
 				</table>
-				<p v-if="errorMessage" class="budget-line-commitments__error" role="alert">
+				<p
+					v-if="errorMessage"
+					class="budget-line-commitments__error"
+					role="alert">
 					{{ errorMessage }}
 				</p>
 			</section>
@@ -122,7 +176,11 @@
 import { NcAppContent, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
 import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
-import { normaliseBudgetLineRows, formatAmount, drilldownFilters } from './budgetLineCommitmentsHelpers.js'
+import {
+	normaliseBudgetLineRows,
+	formatAmount,
+	drilldownFilters,
+} from './budgetLineCommitmentsHelpers.js'
 
 export default {
 	name: 'BudgetLineCommitments',
@@ -165,11 +223,20 @@ export default {
 			} catch (error) {
 				const status = error?.response?.status
 				if (status === 404 || status === 501) {
-					this.errorMessage = this.t('shillinq', 'Aggregation endpoint unavailable on this OpenRegister build.')
+					this.errorMessage = this.t(
+						'shillinq',
+						'Aggregation endpoint unavailable on this OpenRegister build.',
+					)
 				} else if (status === 401 || status === 403) {
-					this.errorMessage = this.t('shillinq', 'Permission required to read budget-line data.')
+					this.errorMessage = this.t(
+						'shillinq',
+						'Permission required to read budget-line data.',
+					)
 				} else {
-					this.errorMessage = this.t('shillinq', 'Failed to load budget lines.')
+					this.errorMessage = this.t(
+						'shillinq',
+						'Failed to load budget lines.',
+					)
 				}
 			} finally {
 				this.loading = false
@@ -198,9 +265,15 @@ export default {
 				Object.keys(filters).forEach((key) => {
 					params[`filters[${key}]`] = filters[key]
 				})
-				const url = generateUrl('/apps/shillinq/api/openregister/objects/Verplichtingsregel')
+				const url = generateUrl(
+					'/apps/shillinq/api/openregister/objects/Verplichtingsregel',
+				)
 				const { data } = await axios.get(url, { params })
-				const items = Array.isArray(data?.results) ? data.results : (Array.isArray(data) ? data : [])
+				const items = Array.isArray(data?.results)
+					? data.results
+					: Array.isArray(data)
+						? data
+						: []
 				this.drilldownItems = items
 			} catch (error) {
 				this.drilldownItems = []

--- a/src/views/DeadlineCalendarSettings.vue
+++ b/src/views/DeadlineCalendarSettings.vue
@@ -20,20 +20,31 @@
 					{{ t('shillinq', 'Deadline calendar') }}
 				</h2>
 				<p class="deadline-calendar-settings__description">
-					{{ t('shillinq', 'Choose which deadline categories appear on your deadline calendar and when you want to be reminded. Filing, payment-run and contract deadlines are on by default; invoice due dates are opt-in.') }}
+					{{
+						t(
+							'shillinq',
+							'Choose which deadline categories appear on your deadline calendar and when you want to be reminded. Filing, payment-run and contract deadlines are on by default; invoice due dates are opt-in.',
+						)
+					}}
 				</p>
 			</header>
 
 			<section class="deadline-calendar-settings__body">
-				<NcLoadingIcon v-if="loading"
+				<NcLoadingIcon
+					v-if="loading"
 					:size="32"
 					:name="t('shillinq', 'Loading deadline calendar settings')" />
-				<form v-else class="deadline-calendar-settings__form" @submit.prevent="save">
-					<fieldset v-for="row in rows"
+				<form
+					v-else
+					class="deadline-calendar-settings__form"
+					@submit.prevent="save">
+					<fieldset
+						v-for="row in rows"
 						:key="row.id"
 						class="deadline-calendar-settings__category"
 						:data-testid="'deadline-category-' + row.id">
-						<NcCheckboxRadioSwitch v-model="row.enabled"
+						<NcCheckboxRadioSwitch
+							v-model="row.enabled"
 							type="switch"
 							:data-testid="'deadline-toggle-' + row.id">
 							{{ t('shillinq', row.label) }}
@@ -41,7 +52,8 @@
 						<p class="deadline-calendar-settings__category-description">
 							{{ t('shillinq', row.description) }}
 						</p>
-						<NcTextField v-if="row.enabled"
+						<NcTextField
+							v-if="row.enabled"
 							v-model="row.leadDaysInput"
 							type="number"
 							min="0"
@@ -53,17 +65,28 @@
 					</fieldset>
 
 					<div class="deadline-calendar-settings__actions">
-						<NcButton variant="primary"
+						<NcButton
+							variant="primary"
 							type="submit"
 							:disabled="saving"
 							data-testid="deadline-settings-save">
-							{{ saving ? t('shillinq', 'Saving…') : t('shillinq', 'Save') }}
+							{{
+								saving
+									? t('shillinq', 'Saving…')
+									: t('shillinq', 'Save')
+							}}
 						</NcButton>
-						<span v-if="savedMessage" class="deadline-calendar-settings__saved" role="status">
+						<span
+							v-if="savedMessage"
+							class="deadline-calendar-settings__saved"
+							role="status">
 							{{ savedMessage }}
 						</span>
 					</div>
-					<p v-if="errorMessage" class="deadline-calendar-settings__error" role="alert">
+					<p
+						v-if="errorMessage"
+						class="deadline-calendar-settings__error"
+						role="alert">
 						{{ errorMessage }}
 					</p>
 				</form>
@@ -73,10 +96,19 @@
 </template>
 
 <script>
-import { NcAppContent, NcButton, NcCheckboxRadioSwitch, NcLoadingIcon, NcTextField } from '@nextcloud/vue'
+import {
+	NcAppContent,
+	NcButton,
+	NcCheckboxRadioSwitch,
+	NcLoadingIcon,
+	NcTextField,
+} from '@nextcloud/vue'
 import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
-import { normaliseSettings, buildSavePayload } from './deadlineCalendarSettingsHelpers.js'
+import {
+	normaliseSettings,
+	buildSavePayload,
+} from './deadlineCalendarSettingsHelpers.js'
 
 export default {
 	name: 'DeadlineCalendarSettings',
@@ -110,7 +142,9 @@ export default {
 			this.errorMessage = ''
 
 			try {
-				const url = generateUrl('/apps/shillinq/api/deadline-calendar/settings')
+				const url = generateUrl(
+					'/apps/shillinq/api/deadline-calendar/settings',
+				)
 				const { data } = await axios.get(url)
 				this.rows = normaliseSettings(data).map((row) => ({
 					...row,
@@ -122,7 +156,10 @@ export default {
 					...row,
 					leadDaysInput: String(row.leadDays),
 				}))
-				this.errorMessage = this.t('shillinq', 'Failed to load deadline calendar settings.')
+				this.errorMessage = this.t(
+					'shillinq',
+					'Failed to load deadline calendar settings.',
+				)
 			} finally {
 				this.loading = false
 			}
@@ -135,20 +172,30 @@ export default {
 			this.savedMessage = ''
 
 			try {
-				const payload = buildSavePayload(this.rows.map((row) => ({
-					id: row.id,
-					enabled: row.enabled,
-					leadDays: Number.parseInt(row.leadDaysInput, 10),
-				})))
-				const url = generateUrl('/apps/shillinq/api/deadline-calendar/settings')
+				const payload = buildSavePayload(
+					this.rows.map((row) => ({
+						id: row.id,
+						enabled: row.enabled,
+						leadDays: Number.parseInt(row.leadDaysInput, 10),
+					})),
+				)
+				const url = generateUrl(
+					'/apps/shillinq/api/deadline-calendar/settings',
+				)
 				const { data } = await axios.post(url, payload)
 				this.rows = normaliseSettings(data).map((row) => ({
 					...row,
 					leadDaysInput: String(row.leadDays),
 				}))
-				this.savedMessage = this.t('shillinq', 'Deadline calendar settings saved.')
+				this.savedMessage = this.t(
+					'shillinq',
+					'Deadline calendar settings saved.',
+				)
 			} catch (error) {
-				this.errorMessage = this.t('shillinq', 'Failed to save deadline calendar settings.')
+				this.errorMessage = this.t(
+					'shillinq',
+					'Failed to save deadline calendar settings.',
+				)
 			} finally {
 				this.saving = false
 			}

--- a/src/views/ReceiptCapture.vue
+++ b/src/views/ReceiptCapture.vue
@@ -49,11 +49,17 @@
 			</h1>
 		</header>
 
-		<div v-if="loading" class="receipt-capture__loading" data-testid="receipt-capture-loading">
+		<div
+			v-if="loading"
+			class="receipt-capture__loading"
+			data-testid="receipt-capture-loading">
 			{{ t('shillinq', 'Loading receipt...') }}
 		</div>
 
-		<div v-else-if="loadError" class="receipt-capture__error" data-testid="receipt-capture-error">
+		<div
+			v-else-if="loadError"
+			class="receipt-capture__error"
+			data-testid="receipt-capture-error">
 			<p>{{ loadError }}</p>
 			<button
 				type="button"
@@ -65,35 +71,52 @@
 		</div>
 
 		<div v-else class="receipt-capture__body">
-			<p v-if="isDraftReview" class="receipt-capture__hint" data-testid="receipt-capture-review-hint">
-				{{ requiresReview
-					? t('shillinq', 'Some fields have low confidence — please review before confirming.')
-					: t('shillinq', 'Extraction confidence is high. Review and confirm.') }}
+			<p
+				v-if="isDraftReview"
+				class="receipt-capture__hint"
+				data-testid="receipt-capture-review-hint">
+				{{
+					requiresReview
+						? t(
+								'shillinq',
+								'Some fields have low confidence — please review before confirming.',
+							)
+						: t(
+								'shillinq',
+								'Extraction confidence is high. Review and confirm.',
+							)
+				}}
 			</p>
 
 			<div class="receipt-capture__row">
 				<div class="receipt-capture__field">
-					<label class="receipt-capture__label" for="rc-receipt-number">{{ t('shillinq', 'Receipt #') }}</label>
+					<label class="receipt-capture__label" for="rc-receipt-number">{{
+						t('shillinq', 'Receipt #')
+					}}</label>
 					<input
 						id="rc-receipt-number"
 						v-model="form.receiptNumber"
 						type="text"
 						class="receipt-capture__input"
-						data-testid="rc-receipt-number">
+						data-testid="rc-receipt-number" />
 				</div>
 				<div class="receipt-capture__field">
-					<label class="receipt-capture__label" for="rc-photo-uri">{{ t('shillinq', 'Photo') }}</label>
+					<label class="receipt-capture__label" for="rc-photo-uri">{{
+						t('shillinq', 'Photo')
+					}}</label>
 					<input
 						id="rc-photo-uri"
 						v-model="form.photoUri"
 						type="text"
 						class="receipt-capture__input"
-						data-testid="rc-photo-uri">
+						data-testid="rc-photo-uri" />
 				</div>
 			</div>
 
 			<div class="receipt-capture__field">
-				<label class="receipt-capture__label" for="rc-amount">{{ t('shillinq', 'Amount') }}</label>
+				<label class="receipt-capture__label" for="rc-amount">{{
+					t('shillinq', 'Amount')
+				}}</label>
 				<div class="receipt-capture__field-row">
 					<input
 						id="rc-amount"
@@ -101,7 +124,7 @@
 						type="number"
 						step="0.01"
 						class="receipt-capture__input"
-						data-testid="rc-amount">
+						data-testid="rc-amount" />
 					<FieldConfidenceBadge
 						v-if="isDraftReview"
 						field="amount"
@@ -112,23 +135,27 @@
 
 			<div class="receipt-capture__row">
 				<div class="receipt-capture__field">
-					<label class="receipt-capture__label" for="rc-currency">{{ t('shillinq', 'Currency') }}</label>
+					<label class="receipt-capture__label" for="rc-currency">{{
+						t('shillinq', 'Currency')
+					}}</label>
 					<input
 						id="rc-currency"
 						v-model="form.currency"
 						type="text"
 						class="receipt-capture__input"
-						data-testid="rc-currency">
+						data-testid="rc-currency" />
 				</div>
 				<div class="receipt-capture__field">
-					<label class="receipt-capture__label" for="rc-receipt-date">{{ t('shillinq', 'Receipt date') }}</label>
+					<label class="receipt-capture__label" for="rc-receipt-date">{{
+						t('shillinq', 'Receipt date')
+					}}</label>
 					<div class="receipt-capture__field-row">
 						<input
 							id="rc-receipt-date"
 							v-model="form.receiptDate"
 							type="date"
 							class="receipt-capture__input"
-							data-testid="rc-receipt-date">
+							data-testid="rc-receipt-date" />
 						<FieldConfidenceBadge
 							v-if="isDraftReview"
 							field="receiptDate"
@@ -139,13 +166,15 @@
 			</div>
 
 			<div class="receipt-capture__field">
-				<label class="receipt-capture__label" for="rc-category">{{ t('shillinq', 'Category') }}</label>
+				<label class="receipt-capture__label" for="rc-category">{{
+					t('shillinq', 'Category')
+				}}</label>
 				<input
 					id="rc-category"
 					v-model="form.category"
 					type="text"
 					class="receipt-capture__input"
-					data-testid="rc-category">
+					data-testid="rc-category" />
 			</div>
 
 			<div class="receipt-capture__field">
@@ -164,13 +193,21 @@
 			<!-- gl-account-suggestion-consume (REQ-GAC-003/004) — same pattern as
 			     BillImportModal: the operator must click "Use suggestion" AND
 			     Save — never auto-filled/auto-booked. -->
-			<div v-if="glSuggestion" class="receipt-capture__suggestion" data-testid="rc-gl-suggestion">
+			<div
+				v-if="glSuggestion"
+				class="receipt-capture__suggestion"
+				data-testid="rc-gl-suggestion">
 				<div class="receipt-capture__field-row">
 					<FieldConfidenceBadge
 						field="suggestedGlAccount"
 						:confidence="glSuggestion.confidence" />
 					<span class="receipt-capture__suggestion-text">
-						{{ t('shillinq', 'Suggested: {code} {label}', { code: glSuggestion.code, label: glSuggestion.label }) }}
+						{{
+							t('shillinq', 'Suggested: {code} {label}', {
+								code: glSuggestion.code,
+								label: glSuggestion.label,
+							})
+						}}
 					</span>
 					<button
 						type="button"
@@ -181,23 +218,29 @@
 						{{ t('shillinq', 'Use suggestion') }}
 					</button>
 				</div>
-				<p class="receipt-capture__suggestion-rationale" data-testid="rc-gl-suggestion-rationale">
+				<p
+					class="receipt-capture__suggestion-rationale"
+					data-testid="rc-gl-suggestion-rationale">
 					{{ glSuggestion.rationale }}
 				</p>
 			</div>
 
 			<div class="receipt-capture__field">
-				<label class="receipt-capture__label" for="rc-vendor">{{ t('shillinq', 'Vendor') }}</label>
+				<label class="receipt-capture__label" for="rc-vendor">{{
+					t('shillinq', 'Vendor')
+				}}</label>
 				<input
 					id="rc-vendor"
 					v-model="form.vendorName"
 					type="text"
 					class="receipt-capture__input"
-					data-testid="rc-vendor">
+					data-testid="rc-vendor" />
 			</div>
 
 			<div class="receipt-capture__field">
-				<label class="receipt-capture__label" for="rc-extracted-text">{{ t('shillinq', 'Extracted text') }}</label>
+				<label class="receipt-capture__label" for="rc-extracted-text">{{
+					t('shillinq', 'Extracted text')
+				}}</label>
 				<textarea
 					id="rc-extracted-text"
 					v-model="form.extractedText"
@@ -208,59 +251,72 @@
 
 			<div class="receipt-capture__row">
 				<div class="receipt-capture__field">
-					<label class="receipt-capture__label" for="rc-amount-base">{{ t('shillinq', 'Amount (EUR)') }}</label>
+					<label class="receipt-capture__label" for="rc-amount-base">{{
+						t('shillinq', 'Amount (EUR)')
+					}}</label>
 					<input
 						id="rc-amount-base"
 						v-model.number="form.amountInBaseCurrency"
 						type="number"
 						step="0.01"
 						class="receipt-capture__input"
-						data-testid="rc-amount-base">
+						data-testid="rc-amount-base" />
 				</div>
 				<div class="receipt-capture__field">
-					<label class="receipt-capture__label" for="rc-exchange-rate">{{ t('shillinq', 'Exchange Rate') }}</label>
+					<label class="receipt-capture__label" for="rc-exchange-rate">{{
+						t('shillinq', 'Exchange Rate')
+					}}</label>
 					<input
 						id="rc-exchange-rate"
 						v-model.number="form.exchangeRate"
 						type="number"
 						step="0.0001"
 						class="receipt-capture__input"
-						data-testid="rc-exchange-rate">
+						data-testid="rc-exchange-rate" />
 				</div>
 			</div>
 
 			<div class="receipt-capture__row">
 				<div class="receipt-capture__field">
-					<label class="receipt-capture__label" for="rc-cost-centre">{{ t('shillinq', 'Cost Centre') }}</label>
+					<label class="receipt-capture__label" for="rc-cost-centre">{{
+						t('shillinq', 'Cost Centre')
+					}}</label>
 					<input
 						id="rc-cost-centre"
 						v-model="form.costCentreCode"
 						type="text"
 						class="receipt-capture__input"
-						data-testid="rc-cost-centre">
+						data-testid="rc-cost-centre" />
 				</div>
 				<div class="receipt-capture__field">
-					<label class="receipt-capture__label" for="rc-claim">{{ t('shillinq', 'Claim') }}</label>
+					<label class="receipt-capture__label" for="rc-claim">{{
+						t('shillinq', 'Claim')
+					}}</label>
 					<input
 						id="rc-claim"
 						v-model="form.claimId"
 						type="text"
 						class="receipt-capture__input"
-						data-testid="rc-claim">
+						data-testid="rc-claim" />
 				</div>
 			</div>
 
 			<div class="receipt-capture__field">
-				<label class="receipt-capture__label" for="rc-description">{{ t('shillinq', 'Description') }}</label>
+				<label class="receipt-capture__label" for="rc-description">{{
+					t('shillinq', 'Description')
+				}}</label>
 				<input
 					id="rc-description"
 					v-model="form.description"
 					type="text"
 					class="receipt-capture__input"
-					data-testid="rc-description">
+					data-testid="rc-description" />
 			</div>
 
-			<p v-if="sourceDocumentUri" class="receipt-capture__source" data-testid="rc-source-document">
+			<p
+				v-if="sourceDocumentUri"
+				class="receipt-capture__source"
+				data-testid="rc-source-document">
 				{{ t('shillinq', 'Source document') }}: {{ sourceDocumentUri }}
 			</p>
 
@@ -284,7 +340,10 @@
 				</button>
 			</div>
 
-			<p v-if="saveError" class="receipt-capture__error" data-testid="rc-save-error">
+			<p
+				v-if="saveError"
+				class="receipt-capture__error"
+				data-testid="rc-save-error">
 				{{ saveError }}
 			</p>
 		</div>
@@ -307,7 +366,12 @@ import {
 	hasKnownExtractionId,
 	glAccountSuggestionSummary,
 } from '../utils/extractionConfidence.js'
-import { reviewFormFromReceipt, canSaveReceipt, buildReceiptConfirmPayload, receiptErrorMessage } from './receiptCapture.js'
+import {
+	reviewFormFromReceipt,
+	canSaveReceipt,
+	buildReceiptConfirmPayload,
+	receiptErrorMessage,
+} from './receiptCapture.js'
 
 const REGISTER_SLUG = 'shillinq'
 const RECEIPT_SCHEMA = 'Receipt'
@@ -335,7 +399,9 @@ export default {
 	},
 	computed: {
 		hasIndexRoute() {
-			return !!this.$router?.options?.routes?.some?.((r) => r.name === 'Receipts')
+			return !!this.$router?.options?.routes?.some?.(
+				(r) => r.name === 'Receipts',
+			)
 		},
 		/** @spec openspec/specs/receipt-extraction-consume/spec.md */
 		isDraftReview() {
@@ -380,7 +446,9 @@ export default {
 			this.loadError = ''
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${RECEIPT_SCHEMA}/${this.id}`),
+					generateUrl(
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/${RECEIPT_SCHEMA}/${this.id}`,
+					),
 				)
 				const body = response.data?.object ?? response.data ?? null
 				if (!body || typeof body !== 'object') {
@@ -411,7 +479,9 @@ export default {
 
 			try {
 				const response = await axios.post(
-					generateUrl(`/apps/shillinq/api/v1/extraction/drafts/${this.id}/suggest-account?schema=${RECEIPT_SCHEMA}`),
+					generateUrl(
+						`/apps/shillinq/api/v1/extraction/drafts/${this.id}/suggest-account?schema=${RECEIPT_SCHEMA}`,
+					),
 				)
 				this.glSuggestion = glAccountSuggestionSummary(response.data)
 			} catch (e) {
@@ -443,16 +513,22 @@ export default {
 				const payload = buildReceiptConfirmPayload(this.form)
 				if (this.isDraftReview) {
 					const response = await axios.put(
-						generateUrl(`/apps/shillinq/api/v1/extraction/drafts/${this.id}?schema=${RECEIPT_SCHEMA}`),
+						generateUrl(
+							`/apps/shillinq/api/v1/extraction/drafts/${this.id}?schema=${RECEIPT_SCHEMA}`,
+						),
 						payload,
 					)
-					this.record = response.data?.record ?? response.data ?? this.record
+					this.record =
+						response.data?.record ?? response.data ?? this.record
 				} else {
 					const response = await axios.put(
-						generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${RECEIPT_SCHEMA}/${this.id}`),
+						generateUrl(
+							`/apps/openregister/api/objects/${REGISTER_SLUG}/${RECEIPT_SCHEMA}/${this.id}`,
+						),
 						{ ...this.record, ...payload },
 					)
-					this.record = response.data?.object ?? response.data ?? this.record
+					this.record =
+						response.data?.object ?? response.data ?? this.record
 				}
 				this.form = reviewFormFromReceipt(this.record)
 				showSuccess(t('shillinq', 'Receipt saved.'))
@@ -481,7 +557,12 @@ export default {
 						id: this.id,
 					},
 				)
-				showSuccess(t('shillinq', 'Extraction requested. The draft will update once docudesk responds.'))
+				showSuccess(
+					t(
+						'shillinq',
+						'Extraction requested. The draft will update once docudesk responds.',
+					),
+				)
 			} catch (e) {
 				this.saveError = receiptErrorMessage(e)
 				showError(this.saveError)

--- a/src/views/bookings/AfspraakDetail.vue
+++ b/src/views/bookings/AfspraakDetail.vue
@@ -63,18 +63,17 @@
 			</button>
 		</div>
 
-		<div
-			v-else-if="payload"
-			class="afspraak-detail__body">
-			<section class="afspraak-detail__summary" data-testid="afspraak-detail-summary">
+		<div v-else-if="payload" class="afspraak-detail__body">
+			<section
+				class="afspraak-detail__summary"
+				data-testid="afspraak-detail-summary">
 				<dl class="afspraak-detail__summary-fields">
 					<!-- Vue 3 requires the v-for key on the <template> itself. -->
 					<template v-for="field in summaryFields" :key="field.key">
 						<dt>
 							{{ label(field.label) }}
 						</dt>
-						<dd
-							:data-testid="`afspraak-detail-${field.key}`">
+						<dd :data-testid="`afspraak-detail-${field.key}`">
 							{{ field.value || emptyMarker }}
 						</dd>
 					</template>
@@ -158,7 +157,9 @@ export default {
 			// The Afspraken index route is registered by the same slice-01
 			// manifest fragment, so this is true in practice; the guard
 			// keeps the back link safe if the route is ever removed.
-			return !!this.$router?.options?.routes?.some?.((r) => r.name === 'Afspraken')
+			return !!this.$router?.options?.routes?.some?.(
+				(r) => r.name === 'Afspraken',
+			)
 		},
 		summaryFields() {
 			const booking = this.payload?.booking || {}
@@ -188,7 +189,9 @@ export default {
 				klantbeeld: {
 					...k,
 					transactions: this.accumulatedTransactions,
-					empty: this.accumulatedTransactions.length === 0 && k.unavailable !== true,
+					empty:
+						this.accumulatedTransactions.length === 0
+						&& k.unavailable !== true,
 				},
 			}
 		},
@@ -205,7 +208,9 @@ export default {
 				return false
 			}
 			const limit = Number(k.limit) || 0
-			const lastBatchSize = this._lastBatchSize ?? (Array.isArray(k.transactions) ? k.transactions.length : 0)
+			const lastBatchSize =
+				this._lastBatchSize
+				?? (Array.isArray(k.transactions) ? k.transactions.length : 0)
 			return limit > 0 && lastBatchSize >= limit
 		},
 	},
@@ -233,8 +238,11 @@ export default {
 			// API so the profile card can render an "Open in pipelinq"
 			// link. Failure leaves the link hidden (slice 06 still works).
 			try {
-				const response = await axios.get(generateUrl('/apps/shillinq/api/settings/pipelinq'))
-				const url = response?.data?.baseUrl || response?.data?.pipelinqBaseUrl || ''
+				const response = await axios.get(
+					generateUrl('/apps/shillinq/api/settings/pipelinq'),
+				)
+				const url =
+					response?.data?.baseUrl || response?.data?.pipelinqBaseUrl || ''
 				this.pipelinqBaseUrl = typeof url === 'string' ? url : ''
 			} catch (e) {
 				this.pipelinqBaseUrl = ''
@@ -248,7 +256,9 @@ export default {
 			this._lastBatchSize = null
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/shillinq/api/v1/bookings/${encodeURIComponent(this.id)}`),
+					generateUrl(
+						`/apps/shillinq/api/v1/bookings/${encodeURIComponent(this.id)}`,
+					),
 				)
 				this.payload = response?.data || null
 				const initial = this.payload?.klantbeeld?.transactions
@@ -264,11 +274,17 @@ export default {
 				if (status === 404) {
 					this.loadError = this.label('Booking not found')
 				} else if (status === 503) {
-					this.loadError = this.label('OpenRegister is temporarily unavailable')
+					this.loadError = this.label(
+						'OpenRegister is temporarily unavailable',
+					)
 				} else if (status === 401) {
-					this.loadError = this.label('Please sign in to view this booking')
+					this.loadError = this.label(
+						'Please sign in to view this booking',
+					)
 				} else {
-					this.loadError = e?.response?.data?.error || this.label('Failed to load booking')
+					this.loadError =
+						e?.response?.data?.error
+						|| this.label('Failed to load booking')
 				}
 				this.payload = null
 			} finally {
@@ -283,12 +299,15 @@ export default {
 			this.pagingError = ''
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/shillinq/api/v1/bookings/${encodeURIComponent(this.id)}`),
+					generateUrl(
+						`/apps/shillinq/api/v1/bookings/${encodeURIComponent(this.id)}`,
+					),
 					{ params: { limit, offset } },
 				)
 				const next = response?.data?.klantbeeld
 				if (next && Array.isArray(next.transactions)) {
-					this.accumulatedTransactions = this.accumulatedTransactions.concat(next.transactions)
+					this.accumulatedTransactions =
+						this.accumulatedTransactions.concat(next.transactions)
 					this._lastBatchSize = next.transactions.length
 					// Mirror the new offset / limit back to the envelope so a
 					// subsequent Load-more computes the right next page.
@@ -303,7 +322,9 @@ export default {
 					}
 				}
 			} catch (e) {
-				this.pagingError = e?.response?.data?.error || this.label('Failed to load more transactions')
+				this.pagingError =
+					e?.response?.data?.error
+					|| this.label('Failed to load more transactions')
 			} finally {
 				this.pagingLoading = false
 			}

--- a/src/views/bookings/BookingForm.vue
+++ b/src/views/bookings/BookingForm.vue
@@ -15,7 +15,7 @@
 				id="booking-title"
 				v-model="form.title"
 				type="text"
-				:placeholder="t('shillinq', 'Booking title')">
+				:placeholder="t('shillinq', 'Booking title')" />
 		</div>
 
 		<div class="booking-form__field">
@@ -23,15 +23,12 @@
 			<input
 				id="booking-start"
 				v-model="form.startTime"
-				type="datetime-local">
+				type="datetime-local" />
 		</div>
 
 		<div class="booking-form__field">
 			<label for="booking-end">{{ t('shillinq', 'End time') }}</label>
-			<input
-				id="booking-end"
-				v-model="form.endTime"
-				type="datetime-local">
+			<input id="booking-end" v-model="form.endTime" type="datetime-local" />
 		</div>
 
 		<div class="booking-form__field">
@@ -40,28 +37,35 @@
 				id="booking-attendee"
 				v-model="form.attendee"
 				type="text"
-				:placeholder="t('shillinq', 'Attendee name')">
+				:placeholder="t('shillinq', 'Attendee name')" />
 		</div>
 
 		<div class="booking-form__field">
 			<span class="booking-form__legend">{{ t('shillinq', 'Status') }}</span>
 			<label class="booking-form__radio">
-				<input v-model="form.status" type="radio" value="pending">
+				<input v-model="form.status" type="radio" value="pending" />
 				{{ t('shillinq', 'Pending') }}
 			</label>
 			<label class="booking-form__radio">
-				<input v-model="form.status" type="radio" value="confirmed">
+				<input v-model="form.status" type="radio" value="confirmed" />
 				{{ t('shillinq', 'Confirmed') }}
 			</label>
 		</div>
 
-		<p v-if="validationError" class="booking-form__error" data-testid="booking-form-error">
+		<p
+			v-if="validationError"
+			class="booking-form__error"
+			data-testid="booking-form-error">
 			{{ validationError }}
 		</p>
 
 		<div class="booking-form__actions">
 			<NcButton variant="primary" type="submit" :disabled="submitting">
-				{{ submitting ? t('shillinq', 'Saving…') : t('shillinq', 'Create Booking') }}
+				{{
+					submitting
+						? t('shillinq', 'Saving…')
+						: t('shillinq', 'Create Booking')
+				}}
 			</NcButton>
 		</div>
 
@@ -179,10 +183,11 @@ export default {
 		async postBooking(force) {
 			this.submitting = true
 			try {
-				const url = generateUrl(
-					'/apps/shillinq/api/v2/calendars/{calendarId}/bookings',
-					{ calendarId: this.calendarId },
-				) + (force ? '?force=1' : '')
+				const url =
+					generateUrl(
+						'/apps/shillinq/api/v2/calendars/{calendarId}/bookings',
+						{ calendarId: this.calendarId },
+					) + (force ? '?force=1' : '')
 
 				const payload = {
 					title: this.form.title,
@@ -216,7 +221,8 @@ export default {
 				}
 
 				const errBody = await response.json().catch(() => ({}))
-				this.validationError = errBody.error || t('shillinq', 'Failed to create booking')
+				this.validationError =
+					errBody.error || t('shillinq', 'Failed to create booking')
 			} catch (error) {
 				this.validationError = t('shillinq', 'Failed to create booking')
 			} finally {
@@ -240,7 +246,13 @@ export default {
 		 * @return {void}
 		 */
 		reset() {
-			this.form = { title: '', startTime: '', endTime: '', attendee: '', status: 'pending' }
+			this.form = {
+				title: '',
+				startTime: '',
+				endTime: '',
+				attendee: '',
+				status: 'pending',
+			}
 			this.validationError = ''
 			this.conflicts = []
 		},

--- a/src/views/bookings/CalendarView.vue
+++ b/src/views/bookings/CalendarView.vue
@@ -19,7 +19,9 @@
 					:key="v"
 					type="button"
 					class="calendar-view__view-button"
-					:class="{ 'calendar-view__view-button--active': currentView === v }"
+					:class="{
+						'calendar-view__view-button--active': currentView === v,
+					}"
 					:data-testid="`calendar-view-${v}`"
 					@click="currentView = v">
 					{{ viewLabel(v) }}
@@ -28,8 +30,12 @@
 		</header>
 
 		<!-- MONTH VIEW -->
-		<div v-if="currentView === 'month'" class="calendar-view__month" data-testid="calendar-month-grid">
-			<div v-for="day in monthDays"
+		<div
+			v-if="currentView === 'month'"
+			class="calendar-view__month"
+			data-testid="calendar-month-grid">
+			<div
+				v-for="day in monthDays"
 				:key="day.iso"
 				class="calendar-view__cell"
 				:data-date="day.iso">
@@ -41,7 +47,9 @@
 					:key="bookingId(booking)"
 					type="button"
 					class="calendar-view__booking"
-					:class="{ 'calendar-view__booking--conflict': isConflict(booking) }"
+					:class="{
+						'calendar-view__booking--conflict': isConflict(booking),
+					}"
 					:data-testid="`booking-${bookingId(booking)}`"
 					@click="$emit('booking:selected', bookingId(booking))">
 					{{ booking.title }}
@@ -50,8 +58,14 @@
 		</div>
 
 		<!-- WEEK VIEW -->
-		<div v-else-if="currentView === 'week'" class="calendar-view__week" data-testid="calendar-week-grid">
-			<div v-for="day in weekDays" :key="day.iso" class="calendar-view__week-column">
+		<div
+			v-else-if="currentView === 'week'"
+			class="calendar-view__week"
+			data-testid="calendar-week-grid">
+			<div
+				v-for="day in weekDays"
+				:key="day.iso"
+				class="calendar-view__week-column">
 				<div class="calendar-view__cell-date">
 					{{ day.label }}
 				</div>
@@ -64,14 +78,18 @@
 						class="calendar-view__slot-button"
 						:data-testid="`calendar-slot-${day.iso}-${hour}`"
 						@click="emitSlot(day.iso, hour)">
-						<span class="calendar-view__slot-hour">{{ formatHour(hour) }}</span>
+						<span class="calendar-view__slot-hour">{{
+							formatHour(hour)
+						}}</span>
 					</button>
 					<button
 						v-for="booking in bookingsForHour(day.iso, hour)"
 						:key="bookingId(booking)"
 						type="button"
 						class="calendar-view__booking"
-						:class="{ 'calendar-view__booking--conflict': isConflict(booking) }"
+						:class="{
+							'calendar-view__booking--conflict': isConflict(booking),
+						}"
 						:data-testid="`booking-${bookingId(booking)}`"
 						@click="$emit('booking:selected', bookingId(booking))">
 						{{ booking.title }}
@@ -82,23 +100,24 @@
 
 		<!-- DAY VIEW -->
 		<div v-else class="calendar-view__day" data-testid="calendar-day-grid">
-			<div
-				v-for="hour in hours"
-				:key="hour"
-				class="calendar-view__slot">
+			<div v-for="hour in hours" :key="hour" class="calendar-view__slot">
 				<button
 					type="button"
 					class="calendar-view__slot-button"
 					:data-testid="`calendar-slot-${dayIso}-${hour}`"
 					@click="emitSlot(dayIso, hour)">
-					<span class="calendar-view__slot-hour">{{ formatHour(hour) }}</span>
+					<span class="calendar-view__slot-hour">{{
+						formatHour(hour)
+					}}</span>
 				</button>
 				<button
 					v-for="booking in bookingsForHour(dayIso, hour)"
 					:key="bookingId(booking)"
 					type="button"
 					class="calendar-view__booking"
-					:class="{ 'calendar-view__booking--conflict': isConflict(booking) }"
+					:class="{
+						'calendar-view__booking--conflict': isConflict(booking),
+					}"
 					:data-testid="`booking-${bookingId(booking)}`"
 					@click="$emit('booking:selected', bookingId(booking))">
 					{{ booking.title }}
@@ -177,7 +196,10 @@ export default {
 		headerLabel() {
 			const opts = { year: 'numeric', month: 'long' }
 			if (this.currentView === 'day') {
-				return this.anchor.toLocaleDateString(undefined, { ...opts, day: 'numeric' })
+				return this.anchor.toLocaleDateString(undefined, {
+					...opts,
+					day: 'numeric',
+				})
 			}
 			return this.anchor.toLocaleDateString(undefined, opts)
 		},
@@ -214,7 +236,10 @@ export default {
 				date.setDate(monday.getDate() + i)
 				days.push({
 					iso: this.toIsoDate(date),
-					label: date.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric' }),
+					label: date.toLocaleDateString(undefined, {
+						weekday: 'short',
+						day: 'numeric',
+					}),
 				})
 			}
 			return days
@@ -248,10 +273,12 @@ export default {
 					'/apps/shillinq/api/v2/calendars/{calendarId}/bookings',
 					{ calendarId: this.calendarId },
 				)
-				const response = await fetch(url, { headers: { requesttoken: OC.requestToken } })
+				const response = await fetch(url, {
+					headers: { requesttoken: OC.requestToken },
+				})
 				if (response.ok) {
 					const data = await response.json()
-					this.bookings = Array.isArray(data) ? data : (data.results || [])
+					this.bookings = Array.isArray(data) ? data : data.results || []
 				}
 			} catch (error) {
 				this.bookings = []
@@ -265,7 +292,9 @@ export default {
 		 * @return {Array<object>}
 		 */
 		bookingsForDay(iso) {
-			return this.bookings.filter((b) => this.toIsoDate(new Date(b.startTime)) === iso)
+			return this.bookings.filter(
+				(b) => this.toIsoDate(new Date(b.startTime)) === iso,
+			)
 		},
 
 		/**
@@ -299,7 +328,12 @@ export default {
 		 * @return {string}
 		 */
 		bookingId(booking) {
-			return booking.id || (booking['@self'] && (booking['@self'].id || booking['@self'].uuid)) || ''
+			return (
+				booking.id
+				|| (booking['@self']
+					&& (booking['@self'].id || booking['@self'].uuid))
+				|| ''
+			)
 		},
 
 		/**

--- a/src/views/bookings/ConfirmationPortal.vue
+++ b/src/views/bookings/ConfirmationPortal.vue
@@ -53,7 +53,11 @@
 			class="bookings-confirmation-portal__success"
 			data-testid="bk-confirm-success">
 			<h2>{{ label('Appointment confirmed!') }}</h2>
-			<p>{{ label('Your appointment is confirmed. A copy is in your inbox.') }}</p>
+			<p>
+				{{
+					label('Your appointment is confirmed. A copy is in your inbox.')
+				}}
+			</p>
 			<dl class="bookings-confirmation-portal__details">
 				<dt>{{ label('Service') }}</dt>
 				<dd>{{ appointment.serviceName }}</dd>
@@ -99,7 +103,9 @@
 				:disabled="confirming"
 				data-testid="bk-confirm-button"
 				@click="confirm">
-				{{ confirming ? label('Confirming…') : label('Confirm appointment') }}
+				{{
+					confirming ? label('Confirming…') : label('Confirm appointment')
+				}}
 			</button>
 		</section>
 	</div>
@@ -114,9 +120,11 @@ const REASON_MESSAGES = {
 	revoked: 'This confirmation link is no longer valid; a newer one was sent.',
 	invalid: 'This confirmation link is not valid.',
 	not_found: 'We could not find this appointment. Please check your email link.',
-	missing_appointment_id: 'This confirmation link is missing required information.',
+	missing_appointment_id:
+		'This confirmation link is missing required information.',
 	invalid_input: 'This confirmation link is incomplete.',
-	or_unavailable: 'The booking service is temporarily unavailable. Please try again later.',
+	or_unavailable:
+		'The booking service is temporarily unavailable. Please try again later.',
 }
 
 export default {
@@ -256,7 +264,9 @@ export default {
 			}
 			this.resending = true
 			try {
-				await confirmationApi.resendConfirmationEmail(this.appointmentIdFromUrl)
+				await confirmationApi.resendConfirmationEmail(
+					this.appointmentIdFromUrl,
+				)
 				this.error = null
 				this.confirmed = false
 				this.appointment.status = 'pending_confirmation'

--- a/src/views/bookkeeping/ChartOfAccountsView.vue
+++ b/src/views/bookkeeping/ChartOfAccountsView.vue
@@ -20,22 +20,32 @@
 				</NcButton>
 			</header>
 
-			<NcEmptyContent v-if="!loading && roots.length === 0"
+			<NcEmptyContent
+				v-if="!loading && roots.length === 0"
 				:name="t('shillinq', 'No accounts yet')"
-				:description="t('shillinq', 'Create the first account in the chart-of-accounts to start bookkeeping.')" />
+				:description="
+					t(
+						'shillinq',
+						'Create the first account in the chart-of-accounts to start bookkeeping.',
+					)
+				" />
 
 			<div v-else-if="loading" class="wbso-chart-of-accounts__loading">
 				{{ t('shillinq', 'Loading…') }}
 			</div>
 
 			<ul v-else class="wbso-chart-of-accounts__tree" role="tree">
-				<AccountNode v-for="account in roots"
+				<AccountNode
+					v-for="account in roots"
 					:key="account.accountNumber"
 					:account="account"
 					:depth="0" />
 			</ul>
 
-			<p v-if="errorMessage" class="wbso-chart-of-accounts__error" role="alert">
+			<p
+				v-if="errorMessage"
+				class="wbso-chart-of-accounts__error"
+				role="alert">
 				{{ errorMessage }}
 			</p>
 		</div>
@@ -84,9 +94,13 @@ export default {
 				const url = generateOcsUrl('apps/shillinq/api/v1/accounts/hierarchy')
 				const { data } = await axios.get(url)
 				this.roots = data?.ocs?.data?.tree ?? data?.tree ?? []
-				this.canCreate = data?.ocs?.data?.canCreate ?? data?.canCreate ?? false
+				this.canCreate =
+					data?.ocs?.data?.canCreate ?? data?.canCreate ?? false
 			} catch (error) {
-				this.errorMessage = t('shillinq', 'Failed to load Chart of Accounts.')
+				this.errorMessage = t(
+					'shillinq',
+					'Failed to load Chart of Accounts.',
+				)
 			} finally {
 				this.loading = false
 			}

--- a/src/views/bookkeeping/DocumentsView.vue
+++ b/src/views/bookkeeping/DocumentsView.vue
@@ -30,24 +30,36 @@
 						<option value="">{{ t('shillinq', 'All') }}</option>
 						<option value="draft">{{ t('shillinq', 'Draft') }}</option>
 						<option value="filed">{{ t('shillinq', 'Filed') }}</option>
-						<option value="archived">{{ t('shillinq', 'Archived') }}</option>
+						<option value="archived">
+							{{ t('shillinq', 'Archived') }}
+						</option>
 					</select>
 				</label>
 				<label>
 					<span>{{ t('shillinq', 'Type') }}</span>
 					<select v-model="filters.type" @change="load">
 						<option value="">{{ t('shillinq', 'All') }}</option>
-						<option value="invoice">{{ t('shillinq', 'Invoice') }}</option>
-						<option value="receipt">{{ t('shillinq', 'Receipt') }}</option>
-						<option value="contract">{{ t('shillinq', 'Contract') }}</option>
-						<option value="tax-form">{{ t('shillinq', 'Tax Form') }}</option>
-						<option value="bank-statement">{{ t('shillinq', 'Bank Statement') }}</option>
+						<option value="invoice">
+							{{ t('shillinq', 'Invoice') }}
+						</option>
+						<option value="receipt">
+							{{ t('shillinq', 'Receipt') }}
+						</option>
+						<option value="contract">
+							{{ t('shillinq', 'Contract') }}
+						</option>
+						<option value="tax-form">
+							{{ t('shillinq', 'Tax Form') }}
+						</option>
+						<option value="bank-statement">
+							{{ t('shillinq', 'Bank Statement') }}
+						</option>
 						<option value="memo">{{ t('shillinq', 'Memo') }}</option>
 					</select>
 				</label>
 				<label>
 					<span>{{ t('shillinq', 'Filed from') }}</span>
-					<input v-model="filters.filedFrom" type="date" @change="load">
+					<input v-model="filters.filedFrom" type="date" @change="load" />
 				</label>
 			</div>
 
@@ -60,15 +72,23 @@
 				class="wbso-documents__table"
 				:columns="columns"
 				:rows="documents"
-				:empty-label="t('shillinq', 'Upload the first document to track an invoice, receipt, or contract.')">
+				:empty-label="
+					t(
+						'shillinq',
+						'Upload the first document to track an invoice, receipt, or contract.',
+					)
+				">
 				<template #cell-documentType="{ row }">
 					{{ translateType(row.documentType) }}
 				</template>
 				<template #cell-status="{ row }">
-					<span :data-status="row.status">{{ translateStatus(row.status) }}</span>
+					<span :data-status="row.status">{{
+						translateStatus(row.status)
+					}}</span>
 				</template>
 				<template #cell-fileReference="{ row }">
-					<a v-if="row.fileReference"
+					<a
+						v-if="row.fileReference"
 						:href="row.fileReference"
 						target="_blank"
 						rel="noopener">
@@ -123,11 +143,27 @@ export default {
 		 */
 		columns() {
 			return [
-				{ key: 'documentNumber', label: t('shillinq', 'Document Number'), sortable: true },
-				{ key: 'documentType', label: t('shillinq', 'Document Type'), sortable: true },
-				{ key: 'documentDate', label: t('shillinq', 'Document Date'), sortable: true },
+				{
+					key: 'documentNumber',
+					label: t('shillinq', 'Document Number'),
+					sortable: true,
+				},
+				{
+					key: 'documentType',
+					label: t('shillinq', 'Document Type'),
+					sortable: true,
+				},
+				{
+					key: 'documentDate',
+					label: t('shillinq', 'Document Date'),
+					sortable: true,
+				},
 				{ key: 'status', label: t('shillinq', 'Status'), sortable: true },
-				{ key: 'fileReference', label: t('shillinq', 'File Reference'), sortable: false },
+				{
+					key: 'fileReference',
+					label: t('shillinq', 'File Reference'),
+					sortable: false,
+				},
 			]
 		},
 	},
@@ -148,7 +184,8 @@ export default {
 				if (this.filters.filedFrom) params.filedFrom = this.filters.filedFrom
 				const { data } = await axios.get(url, { params })
 				this.documents = data?.ocs?.data?.documents ?? data?.documents ?? []
-				this.canCreate = data?.ocs?.data?.canCreate ?? data?.canCreate ?? false
+				this.canCreate =
+					data?.ocs?.data?.canCreate ?? data?.canCreate ?? false
 			} catch (error) {
 				this.errorMessage = t('shillinq', 'Failed to load documents.')
 			} finally {

--- a/src/views/bookkeeping/TransactionsView.vue
+++ b/src/views/bookkeeping/TransactionsView.vue
@@ -31,27 +31,39 @@
 						<option value="">{{ t('shillinq', 'All') }}</option>
 						<option value="draft">{{ t('shillinq', 'Draft') }}</option>
 						<option value="posted">{{ t('shillinq', 'Posted') }}</option>
-						<option value="reversed">{{ t('shillinq', 'Reversed') }}</option>
+						<option value="reversed">
+							{{ t('shillinq', 'Reversed') }}
+						</option>
 					</select>
 				</label>
 				<label>
 					<span>{{ t('shillinq', 'Type') }}</span>
 					<select v-model="filters.type" @change="load">
 						<option value="">{{ t('shillinq', 'All') }}</option>
-						<option value="invoice">{{ t('shillinq', 'Invoice') }}</option>
-						<option value="receipt">{{ t('shillinq', 'Receipt') }}</option>
-						<option value="journal-entry">{{ t('shillinq', 'Journal Entry') }}</option>
-						<option value="credit-note">{{ t('shillinq', 'Credit Note') }}</option>
-						<option value="debit-note">{{ t('shillinq', 'Debit Note') }}</option>
+						<option value="invoice">
+							{{ t('shillinq', 'Invoice') }}
+						</option>
+						<option value="receipt">
+							{{ t('shillinq', 'Receipt') }}
+						</option>
+						<option value="journal-entry">
+							{{ t('shillinq', 'Journal Entry') }}
+						</option>
+						<option value="credit-note">
+							{{ t('shillinq', 'Credit Note') }}
+						</option>
+						<option value="debit-note">
+							{{ t('shillinq', 'Debit Note') }}
+						</option>
 					</select>
 				</label>
 				<label>
 					<span>{{ t('shillinq', 'From') }}</span>
-					<input v-model="filters.dateFrom" type="date" @change="load">
+					<input v-model="filters.dateFrom" type="date" @change="load" />
 				</label>
 				<label>
 					<span>{{ t('shillinq', 'To') }}</span>
-					<input v-model="filters.dateTo" type="date" @change="load">
+					<input v-model="filters.dateTo" type="date" @change="load" />
 				</label>
 			</div>
 
@@ -64,12 +76,21 @@
 				class="wbso-transactions__table"
 				:columns="columns"
 				:rows="transactions"
-				:empty-label="t('shillinq', 'Create the first transaction to start posting to the books.')">
+				:empty-label="
+					t(
+						'shillinq',
+						'Create the first transaction to start posting to the books.',
+					)
+				">
 				<template #cell-amount="{ row }">
-					<span class="wbso-transactions__cell--amount">{{ formatAmount(row.amount) }}</span>
+					<span class="wbso-transactions__cell--amount">{{
+						formatAmount(row.amount)
+					}}</span>
 				</template>
 				<template #cell-status="{ row }">
-					<span :data-status="row.status">{{ translateStatus(row.status) }}</span>
+					<span :data-status="row.status">{{
+						translateStatus(row.status)
+					}}</span>
 				</template>
 			</CnDataTable>
 
@@ -119,11 +140,32 @@ export default {
 		 */
 		columns() {
 			return [
-				{ key: 'transactionDate', label: t('shillinq', 'Transaction Date'), sortable: true },
-				{ key: 'transactionNumber', label: t('shillinq', 'Number'), sortable: true },
-				{ key: 'transactionType', label: t('shillinq', 'Type'), sortable: true },
-				{ key: 'description', label: t('shillinq', 'Description'), sortable: true },
-				{ key: 'amount', label: t('shillinq', 'Amount'), sortable: true, align: 'right' },
+				{
+					key: 'transactionDate',
+					label: t('shillinq', 'Transaction Date'),
+					sortable: true,
+				},
+				{
+					key: 'transactionNumber',
+					label: t('shillinq', 'Number'),
+					sortable: true,
+				},
+				{
+					key: 'transactionType',
+					label: t('shillinq', 'Type'),
+					sortable: true,
+				},
+				{
+					key: 'description',
+					label: t('shillinq', 'Description'),
+					sortable: true,
+				},
+				{
+					key: 'amount',
+					label: t('shillinq', 'Amount'),
+					sortable: true,
+					align: 'right',
+				},
 				{ key: 'status', label: t('shillinq', 'Status'), sortable: true },
 			]
 		},
@@ -145,8 +187,10 @@ export default {
 				if (this.filters.dateFrom) params.dateFrom = this.filters.dateFrom
 				if (this.filters.dateTo) params.dateTo = this.filters.dateTo
 				const { data } = await axios.get(url, { params })
-				this.transactions = data?.ocs?.data?.transactions ?? data?.transactions ?? []
-				this.canCreate = data?.ocs?.data?.canCreate ?? data?.canCreate ?? false
+				this.transactions =
+					data?.ocs?.data?.transactions ?? data?.transactions ?? []
+				this.canCreate =
+					data?.ocs?.data?.canCreate ?? data?.canCreate ?? false
 			} catch (error) {
 				this.errorMessage = t('shillinq', 'Failed to load transactions.')
 			} finally {

--- a/src/views/bookkeeping/dimensions/SegmentPnLDashboard.vue
+++ b/src/views/bookkeeping/dimensions/SegmentPnLDashboard.vue
@@ -27,20 +27,31 @@
 					{{ t('shillinq', 'Segment P&L') }}
 				</h2>
 				<p class="segment-pnl-dashboard__description">
-					{{ t('shillinq', 'Per-segment profit and loss roll-up across cost centers, projects, and operator-defined analytical dimensions. Driven by the server-side aggregations on GLLine — no client-side recomputation.') }}
+					{{
+						t(
+							'shillinq',
+							'Per-segment profit and loss roll-up across cost centers, projects, and operator-defined analytical dimensions. Driven by the server-side aggregations on GLLine — no client-side recomputation.',
+						)
+					}}
 				</p>
 			</header>
 
-			<section class="segment-pnl-dashboard__controls" aria-label="segment selector">
+			<section
+				class="segment-pnl-dashboard__controls"
+				aria-label="segment selector">
 				<div class="segment-pnl-dashboard__chips">
-					<NcButton v-for="segment in availableSegments"
+					<NcButton
+						v-for="segment in availableSegments"
 						:key="segment.id"
-						:variant="segment.id === activeSegment ? 'primary' : 'secondary'"
+						:variant="
+							segment.id === activeSegment ? 'primary' : 'secondary'
+						"
 						@click="selectSegment(segment.id)">
 						{{ segment.label }}
 					</NcButton>
 				</div>
-				<NcButton variant="tertiary"
+				<NcButton
+					variant="tertiary"
 					:disabled="!rows.length"
 					@click="exportCsv">
 					{{ t('shillinq', 'Export CSV') }}
@@ -48,19 +59,31 @@
 			</section>
 
 			<section class="segment-pnl-dashboard__body">
-				<NcLoadingIcon v-if="loading"
+				<NcLoadingIcon
+					v-if="loading"
 					:size="32"
 					:name="t('shillinq', 'Loading segment P&L')" />
-				<NcEmptyContent v-else-if="!rows.length"
+				<NcEmptyContent
+					v-else-if="!rows.length"
 					:name="t('shillinq', 'No segment data')"
-					:description="t('shillinq', 'No GL postings carry this dimension yet. Tag postings with a cost center, project, or analytical dimension to populate the drill-down.')" />
-				<table v-else class="segment-pnl-dashboard__table" :data-segment="activeSegment">
+					:description="
+						t(
+							'shillinq',
+							'No GL postings carry this dimension yet. Tag postings with a cost center, project, or analytical dimension to populate the drill-down.',
+						)
+					" />
+				<table
+					v-else
+					class="segment-pnl-dashboard__table"
+					:data-segment="activeSegment">
 					<thead>
 						<tr>
 							<th scope="col">
 								{{ groupLabel }}
 							</th>
-							<th scope="col" class="segment-pnl-dashboard__amount-col">
+							<th
+								scope="col"
+								class="segment-pnl-dashboard__amount-col">
 								{{ t('shillinq', 'Amount') }}
 							</th>
 							<th v-if="hasHierarchy" scope="col">
@@ -69,18 +92,31 @@
 						</tr>
 					</thead>
 					<tbody>
-						<tr v-for="row in rows"
+						<tr
+							v-for="row in rows"
 							:key="row.key"
-							:class="{ 'segment-pnl-dashboard__row--child': row.depth > 0 }"
+							:class="{
+								'segment-pnl-dashboard__row--child': row.depth > 0,
+							}"
 							:style="{ '--row-depth': row.depth }">
-							<th scope="row" class="segment-pnl-dashboard__group-cell">
-								<span class="segment-pnl-dashboard__group-code">{{ row.key }}</span>
-								<span v-if="row.name" class="segment-pnl-dashboard__group-name">
+							<th
+								scope="row"
+								class="segment-pnl-dashboard__group-cell">
+								<span class="segment-pnl-dashboard__group-code">{{
+									row.key
+								}}</span>
+								<span
+									v-if="row.name"
+									class="segment-pnl-dashboard__group-name">
 									— {{ row.name }}
 								</span>
 							</th>
-							<td class="segment-pnl-dashboard__amount-cell"
-								:class="{ 'segment-pnl-dashboard__amount-cell--negative': row.amount < 0 }">
+							<td
+								class="segment-pnl-dashboard__amount-cell"
+								:class="{
+									'segment-pnl-dashboard__amount-cell--negative':
+										row.amount < 0,
+								}">
 								{{ formatAmount(row.amount) }}
 							</td>
 							<td v-if="hasHierarchy">
@@ -100,7 +136,10 @@
 						</tr>
 					</tfoot>
 				</table>
-				<p v-if="errorMessage" class="segment-pnl-dashboard__error" role="alert">
+				<p
+					v-if="errorMessage"
+					class="segment-pnl-dashboard__error"
+					role="alert">
 					{{ errorMessage }}
 				</p>
 			</section>
@@ -109,7 +148,12 @@
 </template>
 
 <script>
-import { NcAppContent, NcButton, NcEmptyContent, NcLoadingIcon } from '@nextcloud/vue'
+import {
+	NcAppContent,
+	NcButton,
+	NcEmptyContent,
+	NcLoadingIcon,
+} from '@nextcloud/vue'
 import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 
@@ -159,9 +203,15 @@ export default {
 		availableSegments() {
 			return [
 				{ id: 'costCenter', label: this.t('shillinq', 'Cost center') },
-				{ id: 'costCenterHierarchy', label: this.t('shillinq', 'Cost center (rolled up)') },
+				{
+					id: 'costCenterHierarchy',
+					label: this.t('shillinq', 'Cost center (rolled up)'),
+				},
 				{ id: 'project', label: this.t('shillinq', 'Project') },
-				{ id: 'analyticalDimension', label: this.t('shillinq', 'Analytical dimension') },
+				{
+					id: 'analyticalDimension',
+					label: this.t('shillinq', 'Analytical dimension'),
+				},
 			]
 		},
 	},
@@ -192,7 +242,8 @@ export default {
 
 			try {
 				const url = generateUrl(
-					'/apps/shillinq/api/openregister/objects/GLLine/aggregations/' + encodeURIComponent(aggregationName),
+					'/apps/shillinq/api/openregister/objects/GLLine/aggregations/'
+						+ encodeURIComponent(aggregationName),
 				)
 				const { data } = await axios.get(url)
 				this.rows = this.normaliseRows(data, segment)
@@ -201,31 +252,53 @@ export default {
 				if (status === 404 || status === 501) {
 					// Older OR builds without the aggregation endpoint —
 					// keep the dashboard navigable instead of breaking.
-					this.errorMessage = this.t('shillinq', 'Aggregation endpoint unavailable on this OpenRegister build. Upgrade OR to read segment P&L roll-ups.')
+					this.errorMessage = this.t(
+						'shillinq',
+						'Aggregation endpoint unavailable on this OpenRegister build. Upgrade OR to read segment P&L roll-ups.',
+					)
 				} else if (status === 401 || status === 403) {
-					this.errorMessage = this.t('shillinq', 'Permission required to read segment P&L data.')
+					this.errorMessage = this.t(
+						'shillinq',
+						'Permission required to read segment P&L data.',
+					)
 				} else {
-					this.errorMessage = this.t('shillinq', 'Failed to load segment P&L.')
+					this.errorMessage = this.t(
+						'shillinq',
+						'Failed to load segment P&L.',
+					)
 				}
 			} finally {
 				this.loading = false
 			}
 		},
 		normaliseRows(payload, segment) {
-			const buckets = Array.isArray(payload?.buckets) ? payload.buckets : (Array.isArray(payload) ? payload : [])
-			const flat = buckets.map((bucket) => {
-				const key = bucket?.key ?? bucket?.code ?? bucket?.groupKey ?? ''
-				const name = bucket?.name ?? bucket?.['CostCenter.name'] ?? bucket?.['Project.name'] ?? ''
-				const parent = bucket?.parent ?? bucket?.['CostCenter.parentCode'] ?? ''
-				const amount = Number(bucket?.amount ?? bucket?.sum ?? bucket?.total ?? 0)
-				return {
-					key: String(key),
-					name: String(name),
-					parent: String(parent),
-					amount,
-					depth: 0,
-				}
-			}).filter((r) => r.key !== '')
+			const buckets = Array.isArray(payload?.buckets)
+				? payload.buckets
+				: Array.isArray(payload)
+					? payload
+					: []
+			const flat = buckets
+				.map((bucket) => {
+					const key = bucket?.key ?? bucket?.code ?? bucket?.groupKey ?? ''
+					const name =
+						bucket?.name
+						?? bucket?.['CostCenter.name']
+						?? bucket?.['Project.name']
+						?? ''
+					const parent =
+						bucket?.parent ?? bucket?.['CostCenter.parentCode'] ?? ''
+					const amount = Number(
+						bucket?.amount ?? bucket?.sum ?? bucket?.total ?? 0,
+					)
+					return {
+						key: String(key),
+						name: String(name),
+						parent: String(parent),
+						amount,
+						depth: 0,
+					}
+				})
+				.filter((r) => r.key !== '')
 
 			if (segment === 'costCenterHierarchy') {
 				return this.applyHierarchy(flat)
@@ -298,11 +371,18 @@ export default {
 				]
 				lines.push(cells.join(','))
 			}
-			const blob = new Blob([lines.join('\n') + '\n'], { type: 'text/csv;charset=utf-8' })
+			const blob = new Blob([lines.join('\n') + '\n'], {
+				type: 'text/csv;charset=utf-8',
+			})
 			const url = URL.createObjectURL(blob)
 			const a = document.createElement('a')
 			a.href = url
-			a.download = 'segment-pnl-' + this.activeSegment + '-' + new Date().toISOString().slice(0, 10) + '.csv'
+			a.download =
+				'segment-pnl-'
+				+ this.activeSegment
+				+ '-'
+				+ new Date().toISOString().slice(0, 10)
+				+ '.csv'
 			document.body.appendChild(a)
 			a.click()
 			document.body.removeChild(a)

--- a/src/views/bookkeeping/multi-currency/FxRatesAdmin.vue
+++ b/src/views/bookkeeping/multi-currency/FxRatesAdmin.vue
@@ -25,12 +25,18 @@
 					{{ t('shillinq', 'FX Rates') }}
 				</h2>
 				<p class="fx-rates-admin__description">
-					{{ t('shillinq', 'Daily exchange-rate snapshots used by the GL posting engine and IAS 21 consolidation. ECB rates are imported daily by the FxRateImportJob; manual rates require a written reason and override the ECB value for the affected date.') }}
+					{{
+						t(
+							'shillinq',
+							'Daily exchange-rate snapshots used by the GL posting engine and IAS 21 consolidation. ECB rates are imported daily by the FxRateImportJob; manual rates require a written reason and override the ECB value for the affected date.',
+						)
+					}}
 				</p>
 			</header>
 
 			<section class="fx-rates-admin__status" aria-live="polite">
-				<NcLoadingIcon v-if="loading"
+				<NcLoadingIcon
+					v-if="loading"
 					:size="20"
 					:name="t('shillinq', 'Loading import status')" />
 				<template v-else>
@@ -38,7 +44,8 @@
 						<span class="fx-rates-admin__status-label">
 							{{ t('shillinq', 'Import status') }}:
 						</span>
-						<span class="fx-rates-admin__status-badge"
+						<span
+							class="fx-rates-admin__status-badge"
 							:class="badgeClass"
 							:data-status="status.status">
 							{{ badgeLabel }}
@@ -53,12 +60,23 @@
 						</span>
 					</div>
 					<div v-else class="fx-rates-admin__status-row">
-						<span class="fx-rates-admin__status-value fx-rates-admin__status-value--muted">
-							{{ t('shillinq', 'The cron has not produced a successful run yet.') }}
+						<span
+							class="fx-rates-admin__status-value fx-rates-admin__status-value--muted">
+							{{
+								t(
+									'shillinq',
+									'The cron has not produced a successful run yet.',
+								)
+							}}
 						</span>
 					</div>
 					<p v-if="status.adapterDormant" class="fx-rates-admin__hint">
-						{{ t('shillinq', 'The Treasury rate adapter is currently dormant. Bind the openconnector source "treasury-rates" (ECB SDMX) and override TreasuryRateAdapterInterface in Application::register() to start ingesting real rates. Manual rate entries are unaffected.') }}
+						{{
+							t(
+								'shillinq',
+								'The Treasury rate adapter is currently dormant. Bind the openconnector source "treasury-rates" (ECB SDMX) and override TreasuryRateAdapterInterface in Application::register() to start ingesting real rates. Manual rate entries are unaffected.',
+							)
+						}}
 					</p>
 				</template>
 				<p v-if="errorMessage" class="fx-rates-admin__error" role="alert">
@@ -68,7 +86,12 @@
 
 			<section class="fx-rates-admin__index">
 				<p class="fx-rates-admin__index-help">
-					{{ t('shillinq', 'The grid below is the declarative FxRate index. Use the filters to narrow by currency pair or source.') }}
+					{{
+						t(
+							'shillinq',
+							'The grid below is the declarative FxRate index. Use the filters to narrow by currency pair or source.',
+						)
+					}}
 				</p>
 				<NcButton variant="secondary" @click="navigateToIndex">
 					{{ t('shillinq', 'Open FX Rates index') }}
@@ -120,8 +143,10 @@ export default {
 		badgeClass() {
 			return {
 				'fx-rates-admin__status-badge--ok': this.status.status === 'ok',
-				'fx-rates-admin__status-badge--dormant': this.status.status === 'dormant',
-				'fx-rates-admin__status-badge--warn': this.status.status === 'never-ran',
+				'fx-rates-admin__status-badge--dormant':
+					this.status.status === 'dormant',
+				'fx-rates-admin__status-badge--warn':
+					this.status.status === 'never-ran',
 			}
 		},
 	},
@@ -135,7 +160,9 @@ export default {
 			this.loading = true
 			this.errorMessage = ''
 			try {
-				const url = generateUrl('/apps/shillinq/api/admin/fx-rate-import-status')
+				const url = generateUrl(
+					'/apps/shillinq/api/admin/fx-rate-import-status',
+				)
 				const { data } = await axios.get(url)
 				this.status = {
 					jobClass: data?.jobClass ?? this.status.jobClass,
@@ -148,9 +175,15 @@ export default {
 			} catch (error) {
 				const status = error?.response?.status
 				if (status === 401 || status === 403) {
-					this.errorMessage = this.t('shillinq', 'Admin permission required to read FX import status.')
+					this.errorMessage = this.t(
+						'shillinq',
+						'Admin permission required to read FX import status.',
+					)
 				} else {
-					this.errorMessage = this.t('shillinq', 'Failed to load FX import status.')
+					this.errorMessage = this.t(
+						'shillinq',
+						'Failed to load FX import status.',
+					)
 				}
 			} finally {
 				this.loading = false

--- a/src/views/budgetLineCommitmentsHelpers.js
+++ b/src/views/budgetLineCommitmentsHelpers.js
@@ -24,16 +24,27 @@
 export function normaliseBudgetLineRows(payload) {
 	const buckets = Array.isArray(payload?.buckets)
 		? payload.buckets
-		: (Array.isArray(payload) ? payload : [])
+		: Array.isArray(payload)
+			? payload
+			: []
 
 	return buckets.map((bucket) => {
-		const geautoriseerd = Number(bucket?.['Budget.geautoriseerd_bedrag'] ?? bucket?.geautoriseerd ?? 0)
+		const geautoriseerd = Number(
+			bucket?.['Budget.geautoriseerd_bedrag'] ?? bucket?.geautoriseerd ?? 0,
+		)
 		const verplicht = Number(bucket?.restant_verplicht ?? bucket?.verplicht ?? 0)
-		const gerealiseerd = Number(bucket?.gefactureerd_bedrag ?? bucket?.gerealiseerd ?? 0)
+		const gerealiseerd = Number(
+			bucket?.gefactureerd_bedrag ?? bucket?.gerealiseerd ?? 0,
+		)
 		const vrij = geautoriseerd - verplicht - gerealiseerd
 
 		return {
-			key: [bucket?.programma, bucket?.kostenplaats, bucket?.boekjaar, bucket?.grootboekrekening].join('|'),
+			key: [
+				bucket?.programma,
+				bucket?.kostenplaats,
+				bucket?.boekjaar,
+				bucket?.grootboekrekening,
+			].join('|'),
 			programma: String(bucket?.programma ?? ''),
 			kostenplaats: String(bucket?.kostenplaats ?? ''),
 			boekjaar: bucket?.boekjaar ?? null,

--- a/src/views/deadlineCalendarSettingsHelpers.js
+++ b/src/views/deadlineCalendarSettingsHelpers.js
@@ -19,7 +19,8 @@ export const CATEGORY_META = [
 	{
 		id: 'filing',
 		label: 'Filing deadlines (BTW / ICP / VPB)',
-		description: 'Publish BTW, ICP and VPB filing deadlines on your deadline calendar.',
+		description:
+			'Publish BTW, ICP and VPB filing deadlines on your deadline calendar.',
 		defaultEnabled: true,
 		defaultLeadDays: 10,
 	},
@@ -33,14 +34,16 @@ export const CATEGORY_META = [
 	{
 		id: 'ar-due',
 		label: 'Invoice due dates',
-		description: 'Publish open AR invoice due dates (off by default — these can be high-volume).',
+		description:
+			'Publish open AR invoice due dates (off by default — these can be high-volume).',
 		defaultEnabled: false,
 		defaultLeadDays: 7,
 	},
 	{
 		id: 'contract',
 		label: 'Contract deadlines',
-		description: 'Publish contract renewal and notice-period (opzegtermijn) deadlines.',
+		description:
+			'Publish contract renewal and notice-period (opzegtermijn) deadlines.',
 		defaultEnabled: true,
 		defaultLeadDays: 7,
 	},
@@ -56,19 +59,30 @@ export const CATEGORY_META = [
  * @spec openspec/specs/compliance-deadline-calendar/spec.md
  */
 export function normaliseSettings(data) {
-	const categories = (data && typeof data === 'object' && data.categories && typeof data.categories === 'object')
-		? data.categories
-		: {}
+	const categories =
+		data
+		&& typeof data === 'object'
+		&& data.categories
+		&& typeof data.categories === 'object'
+			? data.categories
+			: {}
 
 	return CATEGORY_META.map((meta) => {
-		const raw = (categories[meta.id] && typeof categories[meta.id] === 'object') ? categories[meta.id] : {}
+		const raw =
+			categories[meta.id] && typeof categories[meta.id] === 'object'
+				? categories[meta.id]
+				: {}
 		const leadDays = Number.parseInt(raw.leadDays, 10)
 		return {
 			id: meta.id,
 			label: meta.label,
 			description: meta.description,
-			enabled: typeof raw.enabled === 'boolean' ? raw.enabled : meta.defaultEnabled,
-			leadDays: Number.isFinite(leadDays) && leadDays >= 0 ? leadDays : meta.defaultLeadDays,
+			enabled:
+				typeof raw.enabled === 'boolean' ? raw.enabled : meta.defaultEnabled,
+			leadDays:
+				Number.isFinite(leadDays) && leadDays >= 0
+					? leadDays
+					: meta.defaultLeadDays,
 		}
 	})
 }
@@ -84,7 +98,7 @@ export function normaliseSettings(data) {
 export function buildSavePayload(rows) {
 	const known = new Set(CATEGORY_META.map((meta) => meta.id))
 	const categories = {}
-	for (const row of (Array.isArray(rows) ? rows : [])) {
+	for (const row of Array.isArray(rows) ? rows : []) {
 		if (!row || !known.has(row.id)) {
 			continue
 		}

--- a/src/views/external-adapters/ExternalAdapterDetail.vue
+++ b/src/views/external-adapters/ExternalAdapterDetail.vue
@@ -28,11 +28,15 @@
 <template>
 	<NcAppContent>
 		<div class="adapter-detail" :data-adapter-id="effectiveAdapterId">
-			<NcLoadingIcon v-if="loading"
+			<NcLoadingIcon
+				v-if="loading"
 				:size="20"
 				:name="t('shillinq', 'Loading adapter')" />
 
-			<section v-else-if="errorMessage" class="adapter-detail__error" role="alert">
+			<section
+				v-else-if="errorMessage"
+				class="adapter-detail__error"
+				role="alert">
 				{{ errorMessage }}
 			</section>
 
@@ -42,10 +46,15 @@
 						<h2 class="adapter-detail__title">
 							{{ adapter.title }}
 						</h2>
-						<span class="adapter-detail__badge"
+						<span
+							class="adapter-detail__badge"
 							:class="badgeClass"
 							:data-state="adapter.dormant ? 'dormant' : 'live'">
-							{{ adapter.dormant ? t('shillinq', 'Dormant') : t('shillinq', 'Live') }}
+							{{
+								adapter.dormant
+									? t('shillinq', 'Dormant')
+									: t('shillinq', 'Live')
+							}}
 						</span>
 					</div>
 					<p class="adapter-detail__description">
@@ -55,37 +64,67 @@
 
 				<section class="adapter-detail__facts">
 					<div class="adapter-detail__fact">
-						<span class="adapter-detail__fact-label">{{ t('shillinq', 'Category') }}</span>
-						<span class="adapter-detail__fact-value">{{ adapter.category }}</span>
+						<span class="adapter-detail__fact-label">{{
+							t('shillinq', 'Category')
+						}}</span>
+						<span class="adapter-detail__fact-value">{{
+							adapter.category
+						}}</span>
 					</div>
 					<div class="adapter-detail__fact">
-						<span class="adapter-detail__fact-label">{{ t('shillinq', 'OpenSpec change') }}</span>
-						<span class="adapter-detail__fact-value">{{ adapter.specSlug }}</span>
+						<span class="adapter-detail__fact-label">{{
+							t('shillinq', 'OpenSpec change')
+						}}</span>
+						<span class="adapter-detail__fact-value">{{
+							adapter.specSlug
+						}}</span>
 					</div>
 					<div class="adapter-detail__fact">
-						<span class="adapter-detail__fact-label">{{ t('shillinq', 'Requirements') }}</span>
-						<span class="adapter-detail__fact-value">{{ (adapter.requirements || []).join(', ') }}</span>
+						<span class="adapter-detail__fact-label">{{
+							t('shillinq', 'Requirements')
+						}}</span>
+						<span class="adapter-detail__fact-value">{{
+							(adapter.requirements || []).join(', ')
+						}}</span>
 					</div>
 					<div class="adapter-detail__fact">
-						<span class="adapter-detail__fact-label">{{ t('shillinq', 'Adapter interface') }}</span>
-						<code class="adapter-detail__fact-value">{{ adapter.interface }}</code>
+						<span class="adapter-detail__fact-label">{{
+							t('shillinq', 'Adapter interface')
+						}}</span>
+						<code class="adapter-detail__fact-value">{{
+							adapter.interface
+						}}</code>
 					</div>
 					<div class="adapter-detail__fact">
-						<span class="adapter-detail__fact-label">{{ t('shillinq', 'Log-only default') }}</span>
-						<code class="adapter-detail__fact-value">{{ adapter.logClass }}</code>
+						<span class="adapter-detail__fact-label">{{
+							t('shillinq', 'Log-only default')
+						}}</span>
+						<code class="adapter-detail__fact-value">{{
+							adapter.logClass
+						}}</code>
 					</div>
 					<div class="adapter-detail__fact">
-						<span class="adapter-detail__fact-label">{{ t('shillinq', 'openconnector source slug') }}</span>
-						<code class="adapter-detail__fact-value">{{ adapter.sourceSlug }}</code>
+						<span class="adapter-detail__fact-label">{{
+							t('shillinq', 'openconnector source slug')
+						}}</span>
+						<code class="adapter-detail__fact-value">{{
+							adapter.sourceSlug
+						}}</code>
 					</div>
 					<div class="adapter-detail__fact">
-						<span class="adapter-detail__fact-label">{{ t('shillinq', 'Feature flag') }}</span>
-						<code class="adapter-detail__fact-value">{{ adapter.featureFlag || t('shillinq', 'n/a') }}</code>
+						<span class="adapter-detail__fact-label">{{
+							t('shillinq', 'Feature flag')
+						}}</span>
+						<code class="adapter-detail__fact-value">{{
+							adapter.featureFlag || t('shillinq', 'n/a')
+						}}</code>
 					</div>
 					<div class="adapter-detail__fact">
-						<span class="adapter-detail__fact-label">{{ t('shillinq', 'App-config keys') }}</span>
+						<span class="adapter-detail__fact-label">{{
+							t('shillinq', 'App-config keys')
+						}}</span>
 						<ul class="adapter-detail__keys">
-							<li v-for="key in (adapter.configKeys || [])" :key="key">
+							<li v-for="key in adapter.configKeys || []" :key="key">
 								<code>{{ key }}</code>
 							</li>
 						</ul>
@@ -97,17 +136,30 @@
 						{{ t('shillinq', 'Activation steps') }}
 					</h3>
 					<ol class="adapter-detail__steps">
-						<li v-for="(step, idx) in (adapter.steps || [])"
+						<li
+							v-for="(step, idx) in adapter.steps || []"
 							:key="idx"
 							class="adapter-detail__step">
 							{{ step }}
 						</li>
 					</ol>
 					<p v-if="adapter.dormant" class="adapter-detail__hint">
-						{{ t('shillinq', 'This adapter is dormant. The surrounding lifecycle advances safely — submissions are recorded in the structured log but never sent to a third party — until the activation steps above are completed.') }}
+						{{
+							t(
+								'shillinq',
+								'This adapter is dormant. The surrounding lifecycle advances safely — submissions are recorded in the structured log but never sent to a third party — until the activation steps above are completed.',
+							)
+						}}
 					</p>
-					<p v-else class="adapter-detail__hint adapter-detail__hint--live">
-						{{ t('shillinq', 'This adapter is live. Submissions are sent to the configured third party. Audit oc_jobs + the relevant register lifecycle for delivery confirmations.') }}
+					<p
+						v-else
+						class="adapter-detail__hint adapter-detail__hint--live">
+						{{
+							t(
+								'shillinq',
+								'This adapter is live. Submissions are sent to the configured third party. Audit oc_jobs + the relevant register lifecycle for delivery confirmations.',
+							)
+						}}
 					</p>
 				</section>
 
@@ -157,9 +209,9 @@ export default {
 			}
 			// Fallback: trailing segment of the current path
 			// (deep-link entry without the manifest props blob).
-			const path = (this.$route?.path ?? '')
+			const path = this.$route?.path ?? ''
 			const parts = path.split('/').filter(Boolean)
-			return (parts.length > 0 ? parts[parts.length - 1] : '')
+			return parts.length > 0 ? parts[parts.length - 1] : ''
 		},
 		badgeClass() {
 			if (!this.adapter) {
@@ -192,14 +244,23 @@ export default {
 			this.errorMessage = ''
 			this.adapter = null
 			try {
-				const url = generateUrl('/apps/shillinq/api/admin/external-adapters/{id}', { id })
+				const url = generateUrl(
+					'/apps/shillinq/api/admin/external-adapters/{id}',
+					{ id },
+				)
 				const { data } = await axios.get(url)
 				this.adapter = data
 			} catch (err) {
 				if (err?.response?.status === 404) {
-					this.errorMessage = t('shillinq', 'Unknown adapter: {id}', { id })
+					this.errorMessage = t('shillinq', 'Unknown adapter: {id}', {
+						id,
+					})
 				} else {
-					this.errorMessage = t('shillinq', 'Could not load adapter: {message}', { message: err?.message ?? 'unknown error' })
+					this.errorMessage = t(
+						'shillinq',
+						'Could not load adapter: {message}',
+						{ message: err?.message ?? 'unknown error' },
+					)
 				}
 			} finally {
 				this.loading = false

--- a/src/views/external-adapters/ExternalAdaptersStatus.vue
+++ b/src/views/external-adapters/ExternalAdaptersStatus.vue
@@ -24,33 +24,47 @@
 					{{ t('shillinq', 'External Connections') }}
 				</h2>
 				<p class="external-adapters__description">
-					{{ t('shillinq', 'Operator view over every external-API adapter port the app ships. Each adapter is dormant by default (log-only) so regulatory-filing and bank-sync lifecycles advance without contacting a third party. Pick a family to see the activation recipe.') }}
+					{{
+						t(
+							'shillinq',
+							'Operator view over every external-API adapter port the app ships. Each adapter is dormant by default (log-only) so regulatory-filing and bank-sync lifecycles advance without contacting a third party. Pick a family to see the activation recipe.',
+						)
+					}}
 				</p>
 			</header>
 
 			<section v-if="loading" class="external-adapters__loading">
-				<NcLoadingIcon :size="20" :name="t('shillinq', 'Loading adapter status')" />
+				<NcLoadingIcon
+					:size="20"
+					:name="t('shillinq', 'Loading adapter status')" />
 			</section>
 
-			<section v-else-if="errorMessage" class="external-adapters__error" role="alert">
+			<section
+				v-else-if="errorMessage"
+				class="external-adapters__error"
+				role="alert">
 				{{ errorMessage }}
 			</section>
 
 			<section v-else class="external-adapters__body">
 				<div class="external-adapters__summary" aria-live="polite">
-					<span class="external-adapters__pill external-adapters__pill--total">
+					<span
+						class="external-adapters__pill external-adapters__pill--total">
 						{{ summary.total }} {{ t('shillinq', 'families') }}
 					</span>
-					<span class="external-adapters__pill external-adapters__pill--dormant">
+					<span
+						class="external-adapters__pill external-adapters__pill--dormant">
 						{{ summary.dormant }} {{ t('shillinq', 'dormant') }}
 					</span>
-					<span class="external-adapters__pill external-adapters__pill--live">
+					<span
+						class="external-adapters__pill external-adapters__pill--live">
 						{{ summary.live }} {{ t('shillinq', 'live') }}
 					</span>
 				</div>
 
 				<ul class="external-adapters__list">
-					<li v-for="entry in adapters"
+					<li
+						v-for="entry in adapters"
 						:key="entry.id"
 						class="external-adapters__item"
 						:data-adapter-id="entry.id">
@@ -60,8 +74,12 @@
 									{{ entry.title }}
 								</h3>
 								<p class="external-adapters__item-meta">
-									<span class="external-adapters__category">{{ entry.category }}</span>
-									<span v-if="entry.specSlug" class="external-adapters__spec">
+									<span class="external-adapters__category">{{
+										entry.category
+									}}</span>
+									<span
+										v-if="entry.specSlug"
+										class="external-adapters__spec">
 										{{ entry.specSlug }}
 									</span>
 								</p>
@@ -70,12 +88,19 @@
 								</p>
 							</div>
 							<div class="external-adapters__item-actions">
-								<span class="external-adapters__badge"
+								<span
+									class="external-adapters__badge"
 									:class="badgeClass(entry.dormant)"
 									:data-state="entry.dormant ? 'dormant' : 'live'">
-									{{ entry.dormant ? t('shillinq', 'Dormant') : t('shillinq', 'Live') }}
+									{{
+										entry.dormant
+											? t('shillinq', 'Dormant')
+											: t('shillinq', 'Live')
+									}}
 								</span>
-								<NcButton variant="secondary" @click="openDetail(entry.id)">
+								<NcButton
+									variant="secondary"
+									@click="openDetail(entry.id)">
 									{{ t('shillinq', 'View activation') }}
 								</NcButton>
 							</div>
@@ -126,10 +151,14 @@ export default {
 			try {
 				const url = generateUrl('/apps/shillinq/api/admin/external-adapters')
 				const { data } = await axios.get(url)
-				this.adapters = (data?.adapters ?? [])
-				this.summary = (data?.summary ?? { total: 0, dormant: 0, live: 0 })
+				this.adapters = data?.adapters ?? []
+				this.summary = data?.summary ?? { total: 0, dormant: 0, live: 0 }
 			} catch (err) {
-				this.errorMessage = t('shillinq', 'Could not load external adapter status: {message}', { message: err?.message ?? 'unknown error' })
+				this.errorMessage = t(
+					'shillinq',
+					'Could not load external adapter status: {message}',
+					{ message: err?.message ?? 'unknown error' },
+				)
 			} finally {
 				this.loading = false
 			}
@@ -158,7 +187,7 @@ export default {
 				'csrd-esrs-xbrl': 'ExternalAdapterCsrd',
 				'deposit-payment': 'ExternalAdapterDepositPayment',
 			}
-			return (map[id] ?? null)
+			return map[id] ?? null
 		},
 	},
 }

--- a/src/views/inventory/CountPage.vue
+++ b/src/views/inventory/CountPage.vue
@@ -28,9 +28,20 @@ export default {
 </script>
 
 <style scoped>
-.count-page { display: flex; flex-direction: column; gap: var(--default-grid-baseline, 4px); padding: var(--default-grid-baseline, 4px); }
+.count-page {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline, 4px);
+	padding: var(--default-grid-baseline, 4px);
+}
 
-.count-page__header { display: flex; justify-content: space-between; align-items: center; }
+.count-page__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
 
-.count-page__back { text-decoration: none; }
+.count-page__back {
+	text-decoration: none;
+}
 </style>

--- a/src/views/inventory/MobileScannerHome.vue
+++ b/src/views/inventory/MobileScannerHome.vue
@@ -15,23 +15,38 @@
 		</header>
 
 		<p class="mobile-scanner-home__intro">
-			{{ t('shillinq', 'Select an operation to begin. All operations work offline.') }}
+			{{
+				t(
+					'shillinq',
+					'Select an operation to begin. All operations work offline.',
+				)
+			}}
 		</p>
 
-		<nav class="mobile-scanner-home__grid" :aria-label="t('shillinq', 'Warehouse operations')">
-			<router-link to="/inventory/mobile/receive" class="mobile-scanner-home__tile">
+		<nav
+			class="mobile-scanner-home__grid"
+			:aria-label="t('shillinq', 'Warehouse operations')">
+			<router-link
+				to="/inventory/mobile/receive"
+				class="mobile-scanner-home__tile">
 				<strong>{{ t('shillinq', 'Receive') }}</strong>
 				<span>{{ t('shillinq', 'Goods inbound') }}</span>
 			</router-link>
-			<router-link to="/inventory/mobile/transfer" class="mobile-scanner-home__tile">
+			<router-link
+				to="/inventory/mobile/transfer"
+				class="mobile-scanner-home__tile">
 				<strong>{{ t('shillinq', 'Transfer') }}</strong>
 				<span>{{ t('shillinq', 'Move between locations') }}</span>
 			</router-link>
-			<router-link to="/inventory/mobile/pick" class="mobile-scanner-home__tile">
+			<router-link
+				to="/inventory/mobile/pick"
+				class="mobile-scanner-home__tile">
 				<strong>{{ t('shillinq', 'Pick') }}</strong>
 				<span>{{ t('shillinq', 'Fulfil an order line') }}</span>
 			</router-link>
-			<router-link to="/inventory/mobile/count" class="mobile-scanner-home__tile">
+			<router-link
+				to="/inventory/mobile/count"
+				class="mobile-scanner-home__tile">
 				<strong>{{ t('shillinq', 'Count') }}</strong>
 				<span>{{ t('shillinq', 'Physical count + variance') }}</span>
 			</router-link>
@@ -62,16 +77,32 @@ export default {
 </script>
 
 <style scoped>
-.mobile-scanner-home { display: flex; flex-direction: column; gap: var(--default-grid-baseline, 4px); padding: var(--default-grid-baseline, 4px); }
+.mobile-scanner-home {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline, 4px);
+	padding: var(--default-grid-baseline, 4px);
+}
 
-.mobile-scanner-home__header { display: flex; justify-content: space-between; align-items: center; }
+.mobile-scanner-home__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
 
-.mobile-scanner-home__intro { color: var(--color-text-maxcontrast); }
+.mobile-scanner-home__intro {
+	color: var(--color-text-maxcontrast);
+}
 
-.mobile-scanner-home__grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--default-grid-baseline, 4px); }
+.mobile-scanner-home__grid {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: var(--default-grid-baseline, 4px);
+}
 
 .mobile-scanner-home__tile {
-	display: flex; flex-direction: column;
+	display: flex;
+	flex-direction: column;
 	padding: 16px;
 	border-radius: var(--border-radius-large, 8px);
 	background: var(--color-background-hover);
@@ -79,5 +110,7 @@ export default {
 	color: inherit;
 }
 
-.mobile-scanner-home__tile strong { font-size: 1.2em; }
+.mobile-scanner-home__tile strong {
+	font-size: 1.2em;
+}
 </style>

--- a/src/views/inventory/PickPage.vue
+++ b/src/views/inventory/PickPage.vue
@@ -28,9 +28,20 @@ export default {
 </script>
 
 <style scoped>
-.pick-page { display: flex; flex-direction: column; gap: var(--default-grid-baseline, 4px); padding: var(--default-grid-baseline, 4px); }
+.pick-page {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline, 4px);
+	padding: var(--default-grid-baseline, 4px);
+}
 
-.pick-page__header { display: flex; justify-content: space-between; align-items: center; }
+.pick-page__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
 
-.pick-page__back { text-decoration: none; }
+.pick-page__back {
+	text-decoration: none;
+}
 </style>

--- a/src/views/inventory/ReceivePage.vue
+++ b/src/views/inventory/ReceivePage.vue
@@ -31,9 +31,20 @@ export default {
 </script>
 
 <style scoped>
-.receive-page { display: flex; flex-direction: column; gap: var(--default-grid-baseline, 4px); padding: var(--default-grid-baseline, 4px); }
+.receive-page {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline, 4px);
+	padding: var(--default-grid-baseline, 4px);
+}
 
-.receive-page__header { display: flex; justify-content: space-between; align-items: center; }
+.receive-page__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
 
-.receive-page__back { text-decoration: none; }
+.receive-page__back {
+	text-decoration: none;
+}
 </style>

--- a/src/views/inventory/TransferPage.vue
+++ b/src/views/inventory/TransferPage.vue
@@ -28,9 +28,20 @@ export default {
 </script>
 
 <style scoped>
-.transfer-page { display: flex; flex-direction: column; gap: var(--default-grid-baseline, 4px); padding: var(--default-grid-baseline, 4px); }
+.transfer-page {
+	display: flex;
+	flex-direction: column;
+	gap: var(--default-grid-baseline, 4px);
+	padding: var(--default-grid-baseline, 4px);
+}
 
-.transfer-page__header { display: flex; justify-content: space-between; align-items: center; }
+.transfer-page__header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
 
-.transfer-page__back { text-decoration: none; }
+.transfer-page__back {
+	text-decoration: none;
+}
 </style>

--- a/src/views/invoice/AdminInvoiceDetail.vue
+++ b/src/views/invoice/AdminInvoiceDetail.vue
@@ -20,30 +20,48 @@
 		</header>
 
 		<dl class="admin-invoice-detail__meta">
-			<dt>{{ t('shillinq', 'Billing model') }}</dt><dd>{{ invoice.billingModel }}</dd>
-			<dt>{{ t('shillinq', 'Customer') }}</dt><dd>{{ invoice.customerId }}</dd>
-			<dt>{{ t('shillinq', 'Project') }}</dt><dd>{{ invoice.projectId || '—' }}</dd>
-			<dt>{{ t('shillinq', 'Invoice date') }}</dt><dd>{{ invoice.invoiceDate }}</dd>
-			<dt>{{ t('shillinq', 'Due date') }}</dt><dd>{{ invoice.dueDate }}</dd>
-			<dt>{{ t('shillinq', 'Rate card') }}</dt><dd>{{ invoice.rateCardId || '—' }}</dd>
-			<dt>{{ t('shillinq', 'Retainer schedule') }}</dt><dd>{{ invoice.retainerScheduleId || '—' }}</dd>
-			<dt>{{ t('shillinq', 'Status') }}</dt><dd>{{ invoice.status }} <span v-if="invoice.posted">({{ t('shillinq', 'Posted') }})</span></dd>
-			<dt>{{ t('shillinq', 'Obligation') }}</dt><dd>{{ invoice.obligationId || '—' }}</dd>
+			<dt>{{ t('shillinq', 'Billing model') }}</dt>
+			<dd>{{ invoice.billingModel }}</dd>
+			<dt>{{ t('shillinq', 'Customer') }}</dt>
+			<dd>{{ invoice.customerId }}</dd>
+			<dt>{{ t('shillinq', 'Project') }}</dt>
+			<dd>{{ invoice.projectId || '—' }}</dd>
+			<dt>{{ t('shillinq', 'Invoice date') }}</dt>
+			<dd>{{ invoice.invoiceDate }}</dd>
+			<dt>{{ t('shillinq', 'Due date') }}</dt>
+			<dd>{{ invoice.dueDate }}</dd>
+			<dt>{{ t('shillinq', 'Rate card') }}</dt>
+			<dd>{{ invoice.rateCardId || '—' }}</dd>
+			<dt>{{ t('shillinq', 'Retainer schedule') }}</dt>
+			<dd>{{ invoice.retainerScheduleId || '—' }}</dd>
+			<dt>{{ t('shillinq', 'Status') }}</dt>
+			<dd>
+				{{ invoice.status }}
+				<span v-if="invoice.posted">({{ t('shillinq', 'Posted') }})</span>
+			</dd>
+			<dt>{{ t('shillinq', 'Obligation') }}</dt>
+			<dd>{{ invoice.obligationId || '—' }}</dd>
 		</dl>
 
-		<InvoiceLineItemReview :lines="lines" :summary="invoice.summary || invoice" />
+		<InvoiceLineItemReview
+			:lines="lines"
+			:summary="invoice.summary || invoice" />
 
 		<section v-if="auditTrail.length" class="admin-invoice-detail__audit">
 			<h3>{{ t('shillinq', 'Audit trail') }}</h3>
 			<ul>
 				<li v-for="(event, idx) in auditTrail" :key="idx">
-					<strong>{{ event.timestamp }}</strong> — {{ event.actor }}: {{ event.action }}
+					<strong>{{ event.timestamp }}</strong> — {{ event.actor }}:
+					{{ event.action }}
 				</li>
 			</ul>
 		</section>
 
 		<div class="admin-invoice-detail__actions">
-			<button type="button" :disabled="invoice.status !== 'draft'" @click="post">
+			<button
+				type="button"
+				:disabled="invoice.status !== 'draft'"
+				@click="post">
 				{{ t('shillinq', 'Post to AR') }}
 			</button>
 			<button type="button" @click="pdf">

--- a/src/views/invoice/AdminInvoiceList.vue
+++ b/src/views/invoice/AdminInvoiceList.vue
@@ -29,11 +29,11 @@
 		<div class="admin-invoice-list__filters">
 			<label>
 				{{ t('shillinq', 'From') }}
-				<input v-model="filters.fromDate" type="date" @change="reload">
+				<input v-model="filters.fromDate" type="date" @change="reload" />
 			</label>
 			<label>
 				{{ t('shillinq', 'To') }}
-				<input v-model="filters.toDate" type="date" @change="reload">
+				<input v-model="filters.toDate" type="date" @change="reload" />
 			</label>
 			<label>
 				{{ t('shillinq', 'Billing model') }}
@@ -48,11 +48,16 @@
 			</label>
 			<label>
 				{{ t('shillinq', 'Status') }}
-				<select v-model="filters.status" data-testid="admin-invoice-status-filter" @change="reload">
+				<select
+					v-model="filters.status"
+					data-testid="admin-invoice-status-filter"
+					@change="reload">
 					<option value="">{{ t('shillinq', 'All') }}</option>
 					<option value="draft">{{ t('shillinq', 'Draft') }}</option>
 					<option value="posted">{{ t('shillinq', 'Posted') }}</option>
-					<option value="cancelled">{{ t('shillinq', 'Cancelled') }}</option>
+					<option value="cancelled">
+						{{ t('shillinq', 'Cancelled') }}
+					</option>
 				</select>
 			</label>
 		</div>
@@ -71,7 +76,10 @@
 					<router-link :to="`/invoice/${row.id}`">
 						{{ t('shillinq', 'View') }}
 					</router-link>
-					<button type="button" :disabled="row.status !== 'draft'" @click="post(row)">
+					<button
+						type="button"
+						:disabled="row.status !== 'draft'"
+						@click="post(row)">
 						{{ t('shillinq', 'Post') }}
 					</button>
 					<button type="button" @click="pdf(row)">
@@ -116,14 +124,47 @@ export default {
 		 */
 		columns() {
 			return [
-				{ key: 'invoiceNumber', label: this.t('shillinq', 'Invoice #'), sortable: true },
-				{ key: 'invoiceDate', label: this.t('shillinq', 'Invoice date'), sortable: true },
-				{ key: 'dueDate', label: this.t('shillinq', 'Due date'), sortable: true },
-				{ key: 'customerId', label: this.t('shillinq', 'Customer'), sortable: true },
-				{ key: 'billingModel', label: this.t('shillinq', 'Billing model'), sortable: true },
-				{ key: 'grossAmount', label: this.t('shillinq', 'Gross'), sortable: true, align: 'right' },
-				{ key: 'status', label: this.t('shillinq', 'Status'), sortable: true },
-				{ key: 'actions', label: this.t('shillinq', 'Actions'), sortable: false },
+				{
+					key: 'invoiceNumber',
+					label: this.t('shillinq', 'Invoice #'),
+					sortable: true,
+				},
+				{
+					key: 'invoiceDate',
+					label: this.t('shillinq', 'Invoice date'),
+					sortable: true,
+				},
+				{
+					key: 'dueDate',
+					label: this.t('shillinq', 'Due date'),
+					sortable: true,
+				},
+				{
+					key: 'customerId',
+					label: this.t('shillinq', 'Customer'),
+					sortable: true,
+				},
+				{
+					key: 'billingModel',
+					label: this.t('shillinq', 'Billing model'),
+					sortable: true,
+				},
+				{
+					key: 'grossAmount',
+					label: this.t('shillinq', 'Gross'),
+					sortable: true,
+					align: 'right',
+				},
+				{
+					key: 'status',
+					label: this.t('shillinq', 'Status'),
+					sortable: true,
+				},
+				{
+					key: 'actions',
+					label: this.t('shillinq', 'Actions'),
+					sortable: false,
+				},
 			]
 		},
 	},
@@ -136,7 +177,10 @@ export default {
 		t,
 		formatMoney(value) {
 			const n = Number(value || 0)
-			return n.toLocaleString('nl-NL', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+			return n.toLocaleString('nl-NL', {
+				minimumFractionDigits: 2,
+				maximumFractionDigits: 2,
+			})
 		},
 		async reload() {
 			try {

--- a/src/views/receiptCapture.js
+++ b/src/views/receiptCapture.js
@@ -28,8 +28,14 @@ export function reviewFormFromReceipt(record) {
 		photoUri: String(r.photoUri ?? ''),
 		amount: typeof r.amount === 'number' ? r.amount : Number(r.amount) || 0,
 		currency: String(r.currency ?? 'EUR'),
-		amountInBaseCurrency: typeof r.amountInBaseCurrency === 'number' ? r.amountInBaseCurrency : Number(r.amountInBaseCurrency) || 0,
-		exchangeRate: (r.exchangeRate === null || r.exchangeRate === undefined) ? null : Number(r.exchangeRate),
+		amountInBaseCurrency:
+			typeof r.amountInBaseCurrency === 'number'
+				? r.amountInBaseCurrency
+				: Number(r.amountInBaseCurrency) || 0,
+		exchangeRate:
+			r.exchangeRate === null || r.exchangeRate === undefined
+				? null
+				: Number(r.exchangeRate),
 		receiptDate: String(r.receiptDate ?? ''),
 		category: String(r.category ?? ''),
 		extractedText: String(r.extractedText ?? ''),
@@ -57,8 +63,9 @@ export function canSaveReceipt(form) {
 	if (Number.isFinite(Number(f.amount)) === false || Number(f.amount) < 0) {
 		return false
 	}
-	return ['currency', 'receiptDate', 'category']
-		.every((k) => String(f[k] ?? '').trim().length > 0)
+	return ['currency', 'receiptDate', 'category'].every(
+		(k) => String(f[k] ?? '').trim().length > 0,
+	)
 }
 
 /**
@@ -77,7 +84,12 @@ export function buildReceiptConfirmPayload(form) {
 		amount: Number(f.amount) || 0,
 		currency: f.currency,
 		amountInBaseCurrency: Number(f.amountInBaseCurrency) || 0,
-		exchangeRate: (f.exchangeRate === null || f.exchangeRate === undefined || f.exchangeRate === '') ? null : Number(f.exchangeRate),
+		exchangeRate:
+			f.exchangeRate === null
+			|| f.exchangeRate === undefined
+			|| f.exchangeRate === ''
+				? null
+				: Number(f.exchangeRate),
 		receiptDate: f.receiptDate,
 		category: f.category,
 		extractedText: f.extractedText,
@@ -96,8 +108,10 @@ export function buildReceiptConfirmPayload(form) {
  * @return {string} The message to show inline.
  */
 export function receiptErrorMessage(error) {
-	return error?.response?.data?.error
+	return (
+		error?.response?.data?.error
 		|| error?.response?.data?.message
 		|| error?.message
 		|| 'Failed to load or save the receipt.'
+	)
 }

--- a/src/views/settings/PipelinqIntegration.vue
+++ b/src/views/settings/PipelinqIntegration.vue
@@ -1,16 +1,25 @@
 <template>
 	<CnSettingsSection
 		:name="t('shillinq', 'Pipelinq integration')"
-		:description="t('shillinq', 'Configure the pipelinq customer-management connection used to enrich bookings with customer context.')">
+		:description="
+			t(
+				'shillinq',
+				'Configure the pipelinq customer-management connection used to enrich bookings with customer context.',
+			)
+		">
 		<form @submit.prevent="save">
 			<div class="form-group">
-				<label for="pipelinq-endpoint">{{ t('shillinq', 'API endpoint') }}</label>
+				<label for="pipelinq-endpoint">{{
+					t('shillinq', 'API endpoint')
+				}}</label>
 				<input
 					id="pipelinq-endpoint"
 					v-model="form.endpoint"
 					type="url"
 					autocomplete="off"
-					:placeholder="t('shillinq', 'https://pipelinq.example.com/api')">
+					:placeholder="
+						t('shillinq', 'https://pipelinq.example.com/api')
+					" />
 			</div>
 
 			<div class="form-group">
@@ -20,11 +29,23 @@
 					v-model="form.token"
 					type="password"
 					autocomplete="off"
-					:placeholder="hasToken ? maskedPlaceholder : t('shillinq', 'Paste your pipelinq API token')">
+					:placeholder="
+						hasToken
+							? maskedPlaceholder
+							: t('shillinq', 'Paste your pipelinq API token')
+					" />
 				<p class="form-hint">
-					{{ hasToken
-						? t('shillinq', 'A token is stored. Leave empty to keep the current token, or paste a new one to rotate it.')
-						: t('shillinq', 'The token is stored in the Nextcloud secrets store and never returned to the browser.') }}
+					{{
+						hasToken
+							? t(
+									'shillinq',
+									'A token is stored. Leave empty to keep the current token, or paste a new one to rotate it.',
+								)
+							: t(
+									'shillinq',
+									'The token is stored in the Nextcloud secrets store and never returned to the browser.',
+								)
+					}}
 				</p>
 			</div>
 
@@ -33,17 +54,18 @@
 			</div>
 
 			<div class="actions">
-				<NcButton
-					variant="primary"
-					type="submit"
-					:disabled="saving">
+				<NcButton variant="primary" type="submit" :disabled="saving">
 					{{ saving ? t('shillinq', 'Saving…') : t('shillinq', 'Save') }}
 				</NcButton>
 				<NcButton
 					variant="secondary"
 					:disabled="testing || !form.endpoint"
 					@click="test">
-					{{ testing ? t('shillinq', 'Testing…') : t('shillinq', 'Test connection') }}
+					{{
+						testing
+							? t('shillinq', 'Testing…')
+							: t('shillinq', 'Test connection')
+					}}
 				</NcButton>
 			</div>
 		</form>
@@ -91,9 +113,12 @@ export default {
 	methods: {
 		async fetchSettings() {
 			try {
-				const response = await fetch(generateUrl('/apps/shillinq/api/pipelinq/settings'), {
-					headers: { requesttoken: OC.requestToken },
-				})
+				const response = await fetch(
+					generateUrl('/apps/shillinq/api/pipelinq/settings'),
+					{
+						headers: { requesttoken: OC.requestToken },
+					},
+				)
 				if (response.ok) {
 					const data = await response.json()
 					this.form.endpoint = data.endpoint || ''
@@ -112,14 +137,17 @@ export default {
 				body.token = this.form.token
 			}
 			try {
-				const response = await fetch(generateUrl('/apps/shillinq/api/pipelinq/settings'), {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-						requesttoken: OC.requestToken,
+				const response = await fetch(
+					generateUrl('/apps/shillinq/api/pipelinq/settings'),
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							requesttoken: OC.requestToken,
+						},
+						body: JSON.stringify(body),
 					},
-					body: JSON.stringify(body),
-				})
+				)
 				if (response.ok) {
 					const data = await response.json()
 					this.hasToken = !!data.hasToken
@@ -131,13 +159,21 @@ export default {
 				} else {
 					this.feedback = {
 						kind: 'error',
-						message: t('shillinq', 'Failed to save pipelinq settings (HTTP {status}).', { status: response.status }),
+						message: t(
+							'shillinq',
+							'Failed to save pipelinq settings (HTTP {status}).',
+							{ status: response.status },
+						),
 					}
 				}
 			} catch (error) {
 				this.feedback = {
 					kind: 'error',
-					message: t('shillinq', 'Failed to save pipelinq settings: {message}.', { message: error.message }),
+					message: t(
+						'shillinq',
+						'Failed to save pipelinq settings: {message}.',
+						{ message: error.message },
+					),
 				}
 			} finally {
 				this.saving = false
@@ -147,13 +183,16 @@ export default {
 			this.testing = true
 			this.feedback = null
 			try {
-				const response = await fetch(generateUrl('/apps/shillinq/api/pipelinq/settings/test'), {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json',
-						requesttoken: OC.requestToken,
+				const response = await fetch(
+					generateUrl('/apps/shillinq/api/pipelinq/settings/test'),
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							requesttoken: OC.requestToken,
+						},
 					},
-				})
+				)
 				if (response.ok) {
 					const data = await response.json()
 					this.feedback = {
@@ -163,13 +202,19 @@ export default {
 				} else {
 					this.feedback = {
 						kind: 'error',
-						message: t('shillinq', 'Test connection failed (HTTP {status}).', { status: response.status }),
+						message: t(
+							'shillinq',
+							'Test connection failed (HTTP {status}).',
+							{ status: response.status },
+						),
 					}
 				}
 			} catch (error) {
 				this.feedback = {
 					kind: 'error',
-					message: t('shillinq', 'Test connection failed: {message}.', { message: error.message }),
+					message: t('shillinq', 'Test connection failed: {message}.', {
+						message: error.message,
+					}),
 				}
 			} finally {
 				this.testing = false

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -9,17 +9,14 @@
 					id="register"
 					v-model="form.register"
 					type="text"
-					:placeholder="t('shillinq', 'OpenRegister register ID')">
+					:placeholder="t('shillinq', 'OpenRegister register ID')" />
 			</div>
 
 			<div v-if="successMessage" class="success-message">
 				{{ successMessage }}
 			</div>
 
-			<NcButton
-				variant="primary"
-				type="submit"
-				:disabled="saving">
+			<NcButton variant="primary" type="submit" :disabled="saving">
 				{{ saving ? t('shillinq', 'Saving...') : t('shillinq', 'Save') }}
 			</NcButton>
 		</form>

--- a/src/views/settings/StandardsPolicyEditor.vue
+++ b/src/views/settings/StandardsPolicyEditor.vue
@@ -15,7 +15,12 @@
 		<div class="standards-policy__header">
 			<h2>{{ t('shillinq', 'Accounting standards') }}</h2>
 			<p class="standards-policy__intro">
-				{{ t('shillinq', 'Declare which accounting and reporting frameworks this administration follows, and drag them into order of precedence. When frameworks disagree on a treatment (revenue, leases, inventory, …), business logic follows the highest-ranked enabled framework.') }}
+				{{
+					t(
+						'shillinq',
+						'Declare which accounting and reporting frameworks this administration follows, and drag them into order of precedence. When frameworks disagree on a treatment (revenue, leases, inventory, …), business logic follows the highest-ranked enabled framework.',
+					)
+				}}
 			</p>
 		</div>
 
@@ -41,7 +46,13 @@
 						target="_blank"
 						rel="noopener noreferrer"
 						class="standards-policy__docs"
-						:aria-label="t('shillinq', 'Read about {standard} (opens in a new tab)', { standard: row.label })"
+						:aria-label="
+							t(
+								'shillinq',
+								'Read about {standard} (opens in a new tab)',
+								{ standard: row.label },
+							)
+						"
 						:title="t('shillinq', 'Read about this standard')">
 						<OpenInNew :size="16" />
 					</a>
@@ -67,8 +78,12 @@
 				</li>
 			</ul>
 
-			<div class="standards-policy__resolved" data-testid="standards-policy-resolved">
-				<span class="standards-policy__resolved-label">{{ t('shillinq', 'Resolved framework (highest enabled):') }}</span>
+			<div
+				class="standards-policy__resolved"
+				data-testid="standards-policy-resolved">
+				<span class="standards-policy__resolved-label">{{
+					t('shillinq', 'Resolved framework (highest enabled):')
+				}}</span>
 				<strong>{{ resolvedLabel }}</strong>
 			</div>
 
@@ -106,30 +121,106 @@ const DOCS_BASE = 'https://shillinq.conduction.nl/standards/'
  */
 const FRAMEWORKS = [
 	{ key: 'ifrs', label: 'IFRS / IAS (IASB)', docs: `${DOCS_BASE}ifrs` },
-	{ key: 'ifrs-eu', label: 'IFRS (EU-endorsed)', docs: `${DOCS_BASE}eu-national-gaap#eu-endorsed-ifrs` },
-	{ key: 'dutch-gaap', label: 'Dutch GAAP (BW Title 9 + RJ)', docs: `${DOCS_BASE}dutch-gaap` },
-	{ key: 'de-hgb', label: 'German HGB (+ SKR / DRS)', docs: `${DOCS_BASE}eu-national-gaap#german-hgb` },
-	{ key: 'fr-pcg', label: 'French PCG (ANC)', docs: `${DOCS_BASE}eu-national-gaap#french-pcg` },
-	{ key: 'it-oic', label: 'Italian GAAP (OIC)', docs: `${DOCS_BASE}eu-national-gaap#italian-oic` },
-	{ key: 'es-pgc', label: 'Spanish PGC (ICAC)', docs: `${DOCS_BASE}eu-national-gaap#spanish-pgc` },
-	{ key: 'dutch-tax', label: 'Dutch tax (goed koopmansgebruik)', docs: `${DOCS_BASE}dutch-gaap#deep-dive--goed-koopmansgebruik-fiscal-accounting` },
+	{
+		key: 'ifrs-eu',
+		label: 'IFRS (EU-endorsed)',
+		docs: `${DOCS_BASE}eu-national-gaap#eu-endorsed-ifrs`,
+	},
+	{
+		key: 'dutch-gaap',
+		label: 'Dutch GAAP (BW Title 9 + RJ)',
+		docs: `${DOCS_BASE}dutch-gaap`,
+	},
+	{
+		key: 'de-hgb',
+		label: 'German HGB (+ SKR / DRS)',
+		docs: `${DOCS_BASE}eu-national-gaap#german-hgb`,
+	},
+	{
+		key: 'fr-pcg',
+		label: 'French PCG (ANC)',
+		docs: `${DOCS_BASE}eu-national-gaap#french-pcg`,
+	},
+	{
+		key: 'it-oic',
+		label: 'Italian GAAP (OIC)',
+		docs: `${DOCS_BASE}eu-national-gaap#italian-oic`,
+	},
+	{
+		key: 'es-pgc',
+		label: 'Spanish PGC (ICAC)',
+		docs: `${DOCS_BASE}eu-national-gaap#spanish-pgc`,
+	},
+	{
+		key: 'dutch-tax',
+		label: 'Dutch tax (goed koopmansgebruik)',
+		docs: `${DOCS_BASE}dutch-gaap#deep-dive--goed-koopmansgebruik-fiscal-accounting`,
+	},
 	{ key: 'us-gaap', label: 'US GAAP (FASB ASC)', docs: `${DOCS_BASE}us-gaap` },
-	{ key: 'us-tax-basis', label: 'US income-tax basis (IRC)', docs: `${DOCS_BASE}us-gaap#special-purpose-frameworks-ocboa` },
-	{ key: 'us-cash-basis', label: 'US cash basis (OCBOA)', docs: `${DOCS_BASE}us-gaap#special-purpose-frameworks-ocboa` },
-	{ key: 'us-modified-cash', label: 'US modified-cash basis', docs: `${DOCS_BASE}us-gaap#special-purpose-frameworks-ocboa` },
-	{ key: 'us-frf-smes', label: 'US FRF for SMEs (AICPA)', docs: `${DOCS_BASE}us-gaap#special-purpose-frameworks-ocboa` },
-	{ key: 'ipsas', label: 'IPSAS (public sector)', docs: `${DOCS_BASE}public-sector` },
-	{ key: 'bbv', label: 'Dutch BBV (municipal)', docs: `${DOCS_BASE}public-sector#dutch-bbv` },
-	{ key: 'us-gasb', label: 'US GASB (state & local gov)', docs: `${DOCS_BASE}public-sector#us-gasb` },
-	{ key: 'us-fasab', label: 'US FASAB (federal gov)', docs: `${DOCS_BASE}public-sector#us-fasab` },
-	{ key: 'esrs', label: 'ESRS (CSRD sustainability)', docs: `${DOCS_BASE}sustainability` },
-	{ key: 'ifrs-sustainability', label: 'IFRS S1 / S2 (ISSB)', docs: `${DOCS_BASE}sustainability#ifrs-sustainability-issb` },
+	{
+		key: 'us-tax-basis',
+		label: 'US income-tax basis (IRC)',
+		docs: `${DOCS_BASE}us-gaap#special-purpose-frameworks-ocboa`,
+	},
+	{
+		key: 'us-cash-basis',
+		label: 'US cash basis (OCBOA)',
+		docs: `${DOCS_BASE}us-gaap#special-purpose-frameworks-ocboa`,
+	},
+	{
+		key: 'us-modified-cash',
+		label: 'US modified-cash basis',
+		docs: `${DOCS_BASE}us-gaap#special-purpose-frameworks-ocboa`,
+	},
+	{
+		key: 'us-frf-smes',
+		label: 'US FRF for SMEs (AICPA)',
+		docs: `${DOCS_BASE}us-gaap#special-purpose-frameworks-ocboa`,
+	},
+	{
+		key: 'ipsas',
+		label: 'IPSAS (public sector)',
+		docs: `${DOCS_BASE}public-sector`,
+	},
+	{
+		key: 'bbv',
+		label: 'Dutch BBV (municipal)',
+		docs: `${DOCS_BASE}public-sector#dutch-bbv`,
+	},
+	{
+		key: 'us-gasb',
+		label: 'US GASB (state & local gov)',
+		docs: `${DOCS_BASE}public-sector#us-gasb`,
+	},
+	{
+		key: 'us-fasab',
+		label: 'US FASAB (federal gov)',
+		docs: `${DOCS_BASE}public-sector#us-fasab`,
+	},
+	{
+		key: 'esrs',
+		label: 'ESRS (CSRD sustainability)',
+		docs: `${DOCS_BASE}sustainability`,
+	},
+	{
+		key: 'ifrs-sustainability',
+		label: 'IFRS S1 / S2 (ISSB)',
+		docs: `${DOCS_BASE}sustainability#ifrs-sustainability-issb`,
+	},
 ]
 
 export default {
 	name: 'StandardsPolicyEditor',
 
-	components: { NcButton, NcCheckboxRadioSwitch, NcLoadingIcon, ArrowUp, ArrowDown, ContentSave, OpenInNew },
+	components: {
+		NcButton,
+		NcCheckboxRadioSwitch,
+		NcLoadingIcon,
+		ArrowUp,
+		ArrowDown,
+		ContentSave,
+		OpenInNew,
+	},
 
 	data() {
 		return {
@@ -160,21 +251,29 @@ export default {
 			this.loading = true
 			try {
 				const response = await axios.get(
-					generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}`),
+					generateUrl(
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}`,
+					),
 					{ params: { _limit: 1 } },
 				)
 				const rows = response.data?.results ?? response.data?.objects ?? []
-				const policy = Array.isArray(rows) && rows.length > 0 ? rows[0] : null
+				const policy =
+					Array.isArray(rows) && rows.length > 0 ? rows[0] : null
 				if (policy) {
 					this.recordId = policy['@self']?.id ?? policy.id ?? null
-					this.applyPolicy(Array.isArray(policy.frameworks) ? policy.frameworks : [])
+					this.applyPolicy(
+						Array.isArray(policy.frameworks) ? policy.frameworks : [],
+					)
 				}
 			} catch (e) {
 				// No saved policy yet (or the schema is not seeded) — start from
 				// the default catalogue. This is the expected first-use state, so
 				// it is not surfaced as an error.
 				// eslint-disable-next-line no-console
-				console.debug('[StandardsPolicyEditor] no existing policy; using defaults', e)
+				console.debug(
+					'[StandardsPolicyEditor] no existing policy; using defaults',
+					e,
+				)
 			} finally {
 				this.loading = false
 			}
@@ -187,9 +286,12 @@ export default {
 				const p = byKey.get(key)?.precedence
 				return Number.isFinite(p) ? p : Number.MAX_SAFE_INTEGER
 			}
-			this.rows = FRAMEWORKS
-				.map((f) => ({ key: f.key, label: f.label, docs: f.docs, enabled: byKey.get(f.key)?.enabled === true }))
-				.sort((a, b) => precedenceOf(a.key) - precedenceOf(b.key))
+			this.rows = FRAMEWORKS.map((f) => ({
+				key: f.key,
+				label: f.label,
+				docs: f.docs,
+				enabled: byKey.get(f.key)?.enabled === true,
+			})).sort((a, b) => precedenceOf(a.key) - precedenceOf(b.key))
 		},
 
 		setEnabled(index, value) {
@@ -227,15 +329,22 @@ export default {
 			try {
 				if (this.recordId) {
 					await axios.put(
-						generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}/${this.recordId}`),
+						generateUrl(
+							`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}/${this.recordId}`,
+						),
 						payload,
 					)
 				} else {
 					const response = await axios.post(
-						generateUrl(`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}`),
+						generateUrl(
+							`/apps/openregister/api/objects/${REGISTER_SLUG}/${SCHEMA_SLUG}`,
+						),
 						payload,
 					)
-					this.recordId = response.data?.['@self']?.id ?? response.data?.id ?? this.recordId
+					this.recordId =
+						response.data?.['@self']?.id
+						?? response.data?.id
+						?? this.recordId
 				}
 				showSuccess(this.t('shillinq', 'Standards policy saved.'))
 			} catch (e) {

--- a/src/views/settings/UserSettings.vue
+++ b/src/views/settings/UserSettings.vue
@@ -4,15 +4,18 @@
 		:show-navigation="false"
 		:name="t('shillinq', 'Shillinq settings')"
 		@update:open="$emit('update:open', $event)">
-		<NcAppSettingsSection
-			id="general"
-			:name="t('shillinq', 'General')">
+		<NcAppSettingsSection id="general" :name="t('shillinq', 'General')">
 			<template #icon>
 				<CogIcon :size="20" />
 			</template>
 			<NcEmptyContent
 				:name="t('shillinq', 'No settings available yet')"
-				:description="t('shillinq', 'User settings will appear here in a future update.')">
+				:description="
+					t(
+						'shillinq',
+						'User settings will appear here in a future update.',
+					)
+				">
 				<template #icon>
 					<CogIcon :size="64" />
 				</template>
@@ -22,7 +25,11 @@
 </template>
 
 <script>
-import { NcAppSettingsDialog, NcAppSettingsSection, NcEmptyContent } from '@nextcloud/vue'
+import {
+	NcAppSettingsDialog,
+	NcAppSettingsSection,
+	NcEmptyContent,
+} from '@nextcloud/vue'
 import CogIcon from 'vue-material-design-icons/Cog.vue'
 
 export default {

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,8 +1,11 @@
 module.exports = {
 	extends: '@nextcloud/stylelint-config',
 	rules: {
-		'selector-pseudo-element-no-unknown': [true, {
-			ignorePseudoElements: ['v-deep'],
-		}],
+		'selector-pseudo-element-no-unknown': [
+			true,
+			{
+				ignorePseudoElements: ['v-deep'],
+			},
+		],
 	},
 }

--- a/tests/check-manifest-budget.js
+++ b/tests/check-manifest-budget.js
@@ -101,7 +101,9 @@ function main() {
 		fragmentsSize = sumJsonFileSizes(MANIFEST_D_DIR)
 	} catch (err) {
 		// eslint-disable-next-line no-console
-		console.error(`[check-manifest-budget] could not read manifest files: ${err.message}`)
+		console.error(
+			`[check-manifest-budget] could not read manifest files: ${err.message}`,
+		)
 		process.exit(1)
 		return
 	}
@@ -111,16 +113,16 @@ function main() {
 	// eslint-disable-next-line no-console
 	console.log(
 		`[check-manifest-budget] manifest.json=${manifestSize}B manifest.d/=${fragmentsSize}B `
-		+ `total=${total}B budget=${budget}B`,
+			+ `total=${total}B budget=${budget}B`,
 	)
 
 	if (total > budget) {
 		// eslint-disable-next-line no-console
 		console.error(
 			`[check-manifest-budget] FAIL: combined manifest JSON (${total}B) exceeds the `
-			+ `${budget}B budget shipped in the main webpack chunk (REQ-MBP-001). Either trim `
-			+ `the added fragment(s), or raise MANIFEST_BUDGET_BYTES deliberately if the growth `
-			+ `is justified — re-measure with \`du -bc src/manifest.json src/manifest.d/*.json\`.`,
+				+ `${budget}B budget shipped in the main webpack chunk (REQ-MBP-001). Either trim `
+				+ `the added fragment(s), or raise MANIFEST_BUDGET_BYTES deliberately if the growth `
+				+ `is justified — re-measure with \`du -bc src/manifest.json src/manifest.d/*.json\`.`,
 		)
 		process.exit(1)
 		return

--- a/tests/e2e/AccountantPortalDashboard.spec.js
+++ b/tests/e2e/AccountantPortalDashboard.spec.js
@@ -47,7 +47,9 @@ test.describe('accountant-portal — scoped multi-client dashboard (REQ-ACP-001/
 		page.setViewportSize({ width: 1600, height: 1200 })
 	})
 
-	test('renders client cards or the no-memberships empty state', async ({ page }) => {
+	test('renders client cards or the no-memberships empty state', async ({
+		page,
+	}) => {
 		await page.goto(`${APP}${ROUTE}`)
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -67,14 +69,20 @@ test.describe('accountant-portal — scoped multi-client dashboard (REQ-ACP-001/
 		await expect(card).toBeVisible()
 	})
 
-	test('the handover-pack action requests the scoped export endpoint', async ({ page, context }) => {
+	test('the handover-pack action requests the scoped export endpoint', async ({
+		page,
+		context,
+	}) => {
 		await page.goto(`${APP}${ROUTE}`)
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
 
 		const button = page.getByTestId('accountant-handover-pack-button').first()
 		const hasButton = await button.isVisible().catch(() => false)
-		test.skip(!hasButton, 'no client administration available to test the handover-pack action against')
+		test.skip(
+			!hasButton,
+			'no client administration available to test the handover-pack action against',
+		)
 
 		const [popup] = await Promise.all([
 			context.waitForEvent('page', { timeout: 5_000 }).catch(() => null),

--- a/tests/e2e/DeadlineCalendarSettings.spec.js
+++ b/tests/e2e/DeadlineCalendarSettings.spec.js
@@ -48,14 +48,19 @@ test.describe('compliance-deadline-calendar — per-user category toggles (REQ-C
 		page.setViewportSize({ width: 1600, height: 1200 })
 	})
 
-	test('renders the four deadline categories with AR opt-in off by default', async ({ page }) => {
+	test('renders the four deadline categories with AR opt-in off by default', async ({
+		page,
+	}) => {
 		await page.goto(`${APP}${ROUTE}`)
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
 
 		const filing = page.getByTestId('deadline-category-filing')
 		const deployed = await filing.isVisible().catch(() => false)
-		test.skip(!deployed, 'deadline-calendar settings page not deployed on this build')
+		test.skip(
+			!deployed,
+			'deadline-calendar settings page not deployed on this build',
+		)
 
 		await expect(page.getByTestId('deadline-category-payment-run')).toBeVisible()
 		await expect(page.getByTestId('deadline-category-ar-due')).toBeVisible()
@@ -67,18 +72,24 @@ test.describe('compliance-deadline-calendar — per-user category toggles (REQ-C
 		await expect(page.getByTestId('deadline-lead-filing')).toBeVisible()
 	})
 
-	test('toggling the payment-run category off saves through the settings endpoint', async ({ page }) => {
+	test('toggling the payment-run category off saves through the settings endpoint', async ({
+		page,
+	}) => {
 		await page.goto(`${APP}${ROUTE}`)
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
 
 		const toggle = page.getByTestId('deadline-toggle-payment-run')
 		const deployed = await toggle.isVisible().catch(() => false)
-		test.skip(!deployed, 'deadline-calendar settings page not deployed on this build')
+		test.skip(
+			!deployed,
+			'deadline-calendar settings page not deployed on this build',
+		)
 
 		await toggle.click()
 		const saveResponse = page.waitForResponse(
-			(response) => response.url().includes('/api/deadline-calendar/settings')
+			(response) =>
+				response.url().includes('/api/deadline-calendar/settings')
 				&& response.request().method() === 'POST',
 		)
 		await page.getByTestId('deadline-settings-save').click()

--- a/tests/e2e/ar-invoice-einvoice.spec.ts
+++ b/tests/e2e/ar-invoice-einvoice.spec.ts
@@ -53,8 +53,14 @@ async function openInvoiceByState(page: Page, state: string): Promise<boolean> {
 		return false
 	}
 	await row.click()
-	await page.locator('[data-testid="ar-einvoice-actions"]').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {})
-	return await page.locator('[data-testid="ar-einvoice-actions"]').isVisible().catch(() => false)
+	await page
+		.locator('[data-testid="ar-einvoice-actions"]')
+		.waitFor({ state: 'visible', timeout: 10_000 })
+		.catch(() => {})
+	return await page
+		.locator('[data-testid="ar-einvoice-actions"]')
+		.isVisible()
+		.catch(() => false)
 }
 
 test.describe('add-invoice-pdf-export-with-ubl-peppol-support — Send e-invoice + delivery status (REQ-EINV-007)', () => {
@@ -62,7 +68,9 @@ test.describe('add-invoice-pdf-export-with-ubl-peppol-support — Send e-invoice
 		page.setViewportSize({ width: 1600, height: 1200 })
 	})
 
-	test('issued invoice: status chip renders and Send e-invoice is enabled', async ({ page }) => {
+	test('issued invoice: status chip renders and Send e-invoice is enabled', async ({
+		page,
+	}) => {
 		const opened = await openInvoiceByState(page, 'issued')
 		test.skip(!opened, 'no issued ARInvoice seeded in this administration')
 

--- a/tests/e2e/bank-statement-wizard.spec.ts
+++ b/tests/e2e/bank-statement-wizard.spec.ts
@@ -55,7 +55,9 @@ async function openWizard(page: Page): Promise<boolean> {
 		return false
 	}
 	await importBank.click()
-	await page.locator('[data-testid="bank-statement-wizard"]').waitFor({ state: 'visible', timeout: 8_000 })
+	await page
+		.locator('[data-testid="bank-statement-wizard"]')
+		.waitFor({ state: 'visible', timeout: 8_000 })
 	return true
 }
 
@@ -66,7 +68,10 @@ test.describe('shillinq-bank-statement-wizard', () => {
 	 * @e2e shillinq-bank-statement-wizard::clicking-import-bank-opens-the-wizard
 	 */
 	test('clicking Import bank opens the wizard', async ({ page }) => {
-		test.skip(!(await openWizard(page)), 'Financial dashboard / Import bank action not available for this administration')
+		test.skip(
+			!(await openWizard(page)),
+			'Financial dashboard / Import bank action not available for this administration',
+		)
 		await expect(page.locator('[data-testid="bsw-step-1"]')).toBeVisible()
 	})
 
@@ -110,7 +115,9 @@ test.describe('shillinq-bank-statement-wizard', () => {
 		// Step-2 markup is part of the same dialog; presence of the wizard shell
 		// proves the mapping step is reachable. The skip/remember branch logic is
 		// unit-tested (bankStatementWizard.spec.js: buildMappingDecision).
-		await expect(page.locator('[data-testid="bank-statement-wizard"]')).toBeVisible()
+		await expect(
+			page.locator('[data-testid="bank-statement-wizard"]'),
+		).toBeVisible()
 	})
 
 	/**
@@ -131,7 +138,9 @@ test.describe('shillinq-bank-statement-wizard', () => {
 	 *
 	 * @e2e shillinq-bank-statement-wizard::a-valid-camt053-upload-creates-a-statement-and-lines
 	 */
-	test('a valid CAMT.053 upload creates a statement and lines', async ({ page }) => {
+	test('a valid CAMT.053 upload creates a statement and lines', async ({
+		page,
+	}) => {
 		test.skip(!(await openWizard(page)), 'Import bank action not available')
 		await expect(page.locator('[data-testid="bsw-step-1"]')).toBeVisible()
 	})
@@ -145,7 +154,9 @@ test.describe('shillinq-bank-statement-wizard', () => {
 	 */
 	test('unparseable input is rejected', async ({ page }) => {
 		test.skip(!(await openWizard(page)), 'Import bank action not available')
-		await expect(page.locator('[data-testid="bank-statement-wizard"]')).toBeVisible()
+		await expect(
+			page.locator('[data-testid="bank-statement-wizard"]'),
+		).toBeVisible()
 	})
 
 	/**
@@ -158,7 +169,9 @@ test.describe('shillinq-bank-statement-wizard', () => {
 	 */
 	test('the endpoint never trusts a client administrationId', async ({ page }) => {
 		test.skip(!(await openWizard(page)), 'Import bank action not available')
-		await expect(page.locator('[data-testid="bank-statement-wizard"]')).toBeVisible()
+		await expect(
+			page.locator('[data-testid="bank-statement-wizard"]'),
+		).toBeVisible()
 	})
 
 	/**
@@ -169,7 +182,9 @@ test.describe('shillinq-bank-statement-wizard', () => {
 	 */
 	test('import and review navigates to reconciliation', async ({ page }) => {
 		test.skip(!(await openWizard(page)), 'Import bank action not available')
-		await expect(page.locator('[data-testid="bank-statement-wizard"]')).toBeVisible()
+		await expect(
+			page.locator('[data-testid="bank-statement-wizard"]'),
+		).toBeVisible()
 	})
 
 	/**

--- a/tests/e2e/base-url.ts
+++ b/tests/e2e/base-url.ts
@@ -25,7 +25,11 @@
  * names are accepted; only the absence of all three is an error.
  */
 
-export const BASE_URL_ENV_NAMES = ['PLAYWRIGHT_BASE_URL', 'BASE_URL', 'NEXTCLOUD_URL'] as const
+export const BASE_URL_ENV_NAMES = [
+	'PLAYWRIGHT_BASE_URL',
+	'BASE_URL',
+	'NEXTCLOUD_URL',
+] as const
 
 /**
  * Resolve the base URL, or throw.
@@ -39,9 +43,9 @@ export function resolveBaseURL(): string {
 	}
 	throw new Error(
 		`No Nextcloud base URL configured. Set one of ${BASE_URL_ENV_NAMES.join(' / ')} `
-		+ '— e.g. PLAYWRIGHT_BASE_URL=http://localhost:8087. '
-		+ 'There is deliberately no default: the old fallback was the SHARED dev '
-		+ 'container on :8080, so an unset environment silently drove somebody '
-		+ "else's instance.",
+			+ '— e.g. PLAYWRIGHT_BASE_URL=http://localhost:8087. '
+			+ 'There is deliberately no default: the old fallback was the SHARED dev '
+			+ 'container on :8080, so an unset environment silently drove somebody '
+			+ "else's instance.",
 	)
 }

--- a/tests/e2e/bbv-compliance.spec.ts
+++ b/tests/e2e/bbv-compliance.spec.ts
@@ -40,7 +40,6 @@ async function dismissWizard(page: Page): Promise<void> {
 }
 
 test.describe('BBV — Iv3-aanlevering dashboard shell', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + ROUTE_IV3_AANLEVERING)
 		await page.waitForLoadState('domcontentloaded')
@@ -50,22 +49,27 @@ test.describe('BBV — Iv3-aanlevering dashboard shell', () => {
 	/**
 	 * @e2e bookkeeping-bbv-compliance/REQ-BBV-006/iv3-aanlevering-shell-renders
 	 */
-	test('Iv3-aanlevering dashboard mounts on a gemeente administration', async ({ page }) => {
+	test('Iv3-aanlevering dashboard mounts on a gemeente administration', async ({
+		page,
+	}) => {
 		// The dashboard route should return 200 and mount the page shell. On a
 		// non-BBV admin the menu hides — in that case the route 404s and the
 		// spec is implicitly skipped by the test environment fixture.
 		const status = page.url()
-		test.skip(!status.includes(ROUTE_IV3_AANLEVERING),
-			'Iv3-aanlevering dashboard hidden on this administration type')
+		test.skip(
+			!status.includes(ROUTE_IV3_AANLEVERING),
+			'Iv3-aanlevering dashboard hidden on this administration type',
+		)
 
 		// Dashboard page wrapper renders. The manifest declares
 		// `type: dashboard`, so the CnDashboardPage shell should be present.
-		await expect(page.locator('main, [role="main"]')).toBeVisible({ timeout: 15_000 })
+		await expect(page.locator('main, [role="main"]')).toBeVisible({
+			timeout: 15_000,
+		})
 	})
 })
 
 test.describe('BBV — Iv3-rapportages index shell', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + ROUTE_IV3_RAPPORTAGES)
 		await page.waitForLoadState('domcontentloaded')
@@ -76,12 +80,13 @@ test.describe('BBV — Iv3-rapportages index shell', () => {
 	 * @e2e bookkeeping-bbv-compliance/REQ-BBV-006/iv3-rapportages-index-renders
 	 */
 	test('Iv3-rapportages index mounts', async ({ page }) => {
-		await expect(page.locator('main, [role="main"]')).toBeVisible({ timeout: 15_000 })
+		await expect(page.locator('main, [role="main"]')).toBeVisible({
+			timeout: 15_000,
+		})
 	})
 })
 
 test.describe('BBV — BBV-mapping index shell', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + ROUTE_BBV_MAPPING)
 		await page.waitForLoadState('domcontentloaded')
@@ -91,8 +96,12 @@ test.describe('BBV — BBV-mapping index shell', () => {
 	/**
 	 * @e2e bookkeeping-bbv-compliance/REQ-BBV-001/bbv-mapping-index-renders
 	 */
-	test('BBV-mapping index renders with at least the search affordance', async ({ page }) => {
-		await expect(page.locator('main, [role="main"]')).toBeVisible({ timeout: 15_000 })
+	test('BBV-mapping index renders with at least the search affordance', async ({
+		page,
+	}) => {
+		await expect(page.locator('main, [role="main"]')).toBeVisible({
+			timeout: 15_000,
+		})
 	})
 })
 

--- a/tests/e2e/bill-import-modal.spec.ts
+++ b/tests/e2e/bill-import-modal.spec.ts
@@ -54,7 +54,9 @@ async function openModal(page: Page): Promise<boolean> {
 		return false
 	}
 	await importBill.click()
-	await page.locator('[data-testid="bill-import-modal"]').waitFor({ state: 'visible', timeout: 8_000 })
+	await page
+		.locator('[data-testid="bill-import-modal"]')
+		.waitFor({ state: 'visible', timeout: 8_000 })
 	return true
 }
 
@@ -66,11 +68,16 @@ test.describe('shillinq-bill-import-modal', () => {
 	 * @e2e shillinq-bill-import-modal::ubl-file-uploaded-from-the-dashboard
 	 */
 	test('UBL file uploaded from the dashboard', async ({ page }) => {
-		test.skip(!(await openModal(page)), 'Financial dashboard / Import bill action not available for this administration')
+		test.skip(
+			!(await openModal(page)),
+			'Financial dashboard / Import bill action not available for this administration',
+		)
 		await expect(page.locator('[data-testid="bim-upload-step"]')).toBeVisible()
 		await expect(page.locator('[data-testid="bim-dropzone"]')).toBeVisible()
 		// The hidden file input accepts UBL/e-invoice XML (and CSV/PDF).
-		const accept = await page.locator('[data-testid="bim-file-input"]').getAttribute('accept')
+		const accept = await page
+			.locator('[data-testid="bim-file-input"]')
+			.getAttribute('accept')
 		expect(accept).toContain('.xml')
 	})
 

--- a/tests/e2e/bookings-calendar.spec.ts
+++ b/tests/e2e/bookings-calendar.spec.ts
@@ -27,7 +27,9 @@ import { test, expect } from '@playwright/test'
 const APP = '/apps/shillinq'
 
 test.describe('shillinq — bookings calendar smoke', () => {
-	test('SPA mounts and bookings calendar components are registered @spec REQ-006', async ({ page }) => {
+	test('SPA mounts and bookings calendar components are registered @spec REQ-006', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/')
 		await page.waitForLoadState('domcontentloaded')
 
@@ -57,11 +59,17 @@ test.describe('shillinq — bookings calendar smoke', () => {
 				}
 			}
 			const namespace = win.OCA?.Shillinq ?? {}
-			const candidate = namespace.components
+			const candidate =
+				namespace.components
 				?? namespace.registry
-				?? namespace as Record<string, unknown>
+				?? (namespace as Record<string, unknown>)
 			const keys = candidate ? Object.keys(candidate) : []
-			return keys.filter((k) => /^(bookings|calendar)/i.test(k) || k === 'BookingsCalendar' || k === 'BookingsForm')
+			return keys.filter(
+				(k) =>
+					/^(bookings|calendar)/i.test(k)
+					|| k === 'BookingsCalendar'
+					|| k === 'BookingsForm',
+			)
 		})
 		// Either the registry exposes the keys (component nav wired) or the
 		// SPA simply mounted; both prove the bundle includes the components.
@@ -70,7 +78,9 @@ test.describe('shillinq — bookings calendar smoke', () => {
 		expect(Array.isArray(registryEntries)).toBe(true)
 	})
 
-	test('GET /api/v2/calendars responds 200 with a JSON array @spec REQ-005', async ({ request }) => {
+	test('GET /api/v2/calendars responds 200 with a JSON array @spec REQ-005', async ({
+		request,
+	}) => {
 		const res = await request.get('/index.php/apps/shillinq/api/v2/calendars', {
 			headers: { 'OCS-APIRequest': 'true' },
 		})
@@ -85,8 +95,8 @@ test.describe('shillinq — bookings calendar smoke', () => {
 			// that canonical shape as well as a bare array / { data: [...] }.
 			expect(
 				Array.isArray(body)
-				|| Array.isArray(body?.data)
-				|| Array.isArray(body?.calendars),
+					|| Array.isArray(body?.data)
+					|| Array.isArray(body?.calendars),
 			).toBe(true)
 		}
 	})

--- a/tests/e2e/bookings-notification-triggers.spec.ts
+++ b/tests/e2e/bookings-notification-triggers.spec.ts
@@ -24,7 +24,6 @@ const NOTIFICATION_TRIGGERS_ROUTE = '/communication/notification-triggers'
 const NOTIFICATION_MONITOR_ROUTE = '/communication/notification-monitor'
 
 test.describe('notification triggers — admin index page renders', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + NOTIFICATION_TRIGGERS_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
@@ -46,11 +45,9 @@ test.describe('notification triggers — admin index page renders', () => {
 		const list = page.getByRole('main')
 		await expect(list).toBeVisible({ timeout: 5_000 })
 	})
-
 })
 
 test.describe('notification monitor — admin dashboard renders', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + NOTIFICATION_MONITOR_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
@@ -63,11 +60,9 @@ test.describe('notification monitor — admin dashboard renders', () => {
 		const main = page.getByRole('main')
 		await expect(main).toBeVisible({ timeout: 5_000 })
 	})
-
 })
 
 test.describe('notification config modal — per-booking override', () => {
-
 	/**
 	 * @e2e bookings-notification-triggers/REQ-BNT-007/modal-toggle-trigger
 	 *
@@ -96,5 +91,4 @@ test.describe('notification config modal — per-booking override', () => {
 		// schema migration.
 		await expect(page.getByRole('main')).toBeVisible({ timeout: 5_000 })
 	})
-
 })

--- a/tests/e2e/bookings-resource-calendar.spec.ts
+++ b/tests/e2e/bookings-resource-calendar.spec.ts
@@ -22,7 +22,6 @@ const APP = '/apps/shillinq'
 const CALENDAR_ROUTE = '/verkoop/boekingen-kalender'
 
 test.describe('bookings calendar — month/week/day views render', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + CALENDAR_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
@@ -33,7 +32,9 @@ test.describe('bookings calendar — month/week/day views render', () => {
 			await wizard.waitFor({ state: 'hidden', timeout: 4_000 }).catch(() => {})
 		}
 
-		await page.locator('[data-testid="bk-calendar"]').waitFor({ state: 'visible' })
+		await page
+			.locator('[data-testid="bk-calendar"]')
+			.waitFor({ state: 'visible' })
 	})
 
 	/**
@@ -70,14 +71,18 @@ test.describe('bookings calendar — month/week/day views render', () => {
 	 */
 	test('pending bookings are highlighted as conflicts', async ({ page }) => {
 		await page.locator('[data-testid="bk-calendar-view-month"]').click()
-		const conflict = page.locator('[data-testid^="bk-booking-bk-"].is-conflict').first()
+		const conflict = page
+			.locator('[data-testid^="bk-booking-bk-"].is-conflict')
+			.first()
 		await expect(conflict).toBeVisible({ timeout: 5_000 })
 	})
 
 	/**
 	 * @e2e bookings-resource-calendar/REQ-006/booking-selected-event
 	 */
-	test('clicking a booking emits booking:selected (host page handles silently)', async ({ page }) => {
+	test('clicking a booking emits booking:selected (host page handles silently)', async ({
+		page,
+	}) => {
 		await page.locator('[data-testid="bk-calendar-view-month"]').click()
 		const first = page.locator('[data-testid^="bk-booking-bk-"]').first()
 		await first.click()
@@ -93,13 +98,13 @@ test.describe('bookings calendar — month/week/day views render', () => {
 		await page.locator('[data-testid="bk-calendar-view-day"]').click()
 		const slot = page.locator('[data-testid^="bk-slot-"]').first()
 		await slot.click()
-		await expect(page.locator('[data-testid="bk-form-panel"]')).toBeVisible({ timeout: 3_000 })
+		await expect(page.locator('[data-testid="bk-form-panel"]')).toBeVisible({
+			timeout: 3_000,
+		})
 	})
-
 })
 
 test.describe('booking form — REQ-007 validation + happy/conflict paths', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + CALENDAR_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
@@ -110,7 +115,9 @@ test.describe('booking form — REQ-007 validation + happy/conflict paths', () =
 			await wizard.waitFor({ state: 'hidden', timeout: 4_000 }).catch(() => {})
 		}
 
-		await page.locator('[data-testid="bk-calendar"]').waitFor({ state: 'visible' })
+		await page
+			.locator('[data-testid="bk-calendar"]')
+			.waitFor({ state: 'visible' })
 		// Open the form via a slot click.
 		await page.locator('[data-testid="bk-calendar-view-day"]').click()
 		await page.locator('[data-testid^="bk-slot-"]').first().click()
@@ -120,20 +127,30 @@ test.describe('booking form — REQ-007 validation + happy/conflict paths', () =
 	/**
 	 * @e2e bookings-resource-calendar/REQ-007/form-fields-present
 	 */
-	test('form renders title, start, end, attendee and status fields', async ({ page }) => {
+	test('form renders title, start, end, attendee and status fields', async ({
+		page,
+	}) => {
 		await expect(page.locator('[data-testid="bk-form-title"]')).toBeVisible()
 		await expect(page.locator('[data-testid="bk-form-start"]')).toBeVisible()
 		await expect(page.locator('[data-testid="bk-form-end"]')).toBeVisible()
 		await expect(page.locator('[data-testid="bk-form-attendee"]')).toBeVisible()
-		await expect(page.locator('[data-testid="bk-form-status-pending"]')).toBeVisible()
-		await expect(page.locator('[data-testid="bk-form-status-confirmed"]')).toBeVisible()
+		await expect(
+			page.locator('[data-testid="bk-form-status-pending"]'),
+		).toBeVisible()
+		await expect(
+			page.locator('[data-testid="bk-form-status-confirmed"]'),
+		).toBeVisible()
 	})
 
 	/**
 	 * @e2e bookings-resource-calendar/REQ-007/short-duration-rejected
 	 */
-	test('client-side validation rejects sub-15-minute duration', async ({ page }) => {
-		await page.locator('[data-testid="bk-form-title"]').fill('UI test: too short')
+	test('client-side validation rejects sub-15-minute duration', async ({
+		page,
+	}) => {
+		await page
+			.locator('[data-testid="bk-form-title"]')
+			.fill('UI test: too short')
 		await page.locator('[data-testid="bk-form-attendee"]').fill('UI Tester')
 		// Type a 10-minute window — the form's validate() must surface an error.
 		await page.locator('[data-testid="bk-form-start"]').fill('2027-08-01T10:00')
@@ -147,7 +164,9 @@ test.describe('booking form — REQ-007 validation + happy/conflict paths', () =
 	 */
 	test('cancel button closes the form', async ({ page }) => {
 		await page.locator('[data-testid="bk-form-cancel"]').click()
-		await expect(page.locator('[data-testid="bk-form"]')).not.toBeVisible({ timeout: 3_000 })
+		await expect(page.locator('[data-testid="bk-form"]')).not.toBeVisible({
+			timeout: 3_000,
+		})
 	})
 
 	/**
@@ -156,16 +175,22 @@ test.describe('booking form — REQ-007 validation + happy/conflict paths', () =
 	 * the API into a 409 response — the BookingConflictDialog modal must mount.
 	 */
 	test('conflict modal opens when API returns 409', async ({ page }) => {
-		await page.locator('[data-testid="bk-form-title"]').fill('UI test: known conflict')
+		await page
+			.locator('[data-testid="bk-form-title"]')
+			.fill('UI test: known conflict')
 		await page.locator('[data-testid="bk-form-attendee"]').fill('UI Conflict')
 		await page.locator('[data-testid="bk-form-start"]').fill('2026-05-21T11:15')
 		await page.locator('[data-testid="bk-form-end"]').fill('2026-05-21T11:45')
 		await page.locator('[data-testid="bk-form-status-confirmed"]').check()
 		await page.locator('[data-testid="bk-form-submit"]').click()
-		await expect(page.locator('[data-testid="bk-conflict-dialog"]')).toBeVisible({ timeout: 5_000 })
+		await expect(page.locator('[data-testid="bk-conflict-dialog"]')).toBeVisible(
+			{ timeout: 5_000 },
+		)
 		// Cancel returns the operator to the form without retrying.
 		await page.locator('[data-testid="bk-conflict-cancel"]').click()
-		await expect(page.locator('[data-testid="bk-conflict-dialog"]')).not.toBeVisible({ timeout: 3_000 })
+		await expect(
+			page.locator('[data-testid="bk-conflict-dialog"]'),
+		).not.toBeVisible({ timeout: 3_000 })
 	})
 
 	/**
@@ -174,14 +199,17 @@ test.describe('booking form — REQ-007 validation + happy/conflict paths', () =
 	 * returns 201 — the form must close on success.
 	 */
 	test('successful create closes the form', async ({ page }) => {
-		await page.locator('[data-testid="bk-form-title"]').fill('UI test: clean slot')
+		await page
+			.locator('[data-testid="bk-form-title"]')
+			.fill('UI test: clean slot')
 		await page.locator('[data-testid="bk-form-attendee"]').fill('UI Happy')
 		await page.locator('[data-testid="bk-form-start"]').fill('2028-09-15T09:00')
 		await page.locator('[data-testid="bk-form-end"]').fill('2028-09-15T09:30')
 		await page.locator('[data-testid="bk-form-status-pending"]').check()
 		await page.locator('[data-testid="bk-form-submit"]').click()
 		// On 201, the host view closes the form panel.
-		await expect(page.locator('[data-testid="bk-form-panel"]')).not.toBeVisible({ timeout: 7_000 })
+		await expect(page.locator('[data-testid="bk-form-panel"]')).not.toBeVisible({
+			timeout: 7_000,
+		})
 	})
-
 })

--- a/tests/e2e/bookings-screenshots.spec.ts
+++ b/tests/e2e/bookings-screenshots.spec.ts
@@ -30,7 +30,15 @@ import { test, expect, type Page } from '@playwright/test'
 import * as path from 'path'
 import * as fs from 'fs'
 
-const SHOT_ROOT = path.resolve(__dirname, '..', '..', 'docs', 'static', 'screenshots', 'bookings')
+const SHOT_ROOT = path.resolve(
+	__dirname,
+	'..',
+	'..',
+	'docs',
+	'static',
+	'screenshots',
+	'bookings',
+)
 const APP = '/apps/shillinq'
 
 /**
@@ -43,7 +51,11 @@ async function shoot(page: Page, file: string): Promise<void> {
 	if (!fs.existsSync(SHOT_ROOT)) {
 		fs.mkdirSync(SHOT_ROOT, { recursive: true })
 	}
-	await page.screenshot({ path: path.join(SHOT_ROOT, file), fullPage: false, type: 'png' })
+	await page.screenshot({
+		path: path.join(SHOT_ROOT, file),
+		fullPage: false,
+		type: 'png',
+	})
 }
 
 /**
@@ -53,7 +65,9 @@ async function shoot(page: Page, file: string): Promise<void> {
 async function dismissOverlays(page: Page): Promise<void> {
 	const wizard = page.locator('#firstrunwizard')
 	if (await wizard.isVisible().catch(() => false)) {
-		const close = wizard.getByRole('button', { name: /close|got it|finish|skip/i }).first()
+		const close = wizard
+			.getByRole('button', { name: /close|got it|finish|skip/i })
+			.first()
 		if (await close.isVisible().catch(() => false)) {
 			await close.click().catch(() => {})
 		} else {
@@ -62,22 +76,32 @@ async function dismissOverlays(page: Page): Promise<void> {
 		await wizard.waitFor({ state: 'hidden', timeout: 4000 }).catch(() => {})
 	}
 	const stray = page.locator('[role="dialog"]:not(#firstrunwizard)')
-	if (await stray.first().isVisible().catch(() => false)) {
+	if (
+		await stray
+			.first()
+			.isVisible()
+			.catch(() => false)
+	) {
 		await page.keyboard.press('Escape').catch(() => {})
 		await page.waitForTimeout(300)
 	}
 }
 
 async function go(page: Page, route: string): Promise<void> {
-	const url = (route.startsWith('/apps/') || route.startsWith('/settings'))
-		? route
-		: `${APP}${route.startsWith('/') ? route : `/${route}`}`
-	await page.goto(url).catch(() => { /* tolerate 404 — caller decides */ })
+	const url =
+		route.startsWith('/apps/') || route.startsWith('/settings')
+			? route
+			: `${APP}${route.startsWith('/') ? route : `/${route}`}`
+	await page.goto(url).catch(() => {
+		/* tolerate 404 — caller decides */
+	})
 	// ADR-074 rule 4: `networkidle` never settles on Nextcloud — the shell keeps
 	// long-poll/notification requests open, so the wait always burned its full
 	// timeout and was swallowed by the .catch(). domcontentloaded is the state
 	// that actually arrives; the settle-time wait below covers rendering.
-	await page.waitForLoadState('domcontentloaded').catch(() => { /* tolerate an already-detached navigation */ })
+	await page.waitForLoadState('domcontentloaded').catch(() => {
+		/* tolerate an already-detached navigation */
+	})
 	await dismissOverlays(page)
 	await page.waitForTimeout(900)
 }

--- a/tests/e2e/bookings-widget-embed.spec.ts
+++ b/tests/e2e/bookings-widget-embed.spec.ts
@@ -38,11 +38,12 @@ const SLOTS_API = APP + '/api/widget/slots'
 const APPOINTMENTS_API = APP + '/api/widget/appointments'
 
 test.describe('widget public API — bearer-token gate', () => {
-
 	/**
 	 * @e2e bookings-self-service-widget/REQ-WSW-001/services-without-bearer-401
 	 */
-	test('GET /api/widget/services without bearer returns 401', async ({ request }) => {
+	test('GET /api/widget/services without bearer returns 401', async ({
+		request,
+	}) => {
 		const res = await request.get(SERVICES_API, {
 			headers: { 'OCS-APIREQUEST': 'true', Accept: 'application/json' },
 		})
@@ -56,7 +57,9 @@ test.describe('widget public API — bearer-token gate', () => {
 	/**
 	 * @e2e bookings-self-service-widget/REQ-WSW-001/services-with-bad-bearer-401
 	 */
-	test('GET /api/widget/services with bad bearer returns 401', async ({ request }) => {
+	test('GET /api/widget/services with bad bearer returns 401', async ({
+		request,
+	}) => {
 		const res = await request.get(SERVICES_API + '?businessId=salon-demo', {
 			headers: {
 				'OCS-APIREQUEST': 'true',
@@ -71,16 +74,21 @@ test.describe('widget public API — bearer-token gate', () => {
 	 * @e2e bookings-self-service-widget/REQ-WSW-001/slots-without-bearer-401
 	 */
 	test('GET /api/widget/slots without bearer returns 401', async ({ request }) => {
-		const res = await request.get(SLOTS_API + '?serviceId=haircut&resourceId=chair-1&date=2026-06-09', {
-			headers: { 'OCS-APIREQUEST': 'true', Accept: 'application/json' },
-		})
+		const res = await request.get(
+			SLOTS_API + '?serviceId=haircut&resourceId=chair-1&date=2026-06-09',
+			{
+				headers: { 'OCS-APIREQUEST': 'true', Accept: 'application/json' },
+			},
+		)
 		expect([401, 412].includes(res.status())).toBeTruthy()
 	})
 
 	/**
 	 * @e2e bookings-self-service-widget/REQ-WSW-001/appointments-without-bearer-401
 	 */
-	test('POST /api/widget/appointments without bearer returns 401', async ({ request }) => {
+	test('POST /api/widget/appointments without bearer returns 401', async ({
+		request,
+	}) => {
 		const res = await request.post(APPOINTMENTS_API, {
 			headers: {
 				'OCS-APIREQUEST': 'true',
@@ -97,5 +105,4 @@ test.describe('widget public API — bearer-token gate', () => {
 		})
 		expect([401, 412].includes(res.status())).toBeTruthy()
 	})
-
 })

--- a/tests/e2e/bookkeeping-foundation.spec.ts
+++ b/tests/e2e/bookkeeping-foundation.spec.ts
@@ -39,7 +39,9 @@ test.describe('bookkeeping-foundation — Tier-1 manifest pages', () => {
 		page.setViewportSize({ width: 1280, height: 800 })
 	})
 
-	test('Chart of Accounts (Grootboekschema) — index page mounts on /chart-of-accounts', async ({ page }) => {
+	test('Chart of Accounts (Grootboekschema) — index page mounts on /chart-of-accounts', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/chart-of-accounts')
 		await page.waitForLoadState('domcontentloaded')
 
@@ -57,7 +59,9 @@ test.describe('bookkeeping-foundation — Tier-1 manifest pages', () => {
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('General Ledger (Grootboek) — index page mounts on /general-ledger', async ({ page }) => {
+	test('General Ledger (Grootboek) — index page mounts on /general-ledger', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/general-ledger')
 		await page.waitForLoadState('domcontentloaded')
 
@@ -71,7 +75,9 @@ test.describe('bookkeeping-foundation — Tier-1 manifest pages', () => {
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Journals (Journaalposten) — index page mounts on /journals', async ({ page }) => {
+	test('Journals (Journaalposten) — index page mounts on /journals', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/journals')
 		await page.waitForLoadState('domcontentloaded')
 
@@ -85,7 +91,9 @@ test.describe('bookkeeping-foundation — Tier-1 manifest pages', () => {
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Journals navigation entry is reachable from the Shillinq shell', async ({ page }) => {
+	test('Journals navigation entry is reachable from the Shillinq shell', async ({
+		page,
+	}) => {
 		// Start at the app root.
 		await page.goto(APP + '/')
 		await page.waitForLoadState('domcontentloaded')
@@ -100,14 +108,18 @@ test.describe('bookkeeping-foundation — Tier-1 manifest pages', () => {
 		// The shell may render it under different markup depending on the
 		// renderer version, so accept anchor href OR navigation label.
 		const journalsLink = page
-			.locator('a[href*="/journals"], [data-testid*="journals" i], a:has-text("Journals"), a:has-text("Journaalposten")')
+			.locator(
+				'a[href*="/journals"], [data-testid*="journals" i], a:has-text("Journals"), a:has-text("Journaalposten")',
+			)
 			.first()
 
 		// Mounted means: either the link exists in the DOM (mounted by
 		// CnAppRoot) OR a navigation/sidebar element rendered at all (the
 		// dev container may not have the bookkeeping nav cluster expanded
 		// before the seed runs). Either way the SPA must stay on its URL.
-		await journalsLink.waitFor({ state: 'attached', timeout: 5_000 }).catch(() => {})
+		await journalsLink
+			.waitFor({ state: 'attached', timeout: 5_000 })
+			.catch(() => {})
 		expect(page.url()).toContain('/apps/shillinq')
 	})
 })

--- a/tests/e2e/bookkeeping-ifrs15-revenue.spec.ts
+++ b/tests/e2e/bookkeeping-ifrs15-revenue.spec.ts
@@ -44,7 +44,9 @@ test.describe('shillinq — IFRS 15 Revenue Recognition SPA smoke', () => {
 		expect(page.url()).toContain('/apps/shillinq')
 	})
 
-	test('Contract entry route resolves in the manifest shell (REQ-IFRS15-001)', async ({ page }) => {
+	test('Contract entry route resolves in the manifest shell (REQ-IFRS15-001)', async ({
+		page,
+	}) => {
 		// Browser-Test 1 in tasks.md: contract entry form — required fields
 		// validate, SSP auto-calculate relative allocation, dueDate auto-
 		// populated. The full form is rendered by manifest-v2 's `type: detail`
@@ -57,7 +59,9 @@ test.describe('shillinq — IFRS 15 Revenue Recognition SPA smoke', () => {
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Revenue Waterfall route resolves in the manifest shell (REQ-IFRS15-008)', async ({ page }) => {
+	test('Revenue Waterfall route resolves in the manifest shell (REQ-IFRS15-008)', async ({
+		page,
+	}) => {
 		// Browser-Test 2 in tasks.md: 60-month waterfall chart renders, segment
 		// filter (customer, geography, product) updates chart. Smoke here is
 		// the SPA route mount; the chart's 60-month forecast + segment filter
@@ -68,7 +72,9 @@ test.describe('shillinq — IFRS 15 Revenue Recognition SPA smoke', () => {
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Contract Balances route resolves in the manifest shell (REQ-IFRS15-007)', async ({ page }) => {
+	test('Contract Balances route resolves in the manifest shell (REQ-IFRS15-007)', async ({
+		page,
+	}) => {
 		// Browser-Test 3 in tasks.md: contract-asset/liability bar chart by
 		// customer with drill-down to contract detail. Smoke here is the SPA
 		// route mount; the bar chart + drill-down need a live OR with
@@ -79,7 +85,9 @@ test.describe('shillinq — IFRS 15 Revenue Recognition SPA smoke', () => {
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Contract Modifications route resolves in the manifest shell (REQ-IFRS15-006)', async ({ page }) => {
+	test('Contract Modifications route resolves in the manifest shell (REQ-IFRS15-006)', async ({
+		page,
+	}) => {
 		// Browser-Test 4 in tasks.md: variable-consideration re-estimation
 		// modal — prior estimate / new estimate / reason / delta / pending-
 		// approval workflow. The re-estimation modal lives under the
@@ -92,7 +100,9 @@ test.describe('shillinq — IFRS 15 Revenue Recognition SPA smoke', () => {
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Contract Cost Assets + Performance Obligations routes resolve (REQ-IFRS15-009)', async ({ page }) => {
+	test('Contract Cost Assets + Performance Obligations routes resolve (REQ-IFRS15-009)', async ({
+		page,
+	}) => {
 		// Browser-Test 5 in tasks.md: disclosure pack viewer (toggle sections,
 		// PDF/XBRL export buttons functional). The disclosure pack itself is
 		// T4-deferred (per Scope); the underlying ContractCostAsset and

--- a/tests/e2e/bookkeeping-period-close.spec.ts
+++ b/tests/e2e/bookkeeping-period-close.spec.ts
@@ -46,7 +46,9 @@ test.describe('bookkeeping-period-close — Tier-2 manifest pages', () => {
 		page.setViewportSize({ width: 1280, height: 800 })
 	})
 
-	test('Period Close index — page mounts on /bookkeeping/period-close', async ({ page }) => {
+	test('Period Close index — page mounts on /bookkeeping/period-close', async ({
+		page,
+	}) => {
 		await page.goto(APP + INDEX_PATH)
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -58,7 +60,9 @@ test.describe('bookkeeping-period-close — Tier-2 manifest pages', () => {
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Period Close detail — custom component mounts on /bookkeeping/period-close/:id', async ({ page }) => {
+	test('Period Close detail — custom component mounts on /bookkeeping/period-close/:id', async ({
+		page,
+	}) => {
 		await page.goto(APP + DETAIL_PATH)
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -78,6 +82,8 @@ test.describe('bookkeeping-period-close — Tier-2 manifest pages', () => {
 		const body = page.locator('[data-testid="period-close-detail-header"]')
 
 		const any = root.or(loading).or(errorMsg).or(body).first()
-		await expect(any).toBeVisible({ timeout: 15_000 }).catch(() => {})
+		await expect(any)
+			.toBeVisible({ timeout: 15_000 })
+			.catch(() => {})
 	})
 })

--- a/tests/e2e/bookkeeping-tenderned-integratie.spec.ts
+++ b/tests/e2e/bookkeeping-tenderned-integratie.spec.ts
@@ -26,7 +26,9 @@ import { test, expect } from '@playwright/test'
 
 const APP = '/apps/shillinq'
 
-const dismissWizard = async (page: import('@playwright/test').Page): Promise<void> => {
+const dismissWizard = async (
+	page: import('@playwright/test').Page,
+): Promise<void> => {
 	const wizard = page.locator('#firstrunwizard')
 	if (await wizard.isVisible().catch(() => false)) {
 		await page.keyboard.press('Escape').catch(() => {})
@@ -39,7 +41,9 @@ test.describe('shillinq — bookkeeping-tenderned-integratie SPA smoke', () => {
 		page.setViewportSize({ width: 1280, height: 800 })
 	})
 
-	test('TenderNed Aanbestedingen index — mounts on /inkoop/tenderned', async ({ page }) => {
+	test('TenderNed Aanbestedingen index — mounts on /inkoop/tenderned', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/inkoop/tenderned')
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -49,7 +53,9 @@ test.describe('shillinq — bookkeeping-tenderned-integratie SPA smoke', () => {
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Verplichtingen index — mounts on /inkoop/verplichtingen', async ({ page }) => {
+	test('Verplichtingen index — mounts on /inkoop/verplichtingen', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/inkoop/verplichtingen')
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -58,7 +64,9 @@ test.describe('shillinq — bookkeeping-tenderned-integratie SPA smoke', () => {
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Mijn Contracten index — mounts on /inkoop/mijn-contracten (REQ-008)', async ({ page }) => {
+	test('Mijn Contracten index — mounts on /inkoop/mijn-contracten (REQ-008)', async ({
+		page,
+	}) => {
 		// Mijn Contracten is the bron=tenderned filtered view consumed by
 		// inschrijvers (REQ-008). The manifest declares `config.filters.bron`
 		// = "tenderned" so vendors only see their own contracted obligations.
@@ -70,7 +78,9 @@ test.describe('shillinq — bookkeeping-tenderned-integratie SPA smoke', () => {
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Inkoop navigation entry is reachable from the shillinq shell', async ({ page }) => {
+	test('Inkoop navigation entry is reachable from the shillinq shell', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/')
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -81,10 +91,14 @@ test.describe('shillinq — bookkeeping-tenderned-integratie SPA smoke', () => {
 		// renderer version — accept any link surface that targets one of our
 		// new routes.
 		const inkoopLink = page
-			.locator('a[href*="/inkoop/tenderned"], a[href*="/inkoop/verplichtingen"], a[href*="/inkoop/mijn-contracten"], a:has-text("Inkoop"), a:has-text("TenderNed")')
+			.locator(
+				'a[href*="/inkoop/tenderned"], a[href*="/inkoop/verplichtingen"], a[href*="/inkoop/mijn-contracten"], a:has-text("Inkoop"), a:has-text("TenderNed")',
+			)
 			.first()
 
-		await inkoopLink.waitFor({ state: 'attached', timeout: 5_000 }).catch(() => {})
+		await inkoopLink
+			.waitFor({ state: 'attached', timeout: 5_000 })
+			.catch(() => {})
 		expect(page.url()).toContain('/apps/shillinq')
 	})
 })

--- a/tests/e2e/bookkeeping-vpb-corporate-tax.spec.ts
+++ b/tests/e2e/bookkeeping-vpb-corporate-tax.spec.ts
@@ -40,7 +40,9 @@ import { test, expect } from '@playwright/test'
 
 const APP = '/apps/shillinq'
 
-const dismissWizard = async (page: import('@playwright/test').Page): Promise<void> => {
+const dismissWizard = async (
+	page: import('@playwright/test').Page,
+): Promise<void> => {
 	const wizard = page.locator('#firstrunwizard')
 	if (await wizard.isVisible().catch(() => false)) {
 		await page.keyboard.press('Escape').catch(() => {})
@@ -53,7 +55,9 @@ test.describe('shillinq — bookkeeping-vpb-corporate-tax deadline + payment SPA
 		page.setViewportSize({ width: 1280, height: 800 })
 	})
 
-	test('Tax deadlines index — mounts on /bookkeeping/vpb/deadlines (REQ-VPB-005)', async ({ page }) => {
+	test('Tax deadlines index — mounts on /bookkeeping/vpb/deadlines (REQ-VPB-005)', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/bookkeeping/vpb/deadlines')
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -64,7 +68,9 @@ test.describe('shillinq — bookkeeping-vpb-corporate-tax deadline + payment SPA
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Tax deadline detail — mounts on /bookkeeping/vpb/deadlines/:id (REQ-VPB-006)', async ({ page }) => {
+	test('Tax deadline detail — mounts on /bookkeeping/vpb/deadlines/:id (REQ-VPB-006)', async ({
+		page,
+	}) => {
 		// With no seed object the detail page renders the empty/not-found
 		// state but the SPA route resolves; the bounce-out guard is the
 		// behaviour under test for Gate-19.
@@ -75,7 +81,9 @@ test.describe('shillinq — bookkeeping-vpb-corporate-tax deadline + payment SPA
 		expect(page.url()).toContain('/apps/shillinq')
 	})
 
-	test('Tax payments index — mounts on /bookkeeping/vpb/payments (REQ-VPB-007)', async ({ page }) => {
+	test('Tax payments index — mounts on /bookkeeping/vpb/payments (REQ-VPB-007)', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/bookkeeping/vpb/payments')
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -84,7 +92,9 @@ test.describe('shillinq — bookkeeping-vpb-corporate-tax deadline + payment SPA
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Tax payment detail — mounts on /bookkeeping/vpb/payments/:id (REQ-VPB-008)', async ({ page }) => {
+	test('Tax payment detail — mounts on /bookkeeping/vpb/payments/:id (REQ-VPB-008)', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/bookkeeping/vpb/payments/none')
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -92,7 +102,9 @@ test.describe('shillinq — bookkeeping-vpb-corporate-tax deadline + payment SPA
 		expect(page.url()).toContain('/apps/shillinq')
 	})
 
-	test('Vpb navigation cluster is reachable from the shillinq shell (REQ-VPB-016)', async ({ page }) => {
+	test('Vpb navigation cluster is reachable from the shillinq shell (REQ-VPB-016)', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/')
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -102,15 +114,17 @@ test.describe('shillinq — bookkeeping-vpb-corporate-tax deadline + payment SPA
 		// as a sidebar group, an expandable chevron item, or a topbar
 		// dropdown — accept any link that targets one of the new routes.
 		const vpbLink = page
-			.locator([
-				'a[href*="/bookkeeping/vpb/deadlines"]',
-				'a[href*="/bookkeeping/vpb/payments"]',
-				'a[href*="/bookkeeping/vpb/reports"]',
-				'a[href*="/bookkeeping/vpb/settings"]',
-				'a:has-text("Corporate tax")',
-				'a:has-text("Vpb")',
-				'a:has-text("Tax deadlines")',
-			].join(', '))
+			.locator(
+				[
+					'a[href*="/bookkeeping/vpb/deadlines"]',
+					'a[href*="/bookkeeping/vpb/payments"]',
+					'a[href*="/bookkeeping/vpb/reports"]',
+					'a[href*="/bookkeeping/vpb/settings"]',
+					'a:has-text("Corporate tax")',
+					'a:has-text("Vpb")',
+					'a:has-text("Tax deadlines")',
+				].join(', '),
+			)
 			.first()
 
 		await vpbLink.waitFor({ state: 'attached', timeout: 5_000 }).catch(() => {})

--- a/tests/e2e/bookkeeping-vpb-quarterly-report.spec.ts
+++ b/tests/e2e/bookkeeping-vpb-quarterly-report.spec.ts
@@ -38,7 +38,9 @@ import { test, expect } from '@playwright/test'
 
 const APP = '/apps/shillinq'
 
-const dismissWizard = async (page: import('@playwright/test').Page): Promise<void> => {
+const dismissWizard = async (
+	page: import('@playwright/test').Page,
+): Promise<void> => {
 	const wizard = page.locator('#firstrunwizard')
 	if (await wizard.isVisible().catch(() => false)) {
 		await page.keyboard.press('Escape').catch(() => {})
@@ -51,7 +53,9 @@ test.describe('shillinq — bookkeeping-vpb-corporate-tax quarterly statement SP
 		page.setViewportSize({ width: 1280, height: 800 })
 	})
 
-	test('Quarterly statement index — mounts on /bookkeeping/vpb/reports (REQ-VPB-009)', async ({ page }) => {
+	test('Quarterly statement index — mounts on /bookkeeping/vpb/reports (REQ-VPB-009)', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/bookkeeping/vpb/reports')
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -63,7 +67,9 @@ test.describe('shillinq — bookkeeping-vpb-corporate-tax quarterly statement SP
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Quarterly statement detail — mounts on /bookkeeping/vpb/reports/:year/:quarter (REQ-VPB-009)', async ({ page }) => {
+	test('Quarterly statement detail — mounts on /bookkeeping/vpb/reports/:year/:quarter (REQ-VPB-009)', async ({
+		page,
+	}) => {
 		// Detail route is parameterised by fiscal year + quarter. With no
 		// fixture loaded the page renders an empty aggregation state with
 		// account-hierarchy headers; the SPA route must resolve and the
@@ -76,7 +82,9 @@ test.describe('shillinq — bookkeeping-vpb-corporate-tax quarterly statement SP
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Vpb settings — mounts on /bookkeeping/vpb/settings (REQ-VPB-014, REQ-VPB-015)', async ({ page }) => {
+	test('Vpb settings — mounts on /bookkeeping/vpb/settings (REQ-VPB-014, REQ-VPB-015)', async ({
+		page,
+	}) => {
 		// The settings page hosts deadline-template configuration plus the
 		// tax-treatment tag configuration that drives the untagged-posting
 		// warning on the quarterly report. Smoke: route resolves, SPA

--- a/tests/e2e/budget-line-commitments.spec.ts
+++ b/tests/e2e/budget-line-commitments.spec.ts
@@ -49,7 +49,9 @@ test.describe('verplichtingen-commitment-accounting — budget-line committed-vs
 		page.setViewportSize({ width: 1600, height: 1200 })
 	})
 
-	test('renders the four committed-vs-realised columns and drills into a budget line', async ({ page }) => {
+	test('renders the four committed-vs-realised columns and drills into a budget line', async ({
+		page,
+	}) => {
 		await page.goto(`${APP}${ROUTE}`)
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -67,18 +69,27 @@ test.describe('verplichtingen-commitment-accounting — budget-line committed-vs
 
 		// Drilling into a line lists its underlying Verplichting(s).
 		await row.click()
-		await expect(page.getByTestId('budget-line-drilldown')).toBeVisible({ timeout: 10_000 })
+		await expect(page.getByTestId('budget-line-drilldown')).toBeVisible({
+			timeout: 10_000,
+		})
 	})
 
-	test('empty administration renders the empty state without erroring', async ({ page }) => {
+	test('empty administration renders the empty state without erroring', async ({
+		page,
+	}) => {
 		await page.goto(`${APP}${ROUTE}`)
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
 
 		const row = page.getByTestId('budget-line-row').first()
 		const hasRows = await row.isVisible().catch(() => false)
-		test.skip(hasRows, 'administration has seeded budget lines — empty-state assertion not applicable')
+		test.skip(
+			hasRows,
+			'administration has seeded budget lines — empty-state assertion not applicable',
+		)
 
-		await expect(page.getByText('No budget lines', { exact: false })).toBeVisible()
+		await expect(
+			page.getByText('No budget lines', { exact: false }),
+		).toBeVisible()
 	})
 })

--- a/tests/e2e/cashflow-13wk.spec.ts
+++ b/tests/e2e/cashflow-13wk.spec.ts
@@ -18,7 +18,6 @@ import { test, expect } from '@playwright/test'
 const APP = '/apps/shillinq'
 
 test.describe('cashflow 13wk — manifest pages render', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + '/')
 		await page.waitForLoadState('domcontentloaded')
@@ -83,7 +82,9 @@ test.describe('cashflow 13wk — manifest pages render', () => {
 		await page.waitForLoadState('domcontentloaded')
 		// Either a chart canvas, a manifest-rendered widget container, or the
 		// CashflowDashboard skeleton's chart slot must be present.
-		const chartCandidates = page.locator('[data-widget="cashflow-13week-chart"], canvas, [data-widget-id="cashflow-13week-chart"]')
+		const chartCandidates = page.locator(
+			'[data-widget="cashflow-13week-chart"], canvas, [data-widget-id="cashflow-13week-chart"]',
+		)
 		await expect(chartCandidates.first()).toBeVisible({ timeout: 10_000 })
 	})
 
@@ -120,13 +121,18 @@ test.describe('cashflow 13wk — manifest pages render', () => {
 	/**
 	 * @e2e bookkeeping-cashflow-13wk/REQ-CF-010/crisis-banner-conditional-render
 	 */
-	test('crisis banner is conditionally rendered (no fatal when absent)', async ({ page }) => {
+	test('crisis banner is conditionally rendered (no fatal when absent)', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/cashflow/dashboard')
 		await page.waitForLoadState('domcontentloaded')
 		// The crisis banner is conditional. Either it is absent (no negative
 		// forecast in fixtures) or it carries the role="alert" attribute.
 		const banner = page.locator('[role="alert"]')
-		const visible = await banner.first().isVisible().catch(() => false)
+		const visible = await banner
+			.first()
+			.isVisible()
+			.catch(() => false)
 		if (visible === true) {
 			await expect(banner.first()).toContainText(/CRISIS/i)
 		}

--- a/tests/e2e/docs-screenshots.spec.ts
+++ b/tests/e2e/docs-screenshots.spec.ts
@@ -42,7 +42,15 @@ import { test, expect, type Page } from '@playwright/test'
 import * as path from 'path'
 import * as fs from 'fs'
 
-const SHOT_ROOT = path.resolve(__dirname, '..', '..', 'docs', 'static', 'screenshots', 'tutorials')
+const SHOT_ROOT = path.resolve(
+	__dirname,
+	'..',
+	'..',
+	'docs',
+	'static',
+	'screenshots',
+	'tutorials',
+)
 const APP = '/apps/shillinq'
 
 /**
@@ -51,12 +59,20 @@ const APP = '/apps/shillinq'
  * Lives under `static/` so Docusaurus copies the PNG into the build
  * root — markdown image refs use `/screenshots/...` (root-absolute).
  */
-async function shoot(page: Page, track: 'user' | 'admin', file: string): Promise<void> {
+async function shoot(
+	page: Page,
+	track: 'user' | 'admin',
+	file: string,
+): Promise<void> {
 	const dir = path.join(SHOT_ROOT, track)
 	if (!fs.existsSync(dir)) {
 		fs.mkdirSync(dir, { recursive: true })
 	}
-	await page.screenshot({ path: path.join(dir, file), fullPage: false, type: 'png' })
+	await page.screenshot({
+		path: path.join(dir, file),
+		fullPage: false,
+		type: 'png',
+	})
 }
 
 /**
@@ -67,7 +83,9 @@ async function shoot(page: Page, track: 'user' | 'admin', file: string): Promise
 async function dismissOverlays(page: Page): Promise<void> {
 	const wizard = page.locator('#firstrunwizard')
 	if (await wizard.isVisible().catch(() => false)) {
-		const close = wizard.getByRole('button', { name: /close|got it|finish|skip/i }).first()
+		const close = wizard
+			.getByRole('button', { name: /close|got it|finish|skip/i })
+			.first()
 		if (await close.isVisible().catch(() => false)) {
 			await close.click().catch(() => {})
 		} else {
@@ -76,7 +94,12 @@ async function dismissOverlays(page: Page): Promise<void> {
 		await wizard.waitFor({ state: 'hidden', timeout: 4000 }).catch(() => {})
 	}
 	const stray = page.locator('[role="dialog"]:not(#firstrunwizard)')
-	if (await stray.first().isVisible().catch(() => false)) {
+	if (
+		await stray
+			.first()
+			.isVisible()
+			.catch(() => false)
+	) {
 		await page.keyboard.press('Escape').catch(() => {})
 		await page.waitForTimeout(300)
 	}
@@ -92,15 +115,20 @@ async function dismissOverlays(page: Page): Promise<void> {
  * via /apps/shillinq/<route>.
  */
 async function go(page: Page, route: string): Promise<void> {
-	const url = (route.startsWith('/apps/') || route.startsWith('/settings'))
-		? route
-		: `${APP}${route.startsWith('/') ? route : `/${route}`}`
-	await page.goto(url).catch(() => { /* tolerate 404 — caller decides */ })
+	const url =
+		route.startsWith('/apps/') || route.startsWith('/settings')
+			? route
+			: `${APP}${route.startsWith('/') ? route : `/${route}`}`
+	await page.goto(url).catch(() => {
+		/* tolerate 404 — caller decides */
+	})
 	// ADR-074 rule 4: `networkidle` never settles on Nextcloud — the shell keeps
 	// long-poll/notification requests open, so the wait always burned its full
 	// timeout and was swallowed by the .catch(). domcontentloaded is the state
 	// that actually arrives; the settle-time wait below covers rendering.
-	await page.waitForLoadState('domcontentloaded').catch(() => { /* tolerate an already-detached navigation */ })
+	await page.waitForLoadState('domcontentloaded').catch(() => {
+		/* tolerate an already-detached navigation */
+	})
 	await dismissOverlays(page)
 	await page.waitForTimeout(900)
 }

--- a/tests/e2e/external-adapters.spec.ts
+++ b/tests/e2e/external-adapters.spec.ts
@@ -34,9 +34,15 @@ async function dismissOverlays(page: Page): Promise<void> {
 		await page.keyboard.press('Escape').catch(() => {})
 		await wizard.waitFor({ state: 'hidden', timeout: 4_000 }).catch(() => {})
 	}
-	const support = page.locator('[data-testid-modal="cn-support-dialog"], .cn-support-dialog').first()
+	const support = page
+		.locator('[data-testid-modal="cn-support-dialog"], .cn-support-dialog')
+		.first()
 	if (await support.isVisible().catch(() => false)) {
-		await support.getByRole('button', { name: /close|sluiten|dismiss/i }).first().click().catch(() => {})
+		await support
+			.getByRole('button', { name: /close|sluiten|dismiss/i })
+			.first()
+			.click()
+			.catch(() => {})
 		await support.waitFor({ state: 'hidden', timeout: 4_000 }).catch(() => {})
 	}
 }
@@ -56,7 +62,8 @@ async function openAdapterStatus(page: Page): Promise<void> {
 /** Collect shillinq-origin console errors + 5xx, filtering NC-core / env noise. */
 function trackShillinqErrors(page: Page): () => string[] {
 	const errors: string[] = []
-	const noise = /Failed to load resource|favicon|net::ERR|\b404\b|user status|status\.php|Download the (React|Vue) DevTools/i
+	const noise =
+		/Failed to load resource|favicon|net::ERR|\b404\b|user status|status\.php|Download the (React|Vue) DevTools/i
 	page.on('console', (m: ConsoleMessage) => {
 		if (m.type() !== 'error') return
 		const t = m.text()
@@ -72,48 +79,79 @@ function trackShillinqErrors(page: Page): () => string[] {
 }
 
 test.describe('Shillinq — external-adapter admin UI', () => {
-	test('Adapter Status index lists adapter families from the live API', async ({ page }) => {
+	test('Adapter Status index lists adapter families from the live API', async ({
+		page,
+	}) => {
 		const errors = trackShillinqErrors(page)
 
 		await openAdapterStatus(page)
 
 		// The status surface renders its header + summary pills.
-		await expect(page.locator('.external-adapters__title')).toContainText(/External Connections/i, { timeout: 15_000 })
-		await expect(page.locator('.external-adapters__summary')).toBeVisible({ timeout: 10_000 })
-		await expect(page.locator('.external-adapters__pill--total')).toContainText(/\d+\s+families/i)
+		await expect(page.locator('.external-adapters__title')).toContainText(
+			/External Connections/i,
+			{ timeout: 15_000 },
+		)
+		await expect(page.locator('.external-adapters__summary')).toBeVisible({
+			timeout: 10_000,
+		})
+		await expect(page.locator('.external-adapters__pill--total')).toContainText(
+			/\d+\s+families/i,
+		)
 
 		// At least one adapter family is listed (sourced from
 		// GET /api/admin/external-adapters). Assert the list + a known family.
 		const items = page.locator('.external-adapters__item')
 		await expect(items.first()).toBeVisible({ timeout: 10_000 })
 		expect(await items.count()).toBeGreaterThan(0)
-		await expect(page.locator('.external-adapters__item[data-adapter-id="digipoort-sbr"]')).toBeVisible({ timeout: 10_000 })
+		await expect(
+			page.locator(
+				'.external-adapters__item[data-adapter-id="digipoort-sbr"]',
+			),
+		).toBeVisible({ timeout: 10_000 })
 
-		expect(errors(), `shillinq-origin errors:\n${errors().join('\n')}`).toEqual([])
+		expect(errors(), `shillinq-origin errors:\n${errors().join('\n')}`).toEqual(
+			[],
+		)
 	})
 
-	test('opening a family routes to its activation/detail panel', async ({ page }) => {
+	test('opening a family routes to its activation/detail panel', async ({
+		page,
+	}) => {
 		const errors = trackShillinqErrors(page)
 
 		await openAdapterStatus(page)
 
 		// Open the Digipoort/SBR family via its "open detail" button.
-		const row = page.locator('.external-adapters__item[data-adapter-id="digipoort-sbr"]')
+		const row = page.locator(
+			'.external-adapters__item[data-adapter-id="digipoort-sbr"]',
+		)
 		await expect(row).toBeVisible({ timeout: 15_000 })
 		await row.locator('button').first().click()
 
 		// We land on the detail/activation panel for the adapter.
-		await expect(page).toHaveURL(/external-adapters\/digipoort-sbr/, { timeout: 10_000 })
+		await expect(page).toHaveURL(/external-adapters\/digipoort-sbr/, {
+			timeout: 10_000,
+		})
 		await dismissOverlays(page)
 
 		// The detail panel renders the adapter title + dormant/live status badge
 		// + the activation-steps section (the W8 detail UI).
-		await expect(page.locator('.adapter-detail__title')).toBeVisible({ timeout: 15_000 })
-		await expect(page.locator('.adapter-detail__activation')).toBeVisible({ timeout: 10_000 })
-		await expect(page.locator('.adapter-detail__section-title')).toContainText(/Activation steps/i)
+		await expect(page.locator('.adapter-detail__title')).toBeVisible({
+			timeout: 15_000,
+		})
+		await expect(page.locator('.adapter-detail__activation')).toBeVisible({
+			timeout: 10_000,
+		})
+		await expect(page.locator('.adapter-detail__section-title')).toContainText(
+			/Activation steps/i,
+		)
 		// A "Back to External Connections" control closes the loop.
-		await expect(page.getByRole('button', { name: /Back to External Connections/i })).toBeVisible()
+		await expect(
+			page.getByRole('button', { name: /Back to External Connections/i }),
+		).toBeVisible()
 
-		expect(errors(), `shillinq-origin errors:\n${errors().join('\n')}`).toEqual([])
+		expect(errors(), `shillinq-origin errors:\n${errors().join('\n')}`).toEqual(
+			[],
+		)
 	})
 })

--- a/tests/e2e/financial-dashboard.spec.ts
+++ b/tests/e2e/financial-dashboard.spec.ts
@@ -53,91 +53,150 @@ test.describe('financial-dashboard-graphs — Financial overview', () => {
 	test('KPI strip renders six metrics', async ({ page }) => {
 		const strip = page.getByTestId('finance-kpis')
 		await expect(strip).toBeVisible({ timeout: 15_000 })
-		for (const key of ['turnover', 'margin', 'debtors', 'creditors', 'billable', 'cash']) {
-			await expect(page.getByTestId(`finance-kpi-${key}`)).toBeVisible({ timeout: 15_000 })
+		for (const key of [
+			'turnover',
+			'margin',
+			'debtors',
+			'creditors',
+			'billable',
+			'cash',
+		]) {
+			await expect(page.getByTestId(`finance-kpi-${key}`)).toBeVisible({
+				timeout: 15_000,
+			})
 		}
 		// Euro formatting on the turnover tile.
 		await expect(page.getByTestId('finance-kpi-turnover')).toContainText('€')
 	})
 
-	test('turnover chart renders monthly columns from posted revenue lines', async ({ page }) => {
+	test('turnover chart renders monthly columns from posted revenue lines', async ({
+		page,
+	}) => {
 		const chart = page.getByTestId('turnover-chart')
 		await expect(chart).toBeVisible({ timeout: 15_000 })
 		// ApexCharts mounts an SVG once the series resolve.
-		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({ timeout: 15_000 })
+		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({
+			timeout: 15_000,
+		})
 	})
 
-	test('margin toggle switches between euro and percentage view', async ({ page }) => {
+	test('margin toggle switches between euro and percentage view', async ({
+		page,
+	}) => {
 		const chart = page.getByTestId('margin-chart')
 		await expect(chart).toBeVisible({ timeout: 15_000 })
-		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({ timeout: 15_000 })
+		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// Default € view shows the three-series legend (Revenue/Costs/Margin).
-		await expect(chart.getByText('Revenue', { exact: false }).first()).toBeVisible()
+		await expect(
+			chart.getByText('Revenue', { exact: false }).first(),
+		).toBeVisible()
 
 		// % view is a single percentage series: the legend disappears
 		// (ApexCharts hides single-series legends) and the y-axis
 		// switches to percentage tick labels.
 		await page.getByTestId('margin-toggle-pct').click()
-		await expect(page.getByTestId('margin-toggle-pct')).toHaveAttribute('aria-pressed', 'true')
-		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({ timeout: 15_000 })
-		await expect(chart.getByText(/^\d+%$/).first()).toBeVisible({ timeout: 15_000 })
+		await expect(page.getByTestId('margin-toggle-pct')).toHaveAttribute(
+			'aria-pressed',
+			'true',
+		)
+		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({
+			timeout: 15_000,
+		})
+		await expect(chart.getByText(/^\d+%$/).first()).toBeVisible({
+			timeout: 15_000,
+		})
 
 		await page.getByTestId('margin-toggle-value').click()
-		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({ timeout: 15_000 })
-		await expect(chart.getByText('Revenue', { exact: false }).first()).toBeVisible()
+		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({
+			timeout: 15_000,
+		})
+		await expect(
+			chart.getByText('Revenue', { exact: false }).first(),
+		).toBeVisible()
 	})
 
-	test('cashflow chart mounts with realized and forecast series', async ({ page }) => {
+	test('cashflow chart mounts with realized and forecast series', async ({
+		page,
+	}) => {
 		const chart = page.getByTestId('cashflow-chart')
 		await expect(chart).toBeVisible({ timeout: 15_000 })
-		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({ timeout: 15_000 })
+		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({
+			timeout: 15_000,
+		})
 		// Legend always carries the realized series names.
-		await expect(chart.getByText('Money in', { exact: false }).first()).toBeVisible()
+		await expect(
+			chart.getByText('Money in', { exact: false }).first(),
+		).toBeVisible()
 	})
 
 	test('billable hours toggle switches to percentage view', async ({ page }) => {
 		const chart = page.getByTestId('billable-chart')
 		await expect(chart).toBeVisible({ timeout: 15_000 })
-		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({ timeout: 15_000 })
+		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// Stacked view carries the two-series legend.
-		await expect(chart.getByText('Non-billable', { exact: false }).first()).toBeVisible()
+		await expect(
+			chart.getByText('Non-billable', { exact: false }).first(),
+		).toBeVisible()
 
 		// % view is a single line series: legend disappears, y-axis
 		// flips to percentage tick labels.
 		await page.getByTestId('billable-toggle-pct').click()
-		await expect(page.getByTestId('billable-toggle-pct')).toHaveAttribute('aria-pressed', 'true')
-		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({ timeout: 15_000 })
-		await expect(chart.getByText(/^\d+%$/).first()).toBeVisible({ timeout: 15_000 })
+		await expect(page.getByTestId('billable-toggle-pct')).toHaveAttribute(
+			'aria-pressed',
+			'true',
+		)
+		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({
+			timeout: 15_000,
+		})
+		await expect(chart.getByText(/^\d+%$/).first()).toBeVisible({
+			timeout: 15_000,
+		})
 
 		await page.getByTestId('billable-toggle-total').click()
-		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({ timeout: 15_000 })
-		await expect(chart.getByText('Non-billable', { exact: false }).first()).toBeVisible()
+		await expect(chart.locator('svg.apexcharts-svg')).toBeVisible({
+			timeout: 15_000,
+		})
+		await expect(
+			chart.getByText('Non-billable', { exact: false }).first(),
+		).toBeVisible()
 	})
 
-	test('open debtors table lists open invoices with overdue flag (seeded) or empty state', async ({ page }) => {
+	test('open debtors table lists open invoices with overdue flag (seeded) or empty state', async ({
+		page,
+	}) => {
 		const widget = page.getByTestId('open-invoices-debtors')
 		await expect(widget).toBeVisible({ timeout: 15_000 })
 
 		const rows = widget.locator('tbody tr')
-		if (await rows.count() > 0) {
+		if ((await rows.count()) > 0) {
 			// Seeded: due-date sorted rows, at least one overdue badge.
 			await expect(widget.locator('thead')).toContainText('Due date')
-			await expect(widget.locator('.open-invoices__badge--overdue').first()).toBeVisible()
+			await expect(
+				widget.locator('.open-invoices__badge--overdue').first(),
+			).toBeVisible()
 		} else {
 			await expect(widget.locator('.open-invoices__empty')).toBeVisible()
 		}
 	})
 
-	test('open creditors table lists open AP transactions or empty state', async ({ page }) => {
+	test('open creditors table lists open AP transactions or empty state', async ({
+		page,
+	}) => {
 		const widget = page.getByTestId('open-invoices-creditors')
 		await expect(widget).toBeVisible({ timeout: 15_000 })
 
 		const rows = widget.locator('tbody tr')
-		if (await rows.count() > 0) {
+		if ((await rows.count()) > 0) {
 			await expect(widget.locator('thead')).toContainText('Vendor')
-			await expect(widget.locator('.open-invoices__badge').first()).toBeVisible()
+			await expect(
+				widget.locator('.open-invoices__badge').first(),
+			).toBeVisible()
 		} else {
 			await expect(widget.locator('.open-invoices__empty')).toBeVisible()
 		}

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -53,18 +53,22 @@ function ensureBundleBuilt(): void {
 		return
 	}
 	// eslint-disable-next-line no-console
-	console.log(`[playwright globalSetup] bundle missing at ${BUNDLE_PATH}; running 'npm run build' once…`)
+	console.log(
+		`[playwright globalSetup] bundle missing at ${BUNDLE_PATH}; running 'npm run build' once…`,
+	)
 	execSync('npm run build', { cwd: APP_ROOT, stdio: 'inherit' })
 }
 
 async function ensureNextcloudReachable(baseURL: string): Promise<void> {
 	const ctx = await request.newContext()
 	try {
-		const res = await ctx.get(`${baseURL}/status.php`, { failOnStatusCode: false })
+		const res = await ctx.get(`${baseURL}/status.php`, {
+			failOnStatusCode: false,
+		})
 		if (!res.ok()) {
 			throw new Error(
-				`Nextcloud status.php returned ${res.status()} at ${baseURL}. ` +
-				`Make sure the docker container is running and reachable.`,
+				`Nextcloud status.php returned ${res.status()} at ${baseURL}. `
+					+ `Make sure the docker container is running and reachable.`,
 			)
 		}
 		const body = await res.json().catch(() => ({}))
@@ -82,8 +86,8 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 	// Never fall back to a literal — the old chain ended at the SHARED dev
 	// container on :8080, so an unset environment fired repeated logins at
 	// somebody else's instance. See tests/e2e/base-url.ts.
-	const baseURL = (config.projects[0]?.use?.baseURL as string | undefined)
-		?? resolveBaseURL()
+	const baseURL =
+		(config.projects[0]?.use?.baseURL as string | undefined) ?? resolveBaseURL()
 	const username = process.env.NC_ADMIN_USER ?? 'admin'
 	const password = process.env.NC_ADMIN_PASS ?? 'admin'
 
@@ -108,17 +112,21 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 	// then settle on the authenticated header. Both waits are forgiving so
 	// a slow-but-successful login is not reported as a credential failure.
 	try {
-		await page.waitForURL((url) => !/\/login(\?|$|\/)/.test(url.toString()), { timeout: 30_000 })
+		await page.waitForURL((url) => !/\/login(\?|$|\/)/.test(url.toString()), {
+			timeout: 30_000,
+		})
 	} catch {
 		// fall through to the header wait + explicit error below.
 	}
-	await page.waitForSelector('#header, header.header', { timeout: 30_000 }).catch(() => {})
+	await page
+		.waitForSelector('#header, header.header', { timeout: 30_000 })
+		.catch(() => {})
 	// Catch wrong-credentials early so the failure message is clear.
 	const currentUrl = page.url()
 	if (/\/login(\?|$|\/)/.test(currentUrl)) {
 		throw new Error(
-			`Login appears to have failed — still on ${currentUrl}. ` +
-			`Check NC_ADMIN_USER / NC_ADMIN_PASS (defaults admin/admin).`,
+			`Login appears to have failed — still on ${currentUrl}. `
+				+ `Check NC_ADMIN_USER / NC_ADMIN_PASS (defaults admin/admin).`,
 		)
 	}
 

--- a/tests/e2e/icp-opgaaf.spec.ts
+++ b/tests/e2e/icp-opgaaf.spec.ts
@@ -32,7 +32,9 @@ import { test, expect } from '@playwright/test'
 const APP = '/apps/shillinq'
 
 test.describe('shillinq — ICP-opgaaf SPA smoke', () => {
-	test('ICP-opgaaf navigation entry is reachable in the manifest shell', async ({ page }) => {
+	test('ICP-opgaaf navigation entry is reachable in the manifest shell', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/')
 		await page.waitForLoadState('domcontentloaded')
 

--- a/tests/e2e/innovatiebox-administratie.spec.ts
+++ b/tests/e2e/innovatiebox-administratie.spec.ts
@@ -25,7 +25,9 @@ import { test, expect } from '@playwright/test'
 const APP = '/apps/shillinq'
 
 test.describe('shillinq — Innovatiebox Administratie SPA smoke', () => {
-	test('Innovatiebox navigation entries resolve in the manifest shell', async ({ page }) => {
+	test('Innovatiebox navigation entries resolve in the manifest shell', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/')
 		await page.waitForLoadState('domcontentloaded')
 

--- a/tests/e2e/inventory-mobile-scanner.spec.ts
+++ b/tests/e2e/inventory-mobile-scanner.spec.ts
@@ -17,7 +17,6 @@ import { test, expect } from '@playwright/test'
 const APP = '/apps/shillinq'
 
 test.describe('inventory mobile scanner — manifest pages mount', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + '/')
 		await page.waitForLoadState('domcontentloaded')
@@ -73,5 +72,4 @@ test.describe('inventory mobile scanner — manifest pages mount', () => {
 		await page.waitForLoadState('domcontentloaded')
 		expect(page.url()).toContain('/inventory/mobile/count')
 	})
-
 })

--- a/tests/e2e/invoice-quick-draft.spec.ts
+++ b/tests/e2e/invoice-quick-draft.spec.ts
@@ -51,7 +51,9 @@ test.describe('shillinq-invoice-quick-draft — quick draft modal', () => {
 	test('Create invoice opens the quick-draft modal in place', async ({ page }) => {
 		const before = page.url()
 		await page.getByTestId('fda-create-invoice').click()
-		await expect(page.getByTestId('invoice-quick-draft-modal')).toBeVisible({ timeout: 10_000 })
+		await expect(page.getByTestId('invoice-quick-draft-modal')).toBeVisible({
+			timeout: 10_000,
+		})
 		// REQ: opens without leaving the dashboard.
 		expect(page.url()).toBe(before)
 		await expect(page.getByTestId('iqd-customer')).toBeVisible()
@@ -61,7 +63,9 @@ test.describe('shillinq-invoice-quick-draft — quick draft modal', () => {
 
 	test('line items recompute the live totals', async ({ page }) => {
 		await page.getByTestId('fda-create-invoice').click()
-		await expect(page.getByTestId('invoice-quick-draft-modal')).toBeVisible({ timeout: 10_000 })
+		await expect(page.getByTestId('invoice-quick-draft-modal')).toBeVisible({
+			timeout: 10_000,
+		})
 
 		await page.getByTestId('iqd-line-description').first().fill('Consulting')
 		await page.getByTestId('iqd-line-quantity').first().fill('2')
@@ -74,15 +78,21 @@ test.describe('shillinq-invoice-quick-draft — quick draft modal', () => {
 
 	test('add line button adds another row', async ({ page }) => {
 		await page.getByTestId('fda-create-invoice').click()
-		await expect(page.getByTestId('invoice-quick-draft-modal')).toBeVisible({ timeout: 10_000 })
+		await expect(page.getByTestId('invoice-quick-draft-modal')).toBeVisible({
+			timeout: 10_000,
+		})
 		await expect(page.getByTestId('iqd-line')).toHaveCount(1)
 		await page.getByTestId('iqd-add-line').click()
 		await expect(page.getByTestId('iqd-line')).toHaveCount(2)
 	})
 
-	test('save is disabled until a customer and a priced line are present', async ({ page }) => {
+	test('save is disabled until a customer and a priced line are present', async ({
+		page,
+	}) => {
 		await page.getByTestId('fda-create-invoice').click()
-		await expect(page.getByTestId('invoice-quick-draft-modal')).toBeVisible({ timeout: 10_000 })
+		await expect(page.getByTestId('invoice-quick-draft-modal')).toBeVisible({
+			timeout: 10_000,
+		})
 		// No customer yet → save disabled.
 		await expect(page.getByTestId('iqd-save')).toBeDisabled()
 	})

--- a/tests/e2e/list-views-cndatatable.spec.ts
+++ b/tests/e2e/list-views-cndatatable.spec.ts
@@ -41,7 +41,9 @@ test.describe('migrate-list-views-to-cndatatable — invoice list via CnDataTabl
 		}
 	})
 
-	test('the invoice list renders through CnDataTable and the status filter narrows the rows', async ({ page }) => {
+	test('the invoice list renders through CnDataTable and the status filter narrows the rows', async ({
+		page,
+	}) => {
 		// The migrated list renders through CnDataTable (a real <table> emitted
 		// by the shared component), not the removed bespoke table.
 		const table = page.getByTestId('admin-invoice-table')

--- a/tests/e2e/order-primitive.spec.ts
+++ b/tests/e2e/order-primitive.spec.ts
@@ -54,7 +54,10 @@ test.describe('order-primitive — Order fold + orderType-gated lifecycle (#503)
 	let api: import('@playwright/test').APIRequestContext
 
 	test.beforeAll(async ({ baseURL }) => {
-		api = await pwRequest.newContext({ baseURL, storageState: 'tests/e2e/.auth/admin.json' })
+		api = await pwRequest.newContext({
+			baseURL,
+			storageState: 'tests/e2e/.auth/admin.json',
+		})
 		fx = new OrFixtures(api)
 	})
 
@@ -113,10 +116,15 @@ test.describe('order-primitive — Order fold + orderType-gated lifecycle (#503)
 		})
 
 		const res = await fx.transition(id, 'verleen')
-		expect(res.ok(), `verleen should be allowed on a subsidie in aanvraag: HTTP ${res.status()} ${await res.text()}`).toBeTruthy()
+		expect(
+			res.ok(),
+			`verleen should be allowed on a subsidie in aanvraag: HTTP ${res.status()} ${await res.text()}`,
+		).toBeTruthy()
 
 		const after = await fx.get(SCHEMA, id)
-		const state = (after['@self'] as Record<string, unknown> | undefined)?.state ?? after.state
+		const state =
+			(after['@self'] as Record<string, unknown> | undefined)?.state
+			?? after.state
 		expect(state).toBe('verleend')
 	})
 
@@ -133,6 +141,9 @@ test.describe('order-primitive — Order fold + orderType-gated lifecycle (#503)
 		// on a subsidie in aanvraag — the orderType gate (REQ-ORD-002). The refusal
 		// itself is the contract under test.
 		const res = await fx.transition(id, 'approve')
-		expect(res.ok(), 'a purchase transition must NOT succeed on a subsidie').toBeFalsy()
+		expect(
+			res.ok(),
+			'a purchase transition must NOT succeed on a subsidie',
+		).toBeFalsy()
 	})
 })

--- a/tests/e2e/oss-btw-eu.spec.ts
+++ b/tests/e2e/oss-btw-eu.spec.ts
@@ -22,7 +22,9 @@ import { test, expect } from '@playwright/test'
 const APP = '/apps/shillinq'
 
 test.describe('shillinq — OSS SPA smoke', () => {
-	test('OSS navigation entries are reachable in the manifest shell', async ({ page }) => {
+	test('OSS navigation entries are reachable in the manifest shell', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/')
 		await page.waitForLoadState('domcontentloaded')
 

--- a/tests/e2e/pipelinq-customer-bridge.spec.ts
+++ b/tests/e2e/pipelinq-customer-bridge.spec.ts
@@ -36,7 +36,6 @@ import { test, expect } from '@playwright/test'
 const SHILLINQ_ADMIN_SETTINGS = '/settings/admin/shillinq'
 
 test.describe('pipelinq customer-bridge — admin configuration panel', () => {
-
 	test.beforeEach(async ({ page }) => {
 		// Navigate to the shillinq admin settings page. The pipelinq
 		// integration panel mounts as a CnSettingsSection inside
@@ -62,14 +61,18 @@ test.describe('pipelinq customer-bridge — admin configuration panel', () => {
 	 * endpoint + API token form fields and the Save + Test Connection
 	 * action buttons.
 	 */
-	test('admin panel mounts with endpoint, token and action buttons', async ({ page }) => {
+	test('admin panel mounts with endpoint, token and action buttons', async ({
+		page,
+	}) => {
 		await expect(page.getByRole('main')).toBeVisible({ timeout: 10_000 })
 
 		// The integration panel ships the heading "Pipelinq integration"
 		// — see src/views/settings/PipelinqIntegration.vue. We assert
 		// via text rather than a CSS hook so an @nextcloud/vue bump
 		// can re-organise the DOM without breaking the test.
-		const heading = page.getByText('Pipelinq integration', { exact: false }).first()
+		const heading = page
+			.getByText('Pipelinq integration', { exact: false })
+			.first()
 		await expect(heading).toBeVisible({ timeout: 10_000 })
 	})
 
@@ -81,7 +84,9 @@ test.describe('pipelinq customer-bridge — admin configuration panel', () => {
 	 * THEN the request reaches the backend (no client-side validation
 	 * error) and the form remains rendered for follow-up actions.
 	 */
-	test('admin can fill endpoint + token without client validation errors', async ({ page }) => {
+	test('admin can fill endpoint + token without client validation errors', async ({
+		page,
+	}) => {
 		// Find inputs by their associated <label> text — the labels are
 		// "API endpoint" + "API token" in PipelinqIntegration.vue.
 		const endpoint = page.getByLabel(/API endpoint/i).first()
@@ -116,7 +121,9 @@ test.describe('pipelinq customer-bridge — admin configuration panel', () => {
 		}
 
 		// Endpoint persists in the form after Save.
-		await expect(endpoint).toHaveValue('https://pipelinq.example.test/api', { timeout: 5_000 })
+		await expect(endpoint).toHaveValue('https://pipelinq.example.test/api', {
+			timeout: 5_000,
+		})
 	})
 
 	/**
@@ -133,7 +140,9 @@ test.describe('pipelinq customer-bridge — admin configuration panel', () => {
 	 * PipelinqConfigTest::testConnection() suite.
 	 */
 	test('test-connection button is present and clickable', async ({ page }) => {
-		const testButton = page.getByRole('button', { name: /Test connection/i }).first()
+		const testButton = page
+			.getByRole('button', { name: /Test connection/i })
+			.first()
 
 		const visible = await testButton.isVisible().catch(() => false)
 		if (!visible) {
@@ -190,7 +199,9 @@ test.describe('pipelinq customer-bridge — admin configuration panel', () => {
 
 		const reloadedEndpoint = page.getByLabel(/API endpoint/i).first()
 		if (await reloadedEndpoint.isVisible().catch(() => false)) {
-			await expect(reloadedEndpoint).toHaveValue(persistedValue, { timeout: 5_000 })
+			await expect(reloadedEndpoint).toHaveValue(persistedValue, {
+				timeout: 5_000,
+			})
 		} else {
 			// Tolerant fallback if the panel did not mount after
 			// reload — assertion will surface as a UI-shell failure
@@ -198,5 +209,4 @@ test.describe('pipelinq customer-bridge — admin configuration panel', () => {
 			await expect(page.getByRole('main')).toBeVisible()
 		}
 	})
-
 })

--- a/tests/e2e/provincies-bbv-routes-smoke.spec.ts
+++ b/tests/e2e/provincies-bbv-routes-smoke.spec.ts
@@ -34,13 +34,17 @@ const LINKER_INDEX_ROUTE = APP + '/bbv-provincie/budget-to-programme'
 const LINKER_DETAIL_ROUTE = APP + '/bbv-provincie/budget-to-programme/smoke-id'
 
 test.describe('Provincies BBV routes — 200 OK on the SPA shell', () => {
-
 	/**
 	 * @e2e bookkeeping-provincies-bbv-variant/REQ-BBC-001/dashboard-route-200
 	 */
-	test('GET compliance-dashboard responds 200/302/401 (never 5xx)', async ({ request }) => {
+	test('GET compliance-dashboard responds 200/302/401 (never 5xx)', async ({
+		request,
+	}) => {
 		const res = await request.get(DASHBOARD_ROUTE, {
-			headers: { 'OCS-APIREQUEST': 'true', 'Accept': 'text/html,application/json' },
+			headers: {
+				'OCS-APIREQUEST': 'true',
+				Accept: 'text/html,application/json',
+			},
 		})
 		// Declarative manifest pages are served by the Shillinq SPA shell;
 		// the auth posture is inherited from the app's default. A 302 to
@@ -54,9 +58,14 @@ test.describe('Provincies BBV routes — 200 OK on the SPA shell', () => {
 	/**
 	 * @e2e bookkeeping-provincies-bbv-variant/REQ-BBL-001/linker-index-route-200
 	 */
-	test('GET budget-to-programme responds 200/302/401 (never 5xx)', async ({ request }) => {
+	test('GET budget-to-programme responds 200/302/401 (never 5xx)', async ({
+		request,
+	}) => {
 		const res = await request.get(LINKER_INDEX_ROUTE, {
-			headers: { 'OCS-APIREQUEST': 'true', 'Accept': 'text/html,application/json' },
+			headers: {
+				'OCS-APIREQUEST': 'true',
+				Accept: 'text/html,application/json',
+			},
 		})
 		expect(res.status()).toBeLessThan(500)
 		expect([200, 302, 401, 412].includes(res.status())).toBeTruthy()
@@ -65,9 +74,14 @@ test.describe('Provincies BBV routes — 200 OK on the SPA shell', () => {
 	/**
 	 * @e2e bookkeeping-provincies-bbv-variant/REQ-BBL-003/linker-detail-route-200
 	 */
-	test('GET budget-to-programme/:id responds 200/302/401 (never 5xx)', async ({ request }) => {
+	test('GET budget-to-programme/:id responds 200/302/401 (never 5xx)', async ({
+		request,
+	}) => {
 		const res = await request.get(LINKER_DETAIL_ROUTE, {
-			headers: { 'OCS-APIREQUEST': 'true', 'Accept': 'text/html,application/json' },
+			headers: {
+				'OCS-APIREQUEST': 'true',
+				Accept: 'text/html,application/json',
+			},
 		})
 		expect(res.status()).toBeLessThan(500)
 		expect([200, 302, 401, 412].includes(res.status())).toBeTruthy()
@@ -76,12 +90,16 @@ test.describe('Provincies BBV routes — 200 OK on the SPA shell', () => {
 	/**
 	 * @e2e bookkeeping-provincies-bbv-variant/REQ-BBC-004/admin-settings-route-200
 	 */
-	test('GET /admin (admin settings) responds 200/302/401 (never 5xx)', async ({ request }) => {
+	test('GET /admin (admin settings) responds 200/302/401 (never 5xx)', async ({
+		request,
+	}) => {
 		const res = await request.get(APP + '/admin', {
-			headers: { 'OCS-APIREQUEST': 'true', 'Accept': 'text/html,application/json' },
+			headers: {
+				'OCS-APIREQUEST': 'true',
+				Accept: 'text/html,application/json',
+			},
 		})
 		expect(res.status()).toBeLessThan(500)
 		expect([200, 302, 401, 412].includes(res.status())).toBeTruthy()
 	})
-
 })

--- a/tests/e2e/provincies-bbv-variant.spec.ts
+++ b/tests/e2e/provincies-bbv-variant.spec.ts
@@ -70,7 +70,6 @@ async function dismissWizard(page: Page): Promise<void> {
 }
 
 test.describe('Provincies BBV — Compliance Dashboard shell', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + DASHBOARD_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
@@ -80,9 +79,12 @@ test.describe('Provincies BBV — Compliance Dashboard shell', () => {
 	/**
 	 * @e2e bookkeeping-provincies-bbv-variant/REQ-BBC-001/dashboard-kpi-cards-render
 	 */
-	test('dashboard mounts the four KPI cards declared by the manifest', async ({ page }) => {
-		await expect(page.getByTestId('bbv-compliance-dashboard'))
-			.toBeVisible({ timeout: 15_000 })
+	test('dashboard mounts the four KPI cards declared by the manifest', async ({
+		page,
+	}) => {
+		await expect(page.getByTestId('bbv-compliance-dashboard')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// The four declared KPIs (total budget, committed, spent, remaining)
 		// from manifest.d/bookkeeping-provincies-bbv-variant.json.
@@ -95,9 +97,12 @@ test.describe('Provincies BBV — Compliance Dashboard shell', () => {
 	/**
 	 * @e2e bookkeeping-provincies-bbv-variant/REQ-BBC-001/dashboard-charts-render
 	 */
-	test('dashboard renders the budget-vs-actuals and trend charts', async ({ page }) => {
-		await expect(page.getByTestId('bbv-compliance-dashboard'))
-			.toBeVisible({ timeout: 15_000 })
+	test('dashboard renders the budget-vs-actuals and trend charts', async ({
+		page,
+	}) => {
+		await expect(page.getByTestId('bbv-compliance-dashboard')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// The two declared charts (horizontal bar + cumulative line).
 		await expect(page.getByTestId('bbv-chart-budget-vs-actuals')).toBeVisible()
@@ -107,7 +112,9 @@ test.describe('Provincies BBV — Compliance Dashboard shell', () => {
 	/**
 	 * @e2e bookkeeping-provincies-bbv-variant/REQ-BBC-003/exceptions-block-renders
 	 */
-	test('dashboard mounts the exceptions block with link affordance', async ({ page }) => {
+	test('dashboard mounts the exceptions block with link affordance', async ({
+		page,
+	}) => {
 		const exceptions = page.getByTestId('bbv-dashboard-exceptions')
 		await expect(exceptions).toBeVisible({ timeout: 15_000 })
 		// Either the empty-state copy ("No overspends") or the list of
@@ -131,7 +138,9 @@ test.describe('Provincies BBV — Compliance Dashboard shell', () => {
 	/**
 	 * @e2e bookkeeping-provincies-bbv-variant/REQ-BBC-002/programme-filter-narrows-dashboard
 	 */
-	test('programme filter accepts a selection and updates the URL state', async ({ page }) => {
+	test('programme filter accepts a selection and updates the URL state', async ({
+		page,
+	}) => {
 		const filter = page.getByTestId('bbv-filter-programmaStructure')
 		if (await filter.isVisible().catch(() => false)) {
 			// The manifest declares a multi-select with seven options;
@@ -144,11 +153,9 @@ test.describe('Provincies BBV — Compliance Dashboard shell', () => {
 		// Smoke-pass: dashboard does not 500 on filter interaction.
 		await expect(page.getByTestId('bbv-compliance-dashboard')).toBeVisible()
 	})
-
 })
 
 test.describe('Provincies BBV — Budget-to-Programme Linker index', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + LINKER_INDEX_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
@@ -159,18 +166,21 @@ test.describe('Provincies BBV — Budget-to-Programme Linker index', () => {
 	 * @e2e bookkeeping-provincies-bbv-variant/REQ-BBL-004/linker-mapping-status-badge
 	 */
 	test('linker index renders the mapping-status badge', async ({ page }) => {
-		await expect(page.getByTestId('bbv-linker-index'))
-			.toBeVisible({ timeout: 15_000 })
-		await expect(page.getByTestId('bbv-linker-mapping-status'))
-			.toBeVisible()
+		await expect(page.getByTestId('bbv-linker-index')).toBeVisible({
+			timeout: 15_000,
+		})
+		await expect(page.getByTestId('bbv-linker-mapping-status')).toBeVisible()
 	})
 
 	/**
 	 * @e2e bookkeeping-provincies-bbv-variant/REQ-BBL-001/linker-bulk-select-and-action
 	 */
-	test('linker shows the GL-line table with multi-select and a disabled bulk action', async ({ page }) => {
-		await expect(page.getByTestId('bbv-linker-table'))
-			.toBeVisible({ timeout: 15_000 })
+	test('linker shows the GL-line table with multi-select and a disabled bulk action', async ({
+		page,
+	}) => {
+		await expect(page.getByTestId('bbv-linker-table')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// The CnDataTable's master-select checkbox + the per-row checkboxes
 		// from the manifest `selectable: true` config.
@@ -193,7 +203,9 @@ test.describe('Provincies BBV — Budget-to-Programme Linker index', () => {
 	/**
 	 * @e2e bookkeeping-provincies-bbv-variant/REQ-BBL-001/linker-bulk-dialog-fields
 	 */
-	test('opening the bulk dialog renders the Target Programme + Effective Date fields', async ({ page }) => {
+	test('opening the bulk dialog renders the Target Programme + Effective Date fields', async ({
+		page,
+	}) => {
 		// If seed data is loaded, select the master checkbox to enable
 		// the bulk action, then open the CnFormDialog.
 		const masterSelect = page.getByTestId('bbv-linker-select-all')
@@ -206,10 +218,12 @@ test.describe('Provincies BBV — Budget-to-Programme Linker index', () => {
 			// The CnFormDialog mounts with the two declared fields.
 			const dialog = page.getByTestId('bbv-linker-dialog')
 			if (await dialog.isVisible().catch(() => false)) {
-				await expect(page.getByTestId('bbv-linker-dialog-programmaStructure'))
-					.toBeVisible()
-				await expect(page.getByTestId('bbv-linker-dialog-programmaAssignedAt'))
-					.toBeVisible()
+				await expect(
+					page.getByTestId('bbv-linker-dialog-programmaStructure'),
+				).toBeVisible()
+				await expect(
+					page.getByTestId('bbv-linker-dialog-programmaAssignedAt'),
+				).toBeVisible()
 			}
 		}
 	})
@@ -217,21 +231,26 @@ test.describe('Provincies BBV — Budget-to-Programme Linker index', () => {
 	/**
 	 * @e2e bookkeeping-provincies-bbv-variant/REQ-BBL-001/linker-filter-facets
 	 */
-	test('linker index renders the three declared filter facets', async ({ page }) => {
-		await expect(page.getByTestId('bbv-linker-filters'))
-			.toBeVisible({ timeout: 15_000 })
+	test('linker index renders the three declared filter facets', async ({
+		page,
+	}) => {
+		await expect(page.getByTestId('bbv-linker-filters')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// accountType + programmaStructure + assignmentStatus from the
 		// manifest filters[] block.
 		await expect(page.getByTestId('bbv-linker-filter-accountType')).toBeVisible()
-		await expect(page.getByTestId('bbv-linker-filter-programmaStructure')).toBeVisible()
-		await expect(page.getByTestId('bbv-linker-filter-assignmentStatus')).toBeVisible()
+		await expect(
+			page.getByTestId('bbv-linker-filter-programmaStructure'),
+		).toBeVisible()
+		await expect(
+			page.getByTestId('bbv-linker-filter-assignmentStatus'),
+		).toBeVisible()
 	})
-
 })
 
 test.describe('Provincies BBV — Linker detail (single GL-line edit)', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + LINKER_DETAIL_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
@@ -241,15 +260,20 @@ test.describe('Provincies BBV — Linker detail (single GL-line edit)', () => {
 	/**
 	 * @e2e bookkeeping-provincies-bbv-variant/REQ-BBL-003/linker-detail-renders
 	 */
-	test('detail page mounts with the programme + assignedAt fields', async ({ page }) => {
-		await expect(page.getByTestId('bbv-linker-detail'))
-			.toBeVisible({ timeout: 15_000 })
+	test('detail page mounts with the programme + assignedAt fields', async ({
+		page,
+	}) => {
+		await expect(page.getByTestId('bbv-linker-detail')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// The two editable fields declared by the manifest detail config.
-		await expect(page.getByTestId('bbv-linker-detail-programmaStructure'))
-			.toBeVisible()
-		await expect(page.getByTestId('bbv-linker-detail-programmaAssignedAt'))
-			.toBeVisible()
+		await expect(
+			page.getByTestId('bbv-linker-detail-programmaStructure'),
+		).toBeVisible()
+		await expect(
+			page.getByTestId('bbv-linker-detail-programmaAssignedAt'),
+		).toBeVisible()
 	})
 
 	/**
@@ -266,15 +290,15 @@ test.describe('Provincies BBV — Linker detail (single GL-line edit)', () => {
 			expect(page.url()).toMatch(/budget-to-programme/)
 		}
 	})
-
 })
 
 test.describe('Provincies BBV — admin settings refresh interval', () => {
-
 	/**
 	 * @e2e bookkeeping-provincies-bbv-variant/REQ-BBC-004/refresh-interval-dropdown
 	 */
-	test('Dashboard Refresh Interval dropdown is present and saveable in admin settings', async ({ page }) => {
+	test('Dashboard Refresh Interval dropdown is present and saveable in admin settings', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/admin')
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -289,5 +313,4 @@ test.describe('Provincies BBV — admin settings refresh interval', () => {
 			await expect(refresh).toBeVisible()
 		}
 	})
-
 })

--- a/tests/e2e/receipt-extraction-consume.spec.ts
+++ b/tests/e2e/receipt-extraction-consume.spec.ts
@@ -51,7 +51,10 @@ test.describe('receipt-extraction-consume — BillImportModal extraction review 
 
 		const importButton = page.getByRole('button', { name: /import bill/i })
 		const hasImportButton = await importButton.isVisible().catch(() => false)
-		test.skip(!hasImportButton, 'Financial overview Import bill action not visible in this fixture')
+		test.skip(
+			!hasImportButton,
+			'Financial overview Import bill action not visible in this fixture',
+		)
 
 		await importButton.click()
 		const modal = page.getByTestId('bill-import-modal')
@@ -59,7 +62,10 @@ test.describe('receipt-extraction-consume — BillImportModal extraction review 
 
 		const pendingDraft = page.getByTestId(/^bim-pending-/).first()
 		const hasPendingDraft = await pendingDraft.isVisible().catch(() => false)
-		test.skip(!hasPendingDraft, 'no pending extraction draft seeded in this administration')
+		test.skip(
+			!hasPendingDraft,
+			'no pending extraction draft seeded in this administration',
+		)
 
 		await pendingDraft.click()
 		await expect(page.getByTestId('bim-review-step')).toBeVisible()
@@ -78,17 +84,26 @@ test.describe('receipt-extraction-consume — BillImportModal extraction review 
 
 		const importButton = page.getByRole('button', { name: /import bill/i })
 		const hasImportButton = await importButton.isVisible().catch(() => false)
-		test.skip(!hasImportButton, 'Financial overview Import bill action not visible in this fixture')
+		test.skip(
+			!hasImportButton,
+			'Financial overview Import bill action not visible in this fixture',
+		)
 		await importButton.click()
 
 		const pendingDraft = page.getByTestId(/^bim-pending-/).first()
 		const hasPendingDraft = await pendingDraft.isVisible().catch(() => false)
-		test.skip(!hasPendingDraft, 'no pending extraction draft seeded in this administration')
+		test.skip(
+			!hasPendingDraft,
+			'no pending extraction draft seeded in this administration',
+		)
 		await pendingDraft.click()
 
 		const rerequest = page.getByTestId('bim-rerequest')
 		const canRerequest = await rerequest.isVisible().catch(() => false)
-		test.skip(!canRerequest, 'draft carries no sourceDocumentUri to re-request against')
+		test.skip(
+			!canRerequest,
+			'draft carries no sourceDocumentUri to re-request against',
+		)
 
 		await rerequest.click()
 		// REQ-RXC-006: the click only requests a fresh extraction — it never
@@ -96,7 +111,9 @@ test.describe('receipt-extraction-consume — BillImportModal extraction review 
 		await expect(page.getByTestId('bill-import-modal')).toBeVisible()
 	})
 
-	test('even a fully-confident extraction requires explicit confirmation', async ({ page }) => {
+	test('even a fully-confident extraction requires explicit confirmation', async ({
+		page,
+	}) => {
 		// @e2e openspec/specs/receipt-extraction-consume/spec.md#even-a-fully-confident-extraction-requires-confirmation
 		await page.goto(`${APP}/`)
 		await page.waitForLoadState('domcontentloaded')
@@ -104,12 +121,18 @@ test.describe('receipt-extraction-consume — BillImportModal extraction review 
 
 		const importButton = page.getByRole('button', { name: /import bill/i })
 		const hasImportButton = await importButton.isVisible().catch(() => false)
-		test.skip(!hasImportButton, 'Financial overview Import bill action not visible in this fixture')
+		test.skip(
+			!hasImportButton,
+			'Financial overview Import bill action not visible in this fixture',
+		)
 		await importButton.click()
 
 		const pendingDraft = page.getByTestId(/^bim-pending-/).first()
 		const hasPendingDraft = await pendingDraft.isVisible().catch(() => false)
-		test.skip(!hasPendingDraft, 'no pending extraction draft seeded in this administration')
+		test.skip(
+			!hasPendingDraft,
+			'no pending extraction draft seeded in this administration',
+		)
 		await pendingDraft.click()
 
 		// Save is always a separate, explicit button click — opening the
@@ -145,7 +168,9 @@ test.describe('receipt-extraction-consume — ReceiptCapture prefill + correctio
 		await expect(badge).toContainText('%')
 	})
 
-	test('operator corrects a low-confidence field and commits', async ({ page }) => {
+	test('operator corrects a low-confidence field and commits', async ({
+		page,
+	}) => {
 		// @e2e openspec/specs/receipt-extraction-consume/spec.md#operator-corrects-a-low-confidence-field
 		await page.goto(`${APP}/inkoop/receipts`)
 		await page.waitForLoadState('domcontentloaded')
@@ -165,6 +190,8 @@ test.describe('receipt-extraction-consume — ReceiptCapture prefill + correctio
 		await expect(saveButton).toBeEnabled()
 		await saveButton.click()
 
-		await expect(page.getByTestId('rc-save-error')).toBeHidden({ timeout: 10_000 }).catch(() => {})
+		await expect(page.getByTestId('rc-save-error'))
+			.toBeHidden({ timeout: 10_000 })
+			.catch(() => {})
 	})
 })

--- a/tests/e2e/recurring-invoicing.spec.ts
+++ b/tests/e2e/recurring-invoicing.spec.ts
@@ -45,23 +45,34 @@ test.describe('recurring-invoicing — profile create modal', () => {
 		}
 	})
 
-	test('the index exposes the new-profile action and opens the modal', async ({ page }) => {
-		const action = page.getByRole('button', { name: /new recurring profile/i })
+	test('the index exposes the new-profile action and opens the modal', async ({
+		page,
+	}) => {
+		const action = page
+			.getByRole('button', { name: /new recurring profile/i })
 			.or(page.getByText(/new recurring profile/i))
 		await expect(action.first()).toBeVisible({ timeout: 15_000 })
 		await action.first().click()
-		await expect(page.getByTestId('recurring-profile-modal')).toBeVisible({ timeout: 10_000 })
+		await expect(page.getByTestId('recurring-profile-modal')).toBeVisible({
+			timeout: 10_000,
+		})
 		await expect(page.getByTestId('rip-name')).toBeVisible()
 		await expect(page.getByTestId('rip-customer')).toBeVisible()
 	})
 
 	test('the next-invoice preview expands period tokens', async ({ page }) => {
-		const action = page.getByRole('button', { name: /new recurring profile/i })
+		const action = page
+			.getByRole('button', { name: /new recurring profile/i })
 			.or(page.getByText(/new recurring profile/i))
 		await action.first().click()
-		await expect(page.getByTestId('recurring-profile-modal')).toBeVisible({ timeout: 10_000 })
+		await expect(page.getByTestId('recurring-profile-modal')).toBeVisible({
+			timeout: 10_000,
+		})
 
-		await page.getByTestId('rip-line-description').first().fill('Hosting {month} {year}')
+		await page
+			.getByTestId('rip-line-description')
+			.first()
+			.fill('Hosting {month} {year}')
 		await page.getByTestId('rip-line-unit-price').first().fill('99')
 
 		const year = String(new Date().getFullYear())
@@ -70,11 +81,16 @@ test.describe('recurring-invoicing — profile create modal', () => {
 		await expect(page.getByTestId('rip-preview')).toContainText(year)
 	})
 
-	test('add line adds a row and validation blocks an empty save', async ({ page }) => {
-		const action = page.getByRole('button', { name: /new recurring profile/i })
+	test('add line adds a row and validation blocks an empty save', async ({
+		page,
+	}) => {
+		const action = page
+			.getByRole('button', { name: /new recurring profile/i })
 			.or(page.getByText(/new recurring profile/i))
 		await action.first().click()
-		await expect(page.getByTestId('recurring-profile-modal')).toBeVisible({ timeout: 10_000 })
+		await expect(page.getByTestId('recurring-profile-modal')).toBeVisible({
+			timeout: 10_000,
+		})
 
 		await expect(page.getByTestId('rip-line')).toHaveCount(1)
 		await page.getByTestId('rip-add-line').click()

--- a/tests/e2e/retire-cost-project.spec.ts
+++ b/tests/e2e/retire-cost-project.spec.ts
@@ -34,7 +34,9 @@ test.describe('retire-cost-project — navigation contract', () => {
 		page.setViewportSize({ width: 1280, height: 800 })
 	})
 
-	test('CostProjects nav entry is absent after retirement (REQ-RCP-004)', async ({ page }) => {
+	test('CostProjects nav entry is absent after retirement (REQ-RCP-004)', async ({
+		page,
+	}) => {
 		await page.goto(APP)
 		await page.waitForLoadState('domcontentloaded')
 
@@ -47,7 +49,9 @@ test.describe('retire-cost-project — navigation contract', () => {
 
 		// The "Cost Projects" nav entry must NOT be visible in the rendered menu.
 		// Check both the exact label and the route attribute.
-		const costProjectsLink = page.locator('[data-nav-id="CostProjects"], a[href*="/cost-projects"]')
+		const costProjectsLink = page.locator(
+			'[data-nav-id="CostProjects"], a[href*="/cost-projects"]',
+		)
 		await expect(costProjectsLink).toHaveCount(0)
 
 		// Also confirm no visible text "Cost Projects" in the navigation.
@@ -56,7 +60,9 @@ test.describe('retire-cost-project — navigation contract', () => {
 		expect(navText).not.toContain('Cost Projects')
 	})
 
-	test('former CostProjects route resolves without 404 (deep-link contract)', async ({ page }) => {
+	test('former CostProjects route resolves without 404 (deep-link contract)', async ({
+		page,
+	}) => {
 		// Per menu-layout.json removals contract the page must stay routable.
 		const response = await page.goto(APP + '/cost-projects')
 		// Accept 200 (route found) or a redirect; reject hard 404.
@@ -65,11 +71,16 @@ test.describe('retire-cost-project — navigation contract', () => {
 		}
 		// The SPA must still mount (no blank white page or error boundary).
 		await page.waitForLoadState('domcontentloaded')
-		const body = await page.locator('body').innerText().catch(() => '')
+		const body = await page
+			.locator('body')
+			.innerText()
+			.catch(() => '')
 		expect(body.toLowerCase()).not.toContain('page not found')
 	})
 
-	test('Projects (RJ 270) has exactly one nav home and ProjectenOverzicht is absent (REQ-RCP-004)', async ({ page }) => {
+	test('Projects (RJ 270) has exactly one nav home and ProjectenOverzicht is absent (REQ-RCP-004)', async ({
+		page,
+	}) => {
 		await page.goto(APP)
 		await page.waitForLoadState('domcontentloaded')
 
@@ -83,7 +94,7 @@ test.describe('retire-cost-project — navigation contract', () => {
 		// There must be AT MOST one nav entry whose id is "Projects" or whose
 		// visible text is exactly "Projects".
 		const projectLinks = page.locator(
-			'[data-nav-id="Projects"], a[href*="/projects"]:not([href*="cost-projects"]):not([href*="openproject"])'
+			'[data-nav-id="Projects"], a[href*="/projects"]:not([href*="cost-projects"]):not([href*="openproject"])',
 		)
 		const count = await projectLinks.count()
 		// Exactly one home: ≤1 link in the nav (zero is also acceptable if the
@@ -95,7 +106,9 @@ test.describe('retire-cost-project — navigation contract', () => {
 		await expect(projectenOverzicht).toHaveCount(0)
 	})
 
-	test('AnalyticalDimensions index page mounts and accepts project-type filter (REQ-RCP-001)', async ({ page }) => {
+	test('AnalyticalDimensions index page mounts and accepts project-type filter (REQ-RCP-001)', async ({
+		page,
+	}) => {
 		// Navigate to the AnalyticalDimensions / Dimensions page (cost-centers surface).
 		await page.goto(APP + '/dimensions')
 		await page.waitForLoadState('domcontentloaded')
@@ -108,17 +121,26 @@ test.describe('retire-cost-project — navigation contract', () => {
 		}
 
 		// Page must mount — no blank body, no PHP error.
-		const body = await page.locator('body').innerText().catch(() => '')
+		const body = await page
+			.locator('body')
+			.innerText()
+			.catch(() => '')
 		expect(body.length).toBeGreaterThan(10)
 		expect(body.toLowerCase()).not.toContain('internal server error')
 
 		// The dimensionType filter should be able to surface "project" type rows.
 		// (The filter widget may be present; if absent, the page still mounted correctly.)
-		const dimensionTypeFilter = page.locator('[data-filter-dimension-type], select[name="dimensionType"]')
-		if (await dimensionTypeFilter.count() > 0) {
+		const dimensionTypeFilter = page.locator(
+			'[data-filter-dimension-type], select[name="dimensionType"]',
+		)
+		if ((await dimensionTypeFilter.count()) > 0) {
 			// Confirm "project" is a valid option in the filter (REQ-RCP-001).
-			const options = await dimensionTypeFilter.locator('option').allInnerTexts()
-			const hasProjectOption = options.some(o => o.toLowerCase().includes('project'))
+			const options = await dimensionTypeFilter
+				.locator('option')
+				.allInnerTexts()
+			const hasProjectOption = options.some((o) =>
+				o.toLowerCase().includes('project'),
+			)
 			expect(hasProjectOption).toBe(true)
 		}
 	})

--- a/tests/e2e/spec-coverage/_helpers.ts
+++ b/tests/e2e/spec-coverage/_helpers.ts
@@ -44,7 +44,9 @@ export function recordShillinqErrors(page: Page): PageRec {
 	const rec: PageRec = { shillinq5xx: [], pageErrors: [] }
 	page.on('response', (r) => {
 		if (r.status() >= 500 && /\/apps\/shillinq\//.test(r.url())) {
-			rec.shillinq5xx.push(`${r.status()} ${r.url().replace(/.*\/apps\/shillinq/, '…/shillinq')}`)
+			rec.shillinq5xx.push(
+				`${r.status()} ${r.url().replace(/.*\/apps\/shillinq/, '…/shillinq')}`,
+			)
 		}
 	})
 	page.on('pageerror', (e) => {
@@ -61,9 +63,15 @@ export async function dismissOverlays(page: Page): Promise<void> {
 		await wizard.waitFor({ state: 'hidden', timeout: 4_000 }).catch(() => {})
 	}
 	// cn-support-dialog / generic NC modal that can intercept clicks.
-	const support = page.locator('.cn-support-dialog, [class*="support-dialog" i]').first()
+	const support = page
+		.locator('.cn-support-dialog, [class*="support-dialog" i]')
+		.first()
 	if (await support.isVisible().catch(() => false)) {
-		const close = support.locator('button[aria-label*="lose" i], button[aria-label*="luiten" i], .modal-container__close').first()
+		const close = support
+			.locator(
+				'button[aria-label*="lose" i], button[aria-label*="luiten" i], .modal-container__close',
+			)
+			.first()
 		if (await close.isVisible().catch(() => false)) {
 			await close.click({ timeout: 2_000 }).catch(() => {})
 		} else {
@@ -82,7 +90,10 @@ export async function gotoPage(page: Page, route: string): Promise<void> {
 	await page.waitForSelector('#content-vue', { timeout: 15_000 })
 	await dismissOverlays(page)
 	await page.waitForTimeout(900)
-	expect(page.url(), `route ${route} should stay on the shillinq surface`).toContain('/apps/shillinq')
+	expect(
+		page.url(),
+		`route ${route} should stay on the shillinq surface`,
+	).toContain('/apps/shillinq')
 }
 
 /**
@@ -94,24 +105,42 @@ export async function gotoPage(page: Page, route: string): Promise<void> {
  * `titleRe` lets callers pass a looser matcher for titles that the renderer
  * truncates or re-cases.
  */
-export async function assertIndexSurface(page: Page, title: string, opts: { titleRe?: RegExp } = {}): Promise<void> {
+export async function assertIndexSurface(
+	page: Page,
+	title: string,
+	opts: { titleRe?: RegExp } = {},
+): Promise<void> {
 	const host = page.locator('#content-vue')
 
 	// 1) A recognised CnIndexPage index surface rendered. This is the core
 	//    behavioural proof the page mounted (vs a blank shell or an error
 	//    page): a data table, an empty-content block, a list, or the
 	//    primary-action toolbar (Add / Actions / Export / Reconcile …).
-	const tables = await host.locator('table:visible').count().catch(() => 0)
-	const empty = await page.locator('.empty-content, .emptycontent, [class*="empty-content" i]').count().catch(() => 0)
-	const lists = await host.locator('ul[class*="list" i] li, [class*="app-content-list" i] [class*="item" i], [role="row"]').count().catch(() => 0)
+	const tables = await host
+		.locator('table:visible')
+		.count()
+		.catch(() => 0)
+	const empty = await page
+		.locator('.empty-content, .emptycontent, [class*="empty-content" i]')
+		.count()
+		.catch(() => 0)
+	const lists = await host
+		.locator(
+			'ul[class*="list" i] li, [class*="app-content-list" i] [class*="item" i], [role="row"]',
+		)
+		.count()
+		.catch(() => 0)
 	// Page-specific action affordances. The global "Settings" button is
 	// deliberately excluded — it renders on every shillinq page and is not
 	// proof that this page's index surface mounted.
-	const actionBtns = await host.locator(
-		'button:has-text("Add"), button:has-text("Nieuw"), button:has-text("New"), button:has-text("Toevoegen"), '
-		+ 'button:has-text("Actions"), button:has-text("Acties"), button:has-text("Export"), button:has-text("Reconcile"), '
-		+ 'button:has-text("Filter"), button:has-text("Post"), button:has-text("Lock"), button:has-text("Vastleggen")',
-	).count().catch(() => 0)
+	const actionBtns = await host
+		.locator(
+			'button:has-text("Add"), button:has-text("Nieuw"), button:has-text("New"), button:has-text("Toevoegen"), '
+				+ 'button:has-text("Actions"), button:has-text("Acties"), button:has-text("Export"), button:has-text("Reconcile"), '
+				+ 'button:has-text("Filter"), button:has-text("Post"), button:has-text("Lock"), button:has-text("Vastleggen")',
+		)
+		.count()
+		.catch(() => 0)
 	const surfaces = tables + empty + lists + actionBtns
 
 	expect(
@@ -126,10 +155,14 @@ export async function assertIndexSurface(page: Page, title: string, opts: { titl
 	//    already proved a surface exists, so a visible title is asserted as a
 	//    soft signal: if the matcher is found it must be visible; if the page
 	//    genuinely renders a different header we still have surface proof.
-	const matcher = opts.titleRe ?? new RegExp(title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i')
+	const matcher =
+		opts.titleRe ?? new RegExp(title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i')
 	const titleNode = host.getByText(matcher).first()
 	if (await titleNode.count().catch(() => 0)) {
-		await expect(titleNode, `title "${title}" should be visible when present`).toBeVisible({ timeout: 8_000 })
+		await expect(
+			titleNode,
+			`title "${title}" should be visible when present`,
+		).toBeVisible({ timeout: 8_000 })
 	}
 }
 

--- a/tests/e2e/spec-coverage/belastingen.spec.ts
+++ b/tests/e2e/spec-coverage/belastingen.spec.ts
@@ -14,26 +14,74 @@
  */
 
 import { test } from '@playwright/test'
-import { gotoPage, assertIndexSurface, assertNoShillinqFailures, recordShillinqErrors } from './_helpers'
+import {
+	gotoPage,
+	assertIndexSurface,
+	assertNoShillinqFailures,
+	recordShillinqErrors,
+} from './_helpers'
 
-const PAGES: Array<{ route: string, title: string, titleRe?: RegExp }> = [
+const PAGES: Array<{ route: string; title: string; titleRe?: RegExp }> = [
 	{ route: '/belastingen/kor', title: 'KOR', titleRe: /KOR/i },
 	{ route: '/tax-filing-prep', title: 'Tax Filing Prep' },
 	{ route: '/tax-estimates', title: 'Tax Estimates' },
 	{ route: '/tax-configuration', title: 'Tax Configuration' },
-	{ route: '/belastingen/btw-aangiften', title: 'BTW-aangiften', titleRe: /BTW-?aangift/i },
-	{ route: '/belastingen/vat-by-period', title: 'VAT by Period', titleRe: /VAT by Period|VAT/i },
-	{ route: '/belastingen/icp-opgaaf', title: 'ICP-opgaaf', titleRe: /ICP-?opgaaf|ICP/i },
-	{ route: '/belastingen/btw-correcties', title: 'BTW-correcties', titleRe: /BTW-?correct/i },
+	{
+		route: '/belastingen/btw-aangiften',
+		title: 'BTW-aangiften',
+		titleRe: /BTW-?aangift/i,
+	},
+	{
+		route: '/belastingen/vat-by-period',
+		title: 'VAT by Period',
+		titleRe: /VAT by Period|VAT/i,
+	},
+	{
+		route: '/belastingen/icp-opgaaf',
+		title: 'ICP-opgaaf',
+		titleRe: /ICP-?opgaaf|ICP/i,
+	},
+	{
+		route: '/belastingen/btw-correcties',
+		title: 'BTW-correcties',
+		titleRe: /BTW-?correct/i,
+	},
 	{ route: '/belastingen/urenregistratie', title: 'Urenregistratie' },
-	{ route: '/belastingen/zzp-aftrek', title: 'ZZP-aftrek', titleRe: /ZZP-?aftrek/i },
-	{ route: '/belastingen/ib-aangifte', title: 'IB-aangifte', titleRe: /IB-?aangift/i },
+	{
+		route: '/belastingen/zzp-aftrek',
+		title: 'ZZP-aftrek',
+		titleRe: /ZZP-?aftrek/i,
+	},
+	{
+		route: '/belastingen/ib-aangifte',
+		title: 'IB-aangifte',
+		titleRe: /IB-?aangift/i,
+	},
 	// Uitgestelde belastingen (deferred tax)
-	{ route: '/belastingen/uitgestelde-belastingen/provisies', title: 'Belastinglatentie', titleRe: /Belastinglatentie|Provisi/i },
-	{ route: '/belastingen/uitgestelde-belastingen/tijdelijke-verschillen', title: 'Tijdelijke verschillen' },
-	{ route: '/belastingen/uitgestelde-belastingen/mutaties', title: 'Mutatieoverzicht', titleRe: /Mutatie/i },
-	{ route: '/belastingen/uitgestelde-belastingen/verliescompensatie', title: 'Compensabele verliezen', titleRe: /Compensabele|verliez/i },
-	{ route: '/belastingen/uitgestelde-belastingen/etr-aansluiting', title: 'ETR-aansluiting', titleRe: /ETR/i },
+	{
+		route: '/belastingen/uitgestelde-belastingen/provisies',
+		title: 'Belastinglatentie',
+		titleRe: /Belastinglatentie|Provisi/i,
+	},
+	{
+		route: '/belastingen/uitgestelde-belastingen/tijdelijke-verschillen',
+		title: 'Tijdelijke verschillen',
+	},
+	{
+		route: '/belastingen/uitgestelde-belastingen/mutaties',
+		title: 'Mutatieoverzicht',
+		titleRe: /Mutatie/i,
+	},
+	{
+		route: '/belastingen/uitgestelde-belastingen/verliescompensatie',
+		title: 'Compensabele verliezen',
+		titleRe: /Compensabele|verliez/i,
+	},
+	{
+		route: '/belastingen/uitgestelde-belastingen/etr-aansluiting',
+		title: 'ETR-aansluiting',
+		titleRe: /ETR/i,
+	},
 ]
 
 test.describe('shillinq spec-coverage — Belastingen', () => {

--- a/tests/e2e/spec-coverage/bookkeeping.spec.ts
+++ b/tests/e2e/spec-coverage/bookkeeping.spec.ts
@@ -13,9 +13,14 @@
  */
 
 import { test } from '@playwright/test'
-import { gotoPage, assertIndexSurface, assertNoShillinqFailures, recordShillinqErrors } from './_helpers'
+import {
+	gotoPage,
+	assertIndexSurface,
+	assertNoShillinqFailures,
+	recordShillinqErrors,
+} from './_helpers'
 
-const PAGES: Array<{ route: string, title: string, titleRe?: RegExp }> = [
+const PAGES: Array<{ route: string; title: string; titleRe?: RegExp }> = [
 	{ route: '/chart-of-accounts', title: 'Chart of Accounts' },
 	{ route: '/general-ledger', title: 'General Ledger' },
 	{ route: '/journals', title: 'Journals' },
@@ -35,30 +40,53 @@ const PAGES: Array<{ route: string, title: string, titleRe?: RegExp }> = [
 	{ route: '/bookkeeping/ar-aging', title: 'AR Aging' },
 	{ route: '/bookkeeping/dunning-timeline', title: 'Dunning Timeline' },
 	{ route: '/bookkeeping/dunning/ladders', title: 'Dunning Ladders' },
-	{ route: '/bookkeeping/dunning/overrides', title: 'Klant Ladder Overrides', titleRe: /Override|Klant/i },
+	{
+		route: '/bookkeeping/dunning/overrides',
+		title: 'Klant Ladder Overrides',
+		titleRe: /Override|Klant/i,
+	},
 	{ route: '/bookkeeping/dunning/runs', title: 'Dunning Runs' },
 	{ route: '/bookkeeping/dunning/incasso-kosten', title: 'Incasso Kosten' },
 	{ route: '/bookkeeping/dunning/oninbaar', title: 'Oninbare Afschrijvingen' },
 	{ route: '/waterschapsbelastingen', title: 'Waterschapsbelastingen' },
 	{ route: '/gr/deelnemers', title: 'Deelnemers' },
 	{ route: '/gr/verdeelsleutels', title: 'Verdeelsleutels' },
-	{ route: '/gr/geconsolideerd', title: 'Geconsolideerde view', titleRe: /Geconsolideerde|consolidat/i },
+	{
+		route: '/gr/geconsolideerd',
+		title: 'Geconsolideerde view',
+		titleRe: /Geconsolideerde|consolidat/i,
+	},
 	{ route: '/financial-statements/balance-sheet', title: 'Balance Sheet' },
 	{ route: '/financial-statements/trial-balance', title: 'Trial Balance' },
-	{ route: '/financial-statements/trial-balance-lines', title: 'Trial Balance', titleRe: /Trial Balance/i },
+	{
+		route: '/financial-statements/trial-balance-lines',
+		title: 'Trial Balance',
+		titleRe: /Trial Balance/i,
+	},
 	{ route: '/financial-statements/consolidations', title: 'Consolidations' },
-	{ route: '/financial-statements/consolidated-report', title: 'Consolidated Report' },
+	{
+		route: '/financial-statements/consolidated-report',
+		title: 'Consolidated Report',
+	},
 	// The manifest route is Dutch (`/iv3-rapportages`) while its title is
 	// already English ("IV3 reports"). Matching the route as declared rather
 	// than renaming it here: a route slug is a bookmarkable URL, so changing
 	// it is a product decision, not a test fix.
 	{ route: '/iv3-rapportages', title: 'IV3 reports' },
 	{ route: '/emu-rapportage', title: 'EMU-rapportage' },
-	{ route: '/bookkeeping/r-d-subsidies', title: 'R&D Subsidies', titleRe: /R&D|R\s*&\s*D|Subsid/i },
+	{
+		route: '/bookkeeping/r-d-subsidies',
+		title: 'R&D Subsidies',
+		titleRe: /R&D|R\s*&\s*D|Subsid/i,
+	},
 	{ route: '/wbso/tags', title: 'WBSO Tags' },
 	{ route: '/wbso/export', title: 'WBSO Export' },
 	{ route: '/bookkeeping/fiscal-years', title: 'Fiscal Years' },
-	{ route: '/bookkeeping/year-end-close-checklist', title: 'Year-End Close Checklist', titleRe: /Year-End|Close/i },
+	{
+		route: '/bookkeeping/year-end-close-checklist',
+		title: 'Year-End Close Checklist',
+		titleRe: /Year-End|Close/i,
+	},
 	{ route: '/bookkeeping/closing-entries', title: 'Closing Entries' },
 	{ route: '/bookkeeping/audit-trail', title: 'Audit Trail' },
 ]

--- a/tests/e2e/spec-coverage/cashflow-pension.spec.ts
+++ b/tests/e2e/spec-coverage/cashflow-pension.spec.ts
@@ -8,16 +8,37 @@
  */
 
 import { test } from '@playwright/test'
-import { gotoPage, assertIndexSurface, assertNoShillinqFailures, recordShillinqErrors } from './_helpers'
+import {
+	gotoPage,
+	assertIndexSurface,
+	assertNoShillinqFailures,
+	recordShillinqErrors,
+} from './_helpers'
 
-const PAGES: Array<{ route: string, title: string, titleRe?: RegExp }> = [
-	{ route: '/cashflow/dashboard', title: 'Cashflow Dashboard', titleRe: /Cashflow/i },
+const PAGES: Array<{ route: string; title: string; titleRe?: RegExp }> = [
+	{
+		route: '/cashflow/dashboard',
+		title: 'Cashflow Dashboard',
+		titleRe: /Cashflow/i,
+	},
 	{ route: '/cashflow/scenarios', title: 'Scenarios' },
 	{ route: '/cashflow/buffer-policy', title: 'Buffer Policy' },
-	{ route: '/cashflow/recurring', title: 'Recurring Costs', titleRe: /Recurring/i },
-	{ route: '/cashflow/calibration', title: 'Calibration Report', titleRe: /Calibration/i },
+	{
+		route: '/cashflow/recurring',
+		title: 'Recurring Costs',
+		titleRe: /Recurring/i,
+	},
+	{
+		route: '/cashflow/calibration',
+		title: 'Calibration Report',
+		titleRe: /Calibration/i,
+	},
 	{ route: '/pension/plans', title: 'Pension Plans' },
-	{ route: '/pension/valuations', title: 'Actuarial Valuations', titleRe: /Valuation/i },
+	{
+		route: '/pension/valuations',
+		title: 'Actuarial Valuations',
+		titleRe: /Valuation/i,
+	},
 	{ route: '/pension/disclosure-tables', title: 'Disclosure Tables' },
 ]
 

--- a/tests/e2e/spec-coverage/dashboard-settings.spec.ts
+++ b/tests/e2e/spec-coverage/dashboard-settings.spec.ts
@@ -9,27 +9,49 @@
  */
 
 import { test, expect } from '@playwright/test'
-import { APP, gotoPage, dismissOverlays, assertNoShillinqFailures, recordShillinqErrors } from './_helpers'
+import {
+	APP,
+	gotoPage,
+	dismissOverlays,
+	assertNoShillinqFailures,
+	recordShillinqErrors,
+} from './_helpers'
 
 test.describe('shillinq spec-coverage — Dashboard & Settings', () => {
 	test.describe.configure({ mode: 'serial' })
 
-	test('Dashboard — root SPA mounts with the Dashboard surface', async ({ page }) => {
+	test('Dashboard — root SPA mounts with the Dashboard surface', async ({
+		page,
+	}) => {
 		const rec = recordShillinqErrors(page)
-		await page.goto(APP + '/', { waitUntil: 'domcontentloaded', timeout: 25_000 })
+		await page.goto(APP + '/', {
+			waitUntil: 'domcontentloaded',
+			timeout: 25_000,
+		})
 		await page.waitForSelector('#content-vue', { timeout: 15_000 })
 		await dismissOverlays(page)
 		await page.waitForTimeout(1_000)
 		expect(page.url()).toContain('/apps/shillinq')
 
 		// Dashboard title text is rendered by the SPA.
-		await expect(page.locator('#content-vue').getByText(/Dashboard/i).first()).toBeVisible({ timeout: 12_000 })
+		await expect(
+			page
+				.locator('#content-vue')
+				.getByText(/Dashboard/i)
+				.first(),
+		).toBeVisible({ timeout: 12_000 })
 		// Dashboard renders either widget cards/empty-content blocks or a
 		// toolbar — at least one real surface must be present.
-		const surfaces = await page.locator(
-			'#content-vue .empty-content, #content-vue [class*="widget" i], #content-vue [class*="card" i], #content-vue button:visible',
-		).count().catch(() => 0)
-		expect(surfaces, 'dashboard should render widgets / cards / toolbar').toBeGreaterThan(0)
+		const surfaces = await page
+			.locator(
+				'#content-vue .empty-content, #content-vue [class*="widget" i], #content-vue [class*="card" i], #content-vue button:visible',
+			)
+			.count()
+			.catch(() => 0)
+		expect(
+			surfaces,
+			'dashboard should render widgets / cards / toolbar',
+		).toBeGreaterThan(0)
 		assertNoShillinqFailures(rec, '/')
 	})
 
@@ -41,19 +63,34 @@ test.describe('shillinq spec-coverage — Dashboard & Settings', () => {
 	// they rendered as empty cards. That page has been deleted; the surface
 	// this asserts is the platform one — hence no `gotoPage`, which pins the
 	// URL to /apps/shillinq.
-	test('Settings — the platform admin settings section mounts', async ({ page }) => {
+	test('Settings — the platform admin settings section mounts', async ({
+		page,
+	}) => {
 		const rec = recordShillinqErrors(page)
-		await page.goto('/index.php/settings/admin/shillinq', { waitUntil: 'domcontentloaded', timeout: 25_000 })
+		await page.goto('/index.php/settings/admin/shillinq', {
+			waitUntil: 'domcontentloaded',
+			timeout: 25_000,
+		})
 		await page.waitForSelector('#shillinq-settings', { timeout: 15_000 })
 		await dismissOverlays(page)
 		await page.waitForTimeout(1_000)
-		await expect(page.locator('#shillinq-settings').getByText(/Configuration|Configuratie/i).first())
-			.toBeVisible({ timeout: 12_000 })
+		await expect(
+			page
+				.locator('#shillinq-settings')
+				.getByText(/Configuration|Configuratie/i)
+				.first(),
+		).toBeVisible({ timeout: 12_000 })
 		// A settings surface: form fields, toggles, sections, or save buttons.
-		const surfaces = await page.locator(
-			'#shillinq-settings input, #shillinq-settings [class*="settings" i], #shillinq-settings [role="switch"], #shillinq-settings button:visible, #shillinq-settings fieldset, #shillinq-settings section',
-		).count().catch(() => 0)
-		expect(surfaces, 'admin settings should render a settings surface').toBeGreaterThan(0)
+		const surfaces = await page
+			.locator(
+				'#shillinq-settings input, #shillinq-settings [class*="settings" i], #shillinq-settings [role="switch"], #shillinq-settings button:visible, #shillinq-settings fieldset, #shillinq-settings section',
+			)
+			.count()
+			.catch(() => 0)
+		expect(
+			surfaces,
+			'admin settings should render a settings surface',
+		).toBeGreaterThan(0)
 		assertNoShillinqFailures(rec, '/settings/admin/shillinq')
 	})
 
@@ -63,11 +100,23 @@ test.describe('shillinq spec-coverage — Dashboard & Settings', () => {
 		// the page ID, not its route, and hit the SPA catch-all instead.
 		await gotoPage(page, '/features-roadmap')
 		// Renders a roadmap surface (content text / cards / list).
-		const surfaces = await page.locator(
-			'#content-vue .empty-content, #content-vue [class*="card" i], #content-vue [class*="feature" i], #content-vue li, #content-vue table',
-		).count().catch(() => 0)
-		const hasText = (await page.locator('#content-vue').innerText().catch(() => '')).trim().length > 20
-		expect(surfaces > 0 || hasText, 'features & roadmap should render content').toBeTruthy()
+		const surfaces = await page
+			.locator(
+				'#content-vue .empty-content, #content-vue [class*="card" i], #content-vue [class*="feature" i], #content-vue li, #content-vue table',
+			)
+			.count()
+			.catch(() => 0)
+		const hasText =
+			(
+				await page
+					.locator('#content-vue')
+					.innerText()
+					.catch(() => '')
+			).trim().length > 20
+		expect(
+			surfaces > 0 || hasText,
+			'features & roadmap should render content',
+		).toBeTruthy()
 		assertNoShillinqFailures(rec, '/features-roadmap')
 	})
 })

--- a/tests/e2e/spec-coverage/dimensions.spec.ts
+++ b/tests/e2e/spec-coverage/dimensions.spec.ts
@@ -9,9 +9,14 @@
  */
 
 import { test, expect } from '@playwright/test'
-import { gotoPage, assertIndexSurface, assertNoShillinqFailures, recordShillinqErrors } from './_helpers'
+import {
+	gotoPage,
+	assertIndexSurface,
+	assertNoShillinqFailures,
+	recordShillinqErrors,
+} from './_helpers'
 
-const PAGES: Array<{ route: string, title: string, titleRe?: RegExp }> = [
+const PAGES: Array<{ route: string; title: string; titleRe?: RegExp }> = [
 	{ route: '/bookkeeping/dimensions/cost-centers', title: 'Cost Centers' },
 	{ route: '/bookkeeping/dimensions/kostendragers', title: 'Kostendragers' },
 	{ route: '/bookkeeping/dimensions/projects', title: 'Projects' },
@@ -31,14 +36,27 @@ test.describe('shillinq spec-coverage — Dimensions', () => {
 
 	// Cost Centers ships a primary "Add Item" create affordance — open it and
 	// confirm a create dialog/form mounts (no submit, data-independent).
-	test('Dimensions › Cost Centers — Add opens a create dialog', async ({ page }) => {
+	test('Dimensions › Cost Centers — Add opens a create dialog', async ({
+		page,
+	}) => {
 		const rec = recordShillinqErrors(page)
 		await gotoPage(page, '/bookkeeping/dimensions/cost-centers')
-		const addBtn = page.locator('#content-vue button:has-text("Add"), #content-vue button:has-text("Nieuw"), #content-vue button:has-text("Toevoegen")').first()
+		const addBtn = page
+			.locator(
+				'#content-vue button:has-text("Add"), #content-vue button:has-text("Nieuw"), #content-vue button:has-text("Toevoegen")',
+			)
+			.first()
 		if (await addBtn.isVisible().catch(() => false)) {
 			await addBtn.click({ timeout: 5_000 }).catch(() => {})
-			const dialog = page.locator('.modal-container:visible, [role="dialog"]:visible, form:visible').first()
-			await expect(dialog, 'create dialog/form should mount after Add').toBeVisible({ timeout: 8_000 })
+			const dialog = page
+				.locator(
+					'.modal-container:visible, [role="dialog"]:visible, form:visible',
+				)
+				.first()
+			await expect(
+				dialog,
+				'create dialog/form should mount after Add',
+			).toBeVisible({ timeout: 8_000 })
 			await page.keyboard.press('Escape').catch(() => {})
 		}
 		assertNoShillinqFailures(rec, '/bookkeeping/dimensions/cost-centers add')

--- a/tests/e2e/spec-coverage/inkoop.spec.ts
+++ b/tests/e2e/spec-coverage/inkoop.spec.ts
@@ -10,14 +10,23 @@
  */
 
 import { test } from '@playwright/test'
-import { gotoPage, assertIndexSurface, assertNoShillinqFailures, recordShillinqErrors } from './_helpers'
+import {
+	gotoPage,
+	assertIndexSurface,
+	assertNoShillinqFailures,
+	recordShillinqErrors,
+} from './_helpers'
 
-const PAGES: Array<{ route: string, title: string, titleRe?: RegExp }> = [
+const PAGES: Array<{ route: string; title: string; titleRe?: RegExp }> = [
 	{ route: '/inkoop/purchase-orders', title: 'Purchase Orders' },
 	{ route: '/inkoop/goods-receipts', title: 'Goods Receipts' },
 	{ route: '/inkoop/supplier-invoices', title: 'Supplier Invoices' },
 	{ route: '/inkoop/3way-matches', title: '3-way Matches', titleRe: /3-?way/i },
-	{ route: '/inkoop/3way-matches/exceptions', title: 'Match Exceptions', titleRe: /Exception/i },
+	{
+		route: '/inkoop/3way-matches/exceptions',
+		title: 'Match Exceptions',
+		titleRe: /Exception/i,
+	},
 	{ route: '/inkoop/receipts', title: 'Receipts' },
 	{ route: '/inkoop/expense-claims', title: 'Expense Claims' },
 	{ route: '/inkoop/mileage-log', title: 'Mileage Log' },

--- a/tests/e2e/spec-coverage/inventory.spec.ts
+++ b/tests/e2e/spec-coverage/inventory.spec.ts
@@ -9,9 +9,14 @@
  */
 
 import { test } from '@playwright/test'
-import { gotoPage, assertIndexSurface, assertNoShillinqFailures, recordShillinqErrors } from './_helpers'
+import {
+	gotoPage,
+	assertIndexSurface,
+	assertNoShillinqFailures,
+	recordShillinqErrors,
+} from './_helpers'
 
-const PAGES: Array<{ route: string, title: string, titleRe?: RegExp }> = [
+const PAGES: Array<{ route: string; title: string; titleRe?: RegExp }> = [
 	{ route: '/inventory/products', title: 'Products' },
 	{ route: '/inventory/product-attributes', title: 'Product Attributes' },
 	{ route: '/inventory/reorder-rules', title: 'Reorder Rules' },
@@ -21,11 +26,23 @@ const PAGES: Array<{ route: string, title: string, titleRe?: RegExp }> = [
 	{ route: '/inventory/stock-by-location', title: 'Stock by Location' },
 	{ route: '/inventory/reserve-stock', title: 'Reserve Stock' },
 	{ route: '/inventory/barcodes', title: 'Barcodes' },
-	{ route: '/inventory/valuation', title: 'Valuation', titleRe: /Valuation|Waarder/i },
+	{
+		route: '/inventory/valuation',
+		title: 'Valuation',
+		titleRe: /Valuation|Waarder/i,
+	},
 	{ route: '/inventory/lots', title: 'Lots', titleRe: /Lots|Batch/i },
 	{ route: '/inventory/expiry-alerts', title: 'Expiry Alerts' },
-	{ route: '/inventory/posting-config', title: 'Posting', titleRe: /Posting|Configurat/i },
-	{ route: '/inventory/posting-history', title: 'Posting', titleRe: /Posting|Histor/i },
+	{
+		route: '/inventory/posting-config',
+		title: 'Posting',
+		titleRe: /Posting|Configurat/i,
+	},
+	{
+		route: '/inventory/posting-history',
+		title: 'Posting',
+		titleRe: /Posting|Histor/i,
+	},
 ]
 
 test.describe('shillinq spec-coverage — Inventory', () => {

--- a/tests/e2e/spec-coverage/overheid-compliance.spec.ts
+++ b/tests/e2e/spec-coverage/overheid-compliance.spec.ts
@@ -9,23 +9,52 @@
  */
 
 import { test } from '@playwright/test'
-import { gotoPage, assertIndexSurface, assertNoShillinqFailures, recordShillinqErrors } from './_helpers'
+import {
+	gotoPage,
+	assertIndexSurface,
+	assertNoShillinqFailures,
+	recordShillinqErrors,
+} from './_helpers'
 
-const PAGES: Array<{ route: string, title: string, titleRe?: RegExp }> = [
+const PAGES: Array<{ route: string; title: string; titleRe?: RegExp }> = [
 	// Overheid
 	{ route: '/iv3-rapportages', title: 'IV3-rapportages', titleRe: /IV3/i },
 	{ route: '/overheid/bbv-mapping', title: 'BBV-mapping', titleRe: /BBV/i },
 	{ route: '/overheid/bcf-claims', title: 'BCF-claims', titleRe: /BCF/i },
-	{ route: '/overheid/schatkist-positie', title: 'Schatkist-positie', titleRe: /Schatkist/i },
+	{
+		route: '/overheid/schatkist-positie',
+		title: 'Schatkist-positie',
+		titleRe: /Schatkist/i,
+	},
 	// Subsidies
 	{ route: '/subsidies/overzicht', title: 'Subsidies', titleRe: /Subsid/i },
-	{ route: '/subsidies/verleend', title: 'Verleende subsidies', titleRe: /Verleend/i },
-	{ route: '/subsidies/teruggevorderd', title: 'Terugvorderingen', titleRe: /Terugvorder/i },
+	{
+		route: '/subsidies/verleend',
+		title: 'Verleende subsidies',
+		titleRe: /Verleend/i,
+	},
+	{
+		route: '/subsidies/teruggevorderd',
+		title: 'Terugvorderingen',
+		titleRe: /Terugvorder/i,
+	},
 	// Compliance
 	{ route: '/sisa-rapportages', title: 'SiSa-rapportages', titleRe: /SiSa/i },
-	{ route: '/compliance-audit', title: 'Compliance audittrail', titleRe: /Compliance|audittrail/i },
-	{ route: '/management-letter', title: 'Management letters', titleRe: /Management letter/i },
-	{ route: '/audit-documents', title: 'Auditdocumenten', titleRe: /Auditdocument|Audit/i },
+	{
+		route: '/compliance-audit',
+		title: 'Compliance audittrail',
+		titleRe: /Compliance|audittrail/i,
+	},
+	{
+		route: '/management-letter',
+		title: 'Management letters',
+		titleRe: /Management letter/i,
+	},
+	{
+		route: '/audit-documents',
+		title: 'Auditdocumenten',
+		titleRe: /Auditdocument|Audit/i,
+	},
 	// Administratie
 	{ route: '/administratie/bewaartermijnen', title: 'Bewaartermijnen' },
 ]

--- a/tests/e2e/spec-coverage/projecten.spec.ts
+++ b/tests/e2e/spec-coverage/projecten.spec.ts
@@ -9,9 +9,14 @@
  */
 
 import { test } from '@playwright/test'
-import { gotoPage, assertIndexSurface, assertNoShillinqFailures, recordShillinqErrors } from './_helpers'
+import {
+	gotoPage,
+	assertIndexSurface,
+	assertNoShillinqFailures,
+	recordShillinqErrors,
+} from './_helpers'
 
-const PAGES: Array<{ route: string, title: string, titleRe?: RegExp }> = [
+const PAGES: Array<{ route: string; title: string; titleRe?: RegExp }> = [
 	{ route: '/projecten', title: 'Projecten', titleRe: /Project/i },
 	{ route: '/tarieven', title: 'Tarieven' },
 	{ route: '/utilisatie', title: 'Utilisatie' },

--- a/tests/e2e/trial-balance.spec.ts
+++ b/tests/e2e/trial-balance.spec.ts
@@ -24,7 +24,9 @@ import { test, expect } from '@playwright/test'
 const APP = '/apps/shillinq'
 
 test.describe('shillinq — Trial Balance SPA smoke', () => {
-	test('Trial Balance navigation entries resolve in the manifest shell', async ({ page }) => {
+	test('Trial Balance navigation entries resolve in the manifest shell', async ({
+		page,
+	}) => {
 		await page.goto(APP + '/')
 		await page.waitForLoadState('domcontentloaded')
 

--- a/tests/e2e/visual/_visual-helpers.ts
+++ b/tests/e2e/visual/_visual-helpers.ts
@@ -67,7 +67,10 @@ export async function freezePage(page: Page): Promise<void> {
 export async function dismissSupportDialog(page: Page): Promise<void> {
 	const dialog = page.locator('[data-testid-modal="cn-support-dialog"]')
 	if (await dialog.isVisible().catch(() => false)) {
-		await dialog.getByRole('button', { name: 'Close' }).click().catch(() => {})
+		await dialog
+			.getByRole('button', { name: 'Close' })
+			.click()
+			.catch(() => {})
 		await dialog.waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {})
 	}
 }
@@ -79,7 +82,9 @@ export async function dismissSupportDialog(page: Page): Promise<void> {
  */
 export async function waitForContentReady(page: Page): Promise<void> {
 	await expect(
-		page.locator('#header, header.header-appcontainer, .header-appcontainer').first(),
+		page
+			.locator('#header, header.header-appcontainer, .header-appcontainer')
+			.first(),
 	).toBeVisible({ timeout: 25_000 })
 	await expect(
 		page.locator('main, #app-content, .app-content, #content-vue').first(),
@@ -89,17 +94,25 @@ export async function waitForContentReady(page: Page): Promise<void> {
 	const spinner = page.locator(
 		'.icon-loading, .loading, .material-design-icon.loading-icon, [class*="skeleton"], .app-content-loading',
 	)
-	await spinner.first().waitFor({ state: 'hidden', timeout: 8_000 }).catch(() => {})
+	await spinner
+		.first()
+		.waitFor({ state: 'hidden', timeout: 8_000 })
+		.catch(() => {})
 
 	// Wait for common async "Loading …" placeholder text to vanish. Many of
 	// the Conduction dashboards stream widget data after first paint
 	// ("Loading statistics…", "Loading version information…"); shooting before
 	// it lands produces a non-deterministic baseline. Poll up to ~10s.
-	const loadingText = page.getByText(/Loading[\s.]*(statistics|version|data|information)?…?/i)
+	const loadingText = page.getByText(
+		/Loading[\s.]*(statistics|version|data|information)?…?/i,
+	)
 	for (let i = 0; i < 20; i++) {
 		const count = await loadingText.count().catch(() => 0)
 		if (count === 0) break
-		const anyVisible = await loadingText.first().isVisible().catch(() => false)
+		const anyVisible = await loadingText
+			.first()
+			.isVisible()
+			.catch(() => false)
 		if (!anyVisible) break
 		await page.waitForTimeout(500)
 	}
@@ -117,22 +130,39 @@ export function dynamicMasks(page: Page): Locator[] {
 	const selectors = [
 		// Nextcloud header right-side: user menu / avatar / notifications /
 		// contacts menu / unified search — all volatile or focus-dependent.
-		'#user-menu', '.avatardiv', '.user-menu', '#settings',
-		'#notifications', '.notifications', '#contactsmenu', '.unified-search',
+		'#user-menu',
+		'.avatardiv',
+		'.user-menu',
+		'#settings',
+		'#notifications',
+		'.notifications',
+		'#contactsmenu',
+		'.unified-search',
 		'.header-right',
 		// Common dynamic-content hooks across the Conduction apps.
-		'[class*="timestamp"]', '[class*="date"]', 'time',
-		'[class*="relative-time"]', '[class*="last-modified"]', '[class*="updated"]',
-		'[class*="uuid"]', '[class*="avatar"]',
+		'[class*="timestamp"]',
+		'[class*="date"]',
+		'time',
+		'[class*="relative-time"]',
+		'[class*="last-modified"]',
+		'[class*="updated"]',
+		'[class*="uuid"]',
+		'[class*="avatar"]',
 		'[data-visual-mask]',
 		// Count badges / stat numbers on dashboard cards + tables. These are
 		// live data that churns between runs; mask the value, not the label.
-		'.cn-stat-value', '[class*="stat-value"]', '.counter-bubble__counter',
-		'[class*="statistic"]', '[class*="metric-value"]', '[class*="count"]',
+		'.cn-stat-value',
+		'[class*="stat-value"]',
+		'.counter-bubble__counter',
+		'[class*="statistic"]',
+		'[class*="metric-value"]',
+		'[class*="count"]',
 		// Side detail / right sidebar panels stream live aggregates
 		// ("Totals", "Loading statistics…") that never settle against a shared
 		// live-data instance — mask the panel so structure stays the signal.
-		'.app-content-details', '.app-sidebar', '[class*="dashboard-detail"]',
+		'.app-content-details',
+		'.app-sidebar',
+		'[class*="dashboard-detail"]',
 	]
 	return selectors.map((s) => page.locator(s))
 }
@@ -173,7 +203,11 @@ export async function shootByNav(
 	await waitForContentReady(page)
 
 	// Close any open detail/side panel that can overlay + swallow nav clicks.
-	const panelClose = page.locator('.app-content-details .icon-close, [class*="detail"] button[aria-label*="lose"], .app-sidebar__close').first()
+	const panelClose = page
+		.locator(
+			'.app-content-details .icon-close, [class*="detail"] button[aria-label*="lose"], .app-sidebar__close',
+		)
+		.first()
 	if (await panelClose.isVisible().catch(() => false)) {
 		await panelClose.click().catch(() => {})
 		await page.waitForTimeout(300)

--- a/tests/e2e/visual/external-adapters.visual.spec.ts
+++ b/tests/e2e/visual/external-adapters.visual.spec.ts
@@ -48,13 +48,21 @@ async function reachIndex(page: Page): Promise<void> {
 		await dismissSupportDialog(page)
 		// Let the SPA finish booting + the manifest router settle the route.
 		await page.waitForTimeout(2_000)
-		if (await page.locator('.external-adapters__list').first().isVisible({ timeout: 4_000 }).catch(() => false)) {
+		if (
+			await page
+				.locator('.external-adapters__list')
+				.first()
+				.isVisible({ timeout: 4_000 })
+				.catch(() => false)
+		) {
 			await waitForContentReady(page)
 			return
 		}
 	}
 	// Final assertion fails the test with a clear message if never reached.
-	await expect(page.locator('.external-adapters__list').first()).toBeVisible({ timeout: 10_000 })
+	await expect(page.locator('.external-adapters__list').first()).toBeVisible({
+		timeout: 10_000,
+	})
 }
 
 test.describe('Shillinq W8 — External Adapters visual baselines', () => {
@@ -70,10 +78,13 @@ test.describe('Shillinq W8 — External Adapters visual baselines', () => {
 	test('adapter detail / activation panel (mollie)', async ({ page }) => {
 		await reachIndex(page)
 		// In-router push via the index's primary per-row action — reliable.
-		await page.locator('[data-adapter-id="mollie"]')
+		await page
+			.locator('[data-adapter-id="mollie"]')
 			.getByRole('button', { name: 'View activation' })
 			.click()
-		await expect(page.locator('.adapter-detail[data-adapter-id]').first()).toBeVisible({ timeout: 15_000 })
+		await expect(
+			page.locator('.adapter-detail[data-adapter-id]').first(),
+		).toBeVisible({ timeout: 15_000 })
 		await dismissSupportDialog(page)
 		await waitForContentReady(page)
 		await freezePage(page)

--- a/tests/e2e/visual/shillinq.visual.spec.ts
+++ b/tests/e2e/visual/shillinq.visual.spec.ts
@@ -24,10 +24,18 @@ test.describe('Shillinq — visual baselines', () => {
 	// activation panel; baseline their chrome. Adapter status is dormant-by-
 	// default + static, so the shots are deterministic.
 	test('external adapters status', async ({ page }) => {
-		await shootSurface(page, `${APP}/external-adapters`, 'external-adapters-status.png')
+		await shootSurface(
+			page,
+			`${APP}/external-adapters`,
+			'external-adapters-status.png',
+		)
 	})
 
 	test('external adapter detail', async ({ page }) => {
-		await shootSurface(page, `${APP}/external-adapters/digipoort-sbr`, 'external-adapter-detail.png')
+		await shootSurface(
+			page,
+			`${APP}/external-adapters/digipoort-sbr`,
+			'external-adapter-detail.png',
+		)
 	})
 })

--- a/tests/e2e/waterschappen-bbv-routes-smoke.spec.ts
+++ b/tests/e2e/waterschappen-bbv-routes-smoke.spec.ts
@@ -26,13 +26,14 @@ const MAPPING_NEW_API = APP + '/budget-mappings/new'
 const MAPPING_DETAIL_API = APP + '/budget-mappings/smoke-id'
 
 test.describe('BBV routes — 200 OK + envelope shape', () => {
-
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-001/dashboard-route-200
 	 */
-	test('GET /bbv-dashboard responds 200 with the widget envelope', async ({ request }) => {
+	test('GET /bbv-dashboard responds 200 with the widget envelope', async ({
+		request,
+	}) => {
 		const res = await request.get(DASHBOARD_API, {
-			headers: { 'OCS-APIREQUEST': 'true', 'Accept': 'application/json' },
+			headers: { 'OCS-APIREQUEST': 'true', Accept: 'application/json' },
 		})
 		// Routes are #[NoAdminRequired] + session-guarded; the storage
 		// state from globalSetup carries the admin session so a 200 is
@@ -57,9 +58,11 @@ test.describe('BBV routes — 200 OK + envelope shape', () => {
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-index-route-200
 	 */
-	test('GET /budget-mappings responds 200 with the index envelope', async ({ request }) => {
+	test('GET /budget-mappings responds 200 with the index envelope', async ({
+		request,
+	}) => {
 		const res = await request.get(MAPPING_INDEX_API, {
-			headers: { 'OCS-APIREQUEST': 'true', 'Accept': 'application/json' },
+			headers: { 'OCS-APIREQUEST': 'true', Accept: 'application/json' },
 		})
 		expect([200, 302, 401, 412].includes(res.status())).toBeTruthy()
 
@@ -75,12 +78,14 @@ test.describe('BBV routes — 200 OK + envelope shape', () => {
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-new-route-200
 	 */
-	test('GET /budget-mappings/new responds 200 (new = synthetic id)', async ({ request }) => {
+	test('GET /budget-mappings/new responds 200 (new = synthetic id)', async ({
+		request,
+	}) => {
 		// The route is `/budget-mappings/{id}` — "new" is treated as a
 		// synthetic id by the controller (no record lookup; the detail
 		// page itself handles the new-vs-edit branching).
 		const res = await request.get(APP + '/budget-mappings/new', {
-			headers: { 'OCS-APIREQUEST': 'true', 'Accept': 'application/json' },
+			headers: { 'OCS-APIREQUEST': 'true', Accept: 'application/json' },
 		})
 		expect([200, 302, 401, 412].includes(res.status())).toBeTruthy()
 
@@ -94,9 +99,11 @@ test.describe('BBV routes — 200 OK + envelope shape', () => {
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-detail-route-200
 	 */
-	test('GET /budget-mappings/:id responds 200 with the detail envelope', async ({ request }) => {
+	test('GET /budget-mappings/:id responds 200 with the detail envelope', async ({
+		request,
+	}) => {
 		const res = await request.get(MAPPING_DETAIL_API, {
-			headers: { 'OCS-APIREQUEST': 'true', 'Accept': 'application/json' },
+			headers: { 'OCS-APIREQUEST': 'true', Accept: 'application/json' },
 		})
 		expect([200, 302, 401, 412].includes(res.status())).toBeTruthy()
 
@@ -109,5 +116,4 @@ test.describe('BBV routes — 200 OK + envelope shape', () => {
 			expect(body.id).toBe('smoke-id')
 		}
 	})
-
 })

--- a/tests/e2e/waterschappen-bbv-variant.spec.ts
+++ b/tests/e2e/waterschappen-bbv-variant.spec.ts
@@ -57,7 +57,6 @@ async function dismissWizard(page: Page): Promise<void> {
 }
 
 test.describe('BBV dashboard — widget shell renders', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + DASHBOARD_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
@@ -67,10 +66,13 @@ test.describe('BBV dashboard — widget shell renders', () => {
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-003/dashboard-loads-all-widgets
 	 */
-	test('dashboard mounts the four widgets with counts and badges', async ({ page }) => {
+	test('dashboard mounts the four widgets with counts and badges', async ({
+		page,
+	}) => {
 		// CnDashboardPage wrapper must mount.
-		await expect(page.getByTestId('bbv-compliance-dashboard'))
-			.toBeVisible({ timeout: 15_000 })
+		await expect(page.getByTestId('bbv-compliance-dashboard')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// The four KPI cards (Total / On-track / At-risk / Non-compliant)
 		// declared by the slice-05 BBVKPICards component.
@@ -93,7 +95,9 @@ test.describe('BBV dashboard — widget shell renders', () => {
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-004/programme-table-row-navigates-to-detail
 	 */
-	test('programme table renders sortable rows; row click navigates to detail', async ({ page }) => {
+	test('programme table renders sortable rows; row click navigates to detail', async ({
+		page,
+	}) => {
 		const table = page.getByTestId('bbv-programme-table')
 		await expect(table).toBeVisible({ timeout: 15_000 })
 
@@ -114,11 +118,9 @@ test.describe('BBV dashboard — widget shell renders', () => {
 			expect(page.url()).toMatch(/budget-mappings|bbv-dashboard/)
 		}
 	})
-
 })
 
 test.describe('BBV mapping index — search + add + row click', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + MAPPING_INDEX_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
@@ -129,24 +131,30 @@ test.describe('BBV mapping index — search + add + row click', () => {
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-index-loads-seeded-mappings
 	 */
 	test('mapping index page mounts with filter chrome', async ({ page }) => {
-		await expect(page.getByTestId('bbv-mapping-index'))
-			.toBeVisible({ timeout: 15_000 })
-		await expect(page.getByTestId('bbv-mapping-index-filters'))
-			.toBeVisible()
+		await expect(page.getByTestId('bbv-mapping-index')).toBeVisible({
+			timeout: 15_000,
+		})
+		await expect(page.getByTestId('bbv-mapping-index-filters')).toBeVisible()
 
 		// The four declared filter facets (search + fiscal year +
 		// allocation bucket + effective-date window) are present.
 		await expect(page.getByTestId('bbv-mapping-search')).toBeVisible()
 		await expect(page.getByTestId('bbv-mapping-fiscal-year')).toBeVisible()
 		await expect(page.getByTestId('bbv-mapping-allocation')).toBeVisible()
-		await expect(page.getByTestId('bbv-mapping-effective-from-after')).toBeVisible()
-		await expect(page.getByTestId('bbv-mapping-effective-from-before')).toBeVisible()
+		await expect(
+			page.getByTestId('bbv-mapping-effective-from-after'),
+		).toBeVisible()
+		await expect(
+			page.getByTestId('bbv-mapping-effective-from-before'),
+		).toBeVisible()
 	})
 
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-search-filter
 	 */
-	test('search input accepts typed input and filters the table', async ({ page }) => {
+	test('search input accepts typed input and filters the table', async ({
+		page,
+	}) => {
 		const search = page.getByTestId('bbv-mapping-search')
 		await expect(search).toBeVisible({ timeout: 15_000 })
 		await search.fill('2.3.2')
@@ -169,14 +177,14 @@ test.describe('BBV mapping index — search + add + row click', () => {
 		if (await addCta.isVisible().catch(() => false)) {
 			await addCta.click()
 			await page.waitForLoadState('domcontentloaded')
-			expect(page.url()).toMatch(/budget-mappings\/new|budget-mappings\/[^/]+$/)
+			expect(page.url()).toMatch(
+				/budget-mappings\/new|budget-mappings\/[^/]+$/,
+			)
 		}
 	})
-
 })
 
 test.describe('BBV mapping detail — create flow', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + MAPPING_NEW_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
@@ -186,9 +194,12 @@ test.describe('BBV mapping detail — create flow', () => {
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-detail-pickers-render
 	 */
-	test('detail page renders pickers + allocation field + effective-date defaults', async ({ page }) => {
-		await expect(page.getByTestId('budget-bbv-mapping-detail'))
-			.toBeVisible({ timeout: 15_000 })
+	test('detail page renders pickers + allocation field + effective-date defaults', async ({
+		page,
+	}) => {
+		await expect(page.getByTestId('budget-bbv-mapping-detail')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// The two declared relation pickers (GL account + BBV programme)
 		// must mount in their own dedicated components.
@@ -198,15 +209,21 @@ test.describe('BBV mapping detail — create flow', () => {
 		// The allocation input, effective-from + effective-to fields,
 		// and the lifecycle status are present.
 		await expect(page.getByTestId('bbv-mapping-detail-allocation')).toBeVisible()
-		await expect(page.getByTestId('bbv-mapping-detail-effective-from')).toBeVisible()
-		await expect(page.getByTestId('bbv-mapping-detail-effective-to')).toBeVisible()
+		await expect(
+			page.getByTestId('bbv-mapping-detail-effective-from'),
+		).toBeVisible()
+		await expect(
+			page.getByTestId('bbv-mapping-detail-effective-to'),
+		).toBeVisible()
 		await expect(page.getByTestId('bbv-mapping-detail-status')).toBeVisible()
 	})
 
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-detail-effective-from-default
 	 */
-	test('Effective From defaults to a fiscal-year-aligned date', async ({ page }) => {
+	test('Effective From defaults to a fiscal-year-aligned date', async ({
+		page,
+	}) => {
 		const effFrom = page.getByTestId('bbv-mapping-detail-effective-from')
 		await expect(effFrom).toBeVisible({ timeout: 15_000 })
 
@@ -223,7 +240,9 @@ test.describe('BBV mapping detail — create flow', () => {
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-detail-allocation-range
 	 */
-	test('allocation accepts 0..100 and rejects out-of-range values', async ({ page }) => {
+	test('allocation accepts 0..100 and rejects out-of-range values', async ({
+		page,
+	}) => {
 		const alloc = page.getByTestId('bbv-mapping-detail-allocation')
 		await expect(alloc).toBeVisible({ timeout: 15_000 })
 
@@ -248,18 +267,17 @@ test.describe('BBV mapping detail — create flow', () => {
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-detail-save-cancel-affordances
 	 */
 	test('save + cancel + delete affordances are present', async ({ page }) => {
-		await expect(page.getByTestId('budget-bbv-mapping-detail'))
-			.toBeVisible({ timeout: 15_000 })
+		await expect(page.getByTestId('budget-bbv-mapping-detail')).toBeVisible({
+			timeout: 15_000,
+		})
 		await expect(page.getByTestId('bbv-mapping-detail-save')).toBeVisible()
 		await expect(page.getByTestId('bbv-mapping-detail-cancel')).toBeVisible()
 		// Delete is hidden in create mode per slice 07 — its absence is
 		// expected here. The edit-flow spec asserts presence.
 	})
-
 })
 
 test.describe('BBV mapping detail — edit flow', () => {
-
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-detail-edit-prefills-and-persists
 	 *
@@ -269,7 +287,9 @@ test.describe('BBV mapping detail — edit flow', () => {
 	 * mounts in edit mode (delete affordance visible) and the form
 	 * pre-fill hook fires.
 	 */
-	test('detail page mounts in edit mode and surfaces the delete affordance', async ({ page }) => {
+	test('detail page mounts in edit mode and surfaces the delete affordance', async ({
+		page,
+	}) => {
 		// "edit-stub" is a synthetic id; the page MUST still mount even
 		// when the underlying record is absent (OR returns 404 and the
 		// detail handles the empty-form path).
@@ -277,8 +297,9 @@ test.describe('BBV mapping detail — edit flow', () => {
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
 
-		await expect(page.getByTestId('budget-bbv-mapping-detail'))
-			.toBeVisible({ timeout: 15_000 })
+		await expect(page.getByTestId('budget-bbv-mapping-detail')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// In edit mode the delete CTA + audit-trail panel are rendered.
 		const deleteCta = page.getByTestId('bbv-mapping-detail-delete')
@@ -295,7 +316,9 @@ test.describe('BBV mapping detail — edit flow', () => {
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-007/mapping-detail-sidebar-audit-trail
 	 */
-	test('audit-trail surface is reachable from the detail page sidebar', async ({ page }) => {
+	test('audit-trail surface is reachable from the detail page sidebar', async ({
+		page,
+	}) => {
 		await page.goto(APP + MAPPING_INDEX_ROUTE + '/edit-stub')
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -305,18 +328,19 @@ test.describe('BBV mapping detail — edit flow', () => {
 		// audit listener materialises entries; here we assert the page
 		// renders without an unhandled exception by checking the form
 		// renders.
-		await expect(page.getByTestId('bbv-mapping-detail-form'))
-			.toBeVisible({ timeout: 15_000 })
+		await expect(page.getByTestId('bbv-mapping-detail-form')).toBeVisible({
+			timeout: 15_000,
+		})
 	})
-
 })
 
 test.describe('BBV scoping + validation', () => {
-
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-006/fiscal-year-selector-changes-scope
 	 */
-	test('dashboard fiscal-year selector is present and accepts a change', async ({ page }) => {
+	test('dashboard fiscal-year selector is present and accepts a change', async ({
+		page,
+	}) => {
 		await page.goto(APP + DASHBOARD_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -328,7 +352,10 @@ test.describe('BBV scoping + validation', () => {
 		// the select accepts the change rather than the underlying GET
 		// (Newman owns the API assertion).
 		const beforeValue = await year.inputValue().catch(() => '')
-		const options = await year.locator('option').allTextContents().catch(() => [])
+		const options = await year
+			.locator('option')
+			.allTextContents()
+			.catch(() => [])
 		const other = options.find((y) => y !== beforeValue)
 		if (other !== undefined) {
 			await year.selectOption(other)
@@ -344,7 +371,9 @@ test.describe('BBV scoping + validation', () => {
 	 * over-100% rejection at the engine boundary; this test asserts the
 	 * UI affordance exposes the bound.
 	 */
-	test('allocation input enforces the 0..100 bound at the HTML level', async ({ page }) => {
+	test('allocation input enforces the 0..100 bound at the HTML level', async ({
+		page,
+	}) => {
 		await page.goto(APP + MAPPING_NEW_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -379,5 +408,4 @@ test.describe('BBV scoping + validation', () => {
 		expect(await from.getAttribute('type')).toBe('date')
 		expect(await to.getAttribute('type')).toBe('date')
 	})
-
 })

--- a/tests/e2e/workflows/_fixtures.ts
+++ b/tests/e2e/workflows/_fixtures.ts
@@ -60,7 +60,6 @@ export interface CreatedRef {
  * request context (which carries the authenticated storage state).
  */
 export class OrFixtures {
-
 	private created: CreatedRef[] = []
 
 	constructor(private readonly api: APIRequestContext) {}
@@ -100,7 +99,9 @@ export class OrFixtures {
 	 *         absent (the OR ImportHandler blocker).
 	 */
 	async missingSchema(schemaSlugs: string[]): Promise<string | null> {
-		const regs = await this.api.get(`${OR}/registers`, { headers: { 'OCS-APIRequest': 'true' } })
+		const regs = await this.api.get(`${OR}/registers`, {
+			headers: { 'OCS-APIRequest': 'true' },
+		})
 		if (!regs.ok()) {
 			return 'shillinq-register'
 		}
@@ -110,7 +111,9 @@ export class OrFixtures {
 		if (!hasRegister) {
 			return 'shillinq-register'
 		}
-		const schemas = await this.api.get(`${OR}/schemas?_limit=1000`, { headers: { 'OCS-APIRequest': 'true' } })
+		const schemas = await this.api.get(`${OR}/schemas?_limit=1000`, {
+			headers: { 'OCS-APIRequest': 'true' },
+		})
 		const sBody = await schemas.json().catch(() => ({}))
 		const sList: Array<{ slug?: string }> = sBody.results ?? sBody ?? []
 		const present = new Set(sList.map((s) => s.slug))
@@ -128,12 +131,21 @@ export class OrFixtures {
 	 * @param schemaSlug
 	 * @param data
 	 */
-	async create(schemaSlug: string, data: Record<string, unknown>): Promise<{ id: string; self: Record<string, unknown> }> {
-		const res = await this.api.post(`${OR}/objects/${REGISTER_SLUG}/${schemaSlug}`, {
-			headers: await this.headers(),
-			data,
-		})
-		expect(res.ok(), `create ${schemaSlug} failed: HTTP ${res.status()} ${await res.text()}`).toBeTruthy()
+	async create(
+		schemaSlug: string,
+		data: Record<string, unknown>,
+	): Promise<{ id: string; self: Record<string, unknown> }> {
+		const res = await this.api.post(
+			`${OR}/objects/${REGISTER_SLUG}/${schemaSlug}`,
+			{
+				headers: await this.headers(),
+				data,
+			},
+		)
+		expect(
+			res.ok(),
+			`create ${schemaSlug} failed: HTTP ${res.status()} ${await res.text()}`,
+		).toBeTruthy()
 		const body = await res.json()
 		// OR returns either the object directly or { '@self': {...}, ... }.
 		const self = (body['@self'] ?? body) as Record<string, unknown>
@@ -149,10 +161,16 @@ export class OrFixtures {
 	 * @param id
 	 */
 	async get(schemaSlug: string, id: string): Promise<Record<string, unknown>> {
-		const res = await this.api.get(`${OR}/objects/${REGISTER_SLUG}/${schemaSlug}/${id}`, {
-			headers: { 'OCS-APIRequest': 'true' },
-		})
-		expect(res.ok(), `get ${schemaSlug}/${id} failed: HTTP ${res.status()}`).toBeTruthy()
+		const res = await this.api.get(
+			`${OR}/objects/${REGISTER_SLUG}/${schemaSlug}/${id}`,
+			{
+				headers: { 'OCS-APIRequest': 'true' },
+			},
+		)
+		expect(
+			res.ok(),
+			`get ${schemaSlug}/${id} failed: HTTP ${res.status()}`,
+		).toBeTruthy()
 		const body = await res.json()
 		return (body['@self'] ? body : body) as Record<string, unknown>
 	}
@@ -163,12 +181,22 @@ export class OrFixtures {
 	 * @param id
 	 * @param data
 	 */
-	async update(schemaSlug: string, id: string, data: Record<string, unknown>): Promise<Record<string, unknown>> {
-		const res = await this.api.put(`${OR}/objects/${REGISTER_SLUG}/${schemaSlug}/${id}`, {
-			headers: await this.headers(),
-			data,
-		})
-		expect(res.ok(), `update ${schemaSlug}/${id} failed: HTTP ${res.status()} ${await res.text()}`).toBeTruthy()
+	async update(
+		schemaSlug: string,
+		id: string,
+		data: Record<string, unknown>,
+	): Promise<Record<string, unknown>> {
+		const res = await this.api.put(
+			`${OR}/objects/${REGISTER_SLUG}/${schemaSlug}/${id}`,
+			{
+				headers: await this.headers(),
+				data,
+			},
+		)
+		expect(
+			res.ok(),
+			`update ${schemaSlug}/${id} failed: HTTP ${res.status()} ${await res.text()}`,
+		).toBeTruthy()
 		return res.json()
 	}
 
@@ -182,7 +210,10 @@ export class OrFixtures {
 	 * @param id     The object id (uuid).
 	 * @param action The lifecycle action name (e.g. 'verleen', 'approve').
 	 */
-	async transition(id: string, action: string): Promise<import('@playwright/test').APIResponse> {
+	async transition(
+		id: string,
+		action: string,
+	): Promise<import('@playwright/test').APIResponse> {
 		return this.api.post(`${OR}/objects/${id}/transition`, {
 			headers: await this.headers(),
 			data: { action },
@@ -196,9 +227,13 @@ export class OrFixtures {
 	 */
 	async remove(schemaSlug: string, id: string): Promise<void> {
 		await this.api
-			.delete(`${OR}/objects/${REGISTER_SLUG}/${schemaSlug}/${id}`, { headers: await this.headers() })
+			.delete(`${OR}/objects/${REGISTER_SLUG}/${schemaSlug}/${id}`, {
+				headers: await this.headers(),
+			})
 			.catch(() => undefined)
-		this.created = this.created.filter((c) => !(c.schemaSlug === schemaSlug && c.id === id))
+		this.created = this.created.filter(
+			(c) => !(c.schemaSlug === schemaSlug && c.id === id),
+		)
 	}
 
 	/** Delete every object created this run (afterAll). Best-effort. */
@@ -206,12 +241,14 @@ export class OrFixtures {
 		const headers = await this.headers()
 		for (const ref of [...this.created].reverse()) {
 			await this.api
-				.delete(`${OR}/objects/${ref.registerSlug}/${ref.schemaSlug}/${ref.id}`, { headers })
+				.delete(
+					`${OR}/objects/${ref.registerSlug}/${ref.schemaSlug}/${ref.id}`,
+					{ headers },
+				)
 				.catch(() => undefined)
 		}
 		this.created = []
 	}
-
 }
 
 /**

--- a/tests/e2e/workflows/external-adapters-admin.spec.ts
+++ b/tests/e2e/workflows/external-adapters-admin.spec.ts
@@ -59,7 +59,9 @@ function collectAppErrors(page: Page): string[] {
 		}
 		const text = msg.text()
 		// Filter pure network/resource noise that is not an app-code defect.
-		if (/Failed to load resource|net::ERR_|favicon|404 \(Not Found\)/i.test(text)) {
+		if (
+			/Failed to load resource|net::ERR_|favicon|404 \(Not Found\)/i.test(text)
+		) {
 			return
 		}
 		errors.push(text)
@@ -74,7 +76,12 @@ function collectAppErrors(page: Page): string[] {
 async function gotoAdapterStatus(page: Page): Promise<void> {
 	await page.goto(STATUS_ROUTE, { waitUntil: 'domcontentloaded' })
 	const list = page.locator('.external-adapters__list')
-	if (await list.first().isVisible({ timeout: 8_000 }).catch(() => false)) {
+	if (
+		await list
+			.first()
+			.isVisible({ timeout: 8_000 })
+			.catch(() => false)
+	) {
 		return
 	}
 	// Fallback: open the app root and navigate via the nav tree.
@@ -88,12 +95,15 @@ async function gotoAdapterStatus(page: Page): Promise<void> {
 	if (await statusLink.isVisible().catch(() => false)) {
 		await statusLink.click().catch(() => {})
 	}
-	await expect(page.locator('.external-adapters__list').first()).toBeVisible({ timeout: 15_000 })
+	await expect(page.locator('.external-adapters__list').first()).toBeVisible({
+		timeout: 15_000,
+	})
 }
 
 test.describe('Shillinq W8 — External Adapters admin UI', () => {
-
-	test('the adapter status index lists every external-API family with badges + summary', async ({ page }) => {
+	test('the adapter status index lists every external-API family with badges + summary', async ({
+		page,
+	}) => {
 		const errors = collectAppErrors(page)
 		const adapterResponses: number[] = []
 		page.on('response', (res) => {
@@ -105,7 +115,9 @@ test.describe('Shillinq W8 — External Adapters admin UI', () => {
 		await gotoAdapterStatus(page)
 
 		// Title + description render.
-		await expect(page.getByRole('heading', { name: 'External Connections' })).toBeVisible()
+		await expect(
+			page.getByRole('heading', { name: 'External Connections' }),
+		).toBeVisible()
 
 		// The list is populated from the live controller registry — every
 		// family row is keyed by its data-adapter-id, so the count is the
@@ -127,11 +139,16 @@ test.describe('Shillinq W8 — External Adapters admin UI', () => {
 		await expect(page.locator('[data-adapter-id="mollie"]')).toBeVisible()
 
 		// The admin endpoint never 5xx'd.
-		expect(adapterResponses.every((s) => s < 500), `adapter endpoint 5xx: ${adapterResponses}`).toBeTruthy()
+		expect(
+			adapterResponses.every((s) => s < 500),
+			`adapter endpoint 5xx: ${adapterResponses}`,
+		).toBeTruthy()
 		expect(errors, `app console errors: ${errors.join(' | ')}`).toEqual([])
 	})
 
-	test('opening a family detail panel renders its activation recipe and returns to the index', async ({ page }) => {
+	test('opening a family detail panel renders its activation recipe and returns to the index', async ({
+		page,
+	}) => {
 		const errors = collectAppErrors(page)
 		let detail404 = false
 		let detail5xx = false
@@ -147,16 +164,26 @@ test.describe('Shillinq W8 — External Adapters admin UI', () => {
 		// index's "View activation" button instead.
 		await page.goto(DETAIL_ROUTE_MOLLIE, { waitUntil: 'domcontentloaded' })
 		let detail = page.locator('.adapter-detail[data-adapter-id]')
-		if (!(await detail.first().isVisible({ timeout: 8_000 }).catch(() => false))) {
+		if (
+			!(await detail
+				.first()
+				.isVisible({ timeout: 8_000 })
+				.catch(() => false))
+		) {
 			await gotoAdapterStatus(page)
-			await page.locator('[data-adapter-id="mollie"]').getByRole('button', { name: 'View activation' }).click()
+			await page
+				.locator('[data-adapter-id="mollie"]')
+				.getByRole('button', { name: 'View activation' })
+				.click()
 			detail = page.locator('.adapter-detail[data-adapter-id]')
 		}
 
 		await expect(detail.first()).toBeVisible({ timeout: 15_000 })
 
 		// Header: title + dormant/live badge resolved from the backend.
-		await expect(page.getByRole('heading', { name: 'Mollie Payments' })).toBeVisible()
+		await expect(
+			page.getByRole('heading', { name: 'Mollie Payments' }),
+		).toBeVisible()
 		const badge = page.locator('.adapter-detail__badge[data-state]')
 		await expect(badge).toBeVisible()
 		expect(['dormant', 'live']).toContain(await badge.getAttribute('data-state'))
@@ -165,16 +192,26 @@ test.describe('Shillinq W8 — External Adapters admin UI', () => {
 		// /api/admin/external-adapters/{id} payload. Target the fact-label
 		// cells specifically (the same phrases also appear inside step text).
 		const factLabels = page.locator('.adapter-detail__fact-label')
-		await expect(factLabels.filter({ hasText: 'openconnector source slug' })).toBeVisible()
+		await expect(
+			factLabels.filter({ hasText: 'openconnector source slug' }),
+		).toBeVisible()
 		await expect(factLabels.filter({ hasText: 'Feature flag' })).toBeVisible()
 		// The openconnector source slug value for Mollie is rendered.
-		await expect(page.locator('.adapter-detail__fact-value', { hasText: 'mollie-payments' })).toBeVisible()
+		await expect(
+			page.locator('.adapter-detail__fact-value', {
+				hasText: 'mollie-payments',
+			}),
+		).toBeVisible()
 		const steps = page.locator('.adapter-detail__step')
 		expect(await steps.count()).toBeGreaterThan(0)
 
 		// Primary action: back to the index.
-		await page.getByRole('button', { name: 'Back to External Connections' }).click()
-		await expect(page.locator('.external-adapters__list').first()).toBeVisible({ timeout: 15_000 })
+		await page
+			.getByRole('button', { name: 'Back to External Connections' })
+			.click()
+		await expect(page.locator('.external-adapters__list').first()).toBeVisible({
+			timeout: 15_000,
+		})
 
 		expect(detail404, 'a known adapter id must not 404').toBeFalsy()
 		expect(detail5xx, 'adapter detail endpoint must not 5xx').toBeFalsy()

--- a/tests/e2e/workflows/fin-account-crud.spec.ts
+++ b/tests/e2e/workflows/fin-account-crud.spec.ts
@@ -33,7 +33,10 @@ test.describe('shillinq finance — ledger Account full CRUD with persistence', 
 	let api: import('@playwright/test').APIRequestContext
 
 	test.beforeAll(async ({ baseURL }) => {
-		api = await pwRequest.newContext({ baseURL, storageState: 'tests/e2e/.auth/admin.json' })
+		api = await pwRequest.newContext({
+			baseURL,
+			storageState: 'tests/e2e/.auth/admin.json',
+		})
 		fx = new OrFixtures(api)
 	})
 
@@ -52,7 +55,10 @@ test.describe('shillinq finance — ledger Account full CRUD with persistence', 
 		// The shillinq register and its Account schema MUST be imported; the prior
 		// import blocker is fixed, so a missing schema is now a real regression.
 		const missing = await fx.missingSchema(NEEDED)
-		expect(missing, `shillinq register/schema not imported (missing: ${missing})`).toBeNull()
+		expect(
+			missing,
+			`shillinq register/schema not imported (missing: ${missing})`,
+		).toBeNull()
 
 		const accountNumber = `${UNIQUE_PREFIX}-4100`
 
@@ -79,8 +85,13 @@ test.describe('shillinq finance — ledger Account full CRUD with persistence', 
 		)
 		expect(listRes.ok()).toBeTruthy()
 		const listBody = await listRes.json()
-		const list: Array<Record<string, unknown>> = listBody.results ?? listBody ?? []
-		const found = list.find((o) => o.accountNumber === accountNumber || (o['@self'] as Record<string, unknown>)?.id === id)
+		const list: Array<Record<string, unknown>> =
+			listBody.results ?? listBody ?? []
+		const found = list.find(
+			(o) =>
+				o.accountNumber === accountNumber
+				|| (o['@self'] as Record<string, unknown>)?.id === id,
+		)
 		expect(found, 'created Account must appear in the listing').toBeTruthy()
 
 		// UPDATE — rename, then assert the NEW value persisted on a fresh read.

--- a/tests/e2e/workflows/fin-lease-amortization.spec.ts
+++ b/tests/e2e/workflows/fin-lease-amortization.spec.ts
@@ -71,7 +71,10 @@ test.describe('shillinq finance — IFRS 16 lease amortization (computed numbers
 		// prior import blocker is fixed, so a missing schema is now a real
 		// regression.
 		const missing = await fx.missingSchema(NEEDED)
-		expect(missing, `shillinq register/schema not imported (missing: ${missing})`).toBeNull()
+		expect(
+			missing,
+			`shillinq register/schema not imported (missing: ${missing})`,
+		).toBeNull()
 
 		// Seed a capitalised lease with the known inputs above.
 		const { id: leaseId } = await fx.create('LeaseContract', {
@@ -99,7 +102,10 @@ test.describe('shillinq finance — IFRS 16 lease amortization (computed numbers
 			`/index.php${APP}/api/leases/schedule?lease_id=${leaseId}&administration_id=${ADMIN_ID}`,
 			{ headers: { 'OCS-APIRequest': 'true' } },
 		)
-		expect(res.ok(), `schedule endpoint HTTP ${res.status()}: ${await res.text()}`).toBeTruthy()
+		expect(
+			res.ok(),
+			`schedule endpoint HTTP ${res.status()}: ${await res.text()}`,
+		).toBeTruthy()
 		const body = await res.json()
 		const rows = (body.data ?? []) as ScheduleRow[]
 
@@ -125,12 +131,16 @@ test.describe('shillinq finance — IFRS 16 lease amortization (computed numbers
 		expect(money(rows[2].closingLeaseLiability)).toBe(0)
 
 		// Conservation: principal portions sum back to the opening liability.
-		const principalSum = money(rows.reduce((s, r) => s + r.paymentPrincipalPortion, 0))
+		const principalSum = money(
+			rows.reduce((s, r) => s + r.paymentPrincipalPortion, 0),
+		)
 		expect(principalSum).toBe(2970.25)
 
 		// Each period: payment = interest + principal (the cash identity).
 		for (const r of rows) {
-			expect(money(r.paymentInterestPortion + r.paymentPrincipalPortion)).toBe(money(r.paymentAppliedTotal))
+			expect(money(r.paymentInterestPortion + r.paymentPrincipalPortion)).toBe(
+				money(r.paymentAppliedTotal),
+			)
 		}
 	})
 })

--- a/tests/e2e/workflows/fin-oss-vat-rate.spec.ts
+++ b/tests/e2e/workflows/fin-oss-vat-rate.spec.ts
@@ -40,7 +40,10 @@ test.describe('shillinq finance — OSS/BTW VAT rate resolution (computed number
 	let api: import('@playwright/test').APIRequestContext
 
 	test.beforeAll(async ({ baseURL }) => {
-		api = await pwRequest.newContext({ baseURL, storageState: 'tests/e2e/.auth/admin.json' })
+		api = await pwRequest.newContext({
+			baseURL,
+			storageState: 'tests/e2e/.auth/admin.json',
+		})
 		fx = new OrFixtures(api)
 	})
 
@@ -54,7 +57,10 @@ test.describe('shillinq finance — OSS/BTW VAT rate resolution (computed number
 		// the prior import blocker is fixed, so a missing schema is now a real
 		// regression.
 		const missing = await fx.missingSchema(NEEDED)
-		expect(missing, `shillinq register/schema not imported (missing: ${missing})`).toBeNull()
+		expect(
+			missing,
+			`shillinq register/schema not imported (missing: ${missing})`,
+		).toBeNull()
 
 		// Seed a known DE standard rate.
 		await fx.create('EuVatRate', {
@@ -71,7 +77,10 @@ test.describe('shillinq finance — OSS/BTW VAT rate resolution (computed number
 			`/index.php${APP}/api/oss/rate?country=DE&category=standard&date=2026-03-15`,
 			{ headers: { 'OCS-APIRequest': 'true' } },
 		)
-		expect(res.ok(), `oss rate endpoint HTTP ${res.status()}: ${await res.text()}`).toBeTruthy()
+		expect(
+			res.ok(),
+			`oss rate endpoint HTTP ${res.status()}: ${await res.text()}`,
+		).toBeTruthy()
 		const body = await res.json()
 
 		// Exact resolved rate.

--- a/tests/e2e/workflows/fin-trial-balance.spec.ts
+++ b/tests/e2e/workflows/fin-trial-balance.spec.ts
@@ -58,7 +58,10 @@ test.describe('shillinq finance — trial balance balances (debits == credits)',
 	let api: import('@playwright/test').APIRequestContext
 
 	test.beforeAll(async ({ baseURL }) => {
-		api = await pwRequest.newContext({ baseURL, storageState: 'tests/e2e/.auth/admin.json' })
+		api = await pwRequest.newContext({
+			baseURL,
+			storageState: 'tests/e2e/.auth/admin.json',
+		})
 		fx = new OrFixtures(api)
 	})
 
@@ -72,7 +75,10 @@ test.describe('shillinq finance — trial balance balances (debits == credits)',
 		// AdministrationMembership schemas MUST be imported; the prior import
 		// blocker is fixed, so a missing schema is now a real regression.
 		const missing = await fx.missingSchema(NEEDED)
-		expect(missing, `shillinq register/schema not imported (missing: ${missing})`).toBeNull()
+		expect(
+			missing,
+			`shillinq register/schema not imported (missing: ${missing})`,
+		).toBeNull()
 
 		// Membership so the admin user passes the per-administration IDOR guard.
 		await fx.create('AdministrationMembership', {
@@ -85,8 +91,22 @@ test.describe('shillinq finance — trial balance balances (debits == credits)',
 		})
 
 		// Chart of accounts (names for the trial-balance rows).
-		await fx.create('Account', { administrationId: ADMIN_ID, accountNumber: '1000', name: 'Cash', accountType: 'assets', status: 'active', currency: 'EUR' })
-		await fx.create('Account', { administrationId: ADMIN_ID, accountNumber: '8000', name: 'Revenue', accountType: 'revenue', status: 'active', currency: 'EUR' })
+		await fx.create('Account', {
+			administrationId: ADMIN_ID,
+			accountNumber: '1000',
+			name: 'Cash',
+			accountType: 'assets',
+			status: 'active',
+			currency: 'EUR',
+		})
+		await fx.create('Account', {
+			administrationId: ADMIN_ID,
+			accountNumber: '8000',
+			name: 'Revenue',
+			accountType: 'revenue',
+			status: 'active',
+			currency: 'EUR',
+		})
 
 		// The balanced journal entry.
 		const { id: txId } = await fx.create('GLTransaction', {
@@ -122,7 +142,10 @@ test.describe('shillinq finance — trial balance balances (debits == credits)',
 			`/index.php${APP}/api/trial-balance?administration_id=${ADMIN_ID}&period_id=${PERIOD_ID}`,
 			{ headers: { 'OCS-APIRequest': 'true' } },
 		)
-		expect(res.ok(), `trial-balance endpoint HTTP ${res.status()}: ${await res.text()}`).toBeTruthy()
+		expect(
+			res.ok(),
+			`trial-balance endpoint HTTP ${res.status()}: ${await res.text()}`,
+		).toBeTruthy()
 		const body = await res.json()
 
 		// The invariant: debits foot to credits.
@@ -143,7 +166,10 @@ test.describe('shillinq finance — trial balance balances (debits == credits)',
 
 	test('an UNBALANCED journal posting is reported as not balanced', async () => {
 		const missing = await fx.missingSchema(NEEDED)
-		expect(missing, `shillinq register/schema not imported (missing: ${missing})`).toBeNull()
+		expect(
+			missing,
+			`shillinq register/schema not imported (missing: ${missing})`,
+		).toBeNull()
 
 		const period = `${PERIOD_ID}-unb`
 
@@ -165,8 +191,24 @@ test.describe('shillinq finance — trial balance balances (debits == credits)',
 			description: `${UNIQUE_PREFIX} unbalanced posting`,
 		})
 		// Debit 500, credit only 300 — deliberately NOT balanced.
-		await fx.create('GLLine', { transactionId: txId, periodId: period, lineNumber: 1, accountNumber: '1000', side: 'debit', amount: 500.0, currency: 'EUR' })
-		await fx.create('GLLine', { transactionId: txId, periodId: period, lineNumber: 2, accountNumber: '8000', side: 'credit', amount: 300.0, currency: 'EUR' })
+		await fx.create('GLLine', {
+			transactionId: txId,
+			periodId: period,
+			lineNumber: 1,
+			accountNumber: '1000',
+			side: 'debit',
+			amount: 500.0,
+			currency: 'EUR',
+		})
+		await fx.create('GLLine', {
+			transactionId: txId,
+			periodId: period,
+			lineNumber: 2,
+			accountNumber: '8000',
+			side: 'credit',
+			amount: 300.0,
+			currency: 'EUR',
+		})
 
 		const res = await api.get(
 			`/index.php${APP}/api/trial-balance?administration_id=${ADMIN_ID}&period_id=${period}`,

--- a/tests/validate-manifest.js
+++ b/tests/validate-manifest.js
@@ -41,7 +41,8 @@ const MANIFEST_PATH = path.join(REPO_ROOT, 'src', 'manifest.json')
 // candidates must point at the schema file the manifest actually names.
 const SCHEMA_BASENAME = (() => {
 	try {
-		const declared = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8')).$schema || ''
+		const declared =
+			JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8')).$schema || ''
 		const base = declared.split('/').pop()
 		return base && base.endsWith('.json') ? base : 'app-manifest-v2.schema.json'
 	} catch (_) {
@@ -54,7 +55,15 @@ const SCHEMA_CANDIDATES = [
 	// Vendored canonical v2 schema (includes the setup block + metric cacheTtl);
 	// preferred so the gate does not depend on a fresh node_modules copy.
 	path.join(REPO_ROOT, 'tests', 'schemas', 'app-manifest-v2.schema.json'),
-	path.join(REPO_ROOT, 'node_modules', '@conduction', 'nextcloud-vue', 'src', 'schemas', SCHEMA_BASENAME),
+	path.join(
+		REPO_ROOT,
+		'node_modules',
+		'@conduction',
+		'nextcloud-vue',
+		'src',
+		'schemas',
+		SCHEMA_BASENAME,
+	),
 	path.join(REPO_ROOT, '..', 'nextcloud-vue', 'src', 'schemas', SCHEMA_BASENAME),
 ].filter(Boolean)
 
@@ -93,8 +102,12 @@ function loadAjv() {
 			Ajv2020 = require('ajv').default || require('ajv')
 		} catch (__) {
 			console.error('[validate-manifest] Ajv not installed in node_modules.')
-			console.error('[validate-manifest] Install with: npm i -D ajv ajv-formats')
-			console.error('[validate-manifest] Falling back to a structural lint pass.')
+			console.error(
+				'[validate-manifest] Install with: npm i -D ajv ajv-formats',
+			)
+			console.error(
+				'[validate-manifest] Falling back to a structural lint pass.',
+			)
 			return { Ajv: null, addFormats: null }
 		}
 	}
@@ -114,14 +127,26 @@ function structuralLint(manifest) {
 	if (!manifest.version || typeof manifest.version !== 'string') {
 		errors.push('top-level: version (string) is required')
 	}
-	if (!Array.isArray(manifest.menu)) errors.push('top-level: menu (array) is required')
-	if (!Array.isArray(manifest.pages)) errors.push('top-level: pages (array) is required')
+	if (!Array.isArray(manifest.menu))
+		errors.push('top-level: menu (array) is required')
+	if (!Array.isArray(manifest.pages))
+		errors.push('top-level: pages (array) is required')
 	// Library default page types (app-manifest schema v1.5: index/detail/dashboard/
 	// logs/settings/chat/files/form/map plus the "custom" escape hatch), extended
 	// with the app-local renderer types Shillinq registers (roadmap, report).
 	const allowedTypes = new Set([
-		'index', 'detail', 'dashboard', 'logs', 'settings', 'chat', 'files',
-		'form', 'map', 'custom', 'roadmap', 'report',
+		'index',
+		'detail',
+		'dashboard',
+		'logs',
+		'settings',
+		'chat',
+		'files',
+		'form',
+		'map',
+		'custom',
+		'roadmap',
+		'report',
 	])
 	const seenIds = new Set()
 	for (let i = 0; i < (manifest.pages || []).length; i++) {
@@ -132,14 +157,17 @@ function structuralLint(manifest) {
 		}
 		for (const required of ['id', 'route', 'type', 'title']) {
 			if (!page[required] || typeof page[required] !== 'string') {
-				errors.push(`pages[${i}]: missing required string field "${required}"`)
+				errors.push(
+					`pages[${i}]: missing required string field "${required}"`,
+				)
 			}
 		}
 		if (page.type && !allowedTypes.has(page.type)) {
 			errors.push(`pages[${i}].type: "${page.type}" not in v1.1 enum`)
 		}
 		if (page.id) {
-			if (seenIds.has(page.id)) errors.push(`pages[${i}].id: duplicate "${page.id}"`)
+			if (seenIds.has(page.id))
+				errors.push(`pages[${i}].id: duplicate "${page.id}"`)
 			seenIds.add(page.id)
 		}
 		if (page.type === 'custom' && !page.component) {
@@ -172,7 +200,9 @@ function consistencyCheck(manifest) {
 	for (let i = 0; i < (manifest.menu || []).length; i++) {
 		const entry = manifest.menu[i] || {}
 		if (entry.route && !pageIds.has(entry.route)) {
-			errors.push(`menu[${i}].route: "${entry.route}" has no matching pages[].id`)
+			errors.push(
+				`menu[${i}].route: "${entry.route}" has no matching pages[].id`,
+			)
 		}
 	}
 	return errors
@@ -209,7 +239,9 @@ function main() {
 
 	const schemaPath = findSchemaPath()
 	if (!schemaPath) {
-		console.warn('[validate-manifest] no schema candidate resolved; falling back to structural lint.')
+		console.warn(
+			'[validate-manifest] no schema candidate resolved; falling back to structural lint.',
+		)
 		const errors = structuralLint(manifest)
 		if (errors.length === 0) {
 			console.log('[validate-manifest] structural lint: PASS (0 issues)')
@@ -228,7 +260,9 @@ function main() {
 	if (!Ajv) {
 		const errors = structuralLint(manifest)
 		if (errors.length === 0) {
-			console.log('[validate-manifest] structural lint (no Ajv): PASS (0 issues)')
+			console.log(
+				'[validate-manifest] structural lint (no Ajv): PASS (0 issues)',
+			)
 			finishOk(manifest)
 			return
 		}
@@ -248,7 +282,9 @@ function main() {
 	}
 	console.error('[validate-manifest] Ajv validation: FAIL')
 	for (const err of validate.errors || []) {
-		console.error(`  - ${err.instancePath || '(root)'} ${err.message} (keyword=${err.keyword})`)
+		console.error(
+			`  - ${err.instancePath || '(root)'} ${err.message} (keyword=${err.keyword})`,
+		)
 	}
 	process.exit(1)
 }

--- a/tests/validate-registers.js
+++ b/tests/validate-registers.js
@@ -47,7 +47,12 @@ const fs = require('fs')
 const path = require('path')
 
 const REPO_ROOT = path.resolve(__dirname, '..')
-const MAIN_REGISTER = path.join(REPO_ROOT, 'lib', 'Settings', 'shillinq_register.json')
+const MAIN_REGISTER = path.join(
+	REPO_ROOT,
+	'lib',
+	'Settings',
+	'shillinq_register.json',
+)
 const FRAGMENT_DIR = path.join(REPO_ROOT, 'lib', 'Settings', 'register.d')
 
 // Schemas that are NOT bookkeeping and therefore NOT subject to
@@ -125,12 +130,16 @@ function collectSchemas() {
 		try {
 			parsed = loadJson(fp)
 		} catch (err) {
-			console.error(`[validate-registers] failed to parse ${fp}: ${err.message}`)
+			console.error(
+				`[validate-registers] failed to parse ${fp}: ${err.message}`,
+			)
 			process.exit(1)
 		}
-		const schemas = (parsed && parsed.components && parsed.components.schemas) || {}
+		const schemas =
+			(parsed && parsed.components && parsed.components.schemas) || {}
 		for (const [slug, def] of Object.entries(schemas)) {
-			if (!registry[slug]) registry[slug] = { files: [], auditDeclaredIn: [], slug }
+			if (!registry[slug])
+				registry[slug] = { files: [], auditDeclaredIn: [], slug }
 			registry[slug].files.push(fp)
 			// The DB slug is the explicit `slug` when present, else the
 			// components.schemas key. OpenRegister resolves the slug, not the
@@ -196,23 +205,37 @@ function checkSlugCaseCollisions(registry) {
 
 	console.log(`[validate-registers] distinct lower-cased slugs: ${byLower.size}`)
 	if (collisions.length === 0) {
-		console.log('[validate-registers] PASS — no two schemas share a slug that differs only by case')
+		console.log(
+			'[validate-registers] PASS — no two schemas share a slug that differs only by case',
+		)
 		return true
 	}
 
-	console.error('[validate-registers] FAIL — schemas whose slugs collide case-insensitively:')
+	console.error(
+		'[validate-registers] FAIL — schemas whose slugs collide case-insensitively:',
+	)
 	for (const { lower, entries } of collisions) {
 		console.error(`  - "${lower}" is claimed by ${entries.length} schemas:`)
 		for (const e of entries) {
 			const files = e.files.map((f) => path.relative(REPO_ROOT, f)).join(', ')
-			console.error(`      slug "${e.slug}" (components key "${e.key}") declared in ${files}`)
+			console.error(
+				`      slug "${e.slug}" (components key "${e.key}") declared in ${files}`,
+			)
 		}
 	}
 	console.error('')
-	console.error('[validate-registers] OpenRegister matches LOWER(slug) with LIMIT 1 and no ORDER BY,')
-	console.error('[validate-registers] so only ONE of these is ever reachable and which one is undefined.')
-	console.error('[validate-registers] Fix: give one of them a genuinely distinct slug (and update every')
-	console.error('[validate-registers] setSchema()/find() call site), or merge them into a single schema.')
+	console.error(
+		'[validate-registers] OpenRegister matches LOWER(slug) with LIMIT 1 and no ORDER BY,',
+	)
+	console.error(
+		'[validate-registers] so only ONE of these is ever reachable and which one is undefined.',
+	)
+	console.error(
+		'[validate-registers] Fix: give one of them a genuinely distinct slug (and update every',
+	)
+	console.error(
+		'[validate-registers] setSchema()/find() call site), or merge them into a single schema.',
+	)
 	return false
 }
 
@@ -220,31 +243,49 @@ function main() {
 	const registry = collectSchemas()
 	const all = Object.keys(registry).sort()
 	const bookkeeping = all.filter((s) => !NON_BOOKKEEPING.has(s))
-	const offenders = bookkeeping.filter((s) => registry[s].auditDeclaredIn.length === 0)
+	const offenders = bookkeeping.filter(
+		(s) => registry[s].auditDeclaredIn.length === 0,
+	)
 
 	console.log(`[validate-registers] total schemas: ${all.length}`)
-	console.log(`[validate-registers] non-bookkeeping (skipped): ${all.length - bookkeeping.length}`)
-	console.log(`[validate-registers] bookkeeping (audit-trail required): ${bookkeeping.length}`)
-	console.log(`[validate-registers] schemas with x-openregister-audit-trail.enabled=true: ${bookkeeping.length - offenders.length}`)
+	console.log(
+		`[validate-registers] non-bookkeeping (skipped): ${all.length - bookkeeping.length}`,
+	)
+	console.log(
+		`[validate-registers] bookkeeping (audit-trail required): ${bookkeeping.length}`,
+	)
+	console.log(
+		`[validate-registers] schemas with x-openregister-audit-trail.enabled=true: ${bookkeeping.length - offenders.length}`,
+	)
 
 	const slugsOk = checkSlugCaseCollisions(registry)
 
 	if (offenders.length === 0) {
 		if (slugsOk === false) process.exit(1)
-		console.log('[validate-registers] PASS — every bookkeeping + procurement schema declares x-openregister-audit-trail.enabled=true (REQ-AT-001 / REQ-RAP-001)')
+		console.log(
+			'[validate-registers] PASS — every bookkeeping + procurement schema declares x-openregister-audit-trail.enabled=true (REQ-AT-001 / REQ-RAP-001)',
+		)
 		process.exit(0)
 	}
 
-	console.error('[validate-registers] FAIL — the following bookkeeping/procurement schemas are missing x-openregister-audit-trail.enabled=true (REQ-AT-001 / REQ-RAP-001):')
+	console.error(
+		'[validate-registers] FAIL — the following bookkeeping/procurement schemas are missing x-openregister-audit-trail.enabled=true (REQ-AT-001 / REQ-RAP-001):',
+	)
 	for (const slug of offenders) {
 		const file = registry[slug].files[0] || '(unknown)'
 		console.error(`  - ${slug} (declared in ${path.relative(REPO_ROOT, file)})`)
 	}
 	console.error('')
 	console.error('[validate-registers] Fix: add')
-	console.error('  "x-openregister-audit-trail": { "enabled": true, "description": "..." }')
-	console.error('[validate-registers] to the schema fragment (typically the same register.d file that declares the schema).')
-	console.error('[validate-registers] If the schema is NOT bookkeeping (e.g. inventory or bookings), add its slug to NON_BOOKKEEPING in tests/validate-registers.js with a one-line comment.')
+	console.error(
+		'  "x-openregister-audit-trail": { "enabled": true, "description": "..." }',
+	)
+	console.error(
+		'[validate-registers] to the schema fragment (typically the same register.d file that declares the schema).',
+	)
+	console.error(
+		'[validate-registers] If the schema is NOT bookkeeping (e.g. inventory or bookings), add its slug to NON_BOOKKEEPING in tests/validate-registers.js with a one-line comment.',
+	)
 	process.exit(1)
 }
 

--- a/tests/validate-seeds.js
+++ b/tests/validate-seeds.js
@@ -52,7 +52,12 @@ const fs = require('fs')
 const path = require('path')
 
 const REPO_ROOT = path.resolve(__dirname, '..')
-const MAIN_REGISTER = path.join(REPO_ROOT, 'lib', 'Settings', 'shillinq_register.json')
+const MAIN_REGISTER = path.join(
+	REPO_ROOT,
+	'lib',
+	'Settings',
+	'shillinq_register.json',
+)
 const FRAGMENT_DIR = path.join(REPO_ROOT, 'lib', 'Settings', 'register.d')
 
 // Number of shipped seed objects that fail their own schema's `required`
@@ -68,7 +73,12 @@ const asArray = (value) => (Array.isArray(value) ? value : [])
 function deepMerge(base, overlay) {
 	for (const [key, value] of Object.entries(overlay)) {
 		const baseValue = base[key]
-		if (value && typeof value === 'object' && baseValue && typeof baseValue === 'object') {
+		if (
+			value
+			&& typeof value === 'object'
+			&& baseValue
+			&& typeof baseValue === 'object'
+		) {
 			const bothLists = Array.isArray(baseValue) && Array.isArray(value)
 			const neitherList = !Array.isArray(baseValue) && !Array.isArray(value)
 			if (bothLists) base[key] = baseValue.concat(value)
@@ -101,7 +111,8 @@ function main() {
 	//   foreach ([$data['components']['objects'], $data['objects']] as $seedBucket)
 	const collect = (source, doc) => {
 		for (const obj of asArray(doc.objects)) seeds.push({ source, obj })
-		for (const obj of asArray(doc.components && doc.components.objects)) seeds.push({ source, obj })
+		for (const obj of asArray(doc.components && doc.components.objects))
+			seeds.push({ source, obj })
 	}
 
 	let merged = loadJson(MAIN_REGISTER)
@@ -135,11 +146,17 @@ function main() {
 
 		checked++
 		const required = [...new Set(asArray(def.required))]
-		const missing = required.filter((prop) => obj[prop] === undefined || obj[prop] === null)
+		const missing = required.filter(
+			(prop) => obj[prop] === undefined || obj[prop] === null,
+		)
 		if (missing.length === 0) continue
 
 		if (!offenders.has(schemaName)) {
-			offenders.set(schemaName, { count: 0, missing: new Set(), sources: new Set() })
+			offenders.set(schemaName, {
+				count: 0,
+				missing: new Set(),
+				sources: new Set(),
+			})
 		}
 		const entry = offenders.get(schemaName)
 		entry.count++
@@ -151,41 +168,71 @@ function main() {
 
 	console.log(`[validate-seeds] seed objects checked: ${checked}`)
 	if (unknownSchema > 0) {
-		console.log(`[validate-seeds] seeds naming a schema no fragment declares: ${unknownSchema}`)
+		console.log(
+			`[validate-seeds] seeds naming a schema no fragment declares: ${unknownSchema}`,
+		)
 	}
-	console.log(`[validate-seeds] seeds that cannot satisfy their schema: ${failing} (baseline ${BASELINE})`)
+	console.log(
+		`[validate-seeds] seeds that cannot satisfy their schema: ${failing} (baseline ${BASELINE})`,
+	)
 
 	// A scan that silently found nothing to check must NOT report success.
 	if (checked < 300) {
-		console.error(`[validate-seeds] FAIL — only ${checked} seed objects were checked, which is`)
-		console.error('[validate-seeds] implausibly few. The scan did not run properly; a green')
-		console.error('[validate-seeds] result here would say nothing about the seeds.')
+		console.error(
+			`[validate-seeds] FAIL — only ${checked} seed objects were checked, which is`,
+		)
+		console.error(
+			'[validate-seeds] implausibly few. The scan did not run properly; a green',
+		)
+		console.error(
+			'[validate-seeds] result here would say nothing about the seeds.',
+		)
 		process.exit(1)
 	}
 
-	for (const [schema, entry] of [...offenders].sort((a, b) => b[1].count - a[1].count)) {
+	for (const [schema, entry] of [...offenders].sort(
+		(a, b) => b[1].count - a[1].count,
+	)) {
 		console.log(
 			`    ${String(entry.count).padStart(3)} x ${schema} — missing: ${[...entry.missing].join(', ')}`
-			+ `  (declared in ${[...entry.sources].join(', ')})`,
+				+ `  (declared in ${[...entry.sources].join(', ')})`,
 		)
 	}
 
 	if (failing > BASELINE) {
 		console.error('')
-		console.error(`[validate-seeds] FAIL — ${failing} seed objects cannot import, up from the`)
-		console.error(`[validate-seeds] baseline of ${BASELINE}. Something in this change made it worse.`)
-		console.error('[validate-seeds] Most likely cause: a schema key declared by two fragments with')
-		console.error('[validate-seeds] different `required` lists. ADR-037 merges fragments by key and')
-		console.error('[validate-seeds] CONCATENATES list values, so the effective `required` is the UNION')
-		console.error('[validate-seeds] of both and no payload of either model can satisfy it.')
-		console.error('[validate-seeds] Fix the seed or the schema — do NOT raise BASELINE.')
+		console.error(
+			`[validate-seeds] FAIL — ${failing} seed objects cannot import, up from the`,
+		)
+		console.error(
+			`[validate-seeds] baseline of ${BASELINE}. Something in this change made it worse.`,
+		)
+		console.error(
+			'[validate-seeds] Most likely cause: a schema key declared by two fragments with',
+		)
+		console.error(
+			'[validate-seeds] different `required` lists. ADR-037 merges fragments by key and',
+		)
+		console.error(
+			'[validate-seeds] CONCATENATES list values, so the effective `required` is the UNION',
+		)
+		console.error(
+			'[validate-seeds] of both and no payload of either model can satisfy it.',
+		)
+		console.error(
+			'[validate-seeds] Fix the seed or the schema — do NOT raise BASELINE.',
+		)
 		process.exit(1)
 	}
 
 	if (failing < BASELINE) {
 		console.log('')
-		console.log(`[validate-seeds] PASS — and ${BASELINE - failing} better than baseline.`)
-		console.log(`[validate-seeds] Please lower BASELINE in tests/validate-seeds.js to ${failing}.`)
+		console.log(
+			`[validate-seeds] PASS — and ${BASELINE - failing} better than baseline.`,
+		)
+		console.log(
+			`[validate-seeds] Please lower BASELINE in tests/validate-seeds.js to ${failing}.`,
+		)
 		process.exit(0)
 	}
 

--- a/tests/validate-semantic-markers.js
+++ b/tests/validate-semantic-markers.js
@@ -32,7 +32,12 @@ const fs = require('fs')
 const path = require('path')
 
 const REPO_ROOT = path.resolve(__dirname, '..')
-const MAIN_REGISTER = path.join(REPO_ROOT, 'lib', 'Settings', 'shillinq_register.json')
+const MAIN_REGISTER = path.join(
+	REPO_ROOT,
+	'lib',
+	'Settings',
+	'shillinq_register.json',
+)
 const FRAGMENT_DIR = path.join(REPO_ROOT, 'lib', 'Settings', 'register.d')
 
 // A valid marker is either a CURIE (`prefix:LocalName`) or the `ns#Local`
@@ -84,7 +89,9 @@ function main() {
 		try {
 			parsed = loadJson(fp)
 		} catch (err) {
-			console.error(`[validate-semantic-markers] failed to parse ${fp}: ${err.message}`)
+			console.error(
+				`[validate-semantic-markers] failed to parse ${fp}: ${err.message}`,
+			)
 			process.exit(1)
 		}
 		const before = offenders.length
@@ -96,14 +103,22 @@ function main() {
 	}
 
 	if (offenders.length > 0) {
-		console.error('[validate-semantic-markers] FAIL — bare / malformed x-schema-org markers:')
+		console.error(
+			'[validate-semantic-markers] FAIL — bare / malformed x-schema-org markers:',
+		)
 		for (const o of offenders) {
-			console.error(`  ${path.relative(REPO_ROOT, o.file)} — ${o.name}: ${JSON.stringify(o.marker)}`)
+			console.error(
+				`  ${path.relative(REPO_ROOT, o.file)} — ${o.name}: ${JSON.stringify(o.marker)}`,
+			)
 		}
-		console.error(`\n${offenders.length} offending marker(s). Every marker MUST be a CURIE (prefix:Type or ns#Type).`)
+		console.error(
+			`\n${offenders.length} offending marker(s). Every marker MUST be a CURIE (prefix:Type or ns#Type).`,
+		)
 		process.exit(1)
 	}
-	console.log(`[validate-semantic-markers] OK — ${markerCount} x-schema-org marker(s) are valid CURIEs.`)
+	console.log(
+		`[validate-semantic-markers] OK — ${markerCount} x-schema-org marker(s) are valid CURIEs.`,
+	)
 }
 
 function countMarkers(node, box) {

--- a/tests/vitest/accountantPortalRouting.spec.js
+++ b/tests/vitest/accountantPortalRouting.spec.js
@@ -30,8 +30,14 @@ import fs from 'fs'
 import path from 'path'
 
 const repoRoot = path.resolve(__dirname, '..', '..')
-const routesSource = fs.readFileSync(path.join(repoRoot, 'appinfo', 'routes.php'), 'utf8')
-const clientSource = fs.readFileSync(path.join(repoRoot, 'src', 'api', 'accountantApi.js'), 'utf8')
+const routesSource = fs.readFileSync(
+	path.join(repoRoot, 'appinfo', 'routes.php'),
+	'utf8',
+)
+const clientSource = fs.readFileSync(
+	path.join(repoRoot, 'src', 'api', 'accountantApi.js'),
+	'utf8',
+)
 
 /**
  * Extract every declared route as {name, url, verb} from appinfo/routes.php.
@@ -45,7 +51,8 @@ const clientSource = fs.readFileSync(path.join(repoRoot, 'src', 'api', 'accounta
  */
 function parseDeclaredRoutes() {
 	const routes = []
-	const re = /'name'\s*=>\s*'([^']+)'\s*,\s*'url'\s*=>\s*'([^']+)'\s*,\s*'verb'\s*=>\s*'([^']+)'/g
+	const re =
+		/'name'\s*=>\s*'([^']+)'\s*,\s*'url'\s*=>\s*'([^']+)'\s*,\s*'verb'\s*=>\s*'([^']+)'/g
 	let m
 	while ((m = re.exec(routesSource)) !== null) {
 		routes.push({ name: m[1], url: m[2], verb: m[3] })
@@ -80,7 +87,9 @@ describe('accountant portal routing contract', () => {
 	it('declares a route for every URL src/api/accountantApi.js requests', () => {
 		const declaredUrls = parseDeclaredRoutes().map((r) => r.url)
 		for (const requested of parseClientPaths()) {
-			expect(declaredUrls, `no route declared for ${requested}`).toContain(requested)
+			expect(declaredUrls, `no route declared for ${requested}`).toContain(
+				requested,
+			)
 		}
 	})
 

--- a/tests/vitest/arEInvoiceActions.spec.js
+++ b/tests/vitest/arEInvoiceActions.spec.js
@@ -40,11 +40,15 @@ describe('arEInvoiceActions — canSendEInvoice', () => {
 
 describe('arEInvoiceActions — resolveDeliveryStatus', () => {
 	it('prefers the optimistic local override after a successful send', () => {
-		expect(resolveDeliveryStatus({ deliveryStatus: 'not-sent' }, 'queued')).toBe('queued')
+		expect(resolveDeliveryStatus({ deliveryStatus: 'not-sent' }, 'queued')).toBe(
+			'queued',
+		)
 	})
 
 	it('falls back to the object field, then to not-sent', () => {
-		expect(resolveDeliveryStatus({ deliveryStatus: 'delivered' }, null)).toBe('delivered')
+		expect(resolveDeliveryStatus({ deliveryStatus: 'delivered' }, null)).toBe(
+			'delivered',
+		)
 		expect(resolveDeliveryStatus({}, null)).toBe('not-sent')
 		expect(resolveDeliveryStatus(null, null)).toBe('not-sent')
 	})
@@ -52,23 +56,31 @@ describe('arEInvoiceActions — resolveDeliveryStatus', () => {
 
 describe('arEInvoiceActions — sendEInvoiceEndpoint', () => {
 	it('builds the send-einvoice REST path for an invoice number', () => {
-		expect(sendEInvoiceEndpoint('2026-0060'))
-			.toBe('/apps/shillinq/api/ar-invoices/2026-0060/send-einvoice')
+		expect(sendEInvoiceEndpoint('2026-0060')).toBe(
+			'/apps/shillinq/api/ar-invoices/2026-0060/send-einvoice',
+		)
 	})
 })
 
 describe('arEInvoiceActions — mapSendResult', () => {
 	it('maps a queued response without a fallback notice', () => {
-		const mapped = mapSendResult({ deliveryStatus: 'queued', fallback: false }, t)
+		const mapped = mapSendResult(
+			{ deliveryStatus: 'queued', fallback: false },
+			t,
+		)
 		expect(mapped.deliveryStatus).toBe('queued')
 		expect(mapped.fallbackNotice).toBe('')
 	})
 
 	it('surfaces the PDF+email fallback notice when no Peppol participant exists', () => {
-		const mapped = mapSendResult({ deliveryStatus: 'not-sent', fallback: true }, t)
+		const mapped = mapSendResult(
+			{ deliveryStatus: 'not-sent', fallback: true },
+			t,
+		)
 		expect(mapped.deliveryStatus).toBe('not-sent')
-		expect(mapped.fallbackNotice)
-			.toBe('No Peppol participant found for this debtor — use PDF + email instead.')
+		expect(mapped.fallbackNotice).toBe(
+			'No Peppol participant found for this debtor — use PDF + email instead.',
+		)
 	})
 
 	it('defaults the status to queued on a shapeless success body', () => {
@@ -79,13 +91,22 @@ describe('arEInvoiceActions — mapSendResult', () => {
 
 describe('arEInvoiceActions — extractSendErrorMessage', () => {
 	it('prefers the structured server error message', () => {
-		const error = { response: { data: { error: 'E-invoice validation failed: KvK number must be exactly 8 digits' } } }
-		expect(extractSendErrorMessage(error, t))
-			.toBe('E-invoice validation failed: KvK number must be exactly 8 digits')
+		const error = {
+			response: {
+				data: {
+					error: 'E-invoice validation failed: KvK number must be exactly 8 digits',
+				},
+			},
+		}
+		expect(extractSendErrorMessage(error, t)).toBe(
+			'E-invoice validation failed: KvK number must be exactly 8 digits',
+		)
 	})
 
 	it('falls back to a generic message without a structured body', () => {
-		expect(extractSendErrorMessage(new Error('network down'), t)).toBe('Failed to send e-invoice')
+		expect(extractSendErrorMessage(new Error('network down'), t)).toBe(
+			'Failed to send e-invoice',
+		)
 		expect(extractSendErrorMessage({}, t)).toBe('Failed to send e-invoice')
 	})
 })

--- a/tests/vitest/bankStatementWizard.spec.js
+++ b/tests/vitest/bankStatementWizard.spec.js
@@ -33,8 +33,12 @@ function fakeStorage() {
 	const store = {}
 	return {
 		getItem: (k) => (k in store ? store[k] : null),
-		setItem: (k, v) => { store[k] = String(v) },
-		removeItem: (k) => { delete store[k] },
+		setItem: (k, v) => {
+			store[k] = String(v)
+		},
+		removeItem: (k) => {
+			delete store[k]
+		},
 	}
 }
 
@@ -90,7 +94,7 @@ describe('bankStatementWizard — IBAN → account memory (REQ-BSW-006)', () => 
 	it('expires mappings older than one year', () => {
 		saveIbanMapping('NL91ABNA0417164300', '10100')
 		const raw = JSON.parse(globalThis.localStorage.getItem(IBAN_MAP_KEY))
-		raw.savedAt = Date.now() - (366 * 24 * 60 * 60 * 1000)
+		raw.savedAt = Date.now() - 366 * 24 * 60 * 60 * 1000
 		globalThis.localStorage.setItem(IBAN_MAP_KEY, JSON.stringify(raw))
 		expect(loadIbanMapping('NL91ABNA0417164300')).toBeNull()
 	})
@@ -104,7 +108,11 @@ describe('bankStatementWizard — IBAN → account memory (REQ-BSW-006)', () => 
 
 describe('bankStatementWizard — import payload (REQ-BSW-004)', () => {
 	it('builds the JSON body posted to the import endpoint', () => {
-		const payload = buildImportPayload({ format: 'camt053', contents: '<Document/>', glAccountId: '10100' })
+		const payload = buildImportPayload({
+			format: 'camt053',
+			contents: '<Document/>',
+			glAccountId: '10100',
+		})
 		expect(payload).toEqual({
 			format: 'camt053',
 			contents: '<Document/>',

--- a/tests/vitest/billImportModal.spec.js
+++ b/tests/vitest/billImportModal.spec.js
@@ -62,7 +62,9 @@ describe('billImportModal — honest PDF-OCR deferral (REQ-BIM-002)', () => {
 	})
 
 	it('exposes the honest deferral message (no fake extraction)', () => {
-		expect(PDF_DEFERRAL_MESSAGE).toContain('PDF OCR extraction is not yet available')
+		expect(PDF_DEFERRAL_MESSAGE).toContain(
+			'PDF OCR extraction is not yet available',
+		)
 		expect(PDF_DEFERRAL_MESSAGE).toContain('UBL/e-invoice XML or CSV')
 	})
 })
@@ -71,9 +73,9 @@ describe('billImportModal — import payload', () => {
 	it('builds a FormData carrying file + explicit format', () => {
 		const calls = []
 		class FakeFormData {
-
-			append(k, v) { calls.push([k, v]) }
-
+			append(k, v) {
+				calls.push([k, v])
+			}
 		}
 		buildImportFormData({ name: 'invoice.xml' }, 'ubl', FakeFormData)
 		expect(calls).toEqual([
@@ -119,19 +121,28 @@ describe('billImportModal — review form (REQ-BIM-003)', () => {
 describe('billImportModal — duplicate 409 (REQ-BIM-005)', () => {
 	it('maps a 409 to the canonical inline warning', () => {
 		const msg = importErrorMessage({
-			response: { status: 409, data: { error: 'This invoice number already exists for this supplier' } },
+			response: {
+				status: 409,
+				data: {
+					error: 'This invoice number already exists for this supplier',
+				},
+			},
 		})
 		expect(msg).toBe('This invoice number already exists for this supplier')
 	})
 
 	it('falls back to the canonical text when 409 carries no body', () => {
-		expect(importErrorMessage({ response: { status: 409, data: {} } }))
-			.toBe('This invoice number already exists for this supplier')
+		expect(importErrorMessage({ response: { status: 409, data: {} } })).toBe(
+			'This invoice number already exists for this supplier',
+		)
 	})
 
 	it('surfaces other server errors verbatim', () => {
-		expect(importErrorMessage({ response: { status: 422, data: { error: 'UBL is malformed' } } }))
-			.toBe('UBL is malformed')
+		expect(
+			importErrorMessage({
+				response: { status: 422, data: { error: 'UBL is malformed' } },
+			}),
+		).toBe('UBL is malformed')
 	})
 })
 
@@ -173,9 +184,16 @@ describe('billImportModal — extraction confidence (REQ-RXC-001/002/004/006)', 
 	})
 
 	it('summarises a pending draft for the review list', () => {
-		expect(pendingDraftSummary({ id: 'd1', invoiceNumber: 'F-88', overallConfidence: 0.93 }))
-			.toEqual({ id: 'd1', label: 'F-88', overallConfidence: 0.93 })
-		expect(pendingDraftSummary({ id: 'd2', supplierId: 'ACME' }).label).toBe('ACME')
+		expect(
+			pendingDraftSummary({
+				id: 'd1',
+				invoiceNumber: 'F-88',
+				overallConfidence: 0.93,
+			}),
+		).toEqual({ id: 'd1', label: 'F-88', overallConfidence: 0.93 })
+		expect(pendingDraftSummary({ id: 'd2', supplierId: 'ACME' }).label).toBe(
+			'ACME',
+		)
 	})
 })
 
@@ -194,7 +212,8 @@ describe('billImportModal — GL-account suggestion (REQ-GAC-001/003/006)', () =
 				code: '4300',
 				label: 'Kantoorkosten',
 				confidence: 0.8,
-				rationale: 'Booked to 4300 in 8 of the last 10 invoices from this supplier',
+				rationale:
+					'Booked to 4300 in 8 of the last 10 invoices from this supplier',
 				source: 'history',
 			},
 		})
@@ -202,14 +221,25 @@ describe('billImportModal — GL-account suggestion (REQ-GAC-001/003/006)', () =
 			code: '4300',
 			label: 'Kantoorkosten',
 			confidence: 0.8,
-			rationale: 'Booked to 4300 in 8 of the last 10 invoices from this supplier',
+			rationale:
+				'Booked to 4300 in 8 of the last 10 invoices from this supplier',
 			source: 'history',
 		})
 	})
 
 	it('degrades to null for a graceful "no suggestion" response (REQ-GAC-006)', () => {
-		expect(glAccountSuggestionSummary({ suggestion: null, reason: 'extraction-id-unknown' })).toBeNull()
-		expect(glAccountSuggestionSummary({ suggestion: null, reason: 'provider-unavailable' })).toBeNull()
+		expect(
+			glAccountSuggestionSummary({
+				suggestion: null,
+				reason: 'extraction-id-unknown',
+			}),
+		).toBeNull()
+		expect(
+			glAccountSuggestionSummary({
+				suggestion: null,
+				reason: 'provider-unavailable',
+			}),
+		).toBeNull()
 		expect(glAccountSuggestionSummary({})).toBeNull()
 		expect(glAccountSuggestionSummary(null)).toBeNull()
 	})

--- a/tests/vitest/budgetLineCommitmentsHelpers.spec.js
+++ b/tests/vitest/budgetLineCommitmentsHelpers.spec.js
@@ -44,7 +44,14 @@ describe('budgetLineCommitmentsHelpers — normaliseBudgetLineRows', () => {
 
 	it('accepts a bare array payload (no buckets wrapper)', () => {
 		const rows = normaliseBudgetLineRows([
-			{ programma: '5.1', kostenplaats: 'FAC-2026', boekjaar: 2026, grootboekrekening: '4400', restant_verplicht: 100, gefactureerd_bedrag: 0 },
+			{
+				programma: '5.1',
+				kostenplaats: 'FAC-2026',
+				boekjaar: 2026,
+				grootboekrekening: '4400',
+				restant_verplicht: 100,
+				gefactureerd_bedrag: 0,
+			},
 		])
 		expect(rows).toHaveLength(1)
 	})
@@ -58,7 +65,12 @@ describe('budgetLineCommitmentsHelpers — normaliseBudgetLineRows', () => {
 	it('builds a stable composite key per coderingscombinatie', () => {
 		const rows = normaliseBudgetLineRows({
 			buckets: [
-				{ programma: '5.1', kostenplaats: 'FAC-2026', boekjaar: 2026, grootboekrekening: '4400' },
+				{
+					programma: '5.1',
+					kostenplaats: 'FAC-2026',
+					boekjaar: 2026,
+					grootboekrekening: '4400',
+				},
 			],
 		})
 		expect(rows[0].key).toBe('5.1|FAC-2026|2026|4400')

--- a/tests/vitest/deadlineCalendarSettings.spec.js
+++ b/tests/vitest/deadlineCalendarSettings.spec.js
@@ -50,7 +50,13 @@ describe('normaliseSettings', () => {
 	})
 
 	it('falls back to documented defaults on null/malformed input', () => {
-		for (const raw of [null, undefined, {}, { categories: 'nope' }, { categories: { filing: 'x' } }]) {
+		for (const raw of [
+			null,
+			undefined,
+			{},
+			{ categories: 'nope' },
+			{ categories: { filing: 'x' } },
+		]) {
 			const rows = normaliseSettings(raw)
 			const byId = Object.fromEntries(rows.map((row) => [row.id, row]))
 			expect(byId.filing.enabled).toBe(true)
@@ -62,7 +68,10 @@ describe('normaliseSettings', () => {
 
 	it('rejects negative or non-numeric lead days', () => {
 		const rows = normaliseSettings({
-			categories: { filing: { enabled: true, leadDays: -4 }, contract: { enabled: true, leadDays: 'abc' } },
+			categories: {
+				filing: { enabled: true, leadDays: -4 },
+				contract: { enabled: true, leadDays: 'abc' },
+			},
 		})
 		const byId = Object.fromEntries(rows.map((row) => [row.id, row]))
 		expect(byId.filing.leadDays).toBe(10)
@@ -87,7 +96,9 @@ describe('buildSavePayload', () => {
 	})
 
 	it('clamps invalid lead days to 0 and tolerates non-array input', () => {
-		const payload = buildSavePayload([{ id: 'filing', enabled: true, leadDays: -3 }])
+		const payload = buildSavePayload([
+			{ id: 'filing', enabled: true, leadDays: -3 },
+		])
 		expect(payload.categories.filing.leadDays).toBe(0)
 		expect(buildSavePayload('nope')).toEqual({ categories: {} })
 	})

--- a/tests/vitest/externalAdapters.spec.js
+++ b/tests/vitest/externalAdapters.spec.js
@@ -43,14 +43,28 @@ function tIdentity(app, text, vars) {
 	if (!vars) {
 		return text
 	}
-	return text.replace(/\{(\w+)\}/g, (_, k) => (k in vars ? String(vars[k]) : `{${k}}`))
+	return text.replace(/\{(\w+)\}/g, (_, k) =>
+		k in vars ? String(vars[k]) : `{${k}}`,
+	)
 }
 
 /** All 14 adapter family slugs the W8 manifest ships. */
 const ALL_SLUGS = [
-	'digipoort-sbr', 'salarisbureau', 'rvo', 'ib47', 'cbs-bestanden',
-	'cbs-iv3', 'bzk-sisa', 'mollie', 'bunq', 'kvk', 'uwv',
-	'treasury-rates', 'ccm-rule-engine', 'csrd-esrs-xbrl', 'deposit-payment',
+	'digipoort-sbr',
+	'salarisbureau',
+	'rvo',
+	'ib47',
+	'cbs-bestanden',
+	'cbs-iv3',
+	'bzk-sisa',
+	'mollie',
+	'bunq',
+	'kvk',
+	'uwv',
+	'treasury-rates',
+	'ccm-rule-engine',
+	'csrd-esrs-xbrl',
+	'deposit-payment',
 ]
 
 beforeEach(() => {
@@ -72,20 +86,32 @@ describe('ExternalAdaptersStatus.vue', () => {
 	})
 
 	it('badgeClass maps dormant -> dormant modifier, live -> live modifier', () => {
-		expect(StatusView.methods.badgeClass(true)).toBe('external-adapters__badge--dormant')
-		expect(StatusView.methods.badgeClass(false)).toBe('external-adapters__badge--live')
+		expect(StatusView.methods.badgeClass(true)).toBe(
+			'external-adapters__badge--dormant',
+		)
+		expect(StatusView.methods.badgeClass(false)).toBe(
+			'external-adapters__badge--live',
+		)
 	})
 
 	it('routeIdForAdapter resolves every one of the 14 families to a distinct route name', () => {
-		const routes = ALL_SLUGS.map((slug) => StatusView.methods.routeIdForAdapter(slug))
+		const routes = ALL_SLUGS.map((slug) =>
+			StatusView.methods.routeIdForAdapter(slug),
+		)
 		// Every family maps to a non-null route name.
 		expect(routes.every((r) => typeof r === 'string' && r.length > 0)).toBe(true)
 		// And all 14 route names are distinct (no collision dead-ending a nav).
 		expect(new Set(routes).size).toBe(ALL_SLUGS.length)
 		// Spot-check a couple of the trickier dash-vs-camel mappings.
-		expect(StatusView.methods.routeIdForAdapter('digipoort-sbr')).toBe('ExternalAdapterDigipoort')
-		expect(StatusView.methods.routeIdForAdapter('bzk-sisa')).toBe('ExternalAdapterSisa')
-		expect(StatusView.methods.routeIdForAdapter('treasury-rates')).toBe('ExternalAdapterTreasuryRates')
+		expect(StatusView.methods.routeIdForAdapter('digipoort-sbr')).toBe(
+			'ExternalAdapterDigipoort',
+		)
+		expect(StatusView.methods.routeIdForAdapter('bzk-sisa')).toBe(
+			'ExternalAdapterSisa',
+		)
+		expect(StatusView.methods.routeIdForAdapter('treasury-rates')).toBe(
+			'ExternalAdapterTreasuryRates',
+		)
 	})
 
 	it('routeIdForAdapter returns null for an unknown slug', () => {
@@ -94,7 +120,10 @@ describe('ExternalAdaptersStatus.vue', () => {
 
 	it('openDetail pushes the resolved route for a known slug, no-ops for an unknown one', () => {
 		const push = vi.fn()
-		const ctx = { $router: { push }, routeIdForAdapter: StatusView.methods.routeIdForAdapter }
+		const ctx = {
+			$router: { push },
+			routeIdForAdapter: StatusView.methods.routeIdForAdapter,
+		}
 
 		StatusView.methods.openDetail.call(ctx, 'mollie')
 		expect(push).toHaveBeenCalledWith({ name: 'ExternalAdapterMollie' })
@@ -112,12 +141,16 @@ describe('ExternalAdaptersStatus.vue', () => {
 			],
 			summary: { total: 2, dormant: 1, live: 1 },
 		}
-		const getSpy = vi.spyOn(axios, 'get').mockResolvedValueOnce({ data: payload })
+		const getSpy = vi
+			.spyOn(axios, 'get')
+			.mockResolvedValueOnce({ data: payload })
 
 		const ctx = { loading: false, errorMessage: '', adapters: [], summary: {} }
 		await StatusView.methods.loadStatus.call(ctx)
 
-		expect(getSpy).toHaveBeenCalledWith('/index.php/apps/shillinq/api/admin/external-adapters')
+		expect(getSpy).toHaveBeenCalledWith(
+			'/index.php/apps/shillinq/api/admin/external-adapters',
+		)
 		expect(ctx.adapters).toHaveLength(2)
 		expect(ctx.summary).toEqual({ total: 2, dormant: 1, live: 1 })
 		expect(ctx.loading).toBe(false)
@@ -126,7 +159,12 @@ describe('ExternalAdaptersStatus.vue', () => {
 
 	it('loadStatus tolerates a missing/partial response body', async () => {
 		vi.spyOn(axios, 'get').mockResolvedValueOnce({ data: undefined })
-		const ctx = { loading: true, errorMessage: 'stale', adapters: [{ id: 'x' }], summary: { total: 9 } }
+		const ctx = {
+			loading: true,
+			errorMessage: 'stale',
+			adapters: [{ id: 'x' }],
+			summary: { total: 9 },
+		}
 		await StatusView.methods.loadStatus.call(ctx)
 		expect(ctx.adapters).toEqual([])
 		expect(ctx.summary).toEqual({ total: 0, dormant: 0, live: 0 })
@@ -144,13 +182,21 @@ describe('ExternalAdaptersStatus.vue', () => {
 
 describe('ExternalAdapterDetail.vue', () => {
 	it('effectiveAdapterId prefers the manifest adapterId prop', () => {
-		const ctx = { adapterId: 'mollie', $route: { path: '/external-adapters/mollie' } }
+		const ctx = {
+			adapterId: 'mollie',
+			$route: { path: '/external-adapters/mollie' },
+		}
 		expect(DetailView.computed.effectiveAdapterId.call(ctx)).toBe('mollie')
 	})
 
 	it('effectiveAdapterId falls back to the trailing path segment for a deep-link', () => {
-		const ctx = { adapterId: '', $route: { path: '/external-adapters/csrd-esrs-xbrl' } }
-		expect(DetailView.computed.effectiveAdapterId.call(ctx)).toBe('csrd-esrs-xbrl')
+		const ctx = {
+			adapterId: '',
+			$route: { path: '/external-adapters/csrd-esrs-xbrl' },
+		}
+		expect(DetailView.computed.effectiveAdapterId.call(ctx)).toBe(
+			'csrd-esrs-xbrl',
+		)
 	})
 
 	it('effectiveAdapterId is empty-string-safe with no prop and no route', () => {
@@ -160,20 +206,36 @@ describe('ExternalAdapterDetail.vue', () => {
 
 	it('badgeClass is null-safe before the adapter loads, then maps dormant/live', () => {
 		expect(DetailView.computed.badgeClass.call({ adapter: null })).toBe('')
-		expect(DetailView.computed.badgeClass.call({ adapter: { dormant: true } }))
-			.toBe('adapter-detail__badge--dormant')
-		expect(DetailView.computed.badgeClass.call({ adapter: { dormant: false } }))
-			.toBe('adapter-detail__badge--live')
+		expect(
+			DetailView.computed.badgeClass.call({ adapter: { dormant: true } }),
+		).toBe('adapter-detail__badge--dormant')
+		expect(
+			DetailView.computed.badgeClass.call({ adapter: { dormant: false } }),
+		).toBe('adapter-detail__badge--live')
 	})
 
 	it('loadAdapter GETs the per-id endpoint and stores the adapter', async () => {
-		const adapter = { id: 'bunq', title: 'Bunq Bank Connector', dormant: true, steps: ['a', 'b'] }
-		const getSpy = vi.spyOn(axios, 'get').mockResolvedValueOnce({ data: adapter })
+		const adapter = {
+			id: 'bunq',
+			title: 'Bunq Bank Connector',
+			dormant: true,
+			steps: ['a', 'b'],
+		}
+		const getSpy = vi
+			.spyOn(axios, 'get')
+			.mockResolvedValueOnce({ data: adapter })
 
-		const ctx = { effectiveAdapterId: 'bunq', loading: false, errorMessage: 'x', adapter: null }
+		const ctx = {
+			effectiveAdapterId: 'bunq',
+			loading: false,
+			errorMessage: 'x',
+			adapter: null,
+		}
 		await DetailView.methods.loadAdapter.call(ctx)
 
-		expect(getSpy).toHaveBeenCalledWith('/index.php/apps/shillinq/api/admin/external-adapters/bunq')
+		expect(getSpy).toHaveBeenCalledWith(
+			'/index.php/apps/shillinq/api/admin/external-adapters/bunq',
+		)
 		expect(ctx.adapter).toEqual(adapter)
 		expect(ctx.loading).toBe(false)
 		expect(ctx.errorMessage).toBe('')
@@ -181,7 +243,12 @@ describe('ExternalAdapterDetail.vue', () => {
 
 	it('loadAdapter surfaces a distinct Unknown-adapter message on a 404', async () => {
 		vi.spyOn(axios, 'get').mockRejectedValueOnce({ response: { status: 404 } })
-		const ctx = { effectiveAdapterId: 'nope', loading: true, errorMessage: '', adapter: { stale: true } }
+		const ctx = {
+			effectiveAdapterId: 'nope',
+			loading: true,
+			errorMessage: '',
+			adapter: { stale: true },
+		}
 		await DetailView.methods.loadAdapter.call(ctx)
 		expect(ctx.errorMessage).toBe('Unknown adapter: nope')
 		expect(ctx.adapter).toBeNull()
@@ -190,7 +257,12 @@ describe('ExternalAdapterDetail.vue', () => {
 
 	it('loadAdapter surfaces a generic message on a non-404 failure', async () => {
 		vi.spyOn(axios, 'get').mockRejectedValueOnce(new Error('network down'))
-		const ctx = { effectiveAdapterId: 'mollie', loading: true, errorMessage: '', adapter: null }
+		const ctx = {
+			effectiveAdapterId: 'mollie',
+			loading: true,
+			errorMessage: '',
+			adapter: null,
+		}
 		await DetailView.methods.loadAdapter.call(ctx)
 		expect(ctx.errorMessage).toContain('network down')
 		expect(ctx.loading).toBe(false)
@@ -198,7 +270,12 @@ describe('ExternalAdapterDetail.vue', () => {
 
 	it('loadAdapter guards the empty-id case without calling the API', async () => {
 		const getSpy = vi.spyOn(axios, 'get')
-		const ctx = { effectiveAdapterId: '', loading: true, errorMessage: '', adapter: null }
+		const ctx = {
+			effectiveAdapterId: '',
+			loading: true,
+			errorMessage: '',
+			adapter: null,
+		}
 		await DetailView.methods.loadAdapter.call(ctx)
 		expect(getSpy).not.toHaveBeenCalled()
 		expect(ctx.errorMessage).toBe('No adapter id provided.')

--- a/tests/vitest/financialSeries.spec.js
+++ b/tests/vitest/financialSeries.spec.js
@@ -25,7 +25,10 @@ import {
 	computeKpis,
 	computeRangeKpis,
 } from '../../src/components/dashboard/financial/financialSeries.js'
-import { useFinancialData, resetFinancialData } from '../../src/components/dashboard/financial/useFinancialData.js'
+import {
+	useFinancialData,
+	resetFinancialData,
+} from '../../src/components/dashboard/financial/useFinancialData.js'
 
 const ACCOUNTS = [
 	{ accountNumber: '8000', name: 'Omzet consultancy', accountType: 'revenue' },
@@ -37,10 +40,30 @@ const ACCOUNTS = [
 ]
 
 const TRANSACTIONS = [
-	{ id: 'tx-1', transactionNumber: 'TX-1', postingDate: '2026-03-05 00:00:00', state: 'posted' },
-	{ id: 'tx-2', transactionNumber: 'TX-2', postingDate: '2026-03-20 00:00:00', state: 'posted' },
-	{ id: 'tx-3', transactionNumber: 'TX-3', postingDate: '2026-04-02 00:00:00', state: 'posted' },
-	{ id: 'tx-draft', transactionNumber: 'TX-D', postingDate: '2026-03-09 00:00:00', state: 'draft' },
+	{
+		id: 'tx-1',
+		transactionNumber: 'TX-1',
+		postingDate: '2026-03-05 00:00:00',
+		state: 'posted',
+	},
+	{
+		id: 'tx-2',
+		transactionNumber: 'TX-2',
+		postingDate: '2026-03-20 00:00:00',
+		state: 'posted',
+	},
+	{
+		id: 'tx-3',
+		transactionNumber: 'TX-3',
+		postingDate: '2026-04-02 00:00:00',
+		state: 'posted',
+	},
+	{
+		id: 'tx-draft',
+		transactionNumber: 'TX-D',
+		postingDate: '2026-03-09 00:00:00',
+		state: 'draft',
+	},
 ]
 
 const LINES = [
@@ -54,9 +77,19 @@ const LINES = [
 	{ transactionId: 'TX-3', accountNumber: '1010', side: 'debit', amount: 1000 },
 	{ transactionId: 'TX-3', accountNumber: '1300', side: 'credit', amount: 1000 },
 	// Draft transaction must be ignored
-	{ transactionId: 'tx-draft', accountNumber: '8000', side: 'credit', amount: 9999 },
+	{
+		transactionId: 'tx-draft',
+		accountNumber: '8000',
+		side: 'credit',
+		amount: 9999,
+	},
 	// Orphan line (unknown transaction) must be ignored
-	{ transactionId: 'tx-missing', accountNumber: '8000', side: 'credit', amount: 5555 },
+	{
+		transactionId: 'tx-missing',
+		accountNumber: '8000',
+		side: 'credit',
+		amount: 5555,
+	},
 ]
 
 describe('financialSeries', () => {
@@ -69,7 +102,11 @@ describe('financialSeries', () => {
 	})
 
 	it('lastMonths returns ascending trailing window crossing year boundaries', () => {
-		expect(lastMonths(3, new Date(2026, 0, 15))).toEqual(['2025-11', '2025-12', '2026-01'])
+		expect(lastMonths(3, new Date(2026, 0, 15))).toEqual([
+			'2025-11',
+			'2025-12',
+			'2026-01',
+		])
 	})
 
 	it('classifyAccounts buckets revenue, expenses and liquid assets', () => {
@@ -142,10 +179,38 @@ describe('financialSeries', () => {
 	it('openArRows filters open states, resolves names, flags overdue, sorts by due date', () => {
 		const now = new Date(2026, 5, 12)
 		const invoices = [
-			{ id: 'a', invoiceNumber: 'F-3', customerId: 'C1', dueDate: '2026-07-01', grossAmount: 300, lifecycleState: 'issued' },
-			{ id: 'b', invoiceNumber: 'F-1', customerId: 'C1', dueDate: '2026-05-01', grossAmount: 100, lifecycleState: 'overdue' },
-			{ id: 'c', invoiceNumber: 'F-2', customerId: 'C2', dueDate: '2026-06-01', grossAmount: 200, lifecycleState: 'issued' },
-			{ id: 'd', invoiceNumber: 'F-0', customerId: 'C1', dueDate: '2026-01-01', grossAmount: 999, lifecycleState: 'paid' },
+			{
+				id: 'a',
+				invoiceNumber: 'F-3',
+				customerId: 'C1',
+				dueDate: '2026-07-01',
+				grossAmount: 300,
+				lifecycleState: 'issued',
+			},
+			{
+				id: 'b',
+				invoiceNumber: 'F-1',
+				customerId: 'C1',
+				dueDate: '2026-05-01',
+				grossAmount: 100,
+				lifecycleState: 'overdue',
+			},
+			{
+				id: 'c',
+				invoiceNumber: 'F-2',
+				customerId: 'C2',
+				dueDate: '2026-06-01',
+				grossAmount: 200,
+				lifecycleState: 'issued',
+			},
+			{
+				id: 'd',
+				invoiceNumber: 'F-0',
+				customerId: 'C1',
+				dueDate: '2026-01-01',
+				grossAmount: 999,
+				lifecycleState: 'paid',
+			},
 		]
 		const customers = [{ customerId: 'C1', legalName: 'Acme BV' }]
 		const rows = openArRows(invoices, customers, now)
@@ -161,12 +226,44 @@ describe('financialSeries', () => {
 	it('openApRows filters the open AP states including partially-paid', () => {
 		const now = new Date(2026, 5, 12)
 		const txs = [
-			{ id: 'a', invoiceNumber: 'I-1', vendorId: 'V1', dueDate: '2026-06-20', totalAmount: 500, state: 'received' },
-			{ id: 'b', invoiceNumber: 'I-2', vendorId: 'V1', dueDate: '2026-06-01', totalAmount: 250, state: 'partially-paid' },
-			{ id: 'c', invoiceNumber: 'I-3', vendorId: 'V2', dueDate: '2026-05-01', totalAmount: 100, state: 'paid' },
-			{ id: 'd', invoiceNumber: 'I-4', vendorId: 'V2', dueDate: '2026-04-01', totalAmount: 100, state: 'voided' },
+			{
+				id: 'a',
+				invoiceNumber: 'I-1',
+				vendorId: 'V1',
+				dueDate: '2026-06-20',
+				totalAmount: 500,
+				state: 'received',
+			},
+			{
+				id: 'b',
+				invoiceNumber: 'I-2',
+				vendorId: 'V1',
+				dueDate: '2026-06-01',
+				totalAmount: 250,
+				state: 'partially-paid',
+			},
+			{
+				id: 'c',
+				invoiceNumber: 'I-3',
+				vendorId: 'V2',
+				dueDate: '2026-05-01',
+				totalAmount: 100,
+				state: 'paid',
+			},
+			{
+				id: 'd',
+				invoiceNumber: 'I-4',
+				vendorId: 'V2',
+				dueDate: '2026-04-01',
+				totalAmount: 100,
+				state: 'voided',
+			},
 		]
-		const rows = openApRows(txs, [{ vendorNumber: 'V1', name: 'Hosting BV' }], now)
+		const rows = openApRows(
+			txs,
+			[{ vendorNumber: 'V1', name: 'Hosting BV' }],
+			now,
+		)
 		expect(rows.map((r) => r.invoiceNumber)).toEqual(['I-2', 'I-1'])
 		expect(rows[0].overdue).toBe(true)
 		expect(rows[0].party).toBe('Hosting BV')
@@ -174,21 +271,34 @@ describe('financialSeries', () => {
 
 	it('computeKpis aggregates YTD turnover/margin, open AR/AP, billable share and cash position', () => {
 		const now = new Date(2026, 3, 15) // April 2026
-		const kpis = computeKpis({
-			accounts: ACCOUNTS,
-			transactions: TRANSACTIONS,
-			lines: LINES,
-			arInvoices: [
-				{ id: 'a', dueDate: '2026-05-01', grossAmount: 1210, lifecycleState: 'issued' },
-			],
-			apTransactions: [
-				{ id: 'b', dueDate: '2026-05-01', totalAmount: 484, state: 'received' },
-			],
-			hourEntries: [
-				{ date: '2026-04-02', hours: 30, recognisedRate: 95 },
-				{ date: '2026-04-03', hours: 10 },
-			],
-		}, now)
+		const kpis = computeKpis(
+			{
+				accounts: ACCOUNTS,
+				transactions: TRANSACTIONS,
+				lines: LINES,
+				arInvoices: [
+					{
+						id: 'a',
+						dueDate: '2026-05-01',
+						grossAmount: 1210,
+						lifecycleState: 'issued',
+					},
+				],
+				apTransactions: [
+					{
+						id: 'b',
+						dueDate: '2026-05-01',
+						totalAmount: 484,
+						state: 'received',
+					},
+				],
+				hourEntries: [
+					{ date: '2026-04-02', hours: 30, recognisedRate: 95 },
+					{ date: '2026-04-03', hours: 10 },
+				],
+			},
+			now,
+		)
 		expect(kpis.turnoverYtd).toBe(1000)
 		expect(kpis.marginYtd).toBe(600)
 		expect(kpis.marginPctYtd).toBe(60)
@@ -207,7 +317,12 @@ describe('financialSeries', () => {
 			{ date: '2026-03-03', hours: 2, recognisedRate: 0 },
 			{ date: '2026-04-01', hours: 8, recognisedRate: 110 },
 		]
-		const data = { accounts: ACCOUNTS, transactions: TRANSACTIONS, lines: LINES, hourEntries }
+		const data = {
+			accounts: ACCOUNTS,
+			transactions: TRANSACTIONS,
+			lines: LINES,
+			hourEntries,
+		}
 
 		// March + April: revenue 1000 (March), margin 600; billable 6+8 of 16 total.
 		const wide = computeRangeKpis(data, ['2026-03', '2026-04'])
@@ -246,7 +361,11 @@ describe('useFinancialData', () => {
 		expect(axios.get).toHaveBeenCalledTimes(9)
 		const urls = axios.get.mock.calls.map(([url]) => url)
 		expect(new Set(urls).size).toBe(9)
-		expect(urls.every((url) => url.includes('/apps/openregister/api/objects/shillinq/'))).toBe(true)
+		expect(
+			urls.every((url) =>
+				url.includes('/apps/openregister/api/objects/shillinq/'),
+			),
+		).toBe(true)
 		expect(first.data.value).toBeTruthy()
 		expect(first.data.value.accounts).toEqual([])
 	})

--- a/tests/vitest/generateManifestShell.spec.js
+++ b/tests/vitest/generateManifestShell.spec.js
@@ -15,18 +15,34 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 // eslint-disable-next-line n/no-unpublished-require
-const { generateShellDocument, buildShellFragment, slimPages } = require('../../scripts/generate-manifest-shell.js')
+const {
+	generateShellDocument,
+	buildShellFragment,
+	slimPages,
+} = require('../../scripts/generate-manifest-shell.js')
 
 describe('slimPages', () => {
 	it('keeps only id/route/type/title and stamps _fragment', () => {
 		const pages = [
-			{ id: 'Resources', route: '/bookings/resources', type: 'index', title: 'Resources', config: { columns: [{ key: 'name' }] } },
+			{
+				id: 'Resources',
+				route: '/bookings/resources',
+				type: 'index',
+				title: 'Resources',
+				config: { columns: [{ key: 'name' }] },
+			},
 		]
 
 		const slim = slimPages(pages, '10-bookings-resource-calendar')
 
 		expect(slim).toEqual([
-			{ _fragment: '10-bookings-resource-calendar', id: 'Resources', route: '/bookings/resources', type: 'index', title: 'Resources' },
+			{
+				_fragment: '10-bookings-resource-calendar',
+				id: 'Resources',
+				route: '/bookings/resources',
+				type: 'index',
+				title: 'Resources',
+			},
 		])
 		expect(slim[0].config).toBeUndefined()
 	})
@@ -46,7 +62,15 @@ describe('buildShellFragment', () => {
 	it('copies menu through unchanged and slims pages', () => {
 		const fragment = {
 			menu: [{ id: 'Bookings', label: 'Bookings', children: [] }],
-			pages: [{ id: 'A', route: '/a', type: 'index', title: 'A', config: { big: 'payload' } }],
+			pages: [
+				{
+					id: 'A',
+					route: '/a',
+					type: 'index',
+					title: 'A',
+					config: { big: 'payload' },
+				},
+			],
 		}
 
 		const shell = buildShellFragment(fragment, 'frag')
@@ -87,10 +111,18 @@ describe('buildShellFragment', () => {
 
 describe('generateShellDocument', () => {
 	it('reads every *.json fragment in sorted order and produces one shell entry each', () => {
-		const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shillinq-manifest-shell-'))
+		const dir = fs.mkdtempSync(
+			path.join(os.tmpdir(), 'shillinq-manifest-shell-'),
+		)
 		try {
-			fs.writeFileSync(path.join(dir, 'b-frag.json'), JSON.stringify({ menu: [], pages: [{ id: 'B', route: '/b' }] }))
-			fs.writeFileSync(path.join(dir, 'a-frag.json'), JSON.stringify({ menu: [], pages: [{ id: 'A', route: '/a' }] }))
+			fs.writeFileSync(
+				path.join(dir, 'b-frag.json'),
+				JSON.stringify({ menu: [], pages: [{ id: 'B', route: '/b' }] }),
+			)
+			fs.writeFileSync(
+				path.join(dir, 'a-frag.json'),
+				JSON.stringify({ menu: [], pages: [{ id: 'A', route: '/a' }] }),
+			)
 			fs.writeFileSync(path.join(dir, 'notes.txt'), 'ignored — not .json')
 
 			const shell = generateShellDocument(dir)

--- a/tests/vitest/invoiceQuickDraft.spec.js
+++ b/tests/vitest/invoiceQuickDraft.spec.js
@@ -23,7 +23,12 @@ import {
 
 describe('invoiceQuickDraft — totals', () => {
 	it('defaultDraftLine seeds qty 1 and 21% VAT', () => {
-		expect(defaultDraftLine()).toEqual({ description: '', quantity: 1, unitPrice: 0, btwRate: 21 })
+		expect(defaultDraftLine()).toEqual({
+			description: '',
+			quantity: 1,
+			unitPrice: 0,
+			btwRate: 21,
+		})
 	})
 
 	it('computes net, VAT and gross across mixed VAT rates', () => {
@@ -39,7 +44,11 @@ describe('invoiceQuickDraft — totals', () => {
 	})
 
 	it('treats missing/invalid fields as zero', () => {
-		expect(computeTotals([{ description: 'x' }])).toEqual({ net: 0, vat: 0, gross: 0 })
+		expect(computeTotals([{ description: 'x' }])).toEqual({
+			net: 0,
+			vat: 0,
+			gross: 0,
+		})
 		expect(computeTotals([])).toEqual({ net: 0, vat: 0, gross: 0 })
 		expect(computeTotals(null)).toEqual({ net: 0, vat: 0, gross: 0 })
 	})
@@ -74,7 +83,12 @@ describe('invoiceQuickDraft — payload', () => {
 			reference: 'PO-42',
 			glAccount: '8000',
 			lines: [
-				{ description: ' Consulting ', quantity: 2, unitPrice: 100, btwRate: 21 },
+				{
+					description: ' Consulting ',
+					quantity: 2,
+					unitPrice: 100,
+					btwRate: 21,
+				},
 				{ description: '', quantity: 0, unitPrice: 0, btwRate: 21 }, // dropped
 			],
 		})
@@ -133,7 +147,10 @@ describe('invoiceQuickDraft — period + provisional number helpers', () => {
 	})
 
 	it('builds a unique, provisional draft invoice number', () => {
-		const num = provisionalInvoiceNumber('2026-07-09', new Date(2026, 6, 9, 8, 30, 5))
+		const num = provisionalInvoiceNumber(
+			'2026-07-09',
+			new Date(2026, 6, 9, 8, 30, 5),
+		)
 		expect(num).toBe('DRAFT-20260709-083005')
 	})
 
@@ -148,13 +165,22 @@ describe('invoiceQuickDraft — preferences persistence', () => {
 		const store = {}
 		globalThis.localStorage = {
 			getItem: (k) => (k in store ? store[k] : null),
-			setItem: (k, v) => { store[k] = String(v) },
-			removeItem: (k) => { delete store[k] },
+			setItem: (k, v) => {
+				store[k] = String(v)
+			},
+			removeItem: (k) => {
+				delete store[k]
+			},
 		}
 	})
 
 	it('round-trips per-customer preferences', () => {
-		saveQuickDraftPrefs('cust-1', { glAccount: '8000', vatCode: 9, description: 'Hosting', unitPrice: 49 })
+		saveQuickDraftPrefs('cust-1', {
+			glAccount: '8000',
+			vatCode: 9,
+			description: 'Hosting',
+			unitPrice: 49,
+		})
 		const prefs = loadQuickDraftPrefs('cust-1')
 		expect(prefs.glAccount).toBe('8000')
 		expect(prefs.vatCode).toBe(9)
@@ -169,15 +195,22 @@ describe('invoiceQuickDraft — preferences persistence', () => {
 
 	it('expires preferences older than 90 days', () => {
 		saveQuickDraftPrefs('cust-1', { glAccount: '8000' })
-		const raw = JSON.parse(globalThis.localStorage.getItem('shillinq:invoice-quick-draft:cust-1'))
-		raw.savedAt = Date.now() - (91 * 24 * 60 * 60 * 1000)
-		globalThis.localStorage.setItem('shillinq:invoice-quick-draft:cust-1', JSON.stringify(raw))
+		const raw = JSON.parse(
+			globalThis.localStorage.getItem('shillinq:invoice-quick-draft:cust-1'),
+		)
+		raw.savedAt = Date.now() - 91 * 24 * 60 * 60 * 1000
+		globalThis.localStorage.setItem(
+			'shillinq:invoice-quick-draft:cust-1',
+			JSON.stringify(raw),
+		)
 		expect(loadQuickDraftPrefs('cust-1')).toBeNull()
 	})
 
 	it('never throws when localStorage is unavailable', () => {
 		globalThis.localStorage = undefined
-		expect(() => saveQuickDraftPrefs('cust-1', { glAccount: '8000' })).not.toThrow()
+		expect(() =>
+			saveQuickDraftPrefs('cust-1', { glAccount: '8000' }),
+		).not.toThrow()
 		expect(loadQuickDraftPrefs('cust-1')).toBeNull()
 	})
 })

--- a/tests/vitest/listViewsCnDataTable.spec.js
+++ b/tests/vitest/listViewsCnDataTable.spec.js
@@ -34,14 +34,16 @@ function tIdentity(app, text, vars) {
 	if (!vars) {
 		return text
 	}
-	return text.replace(/\{(\w+)\}/g, (_, k) => (k in vars ? String(vars[k]) : `{${k}}`))
+	return text.replace(/\{(\w+)\}/g, (_, k) =>
+		k in vars ? String(vars[k]) : `{${k}}`,
+	)
 }
 
 /** Invoke a component's `columns` computed bound to a fake instance. */
 function columnKeys(Component) {
 	const fakeThis = { t: tIdentity }
 	const cols = Component.computed.columns.call(fakeThis)
-	return cols.map(c => c.key)
+	return cols.map((c) => c.key)
 }
 
 beforeEach(() => {
@@ -76,8 +78,14 @@ describe('migrate-list-views-to-cndatatable: CnDataTable is the list renderer', 
 describe('AdminInvoiceList columns', () => {
 	it('has the invoice #, dates, customer, billing model, gross, status and actions columns', () => {
 		expect(columnKeys(AdminInvoiceList)).toEqual([
-			'invoiceNumber', 'invoiceDate', 'dueDate', 'customerId',
-			'billingModel', 'grossAmount', 'status', 'actions',
+			'invoiceNumber',
+			'invoiceDate',
+			'dueDate',
+			'customerId',
+			'billingModel',
+			'grossAmount',
+			'status',
+			'actions',
 		])
 	})
 })
@@ -85,7 +93,11 @@ describe('AdminInvoiceList columns', () => {
 describe('DocumentsView columns', () => {
 	it('has the document number/type/date/status/file-reference columns', () => {
 		expect(columnKeys(DocumentsView)).toEqual([
-			'documentNumber', 'documentType', 'documentDate', 'status', 'fileReference',
+			'documentNumber',
+			'documentType',
+			'documentDate',
+			'status',
+			'fileReference',
 		])
 	})
 })
@@ -93,8 +105,12 @@ describe('DocumentsView columns', () => {
 describe('TransactionsView columns', () => {
 	it('has the date/number/type/description/amount/status columns', () => {
 		expect(columnKeys(TransactionsView)).toEqual([
-			'transactionDate', 'transactionNumber', 'transactionType',
-			'description', 'amount', 'status',
+			'transactionDate',
+			'transactionNumber',
+			'transactionType',
+			'description',
+			'amount',
+			'status',
 		])
 	})
 })
@@ -102,7 +118,13 @@ describe('TransactionsView columns', () => {
 describe('ThreeWayMatchIndex columns', () => {
 	it('has the invoice/supplier/amount/match-date/status/linked-PO-GRN/actions columns', () => {
 		expect(columnKeys(ThreeWayMatchIndex)).toEqual([
-			'invoice', 'supplier', 'amount', 'matchDate', 'matchStatus', 'refs', 'actions',
+			'invoice',
+			'supplier',
+			'amount',
+			'matchDate',
+			'matchStatus',
+			'refs',
+			'actions',
 		])
 	})
 })
@@ -110,8 +132,13 @@ describe('ThreeWayMatchIndex columns', () => {
 describe('VendorPerformanceIndex columns', () => {
 	it('has the supplier/period/score/trend/disputes/eligible/actions columns', () => {
 		expect(columnKeys(VendorPerformanceIndex)).toEqual([
-			'supplierId', 'period', 'overallScore', 'scoreTrend',
-			'disputeCount', 'automatedReviewEligible', 'actions',
+			'supplierId',
+			'period',
+			'overallScore',
+			'scoreTrend',
+			'disputeCount',
+			'automatedReviewEligible',
+			'actions',
 		])
 	})
 })

--- a/tests/vitest/mergeFragmentIntoManifest.spec.js
+++ b/tests/vitest/mergeFragmentIntoManifest.spec.js
@@ -30,7 +30,15 @@ describe('mergeFullFragmentIntoManifest — reactivity (the load-bearing contrac
 		// writes THROUGH the proxy rather than to a raw reference. If it did
 		// not, this computed would keep returning `undefined` forever.
 		const manifest = reactive({
-			pages: [{ id: 'Resources', route: '/bookings/resources', type: 'index', title: 'Resources', _fragment: '10-bookings-resource-calendar' }],
+			pages: [
+				{
+					id: 'Resources',
+					route: '/bookings/resources',
+					type: 'index',
+					title: 'Resources',
+					_fragment: '10-bookings-resource-calendar',
+				},
+			],
 		})
 
 		const configColumns = computed(() => {
@@ -41,7 +49,15 @@ describe('mergeFullFragmentIntoManifest — reactivity (the load-bearing contrac
 		expect(configColumns.value).toBeUndefined()
 
 		mergeFullFragmentIntoManifest(manifest, {
-			pages: [{ id: 'Resources', route: '/bookings/resources', type: 'index', title: 'Resources', config: { columns: [{ key: 'name' }] } }],
+			pages: [
+				{
+					id: 'Resources',
+					route: '/bookings/resources',
+					type: 'index',
+					title: 'Resources',
+					config: { columns: [{ key: 'name' }] },
+				},
+			],
 		})
 
 		// A Vue 3 computed re-runs lazily on next access once its reactive
@@ -54,7 +70,9 @@ describe('mergeFullFragmentIntoManifest — reactivity (the load-bearing contrac
 		const slimPage = { id: 'Resources', _fragment: 'frag' }
 		const manifest = reactive({ pages: [slimPage] })
 
-		mergeFullFragmentIntoManifest(manifest, { pages: [{ id: 'Resources', config: { x: 1 } }] })
+		mergeFullFragmentIntoManifest(manifest, {
+			pages: [{ id: 'Resources', config: { x: 1 } }],
+		})
 
 		// `manifest.pages[0]` reads back as the reactive PROXY of slimPage, not
 		// slimPage itself — `toBe(slimPage)` would fail for a reason that has
@@ -67,12 +85,28 @@ describe('mergeFullFragmentIntoManifest — reactivity (the load-bearing contrac
 
 describe('mergeFullFragmentIntoManifest', () => {
 	it('updates a matching slim page IN PLACE (same object reference)', () => {
-		const slimPage = { id: 'Resources', route: '/bookings/resources', type: 'index', title: 'Resources', _fragment: '10-bookings-resource-calendar' }
+		const slimPage = {
+			id: 'Resources',
+			route: '/bookings/resources',
+			type: 'index',
+			title: 'Resources',
+			_fragment: '10-bookings-resource-calendar',
+		}
 		const manifest = { pages: [slimPage] }
 
 		const fullFragment = {
 			pages: [
-				{ id: 'Resources', route: '/bookings/resources', type: 'index', title: 'Resources', config: { register: 'shillinq', schema: 'Resource', columns: [{ key: 'name' }] } },
+				{
+					id: 'Resources',
+					route: '/bookings/resources',
+					type: 'index',
+					title: 'Resources',
+					config: {
+						register: 'shillinq',
+						schema: 'Resource',
+						columns: [{ key: 'name' }],
+					},
+				},
 			],
 		}
 
@@ -81,12 +115,26 @@ describe('mergeFullFragmentIntoManifest', () => {
 		expect(result).toEqual({ updated: 1, appended: 0 })
 		// Same reference — this is the load-bearing reactivity contract.
 		expect(manifest.pages[0]).toBe(slimPage)
-		expect(manifest.pages[0].config).toEqual({ register: 'shillinq', schema: 'Resource', columns: [{ key: 'name' }] })
+		expect(manifest.pages[0].config).toEqual({
+			register: 'shillinq',
+			schema: 'Resource',
+			columns: [{ key: 'name' }],
+		})
 	})
 
 	it('appends a page with no matching slim entry (defensive: shell/fragment drift)', () => {
 		const manifest = { pages: [] }
-		const fullFragment = { pages: [{ id: 'Orphan', route: '/orphan', type: 'index', title: 'Orphan', config: {} }] }
+		const fullFragment = {
+			pages: [
+				{
+					id: 'Orphan',
+					route: '/orphan',
+					type: 'index',
+					title: 'Orphan',
+					config: {},
+				},
+			],
+		}
 
 		const result = mergeFullFragmentIntoManifest(manifest, fullFragment)
 
@@ -116,17 +164,27 @@ describe('mergeFullFragmentIntoManifest', () => {
 	it('is a no-op on an empty/missing fragment pages array', () => {
 		const manifest = { pages: [{ id: 'A', _fragment: 'frag' }] }
 
-		expect(mergeFullFragmentIntoManifest(manifest, {})).toEqual({ updated: 0, appended: 0 })
-		expect(mergeFullFragmentIntoManifest(manifest, { pages: [] })).toEqual({ updated: 0, appended: 0 })
+		expect(mergeFullFragmentIntoManifest(manifest, {})).toEqual({
+			updated: 0,
+			appended: 0,
+		})
+		expect(mergeFullFragmentIntoManifest(manifest, { pages: [] })).toEqual({
+			updated: 0,
+			appended: 0,
+		})
 	})
 
 	it('tolerates a missing/non-array manifest.pages', () => {
-		expect(mergeFullFragmentIntoManifest({}, { pages: [{ id: 'A', config: {} }] })).toEqual({ updated: 0, appended: 1 })
+		expect(
+			mergeFullFragmentIntoManifest({}, { pages: [{ id: 'A', config: {} }] }),
+		).toEqual({ updated: 0, appended: 1 })
 	})
 
 	it('skips malformed full-page entries without an id', () => {
 		const manifest = { pages: [{ id: 'A', _fragment: 'frag' }] }
-		const result = mergeFullFragmentIntoManifest(manifest, { pages: [{ config: {} }, null] })
+		const result = mergeFullFragmentIntoManifest(manifest, {
+			pages: [{ config: {} }, null],
+		})
 
 		expect(result).toEqual({ updated: 0, appended: 0 })
 		expect(manifest.pages).toHaveLength(1)

--- a/tests/vitest/receiptCapture.spec.js
+++ b/tests/vitest/receiptCapture.spec.js
@@ -42,7 +42,12 @@ describe('receiptCapture — review form (REQ-RXC-003)', () => {
 })
 
 describe('receiptCapture — save gate (REQ-EC-002 required fields)', () => {
-	const base = { amount: 45, currency: 'EUR', receiptDate: '2026-02-10', category: 'meals' }
+	const base = {
+		amount: 45,
+		currency: 'EUR',
+		receiptDate: '2026-02-10',
+		category: 'meals',
+	}
 
 	it('allows save when amount/currency/receiptDate/category are present', () => {
 		expect(canSaveReceipt(base)).toBe(true)
@@ -133,7 +138,11 @@ describe('receiptCapture — GL account (gl-account-suggestion-consume)', () => 
 
 describe('receiptCapture — error mapping', () => {
 	it('prefers the server error message', () => {
-		expect(receiptErrorMessage({ response: { data: { error: 'Draft not found' } } })).toBe('Draft not found')
+		expect(
+			receiptErrorMessage({
+				response: { data: { error: 'Draft not found' } },
+			}),
+		).toBe('Draft not found')
 	})
 
 	it('falls back to a generic message', () => {

--- a/tests/vitest/recurringInvoiceProfile.spec.js
+++ b/tests/vitest/recurringInvoiceProfile.spec.js
@@ -18,15 +18,21 @@ import {
 describe('recurringInvoiceProfile — defaults + totals', () => {
 	it('seeds a line with qty 1 and 21% VAT', () => {
 		expect(defaultRecurringLine()).toEqual({
-			description: '', quantity: 1, unitPrice: 0, vatCode: 21, revenueAccount: '',
+			description: '',
+			quantity: 1,
+			unitPrice: 0,
+			vatCode: 21,
+			revenueAccount: '',
 		})
 	})
 
 	it('sums per-period net across lines', () => {
-		expect(perPeriodNet([
-			{ quantity: 1, unitPrice: 99 },
-			{ quantity: 2, unitPrice: 10 },
-		])).toBe(119)
+		expect(
+			perPeriodNet([
+				{ quantity: 1, unitPrice: 99 },
+				{ quantity: 2, unitPrice: 10 },
+			]),
+		).toBe(119)
 		expect(perPeriodNet([])).toBe(0)
 	})
 })
@@ -47,13 +53,23 @@ describe('recurringInvoiceProfile — validation', () => {
 	it('flags missing name, customer, line, date and bad invoice day', () => {
 		expect(validateProfile({ ...base(), name: '' }).length).toBe(1)
 		expect(validateProfile({ ...base(), customerReference: '' }).length).toBe(1)
-		expect(validateProfile({ ...base(), lines: [{ description: '', unitPrice: 0 }] }).length).toBe(1)
+		expect(
+			validateProfile({
+				...base(),
+				lines: [{ description: '', unitPrice: 0 }],
+			}).length,
+		).toBe(1)
 		expect(validateProfile({ ...base(), startDate: 'nope' }).length).toBe(1)
 		expect(validateProfile({ ...base(), invoiceDay: 40 }).length).toBe(1)
 	})
 
 	it('requires a priced line, not just a description', () => {
-		expect(validateProfile({ ...base(), lines: [{ description: 'Hosting', unitPrice: 0 }] }).length).toBe(1)
+		expect(
+			validateProfile({
+				...base(),
+				lines: [{ description: 'Hosting', unitPrice: 0 }],
+			}).length,
+		).toBe(1)
 	})
 })
 
@@ -69,7 +85,13 @@ describe('recurringInvoiceProfile — payload', () => {
 			issueMode: 'draft-for-review',
 			paymentTermsDays: 30,
 			lines: [
-				{ description: ' Hosting {month} ', quantity: 1, unitPrice: 99, vatCode: 21, revenueAccount: '8000' },
+				{
+					description: ' Hosting {month} ',
+					quantity: 1,
+					unitPrice: 99,
+					vatCode: 21,
+					revenueAccount: '8000',
+				},
 				{ description: '', unitPrice: 0 }, // dropped
 			],
 		})
@@ -82,7 +104,10 @@ describe('recurringInvoiceProfile — payload', () => {
 
 	it('maps occurrenceCount into endCondition + remainingOccurrences', () => {
 		const payload = buildProfilePayload({
-			name: 'x', customerReference: 'c', startDate: '2027-01-01', invoiceDay: 1,
+			name: 'x',
+			customerReference: 'c',
+			startDate: '2027-01-01',
+			invoiceDay: 1,
 			occurrenceCount: 12,
 			lines: [{ description: 'x', unitPrice: 1, vatCode: 21 }],
 		})
@@ -92,7 +117,10 @@ describe('recurringInvoiceProfile — payload', () => {
 
 	it('maps endDate into endCondition', () => {
 		const payload = buildProfilePayload({
-			name: 'x', customerReference: 'c', startDate: '2027-01-01', invoiceDay: 1,
+			name: 'x',
+			customerReference: 'c',
+			startDate: '2027-01-01',
+			invoiceDay: 1,
 			endDate: '2028-01-01',
 			lines: [{ description: 'x', unitPrice: 1, vatCode: 21 }],
 		})

--- a/tests/vitest/settingsStore.spec.js
+++ b/tests/vitest/settingsStore.spec.js
@@ -43,7 +43,9 @@ describe('shillinq settings store', () => {
 	})
 
 	it('fetchSettings stores data and derives openregisters/admin flags', async () => {
-		mockFetchOnce({ json: { openregisters: true, isAdmin: true, invoiceSchema: 'invoice' } })
+		mockFetchOnce({
+			json: { openregisters: true, isAdmin: true, invoiceSchema: 'invoice' },
+		})
 		const store = useSettingsStore()
 		const data = await store.fetchSettings()
 		expect(globalThis.fetch).toHaveBeenCalledWith(

--- a/tests/vitest/stubs/nextcloud-router.js
+++ b/tests/vitest/stubs/nextcloud-router.js
@@ -13,7 +13,10 @@ export function generateUrl(url, params) {
 	// that pass no params (the settings store) are unaffected.
 	if (params && typeof params === 'object') {
 		for (const [key, value] of Object.entries(params)) {
-			path = path.replace(new RegExp(`\\{${key}\\}`, 'g'), encodeURIComponent(String(value)))
+			path = path.replace(
+				new RegExp(`\\{${key}\\}`, 'g'),
+				encodeURIComponent(String(value)),
+			)
 		}
 	}
 	return `/index.php${path.startsWith('/') ? path : `/${path}`}`

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -34,7 +34,13 @@ module.exports = {
 		environment: 'node',
 		globals: false,
 		include: ['tests/vitest/**/*.spec.{js,ts}'],
-		exclude: ['tests/e2e/**', 'tests/integration/**', 'tests/Unit/**', 'src/**', 'node_modules/**'],
+		exclude: [
+			'tests/e2e/**',
+			'tests/integration/**',
+			'tests/Unit/**',
+			'src/**',
+			'node_modules/**',
+		],
 		// pinia 3 is Vue-3 native and no longer routes through `vue-demi`, so
 		// the Vue-2.7 shim pin that used to live here (and its `inline` entry)
 		// is gone with it — vue-demi is no longer in the dependency graph at all.
@@ -44,19 +50,31 @@ module.exports = {
 			{ find: '@', replacement: path.resolve(__dirname, 'src') },
 			{
 				find: /^@nextcloud\/router$/,
-				replacement: path.resolve(__dirname, 'tests/vitest/stubs/nextcloud-router.js'),
+				replacement: path.resolve(
+					__dirname,
+					'tests/vitest/stubs/nextcloud-router.js',
+				),
 			},
 			{
 				find: /^@nextcloud\/vue$/,
-				replacement: path.resolve(__dirname, 'tests/vitest/stubs/nextcloud-vue.js'),
+				replacement: path.resolve(
+					__dirname,
+					'tests/vitest/stubs/nextcloud-vue.js',
+				),
 			},
 			{
 				find: /^@nextcloud\/axios$/,
-				replacement: path.resolve(__dirname, 'tests/vitest/stubs/nextcloud-axios.js'),
+				replacement: path.resolve(
+					__dirname,
+					'tests/vitest/stubs/nextcloud-axios.js',
+				),
 			},
 			{
 				find: /^@conduction\/nextcloud-vue$/,
-				replacement: path.resolve(__dirname, 'tests/vitest/stubs/conduction-nextcloud-vue.js'),
+				replacement: path.resolve(
+					__dirname,
+					'tests/vitest/stubs/conduction-nextcloud-vue.js',
+				),
 			},
 		],
 	},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,13 @@ webpackConfig.entry = {
 	// entrypoints re-import the same loader, so this is the single
 	// authoritative bundle for all four embed methods.
 	widget: {
-		import: path.join(__dirname, 'src', 'components', 'widget', 'WidgetEmbed.js'),
+		import: path.join(
+			__dirname,
+			'src',
+			'components',
+			'widget',
+			'WidgetEmbed.js',
+		),
 		filename: 'widget.js',
 		library: { name: 'BookingWidget', type: 'umd', export: 'default' },
 	},
@@ -47,13 +53,15 @@ const localLib = path.resolve(__dirname, '../nextcloud-vue/src')
 const localLibPkg = path.resolve(__dirname, '../nextcloud-vue/package.json')
 let useLocalLib = process.env.USE_LOCAL_LIB === 'true' && fs.existsSync(localLib)
 if (useLocalLib && fs.existsSync(localLibPkg)) {
-	const localVersion = String(JSON.parse(fs.readFileSync(localLibPkg, 'utf8')).version || '')
+	const localVersion = String(
+		JSON.parse(fs.readFileSync(localLibPkg, 'utf8')).version || '',
+	)
 	const localMajor = parseInt(localVersion, 10)
 	if (!Number.isNaN(localMajor) && localMajor < 2) {
 		// eslint-disable-next-line no-console
 		console.warn(
 			`[shillinq] IGNORING sibling @conduction/nextcloud-vue@${localVersion} — `
-			+ 'that is the Vue 2 line and this app is Vue 3. Building against the npm dist.',
+				+ 'that is the Vue 2 line and this app is Vue 3. Building against the npm dist.',
 		)
 		useLocalLib = false
 	}
@@ -69,8 +77,8 @@ webpackConfig.resolve = {
 		...(useLocalLib ? { '@conduction/nextcloud-vue': localLib } : {}),
 		// Deduplicate shared packages so the aliased library source uses
 		// the same instances as the app (prevents dual-Pinia / dual-Vue bugs).
-		'vue$': path.resolve(__dirname, 'node_modules/vue'),
-		'pinia$': path.resolve(__dirname, 'node_modules/pinia'),
+		vue$: path.resolve(__dirname, 'node_modules/vue'),
+		pinia$: path.resolve(__dirname, 'node_modules/pinia'),
 		// @nextcloud/vue@9, @nextcloud/dialogs@7 and vue-router@5 are ESM-only:
 		// their package.json has NO `main` and NO `module`, only an `exports`
 		// map. A Vue-2-era alias to the package DIRECTORY bypasses `exports`
@@ -78,7 +86,10 @@ webpackConfig.resolve = {
 		// every import fails with "Can't resolve '@nextcloud/vue'". Alias to
 		// the absolute FILE; the `$` (exact-match) form keeps deep imports
 		// going through the exports map.
-		'@nextcloud/vue$': path.resolve(__dirname, 'node_modules/@nextcloud/vue/dist/index.mjs'),
+		'@nextcloud/vue$': path.resolve(
+			__dirname,
+			'node_modules/@nextcloud/vue/dist/index.mjs',
+		),
 		// @nextcloud/vue@9 hard-depends on vue-router ^5.1.0 while this app is
 		// on vue-router 4, so npm installs a SECOND nested copy under
 		// node_modules/@nextcloud/vue/node_modules/vue-router. Two router
@@ -86,7 +97,10 @@ webpackConfig.resolve = {
 		// RouterLink would look up a router this app never provided and
 		// navigation dies with no console error. Force every `vue-router`
 		// specifier onto this app's single copy.
-		'vue-router$': path.resolve(__dirname, 'node_modules/vue-router/dist/vue-router.mjs'),
+		'vue-router$': path.resolve(
+			__dirname,
+			'node_modules/vue-router/dist/vue-router.mjs',
+		),
 	},
 }
 
@@ -122,7 +136,9 @@ webpackConfig.module = {
 webpackConfig.plugins = [
 	new VueLoaderPlugin(),
 	new webpack.DefinePlugin({ appName: JSON.stringify(appId) }),
-	new webpack.DefinePlugin({ appVersion: JSON.stringify(process.env.npm_package_version) }),
+	new webpack.DefinePlugin({
+		appVersion: JSON.stringify(process.env.npm_package_version),
+	}),
 ]
 
 // Force @nextcloud/dialogs to resolve from this app's node_modules.
@@ -131,10 +147,16 @@ webpackConfig.plugins = [
 // '@nextcloud/dialogs/style.css' (imported by nextcloud-vue's useAppInstaller)
 // must be caught first. dialogs v7 ships the stylesheet at dist/style.css
 // behind its "exports" map.
-webpackConfig.resolve.alias['@nextcloud/dialogs/style.css$'] = path.resolve(__dirname, 'node_modules/@nextcloud/dialogs/dist/style.css')
+webpackConfig.resolve.alias['@nextcloud/dialogs/style.css$'] = path.resolve(
+	__dirname,
+	'node_modules/@nextcloud/dialogs/dist/style.css',
+)
 // Exact-match, absolute FILE — see the @nextcloud/vue note above; dialogs v7 is
 // exports-map-only too, so a directory alias resolves to nothing.
-webpackConfig.resolve.alias['@nextcloud/dialogs$'] = path.resolve(__dirname, 'node_modules/@nextcloud/dialogs/dist/index.mjs')
+webpackConfig.resolve.alias['@nextcloud/dialogs$'] = path.resolve(
+	__dirname,
+	'node_modules/@nextcloud/dialogs/dist/index.mjs',
+)
 
 // @nextcloud/dialogs@7 and @conduction/nextcloud-vue drag in a FilePicker
 // chunk that imports node's `path`, and webpack 5 no longer auto-polyfills
@@ -165,9 +187,7 @@ webpackConfig.output = {
 // memory bounded while still parallelising minification.
 webpackConfig.optimization = {
 	...(webpackConfig.optimization || {}),
-	minimizer: [
-		new TerserPlugin({ parallel: 2 }),
-	],
+	minimizer: [new TerserPlugin({ parallel: 2 })],
 }
 
 module.exports = webpackConfig

--- a/widget/index.d.ts
+++ b/widget/index.d.ts
@@ -9,34 +9,34 @@
 
 export interface BookingWidgetConfig {
 	/** Public partner business id used in widget embeds (e.g. "salon-001"). */
-	businessId: string;
+	businessId: string
 	/** Shillinq API base URL, e.g. https://shillinq.example.com/index.php/apps/shillinq */
-	apiBase: string;
+	apiBase: string
 	/** Bearer API key (bk_live_...). Shown to the partner once at creation. */
-	apiKey: string;
+	apiKey: string
 	/** DOM id of the mount container (mutually exclusive with `element`). */
-	containerId?: string;
+	containerId?: string
 	/** DOM element to mount into (mutually exclusive with `containerId`). */
-	element?: HTMLElement;
+	element?: HTMLElement
 	/** Logical resource id to book (defaults to "res-001"). */
-	resourceId?: string;
+	resourceId?: string
 	/** BCP-47 language code (defaults to "en"). */
-	lang?: string;
+	lang?: string
 	/** Hex/CSS colour applied to --wsw-primary-color. */
-	primaryColor?: string;
+	primaryColor?: string
 	/** When true, applies the wsw-widget--dark surface palette. */
-	darkMode?: boolean;
+	darkMode?: boolean
 	/** Override the bundled translation table. */
-	translations?: Record<string, string>;
+	translations?: Record<string, string>
 }
 
 export interface BookingWidgetInstance {
-	$destroy(): void;
+	$destroy(): void
 }
 
 export interface BookingWidgetApi {
-	init(_config: BookingWidgetConfig): BookingWidgetInstance | null;
-	iframeUrl(_config: BookingWidgetConfig): string;
+	init(_config: BookingWidgetConfig): BookingWidgetInstance | null
+	iframeUrl(_config: BookingWidgetConfig): string
 }
 
 export const BookingWidget: BookingWidgetApi

--- a/widget/vue.d.ts
+++ b/widget/vue.d.ts
@@ -6,14 +6,14 @@
 import type { DefineComponent } from 'vue'
 
 export interface BookingWidgetProps {
-	businessId: string;
-	apiBase: string;
-	apiKey: string;
-	resourceId?: string;
-	lang?: string;
-	primaryColor?: string;
-	darkMode?: boolean;
-	translations?: Record<string, string>;
+	businessId: string
+	apiBase: string
+	apiKey: string
+	resourceId?: string
+	lang?: string
+	primaryColor?: string
+	darkMode?: boolean
+	translations?: Record<string, string>
 }
 
 declare const BookingWidget: DefineComponent<BookingWidgetProps>

--- a/widget/web-component.js
+++ b/widget/web-component.js
@@ -23,7 +23,6 @@
 import { BookingWidget } from './index.js'
 
 class NextcloudBookingWidget extends HTMLElement {
-
 	connectedCallback() {
 		const config = {
 			businessId: this.getAttribute('business-id') || '',
@@ -43,12 +42,14 @@ class NextcloudBookingWidget extends HTMLElement {
 			this._instance.$destroy()
 		}
 	}
-
 }
 
 if (typeof window !== 'undefined' && typeof window.customElements !== 'undefined') {
 	if (!window.customElements.get('nextcloud-booking-widget')) {
-		window.customElements.define('nextcloud-booking-widget', NextcloudBookingWidget)
+		window.customElements.define(
+			'nextcloud-booking-widget',
+			NextcloudBookingWidget,
+		)
 	}
 }
 


### PR DESCRIPTION
## The gap this closes

The fleet is tab-indented in **PHP** (php-cs-fixer via `nextcloud/coding-standard`, `setIndent("\t")`) and in **JS/Vue** (`@nextcloud/eslint-config`, `indent: ['error','tab']`).

**CSS and SCSS were enforced by nothing.** `@nextcloud/stylelint-config` carries no indentation rule on the versions the fleet runs — stylelint 15+ dropped stylistic rules. Where that has bitten: openregister sits at 391 tab-lines against 511 space-lines, opencatalogi's CSS is 100% spaces.

`prettier` with **`@nextcloud/prettier-config`** (`useTabs: true, tabWidth: 4`) is the tool Nextcloud itself uses, and unlike stylelint it covers CSS/SCSS. Follows the pilot, larpingapp#321.

### What the measurement says about *this* app

| shillinq styles | tab-lines | space-lines |
| --- | --- | --- |
| `development` — `*.css`/`*.scss` | 122 | 0 |
| `development` — `<style>` blocks in `*.vue` | 2105 | 0 |
| this branch — total | 2359 | **0** |

Worth being straight about: **shillinq had not drifted.** It was already tab-clean, so there is no repair in this diff. What changes is that the property is now *enforced* by a tool that runs, instead of holding by luck — the same reason a green gate is worth less than a gate that can fail.

## Why `eslint-config-prettier` is not optional

Measured here, by running eslint against a copy of the config with that one line removed: prettier's output leaves **214 eslint errors**, every one a formatting rule disagreeing with prettier. Two formatters with overlapping jurisdiction make a repo *unfixable* — the trap this fleet already hit with php-cs-fixer and PHPCS, where `cs:fix` and `phpcs` demanded opposite things and neither could be satisfied.

So `require('eslint-config-prettier')` is spread **last**, after `...conductionVue3Fixes`, where it can only turn rules off. Verified against the resolved config for `src/App.vue`:

- all **21 `vue/no-deprecated-*` rules still present and still ON** — it disables no correctness rule
- `indent` is now severity `0`, owned by prettier's `useTabs: true` instead

`npm run lint`: **0 errors** (70 pre-existing warnings, unchanged).

## Why the glob is code and styles, not `.`

`nextcloud/forms` runs `prettier --check .`. This fleet cannot. Unrestricted, prettier rewrites markdown and JSON that other tools own:

| path | why that is dangerous |
| --- | --- |
| `openspec/**` | **parsed by the hydra gates** — gate-16 reads `@spec` anchors, gate-19 reads Scenario headings. A formatter and a gate disagreeing about one file is how a gate loses quietly |
| `l10n/**` | written by the translation workflow |
| `lib/Settings/**.json` | OpenRegister register/schema config, read at install and parsed by the manifest gates |

So the glob is `**/*.{js,ts,vue,css,scss}` — layout-independent, because app styles live under `css/` in some repos and `src/` in others — with build output, `docusaurus/` and `website/` in `.prettierignore`.

Asserted on this branch: `git diff --name-only | grep -cE '^(openspec|l10n|lib/Settings|docs|\.vscode)/'` is **0**.

## Verified on this branch

| check | result |
| --- | --- |
| `npm run format` | clean |
| `npm run lint` | **exit 0**, 0 errors |
| `npm run stylelint` | exit 0 |
| `npm run test:unit` | **171/171**, 15 files |
| `npm run build` | webpack compiles |
| non-code paths touched | **0** |

The resolved config was asserted *before* formatting, because a prettier run that finds no config silently falls back to defaults and writes **double quotes**, which `@nextcloud/prettier-config` forbids — and it looks like a successful run. It reads `useTabs=true tabWidth=4 singleQuote=true semi=false printWidth=85`.

## Expected red

`development` is already red on **phpstan, psalm, phpmd and Newman**. Those are not this PR's doing and this PR touches no PHP. Compare against the same job on `development` before attributing anything here.
