### PR TITLE
fix(security): rate-limit the last nine public endpoints

### DIFF
--- a/lib/Controller/BarcodeLookupController.php
+++ b/lib/Controller/BarcodeLookupController.php
@@ -37,6 +37,7 @@ namespace OCA\Shillinq\Controller;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
@@ -106,6 +107,10 @@ class BarcodeLookupController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// Barcode lookup against published product data — the code is a GTIN, not
+	// a credential, so a volume ceiling and no brute-force counter. Loose,
+	// because a scanner in a stockroom fires these in rapid succession.
+	#[AnonRateLimit(limit: 240, period: 60)]
 	public function lookup(string $code, ?string $uomCode = null): JSONResponse {
 		$guardResponse = $this->guard();
 		if ($guardResponse instanceof JSONResponse) {

--- a/lib/Controller/DepositWebhookController.php
+++ b/lib/Controller/DepositWebhookController.php
@@ -34,6 +34,7 @@ use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Service\DepositReconciliationService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
@@ -84,6 +85,10 @@ class DepositWebhookController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// Payment gateway callback: the caller retries on its own schedule and
+	// authenticates by its own signature. Generous ceiling — dropping a
+	// deposit notification is worse than absorbing a burst.
+	#[AnonRateLimit(limit: 300, period: 60)]
 	public function handle(string $gateway): JSONResponse {
 		$gateway = strtolower($gateway);
 		if (in_array($gateway, ['mollie', 'stripe'], true) === false) {

--- a/lib/Controller/PaymentRequestWebhookController.php
+++ b/lib/Controller/PaymentRequestWebhookController.php
@@ -47,6 +47,7 @@ use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Service\PaymentReconciliationService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
@@ -100,6 +101,7 @@ class PaymentRequestWebhookController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 300, period: 60)]
 	public function handle(string $gateway): JSONResponse {
 		$gateway = strtolower($gateway);
 		if (in_array($gateway, ['mollie', 'stripe'], true) === false) {

--- a/lib/Controller/PayrollWebhookController.php
+++ b/lib/Controller/PayrollWebhookController.php
@@ -36,6 +36,7 @@ namespace OCA\Shillinq\Controller;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
@@ -86,6 +87,8 @@ class PayrollWebhookController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// Payroll provider integration surface — machine caller, own credential.
+	#[AnonRateLimit(limit: 300, period: 60)]
 	public function info(): JSONResponse {
 		return new JSONResponse(
 			data: ['message' => 'Payroll webhook accepts POST with a signed CloudEvent only.'],
@@ -109,6 +112,7 @@ class PayrollWebhookController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 300, period: 60)]
 	public function receive(): JSONResponse {
 		$rawBody = (string)file_get_contents('php://input');
 

--- a/lib/Controller/PortalPaymentInitiationController.php
+++ b/lib/Controller/PortalPaymentInitiationController.php
@@ -42,6 +42,7 @@ use OCA\Shillinq\Portal\PortalAssertionVerifier;
 use OCA\Shillinq\Service\Payment\PortalPaymentSessionService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
@@ -101,6 +102,10 @@ class PortalPaymentInitiationController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// Citizen-facing: starts a payment. Tighter than the receivers because a
+	// human clicks this, and each call creates a payment intent at the
+	// provider — real work, and real cost, per request.
+	#[AnonRateLimit(limit: 20, period: 60)]
 	public function initiate(): JSONResponse {
 		// 1. Verify — the assertion is the ONLY credential (fail-closed 401).
 		$claims = $this->verifier->verify((string)$this->request->getHeader(PortalAssertionVerifier::HEADER));

--- a/lib/Controller/WidgetApiController.php
+++ b/lib/Controller/WidgetApiController.php
@@ -38,6 +38,7 @@ use OCA\Shillinq\Service\WidgetAuthService;
 use OCA\Shillinq\Service\WidgetService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AnonRateLimit;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
@@ -98,6 +99,10 @@ class WidgetApiController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// Public booking widget. These back a citizen-facing embed: services and
+	// slots are read repeatedly as someone picks a date, so the ceiling is
+	// generous. No credential in play, so no brute-force counter.
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function services(): JSONResponse {
 		$authResult = $this->guard();
 		if ($authResult instanceof JSONResponse) {
@@ -177,6 +182,7 @@ class WidgetApiController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	#[AnonRateLimit(limit: 120, period: 60)]
 	public function slots(string $serviceId = '', string $resourceId = '', string $date = ''): JSONResponse {
 		$authResult = $this->guard();
 		if ($authResult instanceof JSONResponse) {
@@ -245,6 +251,9 @@ class WidgetApiController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
+	// Tighter than its siblings: this one BOOKS. services/slots are reads a
+	// visitor repeats while choosing; a booking is a write and a commitment.
+	#[AnonRateLimit(limit: 20, period: 60)]
 	public function appointments(
 		string $serviceId = '',
 		string $resourceId = '',


### PR DESCRIPTION
Closes shillinq's public surface — barcode lookup, deposit/payment-request/payroll webhooks (4), portal payment initiation, booking widget (3). **shillinq now reports zero unthrottled `#[PublicPage]` endpoints.**

No brute-force counters: the receivers authenticate by the caller's own provider signature, the barcode is a GTIN, and the widget reads published availability. None takes a guessable secret.

### Limits split three ways, on purpose

- **300/60 — machine receivers.** They retry on their own schedule; bursts are normal. Tight limits here drop payment and payroll notifications *on the provider's side*, where the failure is invisible to us.
- **240/60 — barcode lookup.** A stockroom scanner fires these in rapid succession; anything tighter breaks the actual use.
- **120/60 reads vs 20/60 writes in the widget.** `services`/`slots` are repeated while a visitor picks a date. `appointments()` **books**, and payment `initiate()` **creates a payment intent at the provider**. A read a human repeats and a write that commits money shouldn't share a ceiling.

### Verification

Full suite: **4121 tests, identical before and after.**

Completes the ADR-081/082 sweep for shillinq (ConductionNL/hydra#554).