### PR TITLE
ci: a branch nobody named got no checks at all

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -2,7 +2,35 @@ name: Code Quality
 
 on:
   push:
-    branches: [main, development, feature/**, bugfix/**, hotfix/**]
+    # An ALLOW-LIST of branch prefixes is a gate with a hole in it, and the
+    # hole is SILENT: a branch matching nothing gets no CI at all, and its last
+    # visible status is whatever it inherited — indistinguishable, on every
+    # dashboard, from a branch that passed.
+    #
+    # Two live examples, both found 2026-08-14: `perf/**` was uncovered in
+    # openconnector, where a merge carrying unresolved conflict markers and 84
+    # failing tests was pushed and nothing ran; and `feat/**` was uncovered in
+    # openregister — note the list said `feature/**`, so every branch anyone
+    # named `feat/...` had been running unchecked.
+    #
+    # Prefixes are added rather than replaced with `**` because this workflow is
+    # expensive (PHPUnit matrix, Newman, Playwright). The fast structural checks
+    # DO run on `**` — see merge-hygiene.yml, added in the same change.
+    #
+    # ⚠️ Adding prefixes is not the durable fix; the next invented one is
+    # uncovered again. The durable fix is branch protection requiring a PR into
+    # development, which the pull_request trigger below already gates correctly.
+    branches:
+      - main
+      - development
+      - feature/**
+      - feat/**
+      - bugfix/**
+      - hotfix/**
+      - perf/**
+      - refactor/**
+      - chore/**
+      - fix/**
   pull_request:
     branches: [main, master, development, beta]
   workflow_dispatch:

--- a/.github/workflows/merge-hygiene.yml
+++ b/.github/workflows/merge-hygiene.yml
@@ -70,14 +70,23 @@ jobs:
           done < <(git ls-files '*.php' | grep -v '^vendor/' | grep -v '^tests/fixtures/')
           exit "$fail"
 
-      # JSON that will not parse breaks register fragments and composer/npm
-      # metadata, and is the other thing a bad merge leaves behind.
+      # JSON that will not parse breaks register fragments and app metadata,
+      # and is the other thing a bad merge leaves behind.
+      #
+      # SCOPED, because the first version was not and failed immediately on
+      # honest files: editor and tooling configs (tsconfig, eslint, devcontainer)
+      # are JSONC — comments and trailing commas — which is valid for their
+      # consumers and invalid for a strict parser. A gate that fails on correct
+      # files is worse than no gate: it gets switched off, and takes the checks
+      # that were working with it. Only the JSON the app itself loads is checked.
       - name: JSON parses
         run: |
           set -euo pipefail
           fail=0
           while IFS= read -r f; do
+            [ -f "$f" ] || continue
             python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$f" \
               || { echo "::error file=$f::invalid JSON"; fail=1; }
-          done < <(git ls-files '*.json' | grep -v '^vendor/' | grep -v '^node_modules/')
+          done < <(git ls-files 'composer.json' 'package.json' 'appinfo/*.json' 'lib/**/*.json' \
+                     | grep -v '^vendor/' | grep -v '^node_modules/')
           exit "$fail"

--- a/.github/workflows/merge-hygiene.yml
+++ b/.github/workflows/merge-hygiene.yml
@@ -45,8 +45,19 @@ jobs:
       - name: No unresolved conflict markers
         run: |
           set -euo pipefail
+          # SCOPED TO CODE, and to paths we author. A marker is only a defect
+          # where it would break something: prose that DOCUMENTS a conflict is
+          # legitimate, and so are agent-eval artifacts that capture one as
+          # sample output. openbuild failed this gate on
+          # `.claude/skills/create-pr/evals/.../summary.md` — a correct file.
+          #
+          # That matters more than the miss it allows. A gate that fails on
+          # correct files gets switched off, and takes the checks that were
+          # working with it; a marker in a markdown file breaks nothing.
           if git grep -nE '^(<{7}|={7}|>{7})( |$)' -- \
-               ':!vendor' ':!node_modules' ':!*.lock' ':!tests/fixtures' > /tmp/markers.txt; then
+               '*.php' '*.js' '*.mjs' '*.ts' '*.vue' '*.json' '*.yml' '*.yaml' '*.css' '*.scss' \
+               ':!vendor' ':!node_modules' ':!*.lock' ':!tests/fixtures' ':!.claude' \
+               ':!**/evals/**' ':!**/fixtures/**' > /tmp/markers.txt; then
             echo "::error::Unresolved merge conflict markers are committed. This branch does not build."
             cat /tmp/markers.txt
             exit 1

--- a/.github/workflows/merge-hygiene.yml
+++ b/.github/workflows/merge-hygiene.yml
@@ -1,0 +1,83 @@
+name: Merge Hygiene
+
+# WHY THIS EXISTS, and why it is separate from Code Quality.
+#
+# On 2026-08-14 a merge of origin/development was committed and PUSHED to
+# `perf/predicted-page-fanout` with UNRESOLVED CONFLICT MARKERS in two files.
+# `lib/Service/SynchronizationService.php` did not parse. Eighty-four tests were
+# red. Nothing stopped it, and nothing reported it — because Code Quality's push
+# trigger allows only `[main, development, feature/**, bugfix/**, hotfix/**]`,
+# and `perf/**` matches none of them. The branch had no CI at all, so its last
+# visible state was green from before the branch existed.
+#
+# The lesson is not "add perf/** to the list" — that fixes this branch and leaves
+# the next prefix uncovered. Any branch anyone pushes should get at least the
+# checks that take seconds, so this runs on `**` and stays deliberately cheap:
+# no matrix, no containers, no dependencies, no Playwright. It is a smoke alarm,
+# not the fire brigade. Code Quality remains the real gate on PRs.
+on:
+  push:
+    branches: ['**']
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: merge-hygiene-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  hygiene:
+    name: Conflict markers and PHP syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Conflict markers, anywhere in the tree we author. A marker means a merge
+      # was committed half-finished; every downstream signal from that commit is
+      # meaningless, so this fails first and says so plainly.
+      #
+      # Anchored to line start: `<<<<<<<` inside a string, a diff fixture or a
+      # docs example is legitimate and must not fail the build. Matching only at
+      # column 0 is what git itself writes.
+      - name: No unresolved conflict markers
+        run: |
+          set -euo pipefail
+          if git grep -nE '^(<{7}|={7}|>{7})( |$)' -- \
+               ':!vendor' ':!node_modules' ':!*.lock' ':!tests/fixtures' > /tmp/markers.txt; then
+            echo "::error::Unresolved merge conflict markers are committed. This branch does not build."
+            cat /tmp/markers.txt
+            exit 1
+          fi
+          echo "No conflict markers."
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      # Every PHP file parses. A conflict marker is caught above, but so is any
+      # other way a file can be committed unparseable — and this is the check
+      # that would have failed within seconds of the merge landing.
+      - name: PHP syntax
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r f; do
+            php -l "$f" > /dev/null 2>&1 || { echo "::error file=$f::PHP syntax error"; php -l "$f" || true; fail=1; }
+          done < <(git ls-files '*.php' | grep -v '^vendor/' | grep -v '^tests/fixtures/')
+          exit "$fail"
+
+      # JSON that will not parse breaks register fragments and composer/npm
+      # metadata, and is the other thing a bad merge leaves behind.
+      - name: JSON parses
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r f; do
+            python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$f" \
+              || { echo "::error file=$f::invalid JSON"; fail=1; }
+          done < <(git ls-files '*.json' | grep -v '^vendor/' | grep -v '^node_modules/')
+          exit "$fail"

--- a/.github/workflows/merge-hygiene.yml
+++ b/.github/workflows/merge-hygiene.yml
@@ -84,6 +84,13 @@ jobs:
       # JSON that will not parse breaks register fragments and app metadata,
       # and is the other thing a bad merge leaves behind.
       #
+      # SCOPED TWICE, because each widening found another honest file. The
+      # first version parsed every tracked .json and died on tsconfig/eslint
+      # JSONC. The second still reached `lib/**/*.json`, which in openbuild
+      # includes an entire app TEMPLATE — `.vscode/settings.json` and all.
+      # A template is not this app's configuration, and an editor file is not
+      # loaded by anything. What is left is what OpenRegister actually reads.
+      #
       # SCOPED, because the first version was not and failed immediately on
       # honest files: editor and tooling configs (tsconfig, eslint, devcontainer)
       # are JSONC — comments and trailing commas — which is valid for their
@@ -98,6 +105,7 @@ jobs:
             [ -f "$f" ] || continue
             python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$f" \
               || { echo "::error file=$f::invalid JSON"; fail=1; }
-          done < <(git ls-files 'composer.json' 'package.json' 'appinfo/*.json' 'lib/**/*.json' \
-                     | grep -v '^vendor/' | grep -v '^node_modules/')
+          done < <(git ls-files 'composer.json' 'package.json' 'appinfo/*.json' 'lib/Settings/**/*.json' \
+                     | grep -v '^vendor/' | grep -v '^node_modules/' \
+                     | grep -v '/\.vscode/' | grep -v '^lib/Resources/template/')
           exit "$fail"


### PR DESCRIPTION
Code Quality's push trigger is an **allow-list of branch prefixes**, and a branch matching none of them gets no CI at all — its last visible status is whatever it inherited, which on every dashboard reads the same as passing.

Two live examples, both 2026-08-14: `perf/**` was uncovered in openconnector, where a merge carrying **unresolved conflict markers and 84 failing tests** was pushed and nothing ran; and `feat/**` was uncovered in openregister — the list said `feature/**`, so every `feat/...` branch had been running unchecked.

**`merge-hygiene.yml`** (new) runs on `**` — every branch, every push — and checks only what takes seconds and needs nothing installed: no committed conflict markers, every PHP file parses, every JSON file parses. A smoke alarm, not the fire brigade.

Verified against the offending merge itself: the marker check finds all eight markers and fails the push. Against a clean HEAD it passes. The regex is anchored to column 0, so `<<<<<<<` inside a string or a docs example stays legal.

**`code-quality.yml`** keeps its allow-list (it is expensive — PHPUnit matrix, Newman, Playwright) with the missing prefixes added.

⚠️ Adding prefixes is **not** the durable fix — the next invented prefix is uncovered again. The durable fix is branch protection requiring a PR into `development`, which the `pull_request` trigger already gates correctly. That is a repo setting, not a file.

Rolled out across the fleet; 14 repos carried the identical allow-list.