### PR TITLE
refactor(deps): inject OpenRegister instead of looking it up (ADR-083)

### DIFF
--- a/lib/BackgroundJob/BookingReminderJob.php
+++ b/lib/BackgroundJob/BookingReminderJob.php
@@ -30,8 +30,8 @@ use OCA\Shillinq\Service\BookingNotificationService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Hourly cron job that evaluates reminder triggers for upcoming bookings.
@@ -77,9 +77,9 @@ class BookingReminderJob extends TimedJob {
 	public function __construct(
 		ITimeFactory $time,
 		private BookingNotificationService $notificationService,
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 		parent::__construct(time: $time);
 		// Run every hour.
@@ -134,7 +134,6 @@ class BookingReminderJob extends TimedJob {
 	 */
 	private function processReminderWindow(int $windowMinutes): int {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->appConfig->getValueString(Application::APP_ID, 'register', 'shillinq');
 			if ($registerSlug === '') {
 				$registerSlug = 'shillinq';
@@ -146,7 +145,7 @@ class BookingReminderJob extends TimedJob {
 
 			// ADR-022: use the real ObjectService fluent API (setRegister/setSchema/findAll);
 			// findObjects() does not exist on OpenRegister's ObjectService.
-			$bookings = $objectService
+			$bookings = $this->objectService
 				->setRegister($registerSlug)
 				->setSchema('Booking')
 				->findAll(

--- a/lib/Consolidation/ConsolidationGuard.php
+++ b/lib/Consolidation/ConsolidationGuard.php
@@ -31,8 +31,8 @@ namespace OCA\Shillinq\Consolidation;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Guards financial-statement lifecycle transitions.
@@ -53,9 +53,9 @@ class ConsolidationGuard {
 	 * @param LoggerInterface $logger Nextcloud logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -105,8 +105,7 @@ class ConsolidationGuard {
 			// findObject() does not exist — it raised an Error that the
 			// \Throwable arm below swallowed into `return false`, so this
 			// guard denied EVERY finalise without ever reading a FiscalYear.
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$fiscalYear = $objectService->find(
+			$fiscalYear = $this->objectService->find(
 				id: $fiscalYearId,
 				register: $this->getRegisterSlug(),
 				schema: 'FiscalYear'
@@ -161,8 +160,7 @@ class ConsolidationGuard {
 
 		try {
 			// ADR-022: find(), not findObject() — see requireFiscalPeriodClosed().
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$consolidationGroup = $objectService->find(
+			$consolidationGroup = $this->objectService->find(
 				id: $consolidationGroupId,
 				register: $this->getRegisterSlug(),
 				schema: 'ConsolidationGroup'
@@ -182,7 +180,7 @@ class ConsolidationGuard {
 			}
 
 			foreach ($administrationIds as $administrationId) {
-				$balanceSheets = $objectService
+				$balanceSheets = $this->objectService
 					->setRegister($this->getRegisterSlug())
 					->setSchema('BalanceSheet')
 					->findAll(

--- a/lib/Controller/BankStatementImportController.php
+++ b/lib/Controller/BankStatementImportController.php
@@ -48,8 +48,8 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * HTTP API for importing a bank statement file into BankStatement + lines.
@@ -90,9 +90,9 @@ class BankStatementImportController extends Controller {
 		IRequest $request,
 		private readonly StatementParser $parser,
 		private readonly AdministrationContextService $administrationContext,
-		private readonly ContainerInterface $container,
 		private readonly IUserSession $session,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -144,10 +144,9 @@ class BankStatementImportController extends Controller {
 				);
 			}
 
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
 			$transactionCount = count($parsed);
-			$statement = $objectService
+			$statement = $this->objectService
 				->setRegister(self::REGISTER_SLUG)
 				->setSchema('BankStatement')
 				->saveObject(
@@ -166,7 +165,7 @@ class BankStatementImportController extends Controller {
 			$lineNumber = 0;
 			foreach ($parsed as $line) {
 				$lineNumber++;
-				$objectService
+				$this->objectService
 					->setRegister(self::REGISTER_SLUG)
 					->setSchema('BankStatementLine')
 					->saveObject($this->mapLine(line: $line, statementId: $statementId, admin: $admin, lineNumber: $lineNumber));

--- a/lib/Controller/BookingNotificationController.php
+++ b/lib/Controller/BookingNotificationController.php
@@ -36,8 +36,8 @@ use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * REST endpoints for notification trigger configuration and admin monitoring.
@@ -65,11 +65,11 @@ class BookingNotificationController extends Controller {
 	public function __construct(
 		IRequest $request,
 		private SettingsService $settingsService,
-		private ContainerInterface $container,
 		private IGroupManager $groupManager,
 		private IUserSession $userSession,
 		private LoggerInterface $logger,
 		private AdministrationContextService $administrationContext,
+		private readonly ObjectService $objectService,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -92,10 +92,9 @@ class BookingNotificationController extends Controller {
 		$this->authorizeBookingAccess(bookingId: $id);
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->settingsService->getRegisterSlug();
 
-			$triggers = $objectService
+			$triggers = $this->objectService
 				->setRegister($registerSlug)
 				->setSchema('BookingNotificationTrigger')
 				->findAll(['filters' => ['bookingId' => $id], 'limit' => 100]);
@@ -132,13 +131,12 @@ class BookingNotificationController extends Controller {
 		}
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->settingsService->getRegisterSlug();
 
 			$saved = [];
 			foreach ($data['triggers'] as $triggerData) {
 				$triggerData['bookingId'] = $id;
-				$saved[] = $objectService->saveObject(
+				$saved[] = $this->objectService->saveObject(
 					object: $triggerData,
 					register: $registerSlug,
 					schema: 'BookingNotificationTrigger',
@@ -167,22 +165,21 @@ class BookingNotificationController extends Controller {
 	#[NoCSRFRequired]
 	public function getNotificationMonitor(): JSONResponse {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->settingsService->getRegisterSlug();
 
 			$todayStart = (new DateTimeImmutable('today', new DateTimeZone('UTC')))->format('c');
 			$weekStart = (new DateTimeImmutable('-7 days', new DateTimeZone('UTC')))->format('c');
 			$monthStart = (new DateTimeImmutable('-30 days', new DateTimeZone('UTC')))->format('c');
 
-			$todayDeliveries = $objectService
+			$todayDeliveries = $this->objectService
 				->setRegister($registerSlug)
 				->setSchema('NotificationDelivery')
 				->findAll(['filters' => ['sentAt[gte]' => $todayStart], 'limit' => 1000]);
-			$weekDeliveries = $objectService
+			$weekDeliveries = $this->objectService
 				->setRegister($registerSlug)
 				->setSchema('NotificationDelivery')
 				->findAll(['filters' => ['sentAt[gte]' => $weekStart], 'limit' => 5000]);
-			$monthDeliveries = $objectService
+			$monthDeliveries = $this->objectService
 				->setRegister($registerSlug)
 				->setSchema('NotificationDelivery')
 				->findAll(['filters' => ['sentAt[gte]' => $monthStart], 'limit' => 10000]);
@@ -223,10 +220,9 @@ class BookingNotificationController extends Controller {
 	#[AuthorizedAdminSetting(Application::APP_ID)]
 	public function disableAllTriggers(): JSONResponse {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->settingsService->getRegisterSlug();
 
-			$triggers = $objectService
+			$triggers = $this->objectService
 				->setRegister($registerSlug)
 				->setSchema('BookingNotificationTrigger')
 				->findAll(['filters' => ['active' => true], 'limit' => 1000]);
@@ -234,7 +230,7 @@ class BookingNotificationController extends Controller {
 			$disabled = 0;
 			foreach ($triggers as $trigger) {
 				$trigger['active'] = false;
-				$objectService->saveObject(
+				$this->objectService->saveObject(
 					object: $trigger,
 					register: $registerSlug,
 					schema: 'BookingNotificationTrigger',
@@ -289,14 +285,13 @@ class BookingNotificationController extends Controller {
 		}
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->settingsService->getRegisterSlug();
 
 			// ADR-022: the real ObjectService API is find()/findAll().
 			// findObject() does not exist — calling it raised an Error that the
 			// \Throwable arm below turned into a blanket 403, so this guard
 			// denied EVERY non-admin instead of checking anything.
-			$booking = $objectService->find(
+			$booking = $this->objectService->find(
 				id: $bookingId,
 				register: $registerSlug,
 				schema: 'Booking'

--- a/lib/Controller/CBSSubmissionController.php
+++ b/lib/Controller/CBSSubmissionController.php
@@ -49,8 +49,8 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * CBS Submission CRUD + lifecycle controller.
@@ -80,11 +80,11 @@ class CBSSubmissionController extends Controller {
 	 */
 	public function __construct(
 		IRequest $request,
-		private readonly ContainerInterface $container,
 		private readonly CBSExportService $exportService,
 		private readonly IAppConfig $appConfig,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -540,7 +540,7 @@ class CBSSubmissionController extends Controller {
 	 * @return object The ObjectService instance.
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Controller/IcpController.php
+++ b/lib/Controller/IcpController.php
@@ -44,8 +44,8 @@ use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * GET ICP ledger / reconciliation / periodicity endpoints.
@@ -80,9 +80,9 @@ class IcpController extends Controller {
 		private readonly IcpFilingService $filingService,
 		private readonly ViesService $viesService,
 		private readonly ArInvoiceIcpPdfRenderer $pdfRenderer,
-		private readonly ContainerInterface $container,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -474,9 +474,7 @@ class IcpController extends Controller {
 	 * @return array{invoice:?array<string,mixed>,customer:array<string,mixed>,seller:array<string,mixed>}
 	 */
 	private function loadInvoiceContext(string $invoiceId, string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-
-		$invoices = $objectService
+		$invoices = $this->objectService
 			->setRegister('shillinq')
 			->setSchema('ARInvoice')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -499,7 +497,7 @@ class IcpController extends Controller {
 		$customer = [];
 		$customerKey = trim((string)($invoice['customerId'] ?? ''));
 		if ($customerKey !== '') {
-			$candidates = $objectService
+			$candidates = $this->objectService
 				->setRegister('shillinq')
 				->setSchema('CustomerMaster')
 				->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -517,7 +515,7 @@ class IcpController extends Controller {
 		}
 
 		$seller = [];
-		$administrations = $objectService
+		$administrations = $this->objectService
 			->setRegister('shillinq')
 			->setSchema('Administration')
 			->findAll(['filters' => []]);

--- a/lib/Controller/InvoiceApiController.php
+++ b/lib/Controller/InvoiceApiController.php
@@ -48,8 +48,8 @@ use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * HTTP API for BillableInvoice drafting + posting.
@@ -70,10 +70,10 @@ class InvoiceApiController extends Controller {
 		IRequest $request,
 		private readonly InvoiceGenerationService $service,
 		private readonly InvoicePdfGenerator $pdfGenerator,
-		private readonly ContainerInterface $container,
 		private readonly IUserSession $session,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -140,8 +140,7 @@ class InvoiceApiController extends Controller {
 				$filters['status'] = $status;
 			}
 
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$all = $objectService
+			$all = $this->objectService
 				->setRegister('shillinq')
 				->setSchema('BillableInvoice')
 				->findAll(['filters' => $filters]);
@@ -174,9 +173,8 @@ class InvoiceApiController extends Controller {
 
 		try {
 			$admin = $this->resolveAdministrationId();
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
-			$invoice = $objectService
+			$invoice = $this->objectService
 				->setRegister('shillinq')
 				->setSchema('BillableInvoice')
 				->find($invoiceId);
@@ -189,7 +187,7 @@ class InvoiceApiController extends Controller {
 				return new JSONResponse(['error' => 'Forbidden'], Http::STATUS_FORBIDDEN);
 			}
 
-			$lines = $objectService
+			$lines = $this->objectService
 				->setRegister('shillinq')
 				->setSchema('BillableInvoiceLine')
 				->findAll(['filters' => ['invoiceId' => $invoiceId]]);
@@ -229,8 +227,7 @@ class InvoiceApiController extends Controller {
 
 		try {
 			$admin = $this->resolveAdministrationId();
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$invoice = $objectService->setRegister('shillinq')->setSchema('BillableInvoice')->find($invoiceId);
+			$invoice = $this->objectService->setRegister('shillinq')->setSchema('BillableInvoice')->find($invoiceId);
 
 			if (is_array($invoice) === false) {
 				return new JSONResponse(['error' => 'Not found'], Http::STATUS_NOT_FOUND);
@@ -273,8 +270,7 @@ class InvoiceApiController extends Controller {
 
 		try {
 			$admin = $this->resolveAdministrationId();
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$invoice = $objectService->setRegister('shillinq')->setSchema('BillableInvoice')->find($invoiceId);
+			$invoice = $this->objectService->setRegister('shillinq')->setSchema('BillableInvoice')->find($invoiceId);
 
 			if (is_array($invoice) === false) {
 				return new JSONResponse(['error' => 'Not found'], Http::STATUS_NOT_FOUND);
@@ -284,7 +280,7 @@ class InvoiceApiController extends Controller {
 				return new JSONResponse(['error' => 'Forbidden'], Http::STATUS_FORBIDDEN);
 			}
 
-			$lines = $objectService
+			$lines = $this->objectService
 				->setRegister('shillinq')
 				->setSchema('BillableInvoiceLine')
 				->findAll(['filters' => ['invoiceId' => $invoiceId]]);

--- a/lib/Controller/PaymentRunController.php
+++ b/lib/Controller/PaymentRunController.php
@@ -51,8 +51,8 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * HTTP API for exporting + reconciling a PaymentRun.
@@ -84,9 +84,9 @@ class PaymentRunController extends Controller {
 		private readonly PaymentRunExportService $exportService,
 		private readonly PaymentRunReconciliationService $reconciliationService,
 		private readonly AdministrationContextService $administrationContext,
-		private readonly ContainerInterface $container,
 		private readonly IUserSession $session,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -204,8 +204,7 @@ class PaymentRunController extends Controller {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$run = $objectService
+		$run = $this->objectService
 			->setRegister(self::REGISTER_SLUG)
 			->setSchema('PaymentRun')
 			->find($id);

--- a/lib/Controller/PayrollWebhookController.php
+++ b/lib/Controller/PayrollWebhookController.php
@@ -41,8 +41,8 @@ use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Receives signed external-payroll CloudEvents and reflects deductions onto Payroll.
@@ -71,8 +71,8 @@ class PayrollWebhookController extends Controller {
 	public function __construct(
 		IRequest $request,
 		private readonly IAppConfig $appConfig,
-		private readonly ContainerInterface $container,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -208,10 +208,9 @@ class PayrollWebhookController extends Controller {
 	 * @return array<string,mixed>|null Summary on success, null when the payroll is unknown.
 	 */
 	private function applyEvent(string $eventId, string $payrollId, array $data): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$payrolls = $objectService
+		$payrolls = $this->objectService
 			->setRegister($register)
 			->setSchema('Payroll')
 			->findAll(['filters' => ['id' => $payrollId]]);
@@ -256,7 +255,7 @@ class PayrollWebhookController extends Controller {
 				$rate = (float)$deduction['rate'];
 			}
 
-			$objectService
+			$this->objectService
 				->setRegister($register)
 				->setSchema('Deduction')
 				->saveObject(
@@ -277,7 +276,7 @@ class PayrollWebhookController extends Controller {
 		// Reflect the external calculation and stamp the idempotency reference.
 		$payroll['status'] = 'calculated';
 		$payroll['externalReference'] = $eventId;
-		$objectService
+		$this->objectService
 			->setRegister($register)
 			->setSchema('Payroll')
 			->saveObject($payroll);

--- a/lib/Controller/SupplierInvoiceImportController.php
+++ b/lib/Controller/SupplierInvoiceImportController.php
@@ -55,9 +55,9 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * HTTP API for the dashboard "Import bill" modal (shillinq-bill-import-modal).
@@ -100,8 +100,8 @@ class SupplierInvoiceImportController extends Controller {
 		private readonly SupplierInvoiceService $supplierInvoiceService,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly IUserSession $session,
-		private readonly ContainerInterface $container,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -307,8 +307,7 @@ class SupplierInvoiceImportController extends Controller {
 		}
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister(self::REGISTER_SLUG)
 				->setSchema(self::SUPPLIER_INVOICE_SCHEMA)
 				->findAll(
@@ -350,8 +349,7 @@ class SupplierInvoiceImportController extends Controller {
 	 * @spec openspec/specs/shillinq-bill-import-modal/spec.md
 	 */
 	private function saveSupplierInvoice(array $record): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$result = $objectService
+		$result = $this->objectService
 			->setRegister(self::REGISTER_SLUG)
 			->setSchema(self::SUPPLIER_INVOICE_SCHEMA)
 			->saveObject($record);

--- a/lib/Guard/AccountBalanceGuard.php
+++ b/lib/Guard/AccountBalanceGuard.php
@@ -29,8 +29,8 @@ namespace OCA\Shillinq\Guard;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Guards Account lifecycle transitions + closing-account uniqueness.
@@ -52,9 +52,9 @@ class AccountBalanceGuard {
 	 * @param LoggerInterface $logger Nextcloud logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -102,7 +102,7 @@ class AccountBalanceGuard {
 		// so that "OR absent" (permit) and "computation failed" (deny, fail-closed)
 		// remain two distinct, independently observable outcomes.
 		try {
-			$this->container->get('OCA\OpenRegister\Service\ObjectService');
+			$this->objectService;
 		} catch (\Throwable) {
 			$this->logger->debug(
 				'AccountBalanceGuard: ObjectService not present (T1 state) — archive permitted by default',
@@ -116,7 +116,6 @@ class AccountBalanceGuard {
 		// The ObjectService is resolved again inside this guarded block so a failure
 		// to resolve it for the computation path also denies (rather than permits).
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			// Page through all GLLine records in batches to avoid hitting the
 			// default findAll() limit when an account has many postings (L1).
 			$pageSize = 500;
@@ -124,7 +123,7 @@ class AccountBalanceGuard {
 			$lines = [];
 			$batchSize = 0;
 			do {
-				$batch = $objectService
+				$batch = $this->objectService
 					->setRegister($this->getRegisterSlug())
 					->setSchema('GLLine')
 					->findAll(
@@ -183,10 +182,9 @@ class AccountBalanceGuard {
 		}
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			// No LIMIT: we need ALL closing accounts in the administration so we
 			// can correctly exclude the current record and count the remainder (L2).
-			$existing = $objectService
+			$existing = $this->objectService
 				->setRegister($this->getRegisterSlug())
 				->setSchema('Account')
 				->findAll(

--- a/lib/Guard/BankReconciliationGuard.php
+++ b/lib/Guard/BankReconciliationGuard.php
@@ -33,8 +33,8 @@ namespace OCA\Shillinq\Guard;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Guards BankReconciliation + BankReconciliationMatch lifecycle invariants.
@@ -57,9 +57,9 @@ class BankReconciliationGuard {
 	 * @param LoggerInterface $logger Nextcloud logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -297,8 +297,7 @@ class BankReconciliationGuard {
 			$reconciledCents = $openingCents + $approvedCents;
 			$varianceCents = $closingCents - $reconciledCents;
 
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$objectService
+			$this->objectService
 				->setRegister($this->getRegisterSlug())
 				->setSchema('BankReconciliation')
 				->updateObject(
@@ -331,14 +330,12 @@ class BankReconciliationGuard {
 	 * @return array<int, array<string, mixed>> The match object arrays.
 	 */
 	private function findMatches(string $reconciliationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-
 		$pageSize = 500;
 		$page = 1;
 		$matches = [];
 		$batchSize = 0;
 		do {
-			$batch = $objectService
+			$batch = $this->objectService
 				->setRegister($this->getRegisterSlug())
 				->setSchema('BankReconciliationMatch')
 				->findAll(
@@ -367,8 +364,7 @@ class BankReconciliationGuard {
 	 */
 	private function fetchObject(string $schema, string $id): ?array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->getRegisterSlug())
 				->setSchema($schema)
 				->find($id);

--- a/lib/Guard/CreditLimitGuard.php
+++ b/lib/Guard/CreditLimitGuard.php
@@ -32,8 +32,8 @@ namespace OCA\Shillinq\Guard;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Guards the ARInvoice `issue` transition against the customer credit limit.
@@ -67,9 +67,9 @@ class CreditLimitGuard {
 	 * @param LoggerInterface $logger Nextcloud logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -124,11 +124,10 @@ class CreditLimitGuard {
 		}
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->getRegisterSlug();
 
 			// Resolve the customer to read their credit limit.
-			$customers = $objectService
+			$customers = $this->objectService
 				->setRegister($registerSlug)
 				->setSchema('CustomerMaster')
 				->findAll(
@@ -213,7 +212,7 @@ class CreditLimitGuard {
 		$batchSize = 0;
 
 		do {
-			$batch = $objectService
+			$batch = $this->objectService
 				->setRegister($registerSlug)
 				->setSchema('ARInvoice')
 				->findAll(

--- a/lib/Guard/RateScheduleOverlapGuard.php
+++ b/lib/Guard/RateScheduleOverlapGuard.php
@@ -44,8 +44,8 @@ namespace OCA\Shillinq\Guard;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Guards RateSchedule `reactivate` — no other active RateSchedule for the
@@ -65,9 +65,9 @@ class RateScheduleOverlapGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -93,8 +93,7 @@ class RateScheduleOverlapGuard {
 		$expiryDate = ($schedule['expiryDate'] ?? null);
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$siblings = $objectService
+			$siblings = $this->objectService
 				->setRegister($this->register())
 				->setSchema('RateSchedule')
 				->findAll(

--- a/lib/Lifecycle/AnnualReportGuard.php
+++ b/lib/Lifecycle/AnnualReportGuard.php
@@ -46,8 +46,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for AnnualReport opmaken and vaststellen.
@@ -69,9 +69,9 @@ class AnnualReportGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -251,10 +251,9 @@ class AnnualReportGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$reports = $objectService
+		$reports = $this->objectService
 			->setRegister($register)
 			->setSchema('AnnualReport')
 			->findAll(['filters' => ['id' => $annualReportId]]);
@@ -276,10 +275,9 @@ class AnnualReportGuard {
 	 * @return array<string,mixed>|null The BalanceSheet, or null when not found.
 	 */
 	private function resolveBalanceSheet(string $reportId): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$sheets = $objectService
+		$sheets = $this->objectService
 			->setRegister($register)
 			->setSchema('BalanceSheet')
 			->findAll(['filters' => ['reportId' => $reportId]]);

--- a/lib/Lifecycle/AuditorStatementGuard.php
+++ b/lib/Lifecycle/AuditorStatementGuard.php
@@ -40,8 +40,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for the AuditorStatement approve transition.
@@ -61,9 +61,9 @@ class AuditorStatementGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -132,10 +132,9 @@ class AuditorStatementGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$records = $objectService
+		$records = $this->objectService
 			->setRegister($register)
 			->setSchema('AuditorStatement')
 			->findAll(['filters' => ['id' => $statementId]]);

--- a/lib/Lifecycle/BcfClaimGuard.php
+++ b/lib/Lifecycle/BcfClaimGuard.php
@@ -46,8 +46,8 @@ use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Service\BcfClaimService;
 use OCA\Shillinq\Service\BcfCompensationCalculator;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for the BcfClaim draft -> submitted transition.
@@ -69,11 +69,11 @@ class BcfClaimGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly BcfClaimService $claimService,
 		private readonly BcfCompensationCalculator $calculator,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -147,8 +147,7 @@ class BcfClaimGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$claims = $objectService
+		$claims = $this->objectService
 			->setRegister($this->register())
 			->setSchema('BcfClaim')
 			->findAll(['filters' => ['id' => $bcfClaimId]]);
@@ -177,8 +176,7 @@ class BcfClaimGuard {
 	 * @return bool True when the quarter's period is closed.
 	 */
 	private function isQuarterClosed(string $administrationId, string $claimQuarter): bool {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$periods = $objectService
+		$periods = $this->objectService
 			->setRegister($this->register())
 			->setSchema('FiscalPeriod')
 			->findAll(

--- a/lib/Lifecycle/BegrotingswijzigingGuard.php
+++ b/lib/Lifecycle/BegrotingswijzigingGuard.php
@@ -36,8 +36,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for Begrotingswijziging vaststellen.
@@ -57,9 +57,9 @@ class BegrotingswijzigingGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -111,13 +111,12 @@ class BegrotingswijzigingGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->appConfig->getValueString(Application::APP_ID, 'register', 'shillinq');
 		if ($register === '') {
 			$register = 'shillinq';
 		}
 
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($register)
 			->setSchema('Begrotingswijziging')
 			->findAll(['filters' => ['id' => $wijzigingId]]);

--- a/lib/Lifecycle/BudgetOverrunGuard.php
+++ b/lib/Lifecycle/BudgetOverrunGuard.php
@@ -39,8 +39,8 @@ namespace OCA\Shillinq\Lifecycle;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Service\BegrotingswijzigingStacker;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Precondition guard preventing GL lasten postings beyond the authorized budget.
@@ -57,10 +57,10 @@ class BudgetOverrunGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly BegrotingswijzigingStacker $stacker,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -109,15 +109,14 @@ class BudgetOverrunGuard {
 				return false;
 			}
 
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$register = $this->resolveRegister();
 
 			$basis = $this->toRows(
-				rows: $objectService->setRegister($register)->setSchema('Taakveld')
+				rows: $this->objectService->setRegister($register)->setSchema('Taakveld')
 					->findAll(['filters' => ['begrotingId' => $begrotingId]])
 			);
 			$wijzigingen = $this->toRows(
-				rows: $objectService->setRegister($register)->setSchema('Begrotingswijziging')
+				rows: $this->objectService->setRegister($register)->setSchema('Begrotingswijziging')
 					->findAll(['filters' => ['begrotingId' => $begrotingId]])
 			);
 
@@ -128,7 +127,7 @@ class BudgetOverrunGuard {
 			);
 
 			$glLines = $this->toRows(
-				rows: $objectService->setRegister($register)->setSchema('GLLine')
+				rows: $this->objectService->setRegister($register)->setSchema('GLLine')
 					->findAll(['filters' => ['taakveldCode' => $taakveldCode, 'side' => 'debit']])
 			);
 			$alreadyPostedCents = 0;

--- a/lib/Lifecycle/CbcrPillar2Guard.php
+++ b/lib/Lifecycle/CbcrPillar2Guard.php
@@ -55,8 +55,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for the CbCR / Pillar 2 registers.
@@ -77,9 +77,9 @@ class CbcrPillar2Guard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -271,10 +271,9 @@ class CbcrPillar2Guard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($register)
 			->setSchema($schema)
 			->findAll(['filters' => ['id' => $id]]);

--- a/lib/Lifecycle/CcmFindingGuard.php
+++ b/lib/Lifecycle/CcmFindingGuard.php
@@ -44,8 +44,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for the CCM finding triage workflow and the
@@ -67,9 +67,9 @@ class CcmFindingGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -181,10 +181,9 @@ class CcmFindingGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($register)
 			->setSchema($schema)
 			->findAll(['filters' => ['id' => $id]]);

--- a/lib/Lifecycle/ComplianceValidator.php
+++ b/lib/Lifecycle/ComplianceValidator.php
@@ -34,8 +34,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Single-method compliance precondition for TreasuryAccount lifecycle transitions.
@@ -60,9 +60,9 @@ class ComplianceValidator {
 	 * @param LoggerInterface $logger Nextcloud logger for compliance audit logging.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -108,9 +108,7 @@ class ComplianceValidator {
 		}
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-
-			$rules = $objectService
+			$rules = $this->objectService
 				->setRegister($this->getRegisterSlug())
 				->setSchema('BankingRule')
 				->findAll(
@@ -280,7 +278,7 @@ class ComplianceValidator {
 		}
 
 		try {
-			$siblings = $objectService
+			$siblings = $this->objectService
 				->setRegister($this->getRegisterSlug())
 				->setSchema('TreasuryAccount')
 				->findAll(

--- a/lib/Lifecycle/ConsolidationGuard.php
+++ b/lib/Lifecycle/ConsolidationGuard.php
@@ -63,8 +63,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for the commercial consolidation registers.
@@ -102,9 +102,9 @@ class ConsolidationGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -279,10 +279,9 @@ class ConsolidationGuard {
 				return false;
 			}
 
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$register = $this->resolveRegister();
 
-			$entries = $objectService
+			$entries = $this->objectService
 				->setRegister($register)
 				->setSchema('EliminationEntry')
 				->findAll(['filters' => ['consolidationPeriodId' => $periodId]]);
@@ -512,10 +511,9 @@ class ConsolidationGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($register)
 			->setSchema($schema)
 			->findAll(['filters' => ['id' => $id]]);

--- a/lib/Lifecycle/CsrdEsrsGuard.php
+++ b/lib/Lifecycle/CsrdEsrsGuard.php
@@ -48,8 +48,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for the CSRD/ESRS sustainability registers.
@@ -70,9 +70,9 @@ class CsrdEsrsGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -330,10 +330,9 @@ class CsrdEsrsGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($register)
 			->setSchema($schema)
 			->findAll(['filters' => ['id' => $id]]);

--- a/lib/Lifecycle/DBAComplianceGuard.php
+++ b/lib/Lifecycle/DBAComplianceGuard.php
@@ -63,8 +63,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards + pure derivation helpers for the DBA
@@ -118,9 +118,9 @@ class DBAComplianceGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -443,10 +443,9 @@ class DBAComplianceGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($register)
 			->setSchema($schema)
 			->findAll(['filters' => ['id' => $id]]);

--- a/lib/Lifecycle/DualGaapGuard.php
+++ b/lib/Lifecycle/DualGaapGuard.php
@@ -48,8 +48,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for the dual GAAP reporting registers.
@@ -70,9 +70,9 @@ class DualGaapGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -220,10 +220,9 @@ class DualGaapGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($register)
 			->setSchema($schema)
 			->findAll(['filters' => ['id' => $id]]);

--- a/lib/Lifecycle/DunningGuard.php
+++ b/lib/Lifecycle/DunningGuard.php
@@ -51,8 +51,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for the credit-control & dunning registers.
@@ -91,9 +91,9 @@ class DunningGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -350,10 +350,9 @@ class DunningGuard {
 			return '';
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($register)
 			->setSchema('IncassoKostenBerekening')
 			->findAll(['filters' => ['factuurId' => $factuurId]]);
@@ -386,10 +385,9 @@ class DunningGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($register)
 			->setSchema($schema)
 			->findAll(['filters' => ['id' => $id]]);

--- a/lib/Lifecycle/DunningRunExecuteGuard.php
+++ b/lib/Lifecycle/DunningRunExecuteGuard.php
@@ -35,8 +35,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for DunningRun.execute.
@@ -61,9 +61,9 @@ class DunningRunExecuteGuard {
 	 * @param LoggerInterface $logger Logger.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -78,13 +78,12 @@ class DunningRunExecuteGuard {
 	 */
 	public function canExecute(string $runId): bool {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$register = $this->appConfig->getValueString(Application::APP_ID, 'register', 'shillinq');
 			if ($register === '') {
 				$register = 'shillinq';
 			}
 
-			$runs = $objectService
+			$runs = $this->objectService
 				->setRegister($register)
 				->setSchema('DunningRun')
 				->findAll(['filters' => ['id' => $runId]]);
@@ -99,7 +98,7 @@ class DunningRunExecuteGuard {
 				return false;
 			}
 
-			$pauses = $objectService
+			$pauses = $this->objectService
 				->setRegister($register)
 				->setSchema('DunningPauseDispute')
 				->findAll(

--- a/lib/Lifecycle/EuExpenditureGuard.php
+++ b/lib/Lifecycle/EuExpenditureGuard.php
@@ -47,8 +47,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for EuExpenditure declare and submit transitions.
@@ -85,9 +85,9 @@ class EuExpenditureGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -219,8 +219,7 @@ class EuExpenditureGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$entries = $objectService
+		$entries = $this->objectService
 			->setRegister($this->resolveRegister())
 			->setSchema('EuExpenditure')
 			->findAll(['filters' => ['id' => $euExpenditureId], 'limit' => 1]);
@@ -246,8 +245,7 @@ class EuExpenditureGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$projects = $objectService
+		$projects = $this->objectService
 			->setRegister($this->resolveRegister())
 			->setSchema('EuProject')
 			->findAll(['filters' => ['id' => $euProjectId], 'limit' => 1]);
@@ -270,8 +268,7 @@ class EuExpenditureGuard {
 	 * @return bool True when an active EligibilityRule lists the category.
 	 */
 	private function isCostCategoryEligible(string $fonds, string $costCategory): bool {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rules = $objectService
+		$rules = $this->objectService
 			->setRegister($this->resolveRegister())
 			->setSchema('EligibilityRule')
 			->findAll(['filters' => ['fonds' => $fonds, 'state' => 'active']]);
@@ -302,8 +299,7 @@ class EuExpenditureGuard {
 	 */
 	private function resolveRequiredEvidence(?string $fonds, string $costCategory): array {
 		if ($fonds !== null) {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rules = $objectService
+			$rules = $this->objectService
 				->setRegister($this->resolveRegister())
 				->setSchema('EligibilityRule')
 				->findAll(['filters' => ['fonds' => $fonds, 'state' => 'active']]);
@@ -334,8 +330,7 @@ class EuExpenditureGuard {
 	 * @return array<string> The present document-type enums.
 	 */
 	private function resolvePresentDocumentTypes(string $euExpenditureId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$documents = $objectService
+		$documents = $this->objectService
 			->setRegister($this->resolveRegister())
 			->setSchema('SupportingDocument')
 			->findAll(['filters' => ['euExpenditureId' => $euExpenditureId]]);

--- a/lib/Lifecycle/ExpenseClaimGuard.php
+++ b/lib/Lifecycle/ExpenseClaimGuard.php
@@ -31,8 +31,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for ExpenseClaimEntry submit and post transitions.
@@ -52,9 +52,9 @@ class ExpenseClaimGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -184,7 +184,6 @@ class ExpenseClaimGuard {
 		array $mileageIds,
 		array $perDiemIds,
 	): bool {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->getRegisterSlug();
 
 		$checks = [
@@ -195,7 +194,7 @@ class ExpenseClaimGuard {
 
 		foreach ($checks as $check) {
 			foreach ($check['ids'] as $itemId) {
-				$item = $objectService
+				$item = $this->objectService
 					->setRegister(register: $register)
 					->setSchema(schema: $check['schema'])
 					->find(id: $itemId);
@@ -233,10 +232,9 @@ class ExpenseClaimGuard {
 		$adminId = (string)($claim['administrationId'] ?? '');
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$register = $this->getRegisterSlug();
 
-			$years = $objectService
+			$years = $this->objectService
 				->setRegister(register: $register)
 				->setSchema(schema: 'FiscalYear')
 				->findAll(

--- a/lib/Lifecycle/ExpenseReimbursementGuard.php
+++ b/lib/Lifecycle/ExpenseReimbursementGuard.php
@@ -41,8 +41,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for ExpenseClaimEntry dual-mode settlement
@@ -74,9 +74,9 @@ class ExpenseReimbursementGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -332,7 +332,6 @@ class ExpenseReimbursementGuard {
 		array $mileageIds,
 		array $perDiemIds,
 	): bool {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->getRegisterSlug();
 
 		$checks = [
@@ -348,7 +347,7 @@ class ExpenseReimbursementGuard {
 					continue;
 				}
 
-				$item = $objectService
+				$item = $this->objectService
 					->setRegister($register)
 					->setSchema($check['schema'])
 					->find($stringId);
@@ -409,10 +408,9 @@ class ExpenseReimbursementGuard {
 	 * @return float|null The threshold amount in base currency, or null.
 	 */
 	private function getMarkupApprovalThresholdForPolicy(string $policyId): ?float {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->getRegisterSlug();
 
-		$matches = $objectService
+		$matches = $this->objectService
 			->setRegister($register)
 			->setSchema('ReimbursementPolicy')
 			->findAll(
@@ -484,7 +482,6 @@ class ExpenseReimbursementGuard {
 	 * @return float|null The weighted average, or null when no rates can be resolved.
 	 */
 	private function weightedAverageMarkupRate(array $claim): ?float {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->getRegisterSlug();
 
 		$totalCost = 0.0;
@@ -503,7 +500,7 @@ class ExpenseReimbursementGuard {
 					continue;
 				}
 
-				$item = $objectService
+				$item = $this->objectService
 					->setRegister($register)
 					->setSchema($source['schema'])
 					->find($stringId);
@@ -549,10 +546,9 @@ class ExpenseReimbursementGuard {
 	 * @return bool True when the GL transaction is reversed.
 	 */
 	private function isGlTransactionReversed(string $glTxnId): bool {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->getRegisterSlug();
 
-		$txn = $objectService
+		$txn = $this->objectService
 			->setRegister($register)
 			->setSchema('GLTransaction')
 			->find($glTxnId);

--- a/lib/Lifecycle/FidoTreasuryGuard.php
+++ b/lib/Lifecycle/FidoTreasuryGuard.php
@@ -50,8 +50,8 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Lifecycle;
 
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for the Wet Fido / Treasurystatuut registers.
@@ -89,9 +89,9 @@ class FidoTreasuryGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -379,7 +379,6 @@ class FidoTreasuryGuard {
 	 * @return array<string,mixed>|null The adopted statuut, or null when unavailable.
 	 */
 	private function resolveAdoptedStatuut(string $organisationId, string $statuutId): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
 		if ($statuutId === '' && $organisationId === '') {
@@ -395,7 +394,7 @@ class FidoTreasuryGuard {
 			$filters['organisationId'] = $organisationId;
 		}
 
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($register)
 			->setSchema('Treasurystatuut')
 			->findAll(['filters' => $filters]);
@@ -447,10 +446,9 @@ class FidoTreasuryGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($register)
 			->setSchema($schema)
 			->findAll(['filters' => ['id' => $id]]);

--- a/lib/Lifecycle/FrameworkAgreementDrawdownGuard.php
+++ b/lib/Lifecycle/FrameworkAgreementDrawdownGuard.php
@@ -36,9 +36,9 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Precondition for a framework-agreement call-off: does it fit the remaining ceiling?
@@ -54,9 +54,9 @@ class FrameworkAgreementDrawdownGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -180,8 +180,7 @@ class FrameworkAgreementDrawdownGuard {
 	 * @return array<string,mixed>|null
 	 */
 	private function findOne(string $schema, array $filters): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema($schema)
 			->findAll(['filters' => $filters]);

--- a/lib/Lifecycle/IntercompanyToleranceGuard.php
+++ b/lib/Lifecycle/IntercompanyToleranceGuard.php
@@ -40,8 +40,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for intercompany-match tolerance evaluation.
@@ -61,9 +61,9 @@ class IntercompanyToleranceGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -192,7 +192,6 @@ class IntercompanyToleranceGuard {
 			return [];
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
 		$relationType = $this->lookupRelationType(
 			objectService: $objectService,
@@ -200,7 +199,7 @@ class IntercompanyToleranceGuard {
 			administrationId: $administrationId
 		);
 
-		$rules = $objectService
+		$rules = $this->objectService
 			->setRegister($this->getRegisterSlug())
 			->setSchema('ToleranceRule')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -222,7 +221,7 @@ class IntercompanyToleranceGuard {
 			return '';
 		}
 
-		$relations = $objectService
+		$relations = $this->objectService
 			->setRegister($this->getRegisterSlug())
 			->setSchema('IntercompanyRelation')
 			->findAll(['filters' => ['relationId' => $relationId, 'administrationId' => $administrationId]]);

--- a/lib/Lifecycle/InventoryPostingGuard.php
+++ b/lib/Lifecycle/InventoryPostingGuard.php
@@ -60,8 +60,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle guard for the inventory-cogs-posting envelope. ADR-031
@@ -82,9 +82,9 @@ class InventoryPostingGuard {
 	 * @param LoggerInterface $logger Logger for structured-warning + fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -284,7 +284,6 @@ class InventoryPostingGuard {
 				'inventoryAdjustmentAccountNumber',
 			];
 
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
 			foreach ($fields as $field) {
 				$accountNumber = (string)($proposed[$field] ?? '');
@@ -292,7 +291,7 @@ class InventoryPostingGuard {
 					continue;
 				}
 
-				$matches = $objectService
+				$matches = $this->objectService
 					->setRegister($this->register())
 					->setSchema('Account')
 					->findAll(
@@ -342,8 +341,7 @@ class InventoryPostingGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$matches = $objectService
+		$matches = $this->objectService
 			->setRegister($this->register())
 			->setSchema('InventoryGLConfig')
 			->findAll(

--- a/lib/Lifecycle/InventoryValuationMethodGuard.php
+++ b/lib/Lifecycle/InventoryValuationMethodGuard.php
@@ -43,8 +43,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Zero-stock precondition guard for InventoryValuation transitions
@@ -61,9 +61,9 @@ class InventoryValuationMethodGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -136,8 +136,7 @@ class InventoryValuationMethodGuard {
 				return true;
 			}
 
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$existing = $objectService
+			$existing = $this->objectService
 				->setRegister($this->register())
 				->setSchema('InventoryValuation')
 				->findAll(

--- a/lib/Lifecycle/InvoiceGuard.php
+++ b/lib/Lifecycle/InvoiceGuard.php
@@ -47,8 +47,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for Invoice post and cancel transitions.
@@ -70,9 +70,9 @@ class InvoiceGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -196,10 +196,9 @@ class InvoiceGuard {
 
 		$ownId = (string)($invoice['id'] ?? '');
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$others = $objectService
+		$others = $this->objectService
 			->setRegister($register)
 			->setSchema('Invoice')
 			->findAll([]);
@@ -319,10 +318,9 @@ class InvoiceGuard {
 			return [];
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$lines = $objectService
+		$lines = $this->objectService
 			->setRegister($register)
 			->setSchema('InvoiceLine')
 			->findAll(['filters' => ['invoiceId' => $invoiceId]]);
@@ -349,10 +347,9 @@ class InvoiceGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($register)
 			->setSchema($schema)
 			->findAll(['filters' => ['id' => $id]]);

--- a/lib/Lifecycle/IrregularityReportGuard.php
+++ b/lib/Lifecycle/IrregularityReportGuard.php
@@ -41,8 +41,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for the IrregularityReport escalate transition.
@@ -70,9 +70,9 @@ class IrregularityReportGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -135,8 +135,7 @@ class IrregularityReportGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$reports = $objectService
+		$reports = $this->objectService
 			->setRegister($this->resolveRegister())
 			->setSchema('IrregularityReport')
 			->findAll(['filters' => ['id' => $irregularityReportId], 'limit' => 1]);

--- a/lib/Lifecycle/JournalEntryGuard.php
+++ b/lib/Lifecycle/JournalEntryGuard.php
@@ -41,8 +41,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for JournalEntry post and void transitions.
@@ -63,9 +63,9 @@ class JournalEntryGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -162,10 +162,9 @@ class JournalEntryGuard {
 				return false;
 			}
 
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$register = $this->resolveRegister();
 
-			$transactions = $objectService
+			$transactions = $this->objectService
 				->setRegister($register)
 				->setSchema('GLTransaction')
 				->findAll(['filters' => ['id' => $glTransactionId]]);
@@ -204,10 +203,9 @@ class JournalEntryGuard {
 			return [];
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$entries = $objectService
+		$entries = $this->objectService
 			->setRegister($register)
 			->setSchema('JournalEntry')
 			->findAll(['filters' => ['id' => $journalEntryId]]);

--- a/lib/Lifecycle/KlantLadderOverrideApprovalGuard.php
+++ b/lib/Lifecycle/KlantLadderOverrideApprovalGuard.php
@@ -30,8 +30,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for KlantLadderOverride.activate.
@@ -54,9 +54,9 @@ class KlantLadderOverrideApprovalGuard {
 	 * @param LoggerInterface $logger Logger.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -71,13 +71,12 @@ class KlantLadderOverrideApprovalGuard {
 	 */
 	public function isApprovedForElevatedStages(string $overrideId): bool {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$register = $this->appConfig->getValueString(Application::APP_ID, 'register', 'shillinq');
 			if ($register === '') {
 				$register = 'shillinq';
 			}
 
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($register)
 				->setSchema('KlantLadderOverride')
 				->findAll(['filters' => ['id' => $overrideId]]);

--- a/lib/Lifecycle/ObjectionPeriodGuard.php
+++ b/lib/Lifecycle/ObjectionPeriodGuard.php
@@ -42,8 +42,8 @@ namespace OCA\Shillinq\Lifecycle;
 use DateTimeImmutable;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Statutory termijn guards for the bezwaar/beroep workflow.
@@ -69,9 +69,9 @@ class ObjectionPeriodGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -194,13 +194,12 @@ class ObjectionPeriodGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
 		// 'DefinitieveAanslag' and the 'aangifte' filter key are the data
 		// contract — the registered schema title and one of its property
 		// columns. Both move with the schema rename and its migration.
-		$assessments = $objectService
+		$assessments = $this->objectService
 			->setRegister($register)
 			->setSchema('DefinitieveAanslag')
 			->findAll(['filters' => ['aangifte' => $taxReturnId]]);
@@ -227,10 +226,9 @@ class ObjectionPeriodGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$objects = $objectService
+		$objects = $this->objectService
 			->setRegister($register)
 			->setSchema($schema)
 			->findAll(['filters' => ['id' => $id]]);

--- a/lib/Lifecycle/PayrollGuard.php
+++ b/lib/Lifecycle/PayrollGuard.php
@@ -45,8 +45,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for Payroll calculate and issue transitions.
@@ -74,9 +74,9 @@ class PayrollGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -224,10 +224,9 @@ class PayrollGuard {
 	 * @return bool True when payroll is permitted for this employee/period.
 	 */
 	private function employeeAllowsPayroll(string $employeeId, string $periodStartDate): bool {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$employees = $objectService
+		$employees = $this->objectService
 			->setRegister($register)
 			->setSchema('Employee')
 			->findAll(['filters' => ['id' => $employeeId]]);
@@ -265,10 +264,9 @@ class PayrollGuard {
 			return [];
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$deductions = $objectService
+		$deductions = $this->objectService
 			->setRegister($register)
 			->setSchema('Deduction')
 			->findAll(['filters' => ['payrollId' => $payrollId]]);
@@ -294,10 +292,9 @@ class PayrollGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$payrolls = $objectService
+		$payrolls = $this->objectService
 			->setRegister($register)
 			->setSchema('Payroll')
 			->findAll(['filters' => ['id' => $payrollId]]);

--- a/lib/Lifecycle/PensionIas19Guard.php
+++ b/lib/Lifecycle/PensionIas19Guard.php
@@ -49,8 +49,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for the IAS 19 / RJ 271 pension registers.
@@ -71,9 +71,9 @@ class PensionIas19Guard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -274,10 +274,9 @@ class PensionIas19Guard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($register)
 			->setSchema($schema)
 			->findAll(['filters' => ['id' => $id]]);

--- a/lib/Lifecycle/PeriodCloseGuard.php
+++ b/lib/Lifecycle/PeriodCloseGuard.php
@@ -51,6 +51,7 @@ use OCA\Shillinq\Service\SuspenseAgeingService;
 use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for the period-close feature.
@@ -92,6 +93,7 @@ class PeriodCloseGuard {
 		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -172,8 +174,7 @@ class PeriodCloseGuard {
 				return true;
 			}
 
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$lines = $objectService
+			$lines = $this->objectService
 				->setRegister($this->register())
 				->setSchema('GLLine')
 				->findAll(['filters' => ['periodId' => $periodId]]);
@@ -358,8 +359,7 @@ class PeriodCloseGuard {
 			return $transaction;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$found = $objectService
+		$found = $this->objectService
 			->setRegister($this->register())
 			->setSchema('GLTransaction')
 			->findAll(['filters' => ['id' => $transaction], 'limit' => 1]);
@@ -383,8 +383,7 @@ class PeriodCloseGuard {
 			return $period;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$found = $objectService
+		$found = $this->objectService
 			->setRegister($this->register())
 			->setSchema('FiscalPeriod')
 			->findAll(['filters' => ['id' => $period], 'limit' => 1]);
@@ -405,13 +404,12 @@ class PeriodCloseGuard {
 	 * @return array<string,mixed>|null The PeriodClose record, or null when none exists.
 	 */
 	private function findPeriod(string $periodId, string $administrationId): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$filters = ['periodId' => $periodId];
 		if ($administrationId !== '') {
 			$filters['administrationId'] = $administrationId;
 		}
 
-		$found = $objectService
+		$found = $this->objectService
 			->setRegister($this->register())
 			->setSchema('FiscalPeriod')
 			->findAll(['filters' => $filters, 'limit' => 1]);

--- a/lib/Lifecycle/PeriodStatusGuard.php
+++ b/lib/Lifecycle/PeriodStatusGuard.php
@@ -38,8 +38,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for the continuous-close feature.
@@ -85,9 +85,9 @@ class PeriodStatusGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -184,8 +184,7 @@ class PeriodStatusGuard {
 			return $transaction;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$found = $objectService
+		$found = $this->objectService
 			->setRegister($this->register())
 			->setSchema('GLTransaction')
 			->findAll(['filters' => ['id' => $transaction], 'limit' => 1]);
@@ -212,13 +211,12 @@ class PeriodStatusGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$filters = ['periodYear' => $year, 'periodMonth' => $month];
 		if ($administrationId !== '') {
 			$filters['administrationId'] = $administrationId;
 		}
 
-		$found = $objectService
+		$found = $this->objectService
 			->setRegister($this->register())
 			->setSchema('PeriodStatus')
 			->findAll(['filters' => $filters, 'limit' => 1]);

--- a/lib/Lifecycle/ProgrammabegrotingGuard.php
+++ b/lib/Lifecycle/ProgrammabegrotingGuard.php
@@ -44,8 +44,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for Programmabegroting behandelen and vaststellen.
@@ -81,9 +81,9 @@ final class ProgrammabegrotingGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -223,10 +223,9 @@ final class ProgrammabegrotingGuard {
 			return [];
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($register)
 			->setSchema('Paragraaf')
 			->findAll(['filters' => ['begrotingId' => $begrotingId]]);
@@ -252,10 +251,9 @@ final class ProgrammabegrotingGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($register)
 			->setSchema('Programmabegroting')
 			->findAll(['filters' => ['id' => $begrotingId]]);

--- a/lib/Lifecycle/ProvisionGuard.php
+++ b/lib/Lifecycle/ProvisionGuard.php
@@ -61,8 +61,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for the IAS 37 / RJ 252 voorzieningen registers.
@@ -105,9 +105,9 @@ class ProvisionGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -406,10 +406,9 @@ class ProvisionGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($register)
 			->setSchema($schema)
 			->findAll(['filters' => ['id' => $id]]);

--- a/lib/Lifecycle/QuoteOrderInvoiceGuard.php
+++ b/lib/Lifecycle/QuoteOrderInvoiceGuard.php
@@ -69,8 +69,8 @@ namespace OCA\Shillinq\Lifecycle;
 use Closure;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for the Sales Funnel (Q2C) registers.
@@ -91,9 +91,9 @@ class QuoteOrderInvoiceGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -643,7 +643,7 @@ class QuoteOrderInvoiceGuard {
 	 * @return object The OpenRegister ObjectService.
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Lifecycle/RetainerGuard.php
+++ b/lib/Lifecycle/RetainerGuard.php
@@ -50,8 +50,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for the retainer-billing-engine registers.
@@ -72,9 +72,9 @@ class RetainerGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -316,10 +316,9 @@ class RetainerGuard {
 	 * @return array<int,array<string,mixed>> The matching pool rows.
 	 */
 	private function findPoolsForClient(string $clientId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($register)
 			->setSchema('RetainerPool')
 			->findAll(['filters' => ['clientId' => $clientId]]);
@@ -353,10 +352,9 @@ class RetainerGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($register)
 			->setSchema($schema)
 			->findAll(['filters' => ['id' => $id]]);

--- a/lib/Lifecycle/RuleComplianceGuard.php
+++ b/lib/Lifecycle/RuleComplianceGuard.php
@@ -38,8 +38,8 @@ namespace OCA\Shillinq\Lifecycle;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Standards\RuleEngine;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle guard enforcing machine-checkable rules on issue/post.
@@ -54,10 +54,10 @@ class RuleComplianceGuard {
 	 * @param BalanceGuard $balanceGuard Existing double-entry balance guard (reused).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
 		private readonly BalanceGuard $balanceGuard,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -150,8 +150,7 @@ class RuleComplianceGuard {
 	 * @return array<string, mixed>|null
 	 */
 	private function loadObject(string $schema, string $id): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$entity = $objectService->find(id: $id, register: $this->register(), schema: $schema);
+		$entity = $this->objectService->find(id: $id, register: $this->register(), schema: $schema);
 		if ($entity === null) {
 			return null;
 		}
@@ -172,7 +171,6 @@ class RuleComplianceGuard {
 	 * @return array<int, array<string, mixed>>
 	 */
 	private function loadLines(array $transaction): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$keys = array_values(
 			array_unique(
 				array_filter(
@@ -186,7 +184,7 @@ class RuleComplianceGuard {
 
 		$lines = [];
 		foreach ($keys as $key) {
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema('GLLine')
 				->findAll(['filters' => ['transactionId' => $key]]);

--- a/lib/Lifecycle/SegregatedLedgerGuard.php
+++ b/lib/Lifecycle/SegregatedLedgerGuard.php
@@ -37,8 +37,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for the SegregatedLedger close transition.
@@ -58,9 +58,9 @@ class SegregatedLedgerGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -126,8 +126,7 @@ class SegregatedLedgerGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$ledgers = $objectService
+		$ledgers = $this->objectService
 			->setRegister($this->resolveRegister())
 			->setSchema('SegregatedLedger')
 			->findAll(['filters' => ['id' => $segregatedLedgerId], 'limit' => 1]);

--- a/lib/Lifecycle/StockReservationGuard.php
+++ b/lib/Lifecycle/StockReservationGuard.php
@@ -46,8 +46,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Per REQ-SM-004 reservation CAS + REQ-SM-005 stock-ledger commit.
@@ -72,9 +72,9 @@ class StockReservationGuard {
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs the full payload.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -323,8 +323,7 @@ class StockReservationGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('InventoryStock')
 			->findAll(
@@ -357,7 +356,6 @@ class StockReservationGuard {
 	 */
 	private function casUpdate(array $row, array $patch): bool {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$id = (string)($row['id'] ?? ($row['@self']['id'] ?? ''));
 			if ($id === '') {
 				return false;
@@ -365,7 +363,7 @@ class StockReservationGuard {
 
 			// Re-read the canonical row to detect concurrent writes; abort on version
 			// mismatch (CAS) so the operator retries with fresh state.
-			$current = $objectService
+			$current = $this->objectService
 				->setRegister($this->register())
 				->setSchema('InventoryStock')
 				->find($id);
@@ -385,7 +383,7 @@ class StockReservationGuard {
 			}
 
 			$merged = array_merge($currentArray, $patch);
-			$objectService
+			$this->objectService
 				->setRegister($this->register())
 				->setSchema('InventoryStock')
 				->updateObject(id: $id, object: $merged, register: $this->register(), schema: 'InventoryStock');
@@ -422,7 +420,6 @@ class StockReservationGuard {
 		float $unitCost,
 	): bool {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$row = [
 				'administrationId' => $administrationId,
 				'locationId' => $locationId,
@@ -434,7 +431,7 @@ class StockReservationGuard {
 				'version' => 1,
 			];
 
-			$objectService->saveObject(object: $row, register: $this->register(), schema: 'InventoryStock');
+			$this->objectService->saveObject(object: $row, register: $this->register(), schema: 'InventoryStock');
 			return true;
 		} catch (\Throwable $e) {
 			$this->logger->error(

--- a/lib/Lifecycle/SubsidieVerantwoordingGuard.php
+++ b/lib/Lifecycle/SubsidieVerantwoordingGuard.php
@@ -42,8 +42,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for the SubsidieVerantwoording approve transition.
@@ -73,9 +73,9 @@ class SubsidieVerantwoordingGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -138,10 +138,9 @@ class SubsidieVerantwoordingGuard {
 	 * @return bool True when a non-blocking auditor statement exists.
 	 */
 	private function hasApprovedAuditorStatement(string $grantId): bool {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$statements = $objectService
+		$statements = $this->objectService
 			->setRegister($register)
 			->setSchema('AuditorStatement')
 			->findAll(['filters' => ['grantId' => $grantId]]);
@@ -169,10 +168,9 @@ class SubsidieVerantwoordingGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$records = $objectService
+		$records = $this->objectService
 			->setRegister($register)
 			->setSchema('SubsidieVerantwoording')
 			->findAll(['filters' => ['id' => $verantwoordingId]]);

--- a/lib/Lifecycle/SupplierQualificationGuard.php
+++ b/lib/Lifecycle/SupplierQualificationGuard.php
@@ -35,9 +35,9 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Precondition for PurchaseOrder creation: is the supplier qualified?
@@ -53,9 +53,9 @@ class SupplierQualificationGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -170,8 +170,7 @@ class SupplierQualificationGuard {
 	 * @return array<string,mixed>|null
 	 */
 	private function findOne(string $schema, array $filters): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema($schema)
 			->findAll(['filters' => $filters]);

--- a/lib/Lifecycle/SupportingDocumentGuard.php
+++ b/lib/Lifecycle/SupportingDocumentGuard.php
@@ -37,8 +37,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for the SupportingDocument certify transition.
@@ -58,9 +58,9 @@ class SupportingDocumentGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -116,8 +116,7 @@ class SupportingDocumentGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$documents = $objectService
+		$documents = $this->objectService
 			->setRegister($this->resolveRegister())
 			->setSchema('SupportingDocument')
 			->findAll(['filters' => ['id' => $supportingDocumentId], 'limit' => 1]);

--- a/lib/Lifecycle/VatPreconditionGuard.php
+++ b/lib/Lifecycle/VatPreconditionGuard.php
@@ -31,8 +31,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for ARInvoice VAT validation on the issue transition.
@@ -69,9 +69,9 @@ class VatPreconditionGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -93,7 +93,6 @@ class VatPreconditionGuard {
 	 */
 	public function validate(string $invoiceId, string $administrationId): bool {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$register = $this->appConfig->getValueString(Application::APP_ID, 'register', 'shillinq');
 			if ($register === '') {
 				$register = 'shillinq';
@@ -112,7 +111,7 @@ class VatPreconditionGuard {
 				return false;
 			}
 
-			$lines = $objectService
+			$lines = $this->objectService
 				->setRegister($register)
 				->setSchema('InvoiceLine')
 				->findAll(['filters' => ['invoiceId' => $invoiceId]]);
@@ -166,7 +165,7 @@ class VatPreconditionGuard {
 		string $register,
 		string $administrationId,
 	): bool {
-		$records = $objectService
+		$records = $this->objectService
 			->setRegister($register)
 			->setSchema('VATGLAccounts')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -201,7 +200,7 @@ class VatPreconditionGuard {
 		string $register,
 		string $administrationId,
 	): array {
-		$overrideRecords = $objectService
+		$overrideRecords = $this->objectService
 			->setRegister($register)
 			->setSchema('ServiceCategoryOverride')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);

--- a/lib/Lifecycle/VpbAangifteGuard.php
+++ b/lib/Lifecycle/VpbAangifteGuard.php
@@ -53,8 +53,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guards for the Vpb registers.
@@ -88,9 +88,9 @@ class VpbAangifteGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -285,9 +285,8 @@ class VpbAangifteGuard {
 			return false;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
-		$claims = $objectService
+		$claims = $this->objectService
 			->setRegister($this->resolveRegister())
 			->setSchema('Innovatiebox')
 			->findAll(['filters' => ['aangifte' => $aangifteId]]);
@@ -318,9 +317,8 @@ class VpbAangifteGuard {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
-		$records = $objectService
+		$records = $this->objectService
 			->setRegister($this->resolveRegister())
 			->setSchema($schema)
 			->findAll(['filters' => ['id' => $id]]);

--- a/lib/Lifecycle/VpbBerekeningGuard.php
+++ b/lib/Lifecycle/VpbBerekeningGuard.php
@@ -44,8 +44,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Pure fiscal calculation fallbacks for the Vpb registers.
@@ -65,9 +65,9 @@ class VpbBerekeningGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -198,10 +198,9 @@ class VpbBerekeningGuard {
 	 * @return array<string,mixed>|null The tarief record, or null when absent.
 	 */
 	private function resolveTariefcatalogus(int $belastingjaar): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$records = $objectService
+		$records = $this->objectService
 			->setRegister($register)
 			->setSchema('VpbTariefcatalogus')
 			->findAll(['filters' => ['belastingjaar' => $belastingjaar]]);

--- a/lib/Lifecycle/WbsoMededelingGuard.php
+++ b/lib/Lifecycle/WbsoMededelingGuard.php
@@ -44,8 +44,8 @@ namespace OCA\Shillinq\Lifecycle;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lifecycle precondition guard for the WbsoMededeling submit / resubmit transitions.
@@ -65,9 +65,9 @@ class WbsoMededelingGuard {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -149,10 +149,9 @@ class WbsoMededelingGuard {
 	 * @return array<string,mixed>|null The beschikking object, or null when not found.
 	 */
 	private function resolveBeschikking(string $administrationId, string $beschikkingNumber): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$beschikkingen = $objectService
+		$beschikkingen = $this->objectService
 			->setRegister($register)
 			->setSchema('WbsoBeschikking')
 			->findAll(

--- a/lib/Listener/PosStockDecrementListener.php
+++ b/lib/Listener/PosStockDecrementListener.php
@@ -77,9 +77,9 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\IAppConfig;
 use OCP\IGroupManager;
 use OCP\Notification\IManager;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Dispatcher from pipelinq's PosStockMovedEvent -> SalesDispatchStockIssueService.
@@ -119,12 +119,12 @@ class PosStockDecrementListener implements IEventListener {
 	 * @param LoggerInterface $logger Logger for fail-soft diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly SalesDispatchStockIssueService $dispatchService,
 		private readonly IAppConfig $appConfig,
 		private readonly IGroupManager $groupManager,
 		private readonly IManager $notificationMgr,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -380,7 +380,7 @@ class PosStockDecrementListener implements IEventListener {
 	 * @return object
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Listener/StockMoveTransitionedListener.php
+++ b/lib/Listener/StockMoveTransitionedListener.php
@@ -50,9 +50,9 @@ use OCA\Shillinq\Service\MovingAverageValuationService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Dispatcher from posted StockMove -> valuation engine + COGS poster.
@@ -83,9 +83,9 @@ class StockMoveTransitionedListener implements IEventListener {
 		private readonly FifoValuationService $fifo,
 		private readonly MovingAverageValuationService $average,
 		private readonly CogsPosterService $cogs,
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -192,8 +192,7 @@ class StockMoveTransitionedListener implements IEventListener {
 		}
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema('InventoryValuation')
 				->findAll(

--- a/lib/Repair/BackfillFiscalPeriods.php
+++ b/lib/Repair/BackfillFiscalPeriods.php
@@ -53,8 +53,8 @@ use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Repair step that backfills FiscalPeriod records for every distinct
@@ -75,7 +75,7 @@ class BackfillFiscalPeriods implements IRepairStep {
 	public function __construct(
 		private SettingsService $settingsService,
 		private LoggerInterface $logger,
-		private ContainerInterface $container,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -102,7 +102,6 @@ class BackfillFiscalPeriods implements IRepairStep {
 	 */
 	public function run(IOutput $output): void {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->settingsService->getRegisterSlug();
 
 			// Stream every GLLine carrying a non-empty periodId; collect
@@ -158,7 +157,7 @@ class BackfillFiscalPeriods implements IRepairStep {
 				// authenticated ('Anonymous'). Bypass RBAC + multi-tenancy so the
 				// backfill persists instead of throwing "User 'Anonymous' does not
 				// have permission to 'create'".
-				$objectService->saveObject(
+				$this->objectService->saveObject(
 					object: $record,
 					register: $registerSlug,
 					schema: 'FiscalPeriod',
@@ -205,7 +204,7 @@ class BackfillFiscalPeriods implements IRepairStep {
 			$filters['administrationId'] = $administrationId;
 		}
 
-		$found = $objectService
+		$found = $this->objectService
 			->setRegister($registerSlug)
 			->setSchema('FiscalPeriod')
 			->findAll(['filters' => $filters, 'limit' => 1]);

--- a/lib/Repair/FoldDunningWriteoffIntoArInvoice.php
+++ b/lib/Repair/FoldDunningWriteoffIntoArInvoice.php
@@ -57,8 +57,8 @@ use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Repair step that folds DunningRun + OninbaarAfschrijving onto ARInvoice.
@@ -80,7 +80,7 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep {
 		private SettingsService $settingsService,
 		private IGroupManager $groupManager,
 		private LoggerInterface $logger,
-		private ContainerInterface $container,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -104,7 +104,6 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep {
 	 */
 	public function run(IOutput $output): void {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->settingsService->getRegisterSlug();
 			$actingUser = $this->resolveAdminUser();
 
@@ -132,7 +131,7 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep {
 				// Load the linked ARInvoice. factuurId is the ARInvoice UUID.
 				$invoice = null;
 				try {
-					$invoice = $objectService->find(
+					$invoice = $this->objectService->find(
 						id: $factuurId,
 						register: $registerSlug,
 						schema: 'ARInvoice',
@@ -201,7 +200,7 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep {
 					$invoiceArr['dunning'] = $dunning;
 				}
 
-				$objectService->saveObject(
+				$this->objectService->saveObject(
 					object: $invoiceArr,
 					register: $registerSlug,
 					schema: 'ARInvoice',

--- a/lib/Repair/FoldExpensesAndHoursIntoProject.php
+++ b/lib/Repair/FoldExpensesAndHoursIntoProject.php
@@ -48,8 +48,8 @@ use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Repair step that folds Receipt/MileageEntry/PerDiem into
@@ -70,7 +70,7 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep {
 		private SettingsService $settingsService,
 		private IGroupManager $groupManager,
 		private LoggerInterface $logger,
-		private ContainerInterface $container,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -93,7 +93,6 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep {
 	 */
 	public function run(IOutput $output): void {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->settingsService->getRegisterSlug();
 			$admin = $this->resolveAdmin();
 
@@ -170,7 +169,7 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep {
 
 				$record = $projectArrays[$projectKey];
 				try {
-					$objectService
+					$this->objectService
 						->setRegister($registerSlug)
 						->setSchema('Project')
 						->saveObject(

--- a/lib/Repair/PeriodCloseBackfill.php
+++ b/lib/Repair/PeriodCloseBackfill.php
@@ -54,9 +54,9 @@ use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Repair step that backfills forward-looking FiscalPeriod records for
@@ -84,7 +84,7 @@ class PeriodCloseBackfill implements IRepairStep {
 	public function __construct(
 		private SettingsService $settingsService,
 		private LoggerInterface $logger,
-		private ContainerInterface $container,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -111,7 +111,6 @@ class PeriodCloseBackfill implements IRepairStep {
 	 */
 	public function run(IOutput $output): void {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->settingsService->getRegisterSlug();
 
 			// List every Administration record. The repair step is
@@ -164,7 +163,7 @@ class PeriodCloseBackfill implements IRepairStep {
 					// authenticated ('Anonymous'). Bypass RBAC + multi-tenancy so
 					// the backfill persists instead of throwing "User 'Anonymous'
 					// does not have permission to 'create'".
-					$objectService->saveObject(
+					$this->objectService->saveObject(
 						object: $record,
 						register: $registerSlug,
 						schema: 'FiscalPeriod',
@@ -212,7 +211,7 @@ class PeriodCloseBackfill implements IRepairStep {
 			'administrationId' => $administrationId,
 		];
 
-		$found = $objectService
+		$found = $this->objectService
 			->setRegister($registerSlug)
 			->setSchema('FiscalPeriod')
 			->findAll(['filters' => $filters, 'limit' => 1]);

--- a/lib/Repair/RematerialiseConvertedCalculations.php
+++ b/lib/Repair/RematerialiseConvertedCalculations.php
@@ -66,6 +66,7 @@ use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Repair step that re-saves every existing object on the 17 schemas whose
@@ -117,6 +118,7 @@ class RematerialiseConvertedCalculations implements IRepairStep {
 		private SettingsService $settingsService,
 		private LoggerInterface $logger,
 		private ContainerInterface $container,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -145,7 +147,6 @@ class RematerialiseConvertedCalculations implements IRepairStep {
 	 */
 	public function run(IOutput $output): void {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->settingsService->getRegisterSlug();
 
 			// Re-saving an object that carries a folder association goes through
@@ -256,7 +257,7 @@ class RematerialiseConvertedCalculations implements IRepairStep {
 			}
 
 			try {
-				$objectService->saveObject(
+				$this->objectService->saveObject(
 					object: $arr,
 					register: $registerSlug,
 					schema: $schema,

--- a/lib/Service/AansluitingService.php
+++ b/lib/Service/AansluitingService.php
@@ -63,9 +63,9 @@ use DateTimeInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Lifecycle\AansluitingResolutionGuard;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Computes, explains, resolves, and reopens AansluitingResult records.
@@ -116,12 +116,12 @@ class AansluitingService {
 	 * @param AansluitingResolutionGuard $resolutionGuard The ADR-031 exception guard for explained -> resolved.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
 		private readonly AansluitingCalculator $calculator,
 		private readonly VATReturnService $vatReturnService,
 		private readonly AansluitingResolutionGuard $resolutionGuard,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -440,10 +440,9 @@ class AansluitingService {
 			return 0.0;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->register();
 
-		$transactions = $objectService
+		$transactions = $this->objectService
 			->setRegister($register)
 			->setSchema('GLTransaction')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -455,7 +454,7 @@ class AansluitingService {
 			}
 		}
 
-		$lines = $objectService
+		$lines = $this->objectService
 			->setRegister($register)
 			->setSchema('GLLine')
 			->findAll(['filters' => ['accountNumber' => $accountNumber]]);
@@ -491,8 +490,7 @@ class AansluitingService {
 	 * @return array<int,array{itemId:string,amount:float}>
 	 */
 	private function openArInvoices(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$invoices = $objectService
+		$invoices = $this->objectService
 			->setRegister($this->register())
 			->setSchema('ARInvoice')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -522,8 +520,7 @@ class AansluitingService {
 	 * @return array<int,array{itemId:string,amount:float}>
 	 */
 	private function openApTransactions(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$transactions = $objectService
+		$transactions = $this->objectService
 			->setRegister($this->register())
 			->setSchema('APTransaction')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -555,8 +552,7 @@ class AansluitingService {
 	 * @return array<string,mixed>|null The VATReturn record, or null when none is filed for the period.
 	 */
 	private function findFiledVatReturn(string $administrationId, string $periodId): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$returns = $objectService
+		$returns = $this->objectService
 			->setRegister($this->register())
 			->setSchema('BtwAangifte')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -610,8 +606,7 @@ class AansluitingService {
 			return null;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$corrections = $objectService
+		$corrections = $this->objectService
 			->setRegister($this->register())
 			->setSchema('VatCorrection')
 			->findAll(['filters' => ['originalVatReturnId' => $originalVatReturnId]]);
@@ -643,8 +638,7 @@ class AansluitingService {
 	 * @return array<string,mixed>
 	 */
 	private function fetchAansluiting(string $aansluitingId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$definition = $objectService
+		$definition = $this->objectService
 			->setRegister($this->register())
 			->setSchema('Aansluiting')
 			->find($aansluitingId);
@@ -664,8 +658,7 @@ class AansluitingService {
 	 * @return array<string,mixed>
 	 */
 	private function fetchResult(string $resultId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$result = $objectService
+		$result = $this->objectService
 			->setRegister($this->register())
 			->setSchema('AansluitingResult')
 			->find($resultId);
@@ -686,8 +679,7 @@ class AansluitingService {
 	 * @return array<string,mixed>|null
 	 */
 	private function fetchExistingResult(string $aansluitingId, string $periodId): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($this->register())
 			->setSchema('AansluitingResult')
 			->findAll(['filters' => ['aansluitingId' => $aansluitingId, 'periodId' => $periodId]]);
@@ -708,8 +700,7 @@ class AansluitingService {
 	 * @return array<string,mixed> The saved record (with id).
 	 */
 	private function saveObject(string $schema, array $data): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema($schema)
 			->saveObject($data);

--- a/lib/Service/AccountantsdossierExportService.php
+++ b/lib/Service/AccountantsdossierExportService.php
@@ -71,10 +71,10 @@ namespace OCA\Shillinq\Service;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use ZipArchive;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Builds the BADO accountantsdossier bundle for one Controleprotocol.
@@ -176,10 +176,10 @@ class AccountantsdossierExportService {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -1071,7 +1071,7 @@ class AccountantsdossierExportService {
 	 * @return mixed
 	 */
 	private function objects(): mixed {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objects()
 
 	/**

--- a/lib/Service/BadoControleprotocolService.php
+++ b/lib/Service/BadoControleprotocolService.php
@@ -43,8 +43,8 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Computes BADO finding aggregation + opinion and guards the protocol/finding
@@ -73,10 +73,10 @@ class BadoControleprotocolService {
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics (no stack traces to client).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly BadoControleprotocolCalculator $calculator,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -645,7 +645,7 @@ class BadoControleprotocolService {
 	 * @return mixed The OpenRegister ObjectService.
 	 */
 	private function objects(): mixed {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objects()
 
 	/**

--- a/lib/Service/BcfClaimService.php
+++ b/lib/Service/BcfClaimService.php
@@ -38,7 +38,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Computes a quarter-scoped, per-account BCF compensable-VAT claim from the GL.
@@ -62,9 +62,9 @@ class BcfClaimService {
 	 * @param BcfCompensationCalculator $calculator Pure-logic compensable-VAT helper.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly BcfCompensationCalculator $calculator,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -122,11 +122,10 @@ class BcfClaimService {
 	 * @return array<string,float> accountNumber => posted amount in currency units.
 	 */
 	private function compensableAmountsByAccount(string $administrationId, string $claimQuarter): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->register();
 
 		// Transactions that belong to this administration + quarter (REQ-BCF-012 scoping).
-		$transactions = $objectService
+		$transactions = $this->objectService
 			->setRegister($register)
 			->setSchema('GLTransaction')
 			->findAll(
@@ -149,7 +148,7 @@ class BcfClaimService {
 		}
 
 		// GLLines for the quarter; cross-check the parent transaction is in scope.
-		$lines = $objectService
+		$lines = $this->objectService
 			->setRegister($register)
 			->setSchema('GLLine')
 			->findAll(['filters' => ['periodId' => $claimQuarter]]);
@@ -216,8 +215,7 @@ class BcfClaimService {
 	 * @return array<string,array<string,mixed>> accountNumber => BbvAccountMapping object.
 	 */
 	private function mappingsByAccount(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$mappings = $objectService
+		$mappings = $this->objectService
 			->setRegister($this->register())
 			->setSchema('BbvAccountMapping')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);

--- a/lib/Service/BookingNotificationService.php
+++ b/lib/Service/BookingNotificationService.php
@@ -30,6 +30,7 @@ use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Evaluates booking notification triggers and dispatches via openconnector.
@@ -71,6 +72,7 @@ class BookingNotificationService {
 		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -256,7 +258,6 @@ class BookingNotificationService {
 	 */
 	public function recordAuditTrail(array $notification, string $status, string $reason): void {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->appConfig->getValueString(Application::APP_ID, 'register', 'shillinq');
 			if ($registerSlug === '') {
 				$registerSlug = 'shillinq';
@@ -280,7 +281,7 @@ class BookingNotificationService {
 				'sentAt' => (new DateTimeImmutable())->format('c'),
 			];
 
-			$objectService->saveObject(
+			$this->objectService->saveObject(
 				object: $record,
 				register: $registerSlug,
 				schema: 'NotificationDelivery',
@@ -418,13 +419,12 @@ class BookingNotificationService {
 	 */
 	public function isOptedOut(string $recipient, string $triggerType): bool {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->appConfig->getValueString(Application::APP_ID, 'register', 'shillinq');
 			if ($registerSlug === '') {
 				$registerSlug = 'shillinq';
 			}
 
-			$results = $objectService
+			$results = $this->objectService
 				->setRegister($registerSlug)
 				->setSchema('NotificationOptOut')
 				->findAll(['filters' => ['recipient' => $recipient], 'limit' => 1]);
@@ -480,7 +480,6 @@ class BookingNotificationService {
 		}
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->appConfig->getValueString(Application::APP_ID, 'register', 'shillinq');
 			if ($registerSlug === '') {
 				$registerSlug = 'shillinq';
@@ -489,7 +488,7 @@ class BookingNotificationService {
 			// Check per-booking hourly limit.
 			if ($bookingId !== '') {
 				$hourStart = (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format('Y-m-d\TH:00:00\Z');
-				$bookingHit = $objectService
+				$bookingHit = $this->objectService
 					->setRegister($registerSlug)
 					->setSchema('NotificationDelivery')
 					->findAll(
@@ -510,7 +509,7 @@ class BookingNotificationService {
 			// Check per-organizer daily limit.
 			if ($organizerId !== '') {
 				$dayStart = (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format('Y-m-d\T00:00:00\Z');
-				$organizerHit = $objectService
+				$organizerHit = $this->objectService
 					->setRegister($registerSlug)
 					->setSchema('NotificationDelivery')
 					->findAll(
@@ -561,7 +560,6 @@ class BookingNotificationService {
 		int $windowMinutes = self::DEFAULT_DEDUP_WINDOW_MINUTES,
 	): bool {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->appConfig->getValueString(Application::APP_ID, 'register', 'shillinq');
 			if ($registerSlug === '') {
 				$registerSlug = 'shillinq';
@@ -572,7 +570,7 @@ class BookingNotificationService {
 				new DateTimeZone('UTC')
 			))->format('c');
 
-			$existing = $objectService
+			$existing = $this->objectService
 				->setRegister($registerSlug)
 				->setSchema('NotificationDelivery')
 				->findAll(
@@ -676,13 +674,12 @@ class BookingNotificationService {
 	 */
 	private function loadActiveTriggers(string $eventType, ?string $bookingId): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->appConfig->getValueString(Application::APP_ID, 'register', 'shillinq');
 			if ($registerSlug === '') {
 				$registerSlug = 'shillinq';
 			}
 
-			return $objectService
+			return $this->objectService
 				->setRegister($registerSlug)
 				->setSchema('BookingNotificationTrigger')
 				->findAll(
@@ -716,7 +713,6 @@ class BookingNotificationService {
 	 */
 	private function loadTemplate(string $triggerId, string $eventType): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->appConfig->getValueString(Application::APP_ID, 'register', 'shillinq');
 			if ($registerSlug === '') {
 				$registerSlug = 'shillinq';
@@ -725,7 +721,7 @@ class BookingNotificationService {
 			if ($triggerId !== '') {
 				// ADR-022: use the real ObjectService API (find/findAll);
 				// findObject()/findObjects() do not exist on OpenRegister's ObjectService.
-				$template = $objectService->find(
+				$template = $this->objectService->find(
 					id: $triggerId,
 					register: $registerSlug,
 					schema: 'BookingNotificationTemplate'
@@ -736,7 +732,7 @@ class BookingNotificationService {
 			}
 
 			// Fallback: find active template matching the event type.
-			$results = $objectService
+			$results = $this->objectService
 				->setRegister($registerSlug)
 				->setSchema('BookingNotificationTemplate')
 				->findAll(

--- a/lib/Service/CBSExportService.php
+++ b/lib/Service/CBSExportService.php
@@ -52,8 +52,8 @@ namespace OCA\Shillinq\Service;
 use DateTimeInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Aggregates GL data into a CBS IV3-extended submission with declarative
@@ -104,9 +104,9 @@ class CBSExportService {
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -686,7 +686,7 @@ class CBSExportService {
 	 * @return object The ObjectService instance.
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Service/CogsPosterService.php
+++ b/lib/Service/CogsPosterService.php
@@ -56,9 +56,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * COGS GLTransaction poster.
@@ -89,9 +89,9 @@ class CogsPosterService {
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -361,8 +361,7 @@ class CogsPosterService {
 	 * @return array<string,mixed>
 	 */
 	private function saveOnSchema(string $schema, array $data): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema($schema)
 			->saveObject($data);

--- a/lib/Service/Commitment/CommitmentMaterialisationService.php
+++ b/lib/Service/Commitment/CommitmentMaterialisationService.php
@@ -68,9 +68,9 @@ use OCA\Shillinq\Lifecycle\MandaatEnforcer;
 use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Assembles a Verplichting + Verplichtingsregels from an approved
@@ -98,12 +98,12 @@ class CommitmentMaterialisationService {
 	 * @param LoggerInterface $logger Logger for fail-soft/fail-closed diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly MandaatEnforcer $mandaat,
 		private readonly BudgetBlocker $budget,
 		private readonly IEventDispatcher $dispatcher,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -532,16 +532,14 @@ class CommitmentMaterialisationService {
 	 * @return array<string, mixed> The persisted Verplichting.
 	 */
 	private function persist(array $draft, array $regelInputs): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister(register: $this->getRegisterSlug())
 			->setSchema(schema: 'Verplichting')
 			->saveObject(object: $draft);
 
 		$regelnummer = 1;
 		foreach ($regelInputs as $regel) {
-			$objectService
+			$this->objectService
 				->setRegister(register: $this->getRegisterSlug())
 				->setSchema(schema: 'Verplichtingsregel')
 				->saveObject(
@@ -585,8 +583,7 @@ class CommitmentMaterialisationService {
 			$boekjaar = (int)($first['financialYear'] ?? (int)(new DateTimeImmutable('today', new DateTimeZone('UTC')))->format('Y'));
 			$bedrag = ((float)($verplichting['totaalbedrag_excl_btw'] ?? 0)) / 100;
 
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$objectService
+			$this->objectService
 				->setRegister(register: $this->getRegisterSlug())
 				->setSchema(schema: 'Rechtmatigheidsbevinding')
 				->saveObject(
@@ -705,13 +702,12 @@ class CommitmentMaterialisationService {
 	 */
 	private function findMany(string $schema, array $filters, int $limit = 0): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$query = ['filters' => $filters];
 			if ($limit > 0) {
 				$query['limit'] = $limit;
 			}
 
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister(register: $this->getRegisterSlug())
 				->setSchema(schema: $schema)
 				->findAll($query);

--- a/lib/Service/ComplianceDeadlineCalendarService.php
+++ b/lib/Service/ComplianceDeadlineCalendarService.php
@@ -87,6 +87,7 @@ use OCP\Notification\IManager as INotificationManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Publishes compliance deadlines as calendar VEVENTs + NC notifications.
@@ -241,6 +242,7 @@ class ComplianceDeadlineCalendarService {
 		private readonly INotificationManager $notificationMgr,
 		private readonly ObligationTaskBridge $obligationTaskBridge,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -1217,8 +1219,7 @@ class ComplianceDeadlineCalendarService {
 	 */
 	private function fetchRows(string $schema): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister(register: $this->registerSlug())
 				->setSchema(schema: $schema)
 				->findAll([]);

--- a/lib/Service/CycleCountService.php
+++ b/lib/Service/CycleCountService.php
@@ -54,8 +54,8 @@ use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Lifecycle\VarianceGate;
 use OCA\Shillinq\Util\ObjectIdentifier;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Per REQ-ICC-006 snapshot fan-out + REQ-ICC-007 variance posting.
@@ -95,10 +95,10 @@ class CycleCountService {
 	 * @param VarianceGate $varianceGate Pure helper for threshold + recalculation.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
 		private readonly VarianceGate $varianceGate,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -157,7 +157,6 @@ class CycleCountService {
 				return true;
 			}
 
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$sequence = 0;
 			foreach ($stockRows as $stock) {
 				if (is_array($stock) === false) {
@@ -200,7 +199,7 @@ class CycleCountService {
 					'administrationId' => $administrationId,
 				];
 
-				$objectService
+				$this->objectService
 					->setRegister($this->register())
 					->setSchema('InventoryCycleCountLine')
 					->saveObject($line);
@@ -268,7 +267,6 @@ class CycleCountService {
 				return true;
 			}
 
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$sequence = 0;
 			foreach ($lines as $line) {
 				if (is_array($line) === false) {
@@ -351,7 +349,7 @@ class CycleCountService {
 					'locked' => false,
 				];
 
-				$saved = $objectService
+				$saved = $this->objectService
 					->setRegister($this->register())
 					->setSchema('StockMove')
 					->saveObject($move);
@@ -368,7 +366,7 @@ class CycleCountService {
 				// Stamp the back-reference on the line so a future retry skips it.
 				$lineUpdate = $line;
 				$lineUpdate['adjustmentStockMoveId'] = $stockMoveId;
-				$objectService
+				$this->objectService
 					->setRegister($this->register())
 					->setSchema('InventoryCycleCountLine')
 					->saveObject($lineUpdate);
@@ -402,8 +400,7 @@ class CycleCountService {
 	public function recalculateLine(array $line): array {
 		$refreshed = $this->varianceGate->recalculateLine(line: $line);
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$objectService
+			$this->objectService
 				->setRegister($this->register())
 				->setSchema('InventoryCycleCountLine')
 				->saveObject($refreshed);
@@ -450,14 +447,13 @@ class CycleCountService {
 		string $categoryFilter,
 	): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$filters = ['administrationId' => $administrationId];
 
 			if ($countType === 'partial' && $locationFilter !== '') {
 				$filters['locationId'] = $locationFilter;
 			}
 
-			$rows = ($objectService
+			$rows = ($this->objectService
 				->setRegister($this->register())
 				->setSchema('InventoryStock')
 				->findAll(['filters' => $filters]) ?? []);
@@ -504,7 +500,6 @@ class CycleCountService {
 	 */
 	private function filterByCategory(array $stockRows, string $administrationId, string $category): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$skuToCategory = [];
 			$rawSkus = [];
 			foreach ($stockRows as $row) {
@@ -522,7 +517,7 @@ class CycleCountService {
 				)
 			);
 			foreach ($skus as $sku) {
-				$product = $objectService
+				$product = $this->objectService
 					->setRegister($this->register())
 					->setSchema('Product')
 					->find(['filters' => ['administrationId' => $administrationId, 'sku' => $sku]]);
@@ -565,8 +560,7 @@ class CycleCountService {
 	 */
 	private function findLinesForCount(string $administrationId, string $countId): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = ($objectService
+			$rows = ($this->objectService
 				->setRegister($this->register())
 				->setSchema('InventoryCycleCountLine')
 				->findAll(

--- a/lib/Service/DepositReconciliationService.php
+++ b/lib/Service/DepositReconciliationService.php
@@ -33,8 +33,8 @@ use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Service\External\DepositPayment\DepositPaymentAdapterInterface;
 use OCA\Shillinq\Service\External\DepositPayment\DepositPaymentResult;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Idempotent reconciliation of DepositPayment records against gateway outcomes.
@@ -126,9 +126,9 @@ class DepositReconciliationService {
 	 * @return void
 	 */
 	public function __construct(
-		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 		private ?DepositPaymentAdapterInterface $adapter = null,
 	) {
 	}//end __construct()
@@ -166,10 +166,9 @@ class DepositReconciliationService {
 			return self::RESULT_NOT_FOUND;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$registerSlug = $this->getRegisterSlug();
 
-		$matches = $objectService
+		$matches = $this->objectService
 			->setRegister($registerSlug)
 			->setSchema('DepositPayment')
 			->findAll(
@@ -212,7 +211,7 @@ class DepositReconciliationService {
 			$deposit['lastErrorMessage'] = ($errorMessage ?? 'Payment failed at gateway.');
 		}
 
-		$objectService->saveObject(
+		$this->objectService->saveObject(
 			object: $deposit,
 			register: $registerSlug,
 			schema: 'DepositPayment',
@@ -240,7 +239,6 @@ class DepositReconciliationService {
 	 * @spec openspec/specs/bookings-deposits/spec.md (REQ-DP-007)
 	 */
 	public function pollPending(callable $statusProvider): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$registerSlug = $this->getRegisterSlug();
 
 		$pageSize = 200;
@@ -250,7 +248,7 @@ class DepositReconciliationService {
 		$batchSize = 0;
 
 		do {
-			$batch = $objectService
+			$batch = $this->objectService
 				->setRegister($registerSlug)
 				->setSchema('DepositPayment')
 				->findAll(

--- a/lib/Service/DoorsnijdingsVerbodValidator.php
+++ b/lib/Service/DoorsnijdingsVerbodValidator.php
@@ -37,7 +37,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Detects innovatiebox/GL cost duplication (doorsnijdingsverbod, REQ-IBA-004).
@@ -64,8 +64,8 @@ class DoorsnijdingsVerbodValidator {
 	 *                                                       OpenRegister event chain.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
+		private readonly ObjectService $objectService,
 		private readonly ?InnovatieboxAuditEventLogger $auditLogger = null,
 	) {
 	}//end __construct()
@@ -199,8 +199,7 @@ class DoorsnijdingsVerbodValidator {
 	 * @return array<int,array<string,mixed>> Exclusive allocation rows.
 	 */
 	private function fetchExclusiveAllocations(string $administrationId, int $boekjaar): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('IBExpenseAllocation')
 			->findAll(
@@ -229,8 +228,7 @@ class DoorsnijdingsVerbodValidator {
 	 * @return array<int,array<string,mixed>> GL lines carrying accountNumber + kostenplaats.
 	 */
 	private function fetchGlDeductions(string $administrationId, int $boekjaar): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('GLLine')
 			->findAll(['filters' => ['administrationId' => $administrationId, 'financialYear' => $boekjaar]]);

--- a/lib/Service/DunningRunService.php
+++ b/lib/Service/DunningRunService.php
@@ -56,6 +56,7 @@ use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Orchestrates DunningRun execution, pause/resume, write-off, and
@@ -96,6 +97,7 @@ class DunningRunService {
 		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -1091,8 +1093,7 @@ class DunningRunService {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);
@@ -1117,8 +1118,7 @@ class DunningRunService {
 	 * @return array<string,mixed> The saved record (with id).
 	 */
 	private function saveObject(string $schema, array $data): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema($schema)
 			->saveObject($data);

--- a/lib/Service/EInvoice/EInvoiceService.php
+++ b/lib/Service/EInvoice/EInvoiceService.php
@@ -45,10 +45,10 @@ use OCA\Shillinq\Service\Peppol\PeppolTransmissionPortInterface;
 use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Orchestrates ARInvoice e-invoice generation, validation and Peppol dispatch.
@@ -95,7 +95,6 @@ final class EInvoiceService {
 	 *                                                         {@see LogPeppolTransmissionAdapter}.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly LoggerInterface $logger,
@@ -103,6 +102,7 @@ final class EInvoiceService {
 		private readonly ArInvoiceUblMapper $ublMapper,
 		private readonly InvoicePdfGenerator $pdfGenerator,
 		private readonly EInvoiceValidationService $validationService,
+		private readonly ObjectService $objectService,
 		?PeppolTransmissionPortInterface $peppolPort = null,
 	) {
 		$this->peppolPort = ($peppolPort ?? new LogPeppolTransmissionAdapter(
@@ -359,8 +359,7 @@ final class EInvoiceService {
 	 */
 	private function saveObject(string $schema, array $object): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->saveObject($object);
@@ -390,8 +389,7 @@ final class EInvoiceService {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/ExceptionResolutionService.php
+++ b/lib/Service/ExceptionResolutionService.php
@@ -67,9 +67,9 @@ use OCA\Shillinq\Service\PurchaseOrder\LogCreditNoteRequestAdapter;
 use OCP\IAppConfig;
 use OCP\IUserSession;
 use OCP\Notification\IManager as INotificationManager;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Slice 08 — resolution-side workflow for out-of-tolerance ThreeWayMatch
@@ -236,12 +236,12 @@ class ExceptionResolutionService {
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly IUserSession $userSession,
 		private readonly INotificationManager $notificationManager,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 		?CreditNoteRequestAdapterInterface $creditNoteAdapter = null,
 	) {
 		$this->creditNoteAdapter = ($creditNoteAdapter ?? new LogCreditNoteRequestAdapter(logger: $logger));
@@ -929,8 +929,7 @@ class ExceptionResolutionService {
 	 */
 	private function saveObject(string $schema, array $object): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->saveObject($object);
@@ -979,8 +978,7 @@ class ExceptionResolutionService {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/FifoValuationService.php
+++ b/lib/Service/FifoValuationService.php
@@ -55,9 +55,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Imperative FIFO cost layer engine driving {@see CogsPosterService}.
@@ -78,9 +78,9 @@ class FifoValuationService {
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -438,8 +438,7 @@ class FifoValuationService {
 		string $warehouse,
 		string $administrationId,
 	): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('StockMove')
 			->findAll(
@@ -493,8 +492,7 @@ class FifoValuationService {
 		string $administrationId,
 		?string $excludeMoveUuid = null,
 	): float {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('StockMove')
 			->findAll(
@@ -542,8 +540,7 @@ class FifoValuationService {
 		string $warehouse,
 		string $administrationId,
 	): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$existing = $objectService
+		$existing = $this->objectService
 			->setRegister($this->register())
 			->setSchema('InventoryValuation')
 			->findAll(
@@ -589,8 +586,7 @@ class FifoValuationService {
 	 * @return array<string,mixed> Persisted snapshot (with id).
 	 */
 	private function saveValuation(array $data): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema('InventoryValuation')
 			->saveObject($data);

--- a/lib/Service/FixedAssetDisposalService.php
+++ b/lib/Service/FixedAssetDisposalService.php
@@ -57,9 +57,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Posts the closing GL journal for a disposed FixedAsset (REQ-GLTAX-001).
@@ -130,11 +130,11 @@ class FixedAssetDisposalService {
 	 * canonical name fleet-wide.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly DisposalJournalEmitter $emitter,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -543,8 +543,7 @@ class FixedAssetDisposalService {
 	 * @throws \RuntimeException When the row type is unsupported.
 	 */
 	private function saveOnSchema(string $schema, array $data): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema($schema)
 			->saveObject($data);
@@ -580,8 +579,7 @@ class FixedAssetDisposalService {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/FluxService.php
+++ b/lib/Service/FluxService.php
@@ -39,8 +39,8 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Variance calculation + driver decomposition for continuous-close (REQ-CLS-005..007).
@@ -76,9 +76,9 @@ class FluxService {
 	 * @param LoggerInterface $logger Logger for diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -620,7 +620,6 @@ class FluxService {
 		array $summary,
 	): void {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$run = [
 				'administrationId' => $administrationId,
 				'periodId' => $periodId,
@@ -633,7 +632,7 @@ class FluxService {
 				'resultSummary' => $summary,
 			];
 
-			$objectService->saveObject(
+			$this->objectService->saveObject(
 				object: $run,
 				register: $this->register(),
 				schema: 'FluxRun',
@@ -643,7 +642,7 @@ class FluxService {
 				$attributions = (array)($item['attributions'] ?? []);
 				unset($item['attributions']);
 
-				$objectService->saveObject(
+				$this->objectService->saveObject(
 					object: $item,
 					register: $this->register(),
 					schema: 'FluxItem',
@@ -651,7 +650,7 @@ class FluxService {
 
 				foreach ($attributions as $attribution) {
 					$attribution['fluxItemId'] = $item['glAccountNumber'] . '@' . $fluxRunId;
-					$objectService->saveObject(
+					$this->objectService->saveObject(
 						object: $attribution,
 						register: $this->register(),
 						schema: 'FluxAttribution',

--- a/lib/Service/GRIRClearingService.php
+++ b/lib/Service/GRIRClearingService.php
@@ -80,9 +80,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Member 09 of bookkeeping-purchase-order-3way: GR/IR clearing + settlement
@@ -286,10 +286,10 @@ class GRIRClearingService {
 	 * canonical name fleet-wide.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -1346,8 +1346,7 @@ class GRIRClearingService {
 	 * @throws \RuntimeException When the row type is unsupported.
 	 */
 	private function saveOnSchema(string $schema, array $data): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema($schema)
 			->saveObject($data);
@@ -1400,8 +1399,7 @@ class GRIRClearingService {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/GoodsReceiptNoteService.php
+++ b/lib/Service/GoodsReceiptNoteService.php
@@ -53,9 +53,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Member 04 of bookkeeping-purchase-order-3way: GRN lifecycle + inventory
@@ -165,10 +165,10 @@ class GoodsReceiptNoteService {
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -906,8 +906,7 @@ class GoodsReceiptNoteService {
 	 */
 	private function saveObject(string $schema, array $object): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->saveObject($object);
@@ -956,8 +955,7 @@ class GoodsReceiptNoteService {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/IcpFilingService.php
+++ b/lib/Service/IcpFilingService.php
@@ -36,9 +36,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use RuntimeException;
 use ZipArchive;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Owns the ICP filing write path: corrections, audit-export bundles, outage scan.
@@ -56,11 +56,11 @@ class IcpFilingService {
 	 * @param ViesService $vies VIES validation / evidence-reuse helper.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly IcpCalculator $calculator,
 		private readonly IcpService $icp,
 		private readonly ViesService $vies,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -210,8 +210,7 @@ class IcpFilingService {
 			}
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$validations = $objectService
+		$validations = $this->objectService
 			->setRegister($this->register())
 			->setSchema('ViesValidation')
 			->findAll(['filters' => ['administrationId' => $administrationId, 'outage' => true]]);
@@ -254,8 +253,7 @@ class IcpFilingService {
 			}
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$validations = $objectService
+		$validations = $this->objectService
 			->setRegister($this->register())
 			->setSchema('ViesValidation')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -282,8 +280,7 @@ class IcpFilingService {
 	 * @return array<string,mixed> The opgaaf record, or [] when none exists.
 	 */
 	private function findOpgaaf(string $administrationId, string $period): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$opgaven = $objectService
+		$opgaven = $this->objectService
 			->setRegister($this->register())
 			->setSchema('IcpOpgaaf')
 			->findAll(['filters' => ['administrationId' => $administrationId, 'period' => $period]]);
@@ -304,8 +301,7 @@ class IcpFilingService {
 	 */
 	private function saveOpgaaf(array $opgaaf): bool {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$objectService->saveObject(
+			$this->objectService->saveObject(
 				object: $opgaaf,
 				register: $this->register(),
 				schema: 'IcpOpgaaf',

--- a/lib/Service/IcpService.php
+++ b/lib/Service/IcpService.php
@@ -37,7 +37,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Computes the ICP ledger, periodicity decision, and reconciliation for a period.
@@ -58,9 +58,9 @@ class IcpService {
 	 * @param IcpCalculator $calculator Pure-logic ICP helper.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly IcpCalculator $calculator,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -175,8 +175,7 @@ class IcpService {
 	 * @return array<int,array<string,mixed>> In-period IcpSupply records.
 	 */
 	private function suppliesForPeriod(string $administrationId, string $period): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$supplies = $objectService
+		$supplies = $this->objectService
 			->setRegister($this->register())
 			->setSchema('IcpSupply')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -206,8 +205,7 @@ class IcpService {
 	 * @return float|null The rubriek 3b value, or null when no BTW-aangifte exists.
 	 */
 	private function rubriek3bForPeriod(string $administrationId, string $period): ?float {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$returns = $objectService
+		$returns = $this->objectService
 			->setRegister($this->register())
 			->setSchema('VatReturn')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);

--- a/lib/Service/InnovatieboxAggregationService.php
+++ b/lib/Service/InnovatieboxAggregationService.php
@@ -36,7 +36,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Computes the per-asset innovatiebox Vpb roll-up (REQ-IBA-006).
@@ -57,10 +57,10 @@ class InnovatieboxAggregationService {
 	 *                                            status='valid' is now stale (REQ-IBA-001).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly CarryForwardLossService $lossService,
 		private readonly QualifyingAssetValidator $validator,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -209,8 +209,7 @@ class InnovatieboxAggregationService {
 	 * @return array<int,array<string,mixed>> Valid assets.
 	 */
 	private function fetchValidAssets(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('QualifyingAsset')
 			->findAll(['filters' => ['administrationId' => $administrationId, 'status' => 'valid']]);
@@ -246,8 +245,7 @@ class InnovatieboxAggregationService {
 	 * @return array<int,array<string,mixed>> Attribution rows.
 	 */
 	private function fetchAttributions(string $administrationId, int $boekjaar): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('IBProfitAttribution')
 			->findAll(['filters' => ['administrationId' => $administrationId, 'financialYear' => $boekjaar]]);
@@ -267,8 +265,7 @@ class InnovatieboxAggregationService {
 	 * @return array<int,array<string,mixed>> Open loss rows.
 	 */
 	private function fetchOpenLosses(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('CarryForwardLoss')
 			->findAll(['filters' => ['administrationId' => $administrationId, 'status' => 'open']]);

--- a/lib/Service/IntercompanyLinkService.php
+++ b/lib/Service/IntercompanyLinkService.php
@@ -48,9 +48,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Creates the mirrored intercompany side and reconciles the pair (REQ-GLTAX-002).
@@ -82,10 +82,10 @@ class IntercompanyLinkService {
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly IntercompanyJournalService $journalService,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -257,8 +257,7 @@ class IntercompanyLinkService {
 	 * @throws \RuntimeException When the row type is unsupported.
 	 */
 	private function saveEntry(array $data): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema(self::SCHEMA_ENTRY)
 			->saveObject($data);
@@ -294,8 +293,7 @@ class IntercompanyLinkService {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/IntercompanyMatchingService.php
+++ b/lib/Service/IntercompanyMatchingService.php
@@ -41,8 +41,8 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Orchestrating service for the intercompany elimination engine.
@@ -60,10 +60,10 @@ class IntercompanyMatchingService {
 	 * @param LoggerInterface $logger Logger for diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly IntercompanyMatchingCalculator $calculator,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -87,7 +87,7 @@ class IntercompanyMatchingService {
 	 * @return object The ObjectService instance.
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Service/InventoryGlAdjustmentPoster.php
+++ b/lib/Service/InventoryGlAdjustmentPoster.php
@@ -46,9 +46,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Balanced two-line GLTransaction poster for inventory adjustments.
@@ -66,9 +66,9 @@ class InventoryGlAdjustmentPoster {
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -227,8 +227,7 @@ class InventoryGlAdjustmentPoster {
 	 * @return array<string,mixed>
 	 */
 	private function saveOnSchema(string $schema, array $data): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema($schema)
 			->saveObject($data);

--- a/lib/Service/InventoryScanService.php
+++ b/lib/Service/InventoryScanService.php
@@ -43,8 +43,8 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Server-authoritative inventory operations for the mobile scanner.
@@ -64,8 +64,8 @@ class InventoryScanService {
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,
-		private readonly ContainerInterface $container,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -535,8 +535,7 @@ class InventoryScanService {
 	 * @return void
 	 */
 	private function saveObject(string $schema, array $object): void {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$objectService->saveObject(
+		$this->objectService->saveObject(
 			object: $object,
 			register: $this->getRegisterSlug(),
 			schema: $schema,
@@ -573,13 +572,12 @@ class InventoryScanService {
 	 */
 	private function findMany(string $schema, array $filters, ?int $limit = null): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$params = ['filters' => $filters];
 			if ($limit !== null) {
 				$params['limit'] = $limit;
 			}
 
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister(register: $this->getRegisterSlug())
 				->setSchema(schema: $schema)
 				->findAll($params);

--- a/lib/Service/InventoryValuationReportService.php
+++ b/lib/Service/InventoryValuationReportService.php
@@ -52,8 +52,8 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Ledger-replay valuation reporting (as-of-date / ageing / turnover).
@@ -75,9 +75,9 @@ class InventoryValuationReportService {
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -511,7 +511,6 @@ class InventoryValuationReportService {
 	 * @return array<string,array<int,array<string,mixed>>>
 	 */
 	private function groupedMoves(string $administrationId, string $cutoff, ?string $sku, ?string $warehouse): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$filters = [
 			'administrationId' => $administrationId,
 			'lifecycleState' => 'posted',
@@ -520,7 +519,7 @@ class InventoryValuationReportService {
 			$filters['itemId'] = $sku;
 		}
 
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('StockMove')
 			->findAll(['filters' => $filters]);
@@ -609,8 +608,7 @@ class InventoryValuationReportService {
 	 * @return array<int,array<string,mixed>>
 	 */
 	private function rawMoves(array $filters): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('StockMove')
 			->findAll(['filters' => $filters]);
@@ -638,8 +636,7 @@ class InventoryValuationReportService {
 	 */
 	private function methodFor(string $administrationId, string $sku, string $warehouse): string {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema('InventoryValuation')
 				->findAll(

--- a/lib/Service/InvoiceGenerationService.php
+++ b/lib/Service/InvoiceGenerationService.php
@@ -30,9 +30,9 @@ namespace OCA\Shillinq\Service;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Request\InvoiceGenerationRequest;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Drafting, validation, and GL posting of BillableInvoice rows.
@@ -56,7 +56,6 @@ class InvoiceGenerationService {
 	 * @param UsageRatingCalculator $usageRating Meter-quantity rating (usage model).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
 		private readonly RateCardResolver $rateCards,
@@ -65,6 +64,7 @@ class InvoiceGenerationService {
 		private readonly InvoiceDeduplicationService $deduper,
 		private readonly VATCalculationService $vat,
 		private readonly UsageRatingCalculator $usageRating,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -698,9 +698,8 @@ class InvoiceGenerationService {
 	 * @return string Invoice number.
 	 */
 	private function generateInvoiceNumber(string $administrationId, string $invoiceDate): string {
-		$existing = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		try {
-			$rs = $existing->setRegister($this->register())
+			$rs = $this->objectService->setRegister($this->register())
 				->setSchema('BillableInvoice')
 				->findAll(['filters' => ['administrationId' => $administrationId]]);
 			if (is_array($rs) === true) {
@@ -759,8 +758,7 @@ class InvoiceGenerationService {
 	 */
 	private function find(string $schema, string $id): ?array {
 		try {
-			$svc = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rs = $svc->setRegister($this->register())->setSchema($schema)->find($id);
+			$rs = $this->objectService->setRegister($this->register())->setSchema($schema)->find($id);
 			if (is_array($rs) === true) {
 				return $rs;
 			}
@@ -781,8 +779,7 @@ class InvoiceGenerationService {
 	 * @return array<string,mixed>
 	 */
 	private function saveObject(string $schema, array $data): array {
-		$svc = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $svc
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema($schema)
 			->saveObject($data);

--- a/lib/Service/KorMonitorService.php
+++ b/lib/Service/KorMonitorService.php
@@ -33,7 +33,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Computes the KOR drempel-status for one administration + year from the AR ledger.
@@ -56,9 +56,9 @@ class KorMonitorService {
 	 * @param KorThresholdCalculator $calculator Pure-logic KOR arithmetic helper.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly KorThresholdCalculator $calculator,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -123,8 +123,7 @@ class KorMonitorService {
 	 */
 	private function resolveOptOutPermitted(string $administrationId): bool {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$registrations = $objectService
+			$registrations = $this->objectService
 				->setRegister($this->register())
 				->setSchema('KORRegistration')
 				->findAll(
@@ -160,8 +159,7 @@ class KorMonitorService {
 	 * @return array<int,array<string,mixed>> KOR-eligible AR-invoice records.
 	 */
 	private function fetchKorInvoices(string $administrationId, int $year): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$invoices = $objectService
+		$invoices = $this->objectService
 			->setRegister($this->register())
 			->setSchema('ARInvoice')
 			->findAll(
@@ -239,8 +237,7 @@ class KorMonitorService {
 		$default = $this->calculator->toCents(amount: 20000);
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$registrations = $objectService
+			$registrations = $this->objectService
 				->setRegister($this->register())
 				->setSchema('KORRegistration')
 				->findAll(

--- a/lib/Service/LandedCostAllocationService.php
+++ b/lib/Service/LandedCostAllocationService.php
@@ -51,9 +51,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Pro-rata landed-cost capitalisation into unit cost + balanced GL (ADR-031 exception).
@@ -93,10 +93,10 @@ class LandedCostAllocationService {
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly InventoryGlAdjustmentPoster $poster,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -335,8 +335,7 @@ class LandedCostAllocationService {
 	 * @return array<int,array<string,mixed>>
 	 */
 	private function receiptLines(string $administrationId, string $receiptReference): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('StockMove')
 			->findAll(
@@ -370,8 +369,7 @@ class LandedCostAllocationService {
 	 * @return array<string,mixed>|null
 	 */
 	private function activeValuation(string $administrationId, string $itemId): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('InventoryValuation')
 			->findAll(
@@ -400,8 +398,7 @@ class LandedCostAllocationService {
 	 * @return array<string,mixed>
 	 */
 	private function saveValuation(array $data): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema('InventoryValuation')
 			->saveObject($data);

--- a/lib/Service/LeaseAuditPackGenerator.php
+++ b/lib/Service/LeaseAuditPackGenerator.php
@@ -37,8 +37,8 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Skeleton audit-pack builder for an IFRS 16 lease.
@@ -63,10 +63,10 @@ class LeaseAuditPackGenerator {
 	 * @param LoggerInterface $logger Logger (no stack traces to client).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LeasePaymentScheduleService $scheduleService,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -308,7 +308,7 @@ class LeaseAuditPackGenerator {
 	 * @return object The ObjectService instance.
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Service/LeaseDisclosureService.php
+++ b/lib/Service/LeaseDisclosureService.php
@@ -34,8 +34,8 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Computes the period-end IFRS 16 disclosure table for one administration.
@@ -68,10 +68,10 @@ class LeaseDisclosureService {
 	 * @param LoggerInterface $logger Logger (no stack traces to client).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LeaseAmortizationCalculator $calculator,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -702,7 +702,7 @@ class LeaseDisclosureService {
 	 * @return object The ObjectService instance.
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Service/LeasePaymentScheduleService.php
+++ b/lib/Service/LeasePaymentScheduleService.php
@@ -32,8 +32,8 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Materialises the LeasePaymentSchedule rows for an active lease (REQ-LA-002).
@@ -55,10 +55,10 @@ class LeasePaymentScheduleService {
 	 * @param LoggerInterface $logger Logger (no stack traces to client).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LeaseAmortizationCalculator $calculator,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -223,7 +223,7 @@ class LeasePaymentScheduleService {
 	 * @return object The ObjectService instance.
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Service/LeaseReassessmentService.php
+++ b/lib/Service/LeaseReassessmentService.php
@@ -46,8 +46,8 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Records and computes IFRS 16 lease-reassessment events.
@@ -92,10 +92,10 @@ class LeaseReassessmentService {
 	 * @param LeaseDecideskWebhookService|null $decideskWebhook Optional decidesk webhook delivery service.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LeaseAmortizationCalculator $calculator,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 		private readonly ?LeaseDecideskWebhookService $decideskWebhook = null,
 	) {
 	}//end __construct()
@@ -796,7 +796,7 @@ class LeaseReassessmentService {
 	 * @return object The ObjectService instance.
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Service/MovingAverageValuationService.php
+++ b/lib/Service/MovingAverageValuationService.php
@@ -50,9 +50,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Imperative moving-average engine driving {@see CogsPosterService}.
@@ -73,9 +73,9 @@ class MovingAverageValuationService {
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -229,8 +229,7 @@ class MovingAverageValuationService {
 		string $warehouse,
 		string $administrationId,
 	): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$existing = $objectService
+		$existing = $this->objectService
 			->setRegister($this->register())
 			->setSchema('InventoryValuation')
 			->findAll(
@@ -276,8 +275,7 @@ class MovingAverageValuationService {
 	 * @return array<string,mixed> Persisted snapshot (with id).
 	 */
 	private function saveValuation(array $data): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema('InventoryValuation')
 			->saveObject($data);

--- a/lib/Service/MultiPoConsolidationService.php
+++ b/lib/Service/MultiPoConsolidationService.php
@@ -63,9 +63,9 @@ use DateTimeImmutable;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Slice 07 — multi-PO consolidated invoice matching.
@@ -187,12 +187,12 @@ class MultiPoConsolidationService {
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly IUserSession $userSession,
 		private readonly SupplierInvoiceService $supplierInvoiceService,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -891,8 +891,7 @@ class MultiPoConsolidationService {
 	 */
 	private function saveObject(string $schema, array $object): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->saveObject($object);
@@ -941,8 +940,7 @@ class MultiPoConsolidationService {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/NrvWriteDownService.php
+++ b/lib/Service/NrvWriteDownService.php
@@ -47,9 +47,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Lower-of-cost-or-NRV period-end write-down + balanced GL (ADR-031 exception).
@@ -89,10 +89,10 @@ class NrvWriteDownService {
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly InventoryGlAdjustmentPoster $poster,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -259,8 +259,7 @@ class NrvWriteDownService {
 	 * @return array<int,array<string,mixed>>
 	 */
 	private function activeValuations(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('InventoryValuation')
 			->findAll(
@@ -292,8 +291,7 @@ class NrvWriteDownService {
 	 * @return array<string,mixed>
 	 */
 	private function saveValuation(array $data): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema('InventoryValuation')
 			->saveObject($data);

--- a/lib/Service/ObligationTaskBridge.php
+++ b/lib/Service/ObligationTaskBridge.php
@@ -40,6 +40,7 @@ namespace OCA\Shillinq\Service;
 
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Creates / links the NC Tasks VTODO (or Deck card) for a ContractObligation.
@@ -64,6 +65,7 @@ class ObligationTaskBridge {
 	public function __construct(
 		private readonly ContainerInterface $container,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -227,8 +229,7 @@ class ObligationTaskBridge {
 	 */
 	public function listOpenObligationDeadlines(): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister(register: $this->registerSlug())
 				->setSchema(schema: 'ContractObligation')
 				->findAll([]);

--- a/lib/Service/OssRateResolver.php
+++ b/lib/Service/OssRateResolver.php
@@ -38,7 +38,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Resolves destination-country VAT rates from the seeded EuVatRate (TEDB) table.
@@ -94,8 +94,8 @@ class OssRateResolver {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -171,8 +171,7 @@ class OssRateResolver {
 	 * @spec openspec/specs/bookkeeping-btw-oss-eu/spec.md
 	 */
 	public function resolve(string $countryCode, string $rateCategory, string $invoiceDate): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rates = $objectService
+		$rates = $this->objectService
 			->setRegister($this->register())
 			->setSchema('EuVatRate')
 			->findAll(

--- a/lib/Service/OssRecordResolver.php
+++ b/lib/Service/OssRecordResolver.php
@@ -38,9 +38,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Reads OssReturn / OssPayment records through the real ObjectService API.
@@ -71,9 +71,9 @@ class OssRecordResolver {
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -144,8 +144,7 @@ class OssRecordResolver {
 	 * @spec openspec/specs/revive-gl-tax-capabilities/spec.md
 	 */
 	public function savePayment(array $data): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema(self::SCHEMA_PAYMENT)
 			->saveObject($data);
@@ -181,8 +180,7 @@ class OssRecordResolver {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/OssReturnGenerator.php
+++ b/lib/Service/OssReturnGenerator.php
@@ -33,7 +33,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Generates draft OssReturn line items by aggregating OSS-eligible documents.
@@ -51,8 +51,8 @@ class OssReturnGenerator {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -172,10 +172,9 @@ class OssReturnGenerator {
 	 */
 	public function generateDraft(string $administrationId, int $periodYear, string $periodQuarter, string $registrationId): array {
 		$period = $periodYear . '-' . $periodQuarter;
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->register();
 
-		$invoices = $objectService
+		$invoices = $this->objectService
 			->setRegister($register)
 			->setSchema('Invoice')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);

--- a/lib/Service/PaymentReconciliationService.php
+++ b/lib/Service/PaymentReconciliationService.php
@@ -56,6 +56,7 @@ use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Idempotent reconciliation of PaymentRequest AND DepositPayment records against
@@ -192,6 +193,7 @@ class PaymentReconciliationService {
 		private ContainerInterface $container,
 		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -230,14 +232,13 @@ class PaymentReconciliationService {
 			return ['result' => self::RESULT_NOT_FOUND, 'schema' => null];
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$registerSlug = $this->getRegisterSlug();
 
 		// Resolve across both schemas — the shared surface (REQ-APL-004).
 		$record = null;
 		$schema = null;
 		foreach (self::SCHEMAS as $candidateSchema) {
-			$matches = $objectService
+			$matches = $this->objectService
 				->setRegister($registerSlug)
 				->setSchema($candidateSchema)
 				->findAll(
@@ -304,7 +305,7 @@ class PaymentReconciliationService {
 			);
 			if ($settledInvoice === null) {
 				$record['state'] = 'captured_unapplied';
-				$objectService->saveObject(
+				$this->objectService->saveObject(
 					object: $record,
 					register: $registerSlug,
 					schema: $schema,
@@ -318,7 +319,7 @@ class PaymentReconciliationService {
 			$record['confirmationSummary'] = $this->buildConfirmationSummary(invoice: $settledInvoice, request: $record);
 		}//end if
 
-		$objectService->saveObject(
+		$this->objectService->saveObject(
 			object: $record,
 			register: $registerSlug,
 			schema: $schema,
@@ -356,7 +357,7 @@ class PaymentReconciliationService {
 		}
 
 		try {
-			$invoices = $objectService
+			$invoices = $this->objectService
 				->setRegister($registerSlug)
 				->setSchema('ARInvoice')
 				->findAll(
@@ -367,7 +368,7 @@ class PaymentReconciliationService {
 				);
 
 			if (empty($invoices) === true) {
-				$invoices = $objectService
+				$invoices = $this->objectService
 					->setRegister($registerSlug)
 					->setSchema('ARInvoice')
 					->findAll(
@@ -406,7 +407,7 @@ class PaymentReconciliationService {
 			$invoice['paymentEvidenceRef'] = (string)($request['paymentIntentId'] ?? '');
 			$invoice['settlementReference'] = (string)($request['settlementReference'] ?? '');
 
-			$objectService->saveObject(
+			$this->objectService->saveObject(
 				object: $invoice,
 				register: $registerSlug,
 				schema: 'ARInvoice',
@@ -521,7 +522,6 @@ class PaymentReconciliationService {
 	 * @spec openspec/changes/ar-invoice-payment-links/specs/ar-invoice-payment-links/spec.md (REQ-APL-004)
 	 */
 	public function pollPending(callable $statusProvider): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$registerSlug = $this->getRegisterSlug();
 
 		$pageSize = 200;
@@ -533,7 +533,7 @@ class PaymentReconciliationService {
 			$batchSize = 0;
 
 			do {
-				$batch = $objectService
+				$batch = $this->objectService
 					->setRegister($registerSlug)
 					->setSchema($schema)
 					->findAll(

--- a/lib/Service/PayrollJaaropgaveService.php
+++ b/lib/Service/PayrollJaaropgaveService.php
@@ -38,9 +38,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Aggregates the yearly Jaaropgave per employee from the period loonstroken.
@@ -61,10 +61,10 @@ class PayrollJaaropgaveService {
 	 * @param LoggerInterface $logger Logger (no BSN / special-category data).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly PayrollCalculator $calculator,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -227,7 +227,7 @@ class PayrollJaaropgaveService {
 	 * @return object The ObjectService.
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Service/PayrollLivLkvHandoffService.php
+++ b/lib/Service/PayrollLivLkvHandoffService.php
@@ -31,7 +31,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Pure aggregate: per-(werknemer, jaar) LIV/LKV eligibility payload.
@@ -47,9 +47,9 @@ class PayrollLivLkvHandoffService {
 	 * @param PayrollCalculator $calculator Cents arithmetic helper.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly PayrollCalculator $calculator,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -165,7 +165,7 @@ class PayrollLivLkvHandoffService {
 	 * @return object The ObjectService.
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Service/PayrollService.php
+++ b/lib/Service/PayrollService.php
@@ -36,9 +36,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Period-scoped Dutch payroll processing over OpenRegister.
@@ -61,10 +61,10 @@ class PayrollService {
 	 * @param LoggerInterface $logger Logger (no BSN / special-category data).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly PayrollCalculator $calculator,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -651,7 +651,7 @@ class PayrollService {
 	 * @return object The ObjectService.
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Service/PayrollUpaHandoffService.php
+++ b/lib/Service/PayrollUpaHandoffService.php
@@ -34,8 +34,8 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Aggregates UPA submission payloads from LoonStrook records.
@@ -51,9 +51,9 @@ class PayrollUpaHandoffService {
 	 * @param LoggerInterface $logger Logger (no BSN / special-category data).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -197,7 +197,7 @@ class PayrollUpaHandoffService {
 	 * @return object The ObjectService.
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Service/PayrollWkrHandoffService.php
+++ b/lib/Service/PayrollWkrHandoffService.php
@@ -35,7 +35,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Emits the period loonsom for the WKR app to compute the free-space ceiling.
@@ -51,9 +51,9 @@ class PayrollWkrHandoffService {
 	 * @param PayrollCalculator $calculator Cents arithmetic helper.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly PayrollCalculator $calculator,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -127,7 +127,7 @@ class PayrollWkrHandoffService {
 	 * @return object The ObjectService.
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Service/PeriodCloseAssistantService.php
+++ b/lib/Service/PeriodCloseAssistantService.php
@@ -47,7 +47,7 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Detects incomplete pre-close tasks and formats them as close-assistant flags.
@@ -63,9 +63,9 @@ class PeriodCloseAssistantService {
 	 * @param SuspenseAgeingService $suspenseAgeing Aged suspense worklist source (REQ-PCG-002).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly SuspenseAgeingService $suspenseAgeing,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -120,10 +120,9 @@ class PeriodCloseAssistantService {
 	 * @spec openspec/changes/bookkeeping-period-close/tasks.md#task-8
 	 */
 	public function detectOpenSubLedger(string $administrationId, string $periodId, string $subLedgerType): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->register();
 
-		$transactions = $objectService
+		$transactions = $this->objectService
 			->setRegister($register)
 			->setSchema('GLTransaction')
 			->findAll(
@@ -148,7 +147,7 @@ class PeriodCloseAssistantService {
 			return ['count' => 0, 'total' => 0.0];
 		}
 
-		$lines = $objectService
+		$lines = $this->objectService
 			->setRegister($register)
 			->setSchema('GLLine')
 			->findAll(
@@ -196,17 +195,16 @@ class PeriodCloseAssistantService {
 	 * @spec openspec/changes/bookkeeping-period-close/tasks.md#task-8
 	 */
 	public function detectUnreconciledBankReceipts(string $administrationId, string $periodId, string $endDate = ''): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->register();
 
-		$statements = $objectService
+		$statements = $this->objectService
 			->setRegister($register)
 			->setSchema('BankStatement')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
 
 		// Posted GL transactions for the period — their sourceReference set lets
 		// us recognise statements that have already been reconciled / posted.
-		$posted = $objectService
+		$posted = $this->objectService
 			->setRegister($register)
 			->setSchema('GLTransaction')
 			->findAll(
@@ -259,9 +257,7 @@ class PeriodCloseAssistantService {
 	 * @spec openspec/changes/bookkeeping-period-close/tasks.md#task-8
 	 */
 	public function detectOutstandingExpenseClaims(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-
-		$claims = $objectService
+		$claims = $this->objectService
 			->setRegister($this->register())
 			->setSchema('ExpenseClaimEntry')
 			->findAll(

--- a/lib/Service/PeriodCloseService.php
+++ b/lib/Service/PeriodCloseService.php
@@ -42,8 +42,8 @@ use DateTimeInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
 use OCP\IGroupManager;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Orchestrates the PeriodClose lifecycle with server-side role enforcement.
@@ -89,11 +89,11 @@ class PeriodCloseService {
 	 * @param LoggerInterface $logger Logger for diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly IGroupManager $groupManager,
 		private readonly SuspenseAgeingService $suspenseAgeing,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -443,7 +443,6 @@ class PeriodCloseService {
 	 * @return array<string,mixed>|null The record, or null when not found.
 	 */
 	private function find(string $periodId, string $administrationId): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->register();
 
 		// Match on the business periodId within the administration first (the
@@ -453,7 +452,7 @@ class PeriodCloseService {
 			$filters['administrationId'] = $administrationId;
 		}
 
-		$found = $objectService
+		$found = $this->objectService
 			->setRegister($register)
 			->setSchema('FiscalPeriod')
 			->findAll(['filters' => $filters, 'limit' => 1]);
@@ -463,7 +462,7 @@ class PeriodCloseService {
 		}
 
 		// Fall back to the record-id lookup, still scoped to the administration.
-		$byId = $objectService
+		$byId = $this->objectService
 			->setRegister($register)
 			->setSchema('FiscalPeriod')
 			->findAll(['filters' => ['id' => $periodId], 'limit' => 1]);
@@ -532,8 +531,7 @@ class PeriodCloseService {
 	 * @return array<string,mixed> The saved record (echoes the input on stub backends).
 	 */
 	private function persist(array $record): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$objectService->saveObject(
+		$this->objectService->saveObject(
 			object: $record,
 			register: $this->register(),
 			schema: 'FiscalPeriod',

--- a/lib/Service/ProgrammabegrotingService.php
+++ b/lib/Service/ProgrammabegrotingService.php
@@ -34,7 +34,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Reads programmabegroting data and produces sluitend-status and exports.
@@ -52,10 +52,10 @@ class ProgrammabegrotingService {
 	 * @param ProgrammabegrotingExporter $exporter Produces iv3 / EMU / JSON export shapes.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly SluitendCalculator $sluitend,
 		private readonly ProgrammabegrotingExporter $exporter,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -171,10 +171,9 @@ class ProgrammabegrotingService {
 	 * @return array<int,array<string,mixed>> The matching rows.
 	 */
 	private function fetchMany(string $schema, array $filters): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->resolveRegister();
 
-		$rows = $objectService->setRegister($register)->setSchema($schema)->findAll(['filters' => $filters]);
+		$rows = $this->objectService->setRegister($register)->setSchema($schema)->findAll(['filters' => $filters]);
 		$result = [];
 		foreach ($rows as $row) {
 			if (is_array($row) === true) {

--- a/lib/Service/PurchaseOrderApprovalService.php
+++ b/lib/Service/PurchaseOrderApprovalService.php
@@ -51,9 +51,9 @@ namespace OCA\Shillinq\Service;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Slice 11 — records approver identity + decidedAt on the next pending
@@ -131,11 +131,11 @@ class PurchaseOrderApprovalService {
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 		private readonly ?ApprovalActivityEmitter $activityEmitter = null,
 	) {
 
@@ -392,8 +392,7 @@ class PurchaseOrderApprovalService {
 	 */
 	private function saveObject(string $schema, array $object): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->saveObject($object);
@@ -423,8 +422,7 @@ class PurchaseOrderApprovalService {
 	 */
 	private function findOne(string $schema, array $filters): ?array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/PurchaseOrderService.php
+++ b/lib/Service/PurchaseOrderService.php
@@ -55,9 +55,9 @@ use OCA\Shillinq\Service\PurchaseOrder\PeppolTransmissionAdapterInterface;
 use OCA\Shillinq\Service\PurchaseOrder\PurchaseOrderMailerInterface;
 use OCP\IAppConfig;
 use OCP\Notification\IManager as INotificationManager;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Member 02 of bookkeeping-purchase-order-3way: PO creation + approval routing.
@@ -184,11 +184,11 @@ class PurchaseOrderService {
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly INotificationManager $notificationManager,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 		?PeppolTransmissionAdapterInterface $peppolAdapter = null,
 		?PurchaseOrderMailerInterface $purchaseOrderMailer = null,
 		?PeppolBisOrderMapper $peppolMapper = null,
@@ -1096,8 +1096,7 @@ class PurchaseOrderService {
 	 */
 	private function saveObject(string $schema, array $object): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->saveObject($object);
@@ -1146,8 +1145,7 @@ class PurchaseOrderService {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/RequisitionConversionService.php
+++ b/lib/Service/RequisitionConversionService.php
@@ -41,9 +41,9 @@ namespace OCA\Shillinq\Service;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Lifecycle\RequisitionConversionGuard;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Materialises an approved Requisition into a PurchaseOrder (REQ-REQ-005).
@@ -65,12 +65,12 @@ class RequisitionConversionService {
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly RequisitionConversionGuard $guard,
 		private readonly PurchaseOrderService $purchaseOrderService,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -187,8 +187,7 @@ class RequisitionConversionService {
 	 */
 	private function saveObject(string $schema, array $object): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->saveObject($object);
@@ -237,8 +236,7 @@ class RequisitionConversionService {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/RequisitionService.php
+++ b/lib/Service/RequisitionService.php
@@ -43,9 +43,9 @@ namespace OCA\Shillinq\Service;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Lifecycle\BudgetBlocker;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Requisition create / submit / approve / reject (REQ-REQ-001..004).
@@ -66,11 +66,11 @@ class RequisitionService {
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly BudgetBlocker $budgetBlocker,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -452,8 +452,7 @@ class RequisitionService {
 	 */
 	private function saveObject(string $schema, array $object): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->saveObject($object);
@@ -502,8 +501,7 @@ class RequisitionService {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/RevenueCutoffService.php
+++ b/lib/Service/RevenueCutoffService.php
@@ -42,7 +42,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Computes per-contract revenue cut-off balances and waterfall rows.
@@ -65,9 +65,9 @@ class RevenueCutoffService {
 	 * @param RevenueRecognitionCalculator $calculator Pure-logic IFRS 15 arithmetic helper.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly RevenueRecognitionCalculator $calculator,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -141,8 +141,7 @@ class RevenueCutoffService {
 	 * @return array<string,array<string,mixed>> contractNumber => Contract object.
 	 */
 	private function fetchContracts(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$contracts = $objectService
+		$contracts = $this->objectService
 			->setRegister($this->register())
 			->setSchema('Contract')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -167,8 +166,7 @@ class RevenueCutoffService {
 	 * @return array<string,array{cumulative:float,period:float}> contractId => recognised amounts.
 	 */
 	private function recognisedByContract(string $administrationId, string $periodEnd): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$events = $objectService
+		$events = $this->objectService
 			->setRegister($this->register())
 			->setSchema('RevenueRecognitionEvent')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -216,8 +214,7 @@ class RevenueCutoffService {
 	 * @return array<string,float> contractId => total allocated price.
 	 */
 	private function allocatedByContract(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$allocations = $objectService
+		$allocations = $this->objectService
 			->setRegister($this->register())
 			->setSchema('PriceAllocation')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);

--- a/lib/Service/RuleAuditService.php
+++ b/lib/Service/RuleAuditService.php
@@ -35,8 +35,8 @@ use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Standards\RuleCatalogue;
 use OCA\Shillinq\Standards\RuleEngine;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Read-only compliance auditor over the register's bookkeeping objects.
@@ -58,9 +58,9 @@ class RuleAuditService {
 	 * @param LoggerInterface $logger Logger.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -226,7 +226,7 @@ class RuleAuditService {
 	 * @return mixed The OpenRegister ObjectService.
 	 */
 	private function objectService(): mixed {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Service/RuleTestDataSeeder.php
+++ b/lib/Service/RuleTestDataSeeder.php
@@ -36,8 +36,8 @@ use OCP\IAppConfig;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Makes the local test data compliant with the enforced rules (idempotent).
@@ -61,11 +61,11 @@ class RuleTestDataSeeder {
 	 * @param LoggerInterface $logger Logger.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly IUserManager $userManager,
 		private readonly IGroupManager $groupManager,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -359,7 +359,7 @@ class RuleTestDataSeeder {
 	 * @return mixed The OpenRegister ObjectService.
 	 */
 	private function objectService(): mixed {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Service/SalesDispatchStockIssueService.php
+++ b/lib/Service/SalesDispatchStockIssueService.php
@@ -66,6 +66,7 @@ use OCA\Shillinq\Lifecycle\LotSellabilityGuard;
 use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Wires Delivery confirm/cancel into the existing StockMove issue/cancel
@@ -99,6 +100,7 @@ class SalesDispatchStockIssueService {
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
 		private readonly LotSellabilityGuard $lotGuard,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -747,7 +749,7 @@ class SalesDispatchStockIssueService {
 	 * @return object
 	 */
 	private function objectService(): object {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 
 	/**

--- a/lib/Service/SepaAuditService.php
+++ b/lib/Service/SepaAuditService.php
@@ -35,9 +35,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use ZipArchive;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Builds the SEPA mandate audit dossier ZIP (REQ-SDD-010).
@@ -54,10 +54,10 @@ class SepaAuditService {
 	 * @param LoggerInterface $logger Logger.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly AdministrationContextService $context,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -87,7 +87,6 @@ class SepaAuditService {
 		}
 
 		$register = $this->resolveRegister();
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
 		$mandate = $this->findOne(
 			objectService: $objectService,
@@ -334,7 +333,7 @@ class SepaAuditService {
 	 * @return array<int,mixed> The matching records.
 	 */
 	private function findMany(object $objectService, string $register, string $schema, array $filters): array {
-		$result = $objectService
+		$result = $this->objectService
 			->setRegister($register)
 			->setSchema($schema)
 			->findAll(['filters' => $filters]);

--- a/lib/Service/ServiceReceiptService.php
+++ b/lib/Service/ServiceReceiptService.php
@@ -52,9 +52,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Member 12 of bookkeeping-purchase-order-3way: SvcReceipt (prestatieverklaring)
@@ -125,10 +125,10 @@ class ServiceReceiptService {
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -733,8 +733,7 @@ class ServiceReceiptService {
 	 */
 	private function saveObject(string $schema, array $object): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->saveObject($object);
@@ -783,8 +782,7 @@ class ServiceReceiptService {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/SoftCloseExecutor.php
+++ b/lib/Service/SoftCloseExecutor.php
@@ -47,6 +47,7 @@ use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Orchestrates the nightly soft-close execution per administratie (ADR-031 exception).
@@ -85,6 +86,7 @@ class SoftCloseExecutor {
 		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -318,13 +320,12 @@ class SoftCloseExecutor {
 	 * @return array<int,array<string,mixed>> The active rules (possibly empty).
 	 */
 	private function findActiveRules(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$filters = ['lifecycleState' => 'active'];
 		if ($administrationId !== '') {
 			$filters['administrationId'] = $administrationId;
 		}
 
-		$found = $objectService
+		$found = $this->objectService
 			->setRegister($this->register())
 			->setSchema('AutoAccrualRule')
 			->findAll(['filters' => $filters]);
@@ -359,8 +360,7 @@ class SoftCloseExecutor {
 			'reversalState' => 'posted',
 		];
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$objectService->saveObject(
+		$this->objectService->saveObject(
 			object: $posting,
 			register: $this->register(),
 			schema: 'AutoAccrualPosting',
@@ -520,8 +520,7 @@ class SoftCloseExecutor {
 			return;
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$found = $objectService
+		$found = $this->objectService
 			->setRegister($this->register())
 			->setSchema('PeriodStatus')
 			->findAll(
@@ -560,7 +559,7 @@ class SoftCloseExecutor {
 		];
 		$record['stageChangeHistory'] = $history;
 
-		$objectService->saveObject(
+		$this->objectService->saveObject(
 			object: $record,
 			register: $this->register(),
 			schema: 'PeriodStatus',
@@ -591,8 +590,7 @@ class SoftCloseExecutor {
 		];
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$objectService->saveObject(
+			$this->objectService->saveObject(
 				object: $alert,
 				register: $this->register(),
 				schema: 'ContinuousCloseAlert',

--- a/lib/Service/StockLedgerService.php
+++ b/lib/Service/StockLedgerService.php
@@ -47,8 +47,8 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * REQ-SM-005 + REQ-SM-009 read-side aggregation for the Stock Ledger
@@ -67,9 +67,9 @@ class StockLedgerService {
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -252,18 +252,17 @@ class StockLedgerService {
 			return [];
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$base = [
 			'administrationId' => $administrationId,
 			'itemId' => $sku,
 			'lifecycleState' => 'posted',
 		];
 
-		$sourceSide = ($objectService
+		$sourceSide = ($this->objectService
 			->setRegister($this->register())
 			->setSchema('StockMove')
 			->findAll(['filters' => array_merge($base, ['sourceLocationId' => $locationId])]) ?? []);
-		$destinationSide = ($objectService
+		$destinationSide = ($this->objectService
 			->setRegister($this->register())
 			->setSchema('StockMove')
 			->findAll(['filters' => array_merge($base, ['destinationLocationId' => $locationId])]) ?? []);
@@ -307,8 +306,7 @@ class StockLedgerService {
 			return [];
 		}
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = ($objectService
+		$rows = ($this->objectService
 			->setRegister($this->register())
 			->setSchema('StockMove')
 			->findAll(

--- a/lib/Service/SupplierInvoiceService.php
+++ b/lib/Service/SupplierInvoiceService.php
@@ -46,10 +46,10 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use SimpleXMLElement;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Slice 05 — Supplier invoice ingestion from UBL (Peppol) and PDF (OCR).
@@ -144,10 +144,10 @@ class SupplierInvoiceService {
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -862,8 +862,7 @@ class SupplierInvoiceService {
 	 */
 	private function saveObject(string $schema, array $object): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->saveObject($object);
@@ -912,8 +911,7 @@ class SupplierInvoiceService {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/SupplierQualificationService.php
+++ b/lib/Service/SupplierQualificationService.php
@@ -31,9 +31,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * OpenRegister-backed supplier qualification service.
@@ -52,10 +52,10 @@ class SupplierQualificationService {
 	 * @param LoggerInterface $logger Logger for diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly AdministrationContextService $administrationContext,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -245,8 +245,7 @@ class SupplierQualificationService {
 	 */
 	private function saveObject(string $schema, array $object): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->saveObject($object);
@@ -276,8 +275,7 @@ class SupplierQualificationService {
 	 */
 	private function findOne(string $schema, array $filters): ?array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/TaxCalculationService.php
+++ b/lib/Service/TaxCalculationService.php
@@ -37,8 +37,8 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Orchestrates deferred-tax calculation at fiscal-period close.
@@ -63,10 +63,10 @@ class TaxCalculationService {
 	 * @param LoggerInterface $logger PSR-3 logger.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly TaxCalculationHelper $helper,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -951,6 +951,6 @@ class TaxCalculationService {
 	 * @return mixed OR ObjectService instance.
 	 */
 	private function objectService(): mixed {
-		return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		return $this->objectService;
 	}//end objectService()
 }//end class

--- a/lib/Service/TaxNotificationService.php
+++ b/lib/Service/TaxNotificationService.php
@@ -38,8 +38,8 @@ use DateTimeInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
 use OCP\Notification\IManager;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Dispatches Vpb deadline reminders (REQ-VPB-013).
@@ -68,10 +68,10 @@ class TaxNotificationService {
 	 * @param LoggerInterface $logger Logger for diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly IManager $notificationMgr,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -177,8 +177,7 @@ class TaxNotificationService {
 	 * @return array<int,array<string,mixed>> Open TaxDeadline records.
 	 */
 	private function fetchPendingDeadlines(): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$deadlines = $objectService
+		$deadlines = $this->objectService
 			->setRegister($this->register())
 			->setSchema('TaxDeadline')
 			->findAll([]);

--- a/lib/Service/TaxPaymentReconciliationService.php
+++ b/lib/Service/TaxPaymentReconciliationService.php
@@ -31,7 +31,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Reconciles a Vpb payment record against the general ledger (REQ-VPB-008).
@@ -53,9 +53,9 @@ class TaxPaymentReconciliationService {
 	 * @param TaxReportCalculator $calculator Pure-logic cents helper (reused for precision).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly TaxReportCalculator $calculator,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -140,8 +140,7 @@ class TaxPaymentReconciliationService {
 	 * @return array{0:int,1:int} [summed cents, matched line count].
 	 */
 	private function glMovementForAccount(string $periodId, string $accountNumber): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$lines = $objectService
+		$lines = $this->objectService
 			->setRegister($this->register())
 			->setSchema('GLLine')
 			->findAll(['filters' => ['periodId' => $periodId, 'accountNumber' => $accountNumber]]);
@@ -173,8 +172,7 @@ class TaxPaymentReconciliationService {
 	 * @return array<string,mixed>|null The payment record, or null when absent.
 	 */
 	private function findPayment(string $administrationId, string $paymentId): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$payments = $objectService
+		$payments = $this->objectService
 			->setRegister($this->register())
 			->setSchema('TaxPaymentTracking')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);

--- a/lib/Service/TaxReportService.php
+++ b/lib/Service/TaxReportService.php
@@ -36,7 +36,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Computes a period-scoped Vpb quarterly tax statement from the general ledger.
@@ -61,9 +61,9 @@ class TaxReportService {
 	 * @param TaxReportCalculator $calculator Pure-logic aggregation helper.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly TaxReportCalculator $calculator,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -169,10 +169,9 @@ class TaxReportService {
 	 *                                        accountType, taxTreatment, amount, side.
 	 */
 	private function fetchTaxRows(string $administrationId, string $periodId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->register();
 
-		$transactions = $objectService
+		$transactions = $this->objectService
 			->setRegister($register)
 			->setSchema('GLTransaction')
 			->findAll(
@@ -189,7 +188,7 @@ class TaxReportService {
 
 		$accounts = $this->fetchAccounts(administrationId: $administrationId);
 
-		$lines = $objectService
+		$lines = $this->objectService
 			->setRegister($register)
 			->setSchema('GLLine')
 			->findAll(['filters' => ['periodId' => $periodId]]);
@@ -232,8 +231,7 @@ class TaxReportService {
 	 * @return array<string,array<string,mixed>> accountNumber => Account object.
 	 */
 	private function fetchAccounts(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$accounts = $objectService
+		$accounts = $this->objectService
 			->setRegister($this->register())
 			->setSchema('Account')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);

--- a/lib/Service/ThreeWayMatchingEngine.php
+++ b/lib/Service/ThreeWayMatchingEngine.php
@@ -70,9 +70,9 @@ namespace OCA\Shillinq\Service;
 use DateTimeImmutable;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Slice 06 — single-PO 3-way matching engine.
@@ -237,11 +237,11 @@ class ThreeWayMatchingEngine {
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly ToleranceProfileService $toleranceService,
 		private readonly SupplierInvoiceService $invoiceService,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 		private readonly ?ExceptionResolutionService $exceptionResolution = null,
 	) {
 
@@ -1109,8 +1109,7 @@ class ThreeWayMatchingEngine {
 	 */
 	private function saveObject(string $schema, array $object): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->saveObject($object);
@@ -1159,8 +1158,7 @@ class ThreeWayMatchingEngine {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/TimeIntakeService.php
+++ b/lib/Service/TimeIntakeService.php
@@ -68,9 +68,9 @@ use InvalidArgumentException;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Request\InvoiceGenerationRequest;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Validates, materialises, and delegates a pipelinq time-billing batch.
@@ -104,10 +104,10 @@ class TimeIntakeService {
 	 * @param InvoiceGenerationService $invoices Existing, unmodified draftInvoice() machinery.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
 		private readonly InvoiceGenerationService $invoices,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -717,8 +717,7 @@ class TimeIntakeService {
 	 */
 	private function find(string $schema, string $id): ?array {
 		try {
-			$svc = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rs = $svc->setRegister($this->register())->setSchema($schema)->find($id);
+			$rs = $this->objectService->setRegister($this->register())->setSchema($schema)->find($id);
 			if (is_array($rs) === true) {
 				return $rs;
 			}
@@ -740,8 +739,7 @@ class TimeIntakeService {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$svc = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rs = $svc->setRegister($this->register())->setSchema($schema)->findAll(['filters' => $filters]);
+			$rs = $this->objectService->setRegister($this->register())->setSchema($schema)->findAll(['filters' => $filters]);
 			if (is_array($rs) === true) {
 				return $rs;
 			}
@@ -763,8 +761,7 @@ class TimeIntakeService {
 	 * @return array<string,mixed>
 	 */
 	private function saveObject(string $schema, array $data): array {
-		$svc = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $svc->setRegister($this->register())->setSchema($schema)->saveObject($data);
+		$saved = $this->objectService->setRegister($this->register())->setSchema($schema)->saveObject($data);
 
 		if (is_array($saved) === false) {
 			throw new RuntimeException(sprintf('ObjectService::saveObject(%s) did not return an array', $schema));

--- a/lib/Service/Treasury/FxRevaluationService.php
+++ b/lib/Service/Treasury/FxRevaluationService.php
@@ -50,9 +50,9 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Period-end FX revaluation of open FXPosition balances (ADR-031 exception).
@@ -106,10 +106,10 @@ class FxRevaluationService {
 	 * @param LoggerInterface $logger Structured logger.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly TreasuryRateService $treasuryRateService,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -338,8 +338,7 @@ class FxRevaluationService {
 		$record['unrealisedPL'] = $unrealisedPL;
 		$record['lastUpdated'] = $asOf->format(DateTimeInterface::ATOM);
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$objectService->saveObject(
+		$this->objectService->saveObject(
 			object: $record,
 			register: $this->register(),
 			schema: 'FXPosition',
@@ -409,8 +408,7 @@ class FxRevaluationService {
 			'reversalState' => 'posted',
 		];
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$objectService->saveObject(
+		$this->objectService->saveObject(
 			object: $posting,
 			register: $this->register(),
 			schema: 'FxRevaluationPosting',
@@ -427,8 +425,7 @@ class FxRevaluationService {
 	 */
 	private function functionalCurrencyFor(string $administrationId): string {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$found = $objectService
+			$found = $this->objectService
 				->setRegister($this->register())
 				->setSchema('Administration')
 				->findAll(
@@ -467,8 +464,7 @@ class FxRevaluationService {
 	 */
 	private function findOpenPositions(string $administrationId): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$found = $objectService
+			$found = $this->objectService
 				->setRegister($this->register())
 				->setSchema('FXPosition')
 				->findAll(['filters' => ['administrationId' => $administrationId]]);

--- a/lib/Service/TrialBalanceService.php
+++ b/lib/Service/TrialBalanceService.php
@@ -46,7 +46,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Computes a period-scoped, per-account trial balance from the general ledger.
@@ -79,9 +79,9 @@ class TrialBalanceService {
 	 * @param TrialBalanceCalculator $calculator Pure-logic arithmetic helper.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly TrialBalanceCalculator $calculator,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -185,11 +185,10 @@ class TrialBalanceService {
 	 * @return array<string,array{debit:int,credit:int}> accountNumber => debit/credit cents.
 	 */
 	private function movementsByAccount(string $administrationId, string $periodId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->register();
 
 		// Transactions that belong to this administration + period (REQ-TB-017 scoping).
-		$transactions = $objectService
+		$transactions = $this->objectService
 			->setRegister($register)
 			->setSchema('GLTransaction')
 			->findAll(
@@ -207,7 +206,7 @@ class TrialBalanceService {
 		}
 
 		// GLLines for the period; cross-check the parent transaction is in scope.
-		$lines = $objectService
+		$lines = $this->objectService
 			->setRegister($register)
 			->setSchema('GLLine')
 			->findAll(['filters' => ['periodId' => $periodId]]);
@@ -269,8 +268,7 @@ class TrialBalanceService {
 	 * @return array<string,array<string,mixed>> accountNumber => Account object.
 	 */
 	private function fetchAccounts(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$accounts = $objectService
+		$accounts = $this->objectService
 			->setRegister($this->register())
 			->setSchema('Account')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);

--- a/lib/Service/VATReturnService.php
+++ b/lib/Service/VATReturnService.php
@@ -49,9 +49,9 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Composes VAT returns from GL transactions using the real OpenRegister API.
@@ -76,9 +76,9 @@ class VATReturnService {
 	 * @param LoggerInterface $logger Logger for diagnostics.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -286,8 +286,7 @@ class VATReturnService {
 	 * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
 	 */
 	public function fetchFiledDeclarations(string $returnId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('VATDeclaration')
 			->findAll(['filters' => ['returnId' => $returnId]]);
@@ -657,28 +656,27 @@ class VATReturnService {
 	 * @return void
 	 */
 	private function purgeChildren(string $returnId): void {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->register();
 
-		$lines = $objectService
+		$lines = $this->objectService
 			->setRegister($register)
 			->setSchema('VATLine')
 			->findAll(['filters' => ['returnId' => $returnId]]);
 		foreach ($lines as $line) {
 			$id = (string)($line['id'] ?? ($line['@self']['id'] ?? ''));
 			if ($id !== '') {
-				$objectService->setRegister($register)->setSchema('VATLine')->deleteObject($id);
+				$this->objectService->setRegister($register)->setSchema('VATLine')->deleteObject($id);
 			}
 		}
 
-		$declarations = $objectService
+		$declarations = $this->objectService
 			->setRegister($register)
 			->setSchema('VATDeclaration')
 			->findAll(['filters' => ['returnId' => $returnId]]);
 		foreach ($declarations as $declaration) {
 			$id = (string)($declaration['id'] ?? ($declaration['@self']['id'] ?? ''));
 			if ($id !== '') {
-				$objectService->setRegister($register)->setSchema('VATDeclaration')->deleteObject($id);
+				$this->objectService->setRegister($register)->setSchema('VATDeclaration')->deleteObject($id);
 			}
 		}
 
@@ -705,8 +703,7 @@ class VATReturnService {
 	 * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
 	 */
 	public function findReturn(string $returnId): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$found = $objectService
+		$found = $this->objectService
 			->setRegister($this->register())
 			->setSchema('BtwAangifte')
 			->find($returnId);
@@ -742,8 +739,7 @@ class VATReturnService {
 	 * @return array<string,array<string,mixed>> accountNumber => Account.
 	 */
 	private function fetchVATAccounts(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$accounts = $objectService
+		$accounts = $this->objectService
 			->setRegister($this->register())
 			->setSchema('Account')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -773,8 +769,7 @@ class VATReturnService {
 	 * @return array<int,array<string,mixed>> List of GLTransaction objects.
 	 */
 	private function fetchGLTransactions(string $administrationId, string $startDate, string $endDate): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('GLTransaction')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -869,8 +864,7 @@ class VATReturnService {
 	 * @throws RuntimeException When the row cannot be normalised to an array.
 	 */
 	private function saveObject(string $schema, array $data): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema($schema)
 			->saveObject($data);

--- a/lib/Service/VatSuppletieDetectionService.php
+++ b/lib/Service/VatSuppletieDetectionService.php
@@ -65,9 +65,9 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Detects filed-vs-ledger drift on a VATReturn and compiles a VatCorrection.
@@ -124,10 +124,10 @@ class VatSuppletieDetectionService {
 	 * @param VATReturnService $vatReturnService The GL-derivation engine this service diffs against.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
 		private readonly VATReturnService $vatReturnService,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -392,8 +392,7 @@ class VatSuppletieDetectionService {
 	private function attachAccounts(array $deltas, string $originalReturnId): array {
 		$lines = [];
 		if ($originalReturnId !== '') {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$lines = $objectService
+			$lines = $this->objectService
 				->setRegister($this->register())
 				->setSchema('VATLine')
 				->findAll(['filters' => ['returnId' => $originalReturnId]]);
@@ -561,8 +560,7 @@ class VatSuppletieDetectionService {
 	 * @return array<string,mixed>
 	 */
 	private function fetchCorrection(string $vatCorrectionId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$correction = $objectService
+		$correction = $this->objectService
 			->setRegister($this->register())
 			->setSchema('VatCorrection')
 			->find($vatCorrectionId);
@@ -583,8 +581,7 @@ class VatSuppletieDetectionService {
 	 * @return array<string,mixed> The saved record (with id).
 	 */
 	private function saveObject(string $schema, array $data): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$saved = $objectService
+		$saved = $this->objectService
 			->setRegister($this->register())
 			->setSchema($schema)
 			->saveObject($data);

--- a/lib/Service/VendorPerformanceAggregation.php
+++ b/lib/Service/VendorPerformanceAggregation.php
@@ -88,10 +88,10 @@ namespace OCA\Shillinq\Service;
 use DateTimeImmutable;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Member 10 of bookkeeping-purchase-order-3way: monthly vendor performance
@@ -205,9 +205,9 @@ class VendorPerformanceAggregation {
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 
 	}//end __construct()
@@ -1124,8 +1124,7 @@ class VendorPerformanceAggregation {
 	 */
 	private function saveObject(string $schema, array $object): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->saveObject($object);
@@ -1174,8 +1173,7 @@ class VendorPerformanceAggregation {
 	 */
 	private function findAll(string $schema, array $filters): array {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema($schema)
 				->findAll(['filters' => $filters]);

--- a/lib/Service/ViesService.php
+++ b/lib/Service/ViesService.php
@@ -43,8 +43,8 @@ namespace OCA\Shillinq\Service;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\Http\Client\IClientService;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Validates EU VAT-IDs against VIES and persists immutable evidence records.
@@ -87,10 +87,10 @@ class ViesService {
 	 * @param LoggerInterface $logger Logger (no special-category data logged).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly IClientService $clientService,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -241,8 +241,7 @@ class ViesService {
 	 * @spec openspec/specs/bookkeeping-icp-opgaaf/spec.md
 	 */
 	public function findRecentValid(string $administrationId, string $vatId): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$records = $objectService
+		$records = $this->objectService
 			->setRegister($this->register())
 			->setSchema('ViesValidation')
 			->findAll(['filters' => ['administrationId' => $administrationId, 'vatId' => $vatId]]);
@@ -363,8 +362,7 @@ class ViesService {
 		];
 
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$objectService->saveObject(
+			$this->objectService->saveObject(
 				object: $record,
 				register: $this->register(),
 				schema: 'ViesValidation',

--- a/lib/Service/WbsoAccountService.php
+++ b/lib/Service/WbsoAccountService.php
@@ -31,7 +31,7 @@ namespace OCA\Shillinq\Service;
 use InvalidArgumentException;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Account-register helper service (REQ-WBSO-001 / REQ-WBSO-006).
@@ -59,8 +59,8 @@ class WbsoAccountService {
 	 * @param IAppConfig $appConfig App config (register slug).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -72,8 +72,7 @@ class WbsoAccountService {
 	 * @return array<int,array<string,mixed>>
 	 */
 	public function getAccountsByAdministration(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		return $objectService
+		return $this->objectService
 			->setRegister($this->register())
 			->setSchema('Account')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -179,9 +178,8 @@ class WbsoAccountService {
 			parent: (string)($payload['parentAccountNumber'] ?? ''),
 		);
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
-		return $objectService
+		return $this->objectService
 			->setRegister($this->register())
 			->setSchema('Account')
 			->saveObject($payload);
@@ -224,9 +222,8 @@ class WbsoAccountService {
 			parent: (string)($merged['parentAccountNumber'] ?? ''),
 		);
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
-		return $objectService
+		return $this->objectService
 			->setRegister($this->register())
 			->setSchema('Account')
 			->saveObject($merged);

--- a/lib/Service/WbsoAdministratieService.php
+++ b/lib/Service/WbsoAdministratieService.php
@@ -37,7 +37,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Computes a per-beschikking realisatie summary from the S&O hour administration.
@@ -54,8 +54,8 @@ class WbsoAdministratieService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -120,10 +120,9 @@ class WbsoAdministratieService {
 	 * @return array<string,int> beschikkingNumber => realised hours in tenths.
 	 */
 	private function realisedHoursByBeschikking(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 		$register = $this->register();
 
-		$entries = $objectService
+		$entries = $this->objectService
 			->setRegister($register)
 			->setSchema('SoUurregistratie')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -167,8 +166,7 @@ class WbsoAdministratieService {
 	 * @return array<string,array<string,mixed>> beschikkingNumber => beschikking object.
 	 */
 	private function fetchBeschikkingen(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$records = $objectService
+		$records = $this->objectService
 			->setRegister($this->register())
 			->setSchema('WbsoBeschikking')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);

--- a/lib/Service/WbsoDocumentService.php
+++ b/lib/Service/WbsoDocumentService.php
@@ -36,8 +36,8 @@ use InvalidArgumentException;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Document-register helper service (REQ-WBSO-003 / REQ-WBSO-007 / REQ-WBSO-009).
@@ -78,9 +78,9 @@ class WbsoDocumentService {
 	 * @param IUserSession $userSession Authenticated session (createdBy).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly IUserSession $userSession,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -92,8 +92,7 @@ class WbsoDocumentService {
 	 * @return array<int,array<string,mixed>>
 	 */
 	public function getDocumentsByAdministration(string $administrationId): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		return $objectService
+		return $this->objectService
 			->setRegister($this->register())
 			->setSchema('Document')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -160,9 +159,8 @@ class WbsoDocumentService {
 
 		$this->validateDocumentPayload(payload: $payload);
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
-		return $objectService
+		return $this->objectService
 			->setRegister($this->register())
 			->setSchema('Document')
 			->saveObject($payload);
@@ -204,9 +202,8 @@ class WbsoDocumentService {
 		$document['filedAt'] = (new DateTimeImmutable())->format(DateTimeInterface::ATOM);
 		$document['filedBy'] = $approver;
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
-		return $objectService
+		return $this->objectService
 			->setRegister($this->register())
 			->setSchema('Document')
 			->saveObject($document);
@@ -254,9 +251,8 @@ class WbsoDocumentService {
 		$document['archivedAt'] = (new DateTimeImmutable())->format(DateTimeInterface::ATOM);
 		$document['archivalReason'] = $reason;
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
-		return $objectService
+		return $this->objectService
 			->setRegister($this->register())
 			->setSchema('Document')
 			->saveObject($document);

--- a/lib/Service/WbsoTransactionService.php
+++ b/lib/Service/WbsoTransactionService.php
@@ -39,8 +39,8 @@ use InvalidArgumentException;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
 use OCP\IUserSession;
-use Psr\Container\ContainerInterface;
 use RuntimeException;
+use OCA\OpenRegister\Service\ObjectService;
 
 /**
  * Transaction-register helper service (REQ-WBSO-002 / REQ-WBSO-008).
@@ -71,9 +71,9 @@ class WbsoTransactionService {
 	 * @param IUserSession $userSession Authenticated session (used to record createdBy).
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly IUserSession $userSession,
+		private readonly ObjectService $objectService,
 	) {
 	}//end __construct()
 
@@ -86,8 +86,7 @@ class WbsoTransactionService {
 	 * @return array<int,array<string,mixed>>
 	 */
 	public function listTransactions(string $administrationId, array $filters = []): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$transactions = $objectService
+		$transactions = $this->objectService
 			->setRegister($this->register())
 			->setSchema('Transaction')
 			->findAll(['filters' => ['administrationId' => $administrationId]]);
@@ -163,9 +162,8 @@ class WbsoTransactionService {
 
 		$this->validateTransactionPayload(payload: $payload);
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
-		return $objectService
+		return $this->objectService
 			->setRegister($this->register())
 			->setSchema('Transaction')
 			->saveObject($payload);
@@ -198,9 +196,8 @@ class WbsoTransactionService {
 		$existing['status'] = 'posted';
 		$existing['postedAt'] = (new DateTimeImmutable())->format(DateTimeInterface::ATOM);
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
-		return $objectService
+		return $this->objectService
 			->setRegister($this->register())
 			->setSchema('Transaction')
 			->saveObject($existing);
@@ -252,9 +249,8 @@ class WbsoTransactionService {
 			'reversalReason' => $reason,
 		];
 
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 
-		return $objectService
+		return $this->objectService
 			->setRegister($this->register())
 			->setSchema('Transaction')
 			->saveObject($reversal);


### PR DESCRIPTION
147 file(s) reached OpenRegister through `$this->container->get(...)` on an **unconditional** path — no availability check, no degrading catch. The dependency was announced nowhere: not in the constructor, not in the `use` block, not in any type. It appeared mid-method, as a **string**.

Now constructor-injected and typed. Behaviour is unchanged — same object, same container, resolved at construction instead of at first use. `ContainerInterface` is dropped only where nothing else used it.

**Deliberately not converted**, because they are correct as written (ADR-083 rule 1's exception): lookups behind `isInstalled()`/`getInstalledApps()`, and lookups whose `catch` degrades rather than rethrows. Converting those would make the service unconstructable without OpenRegister and turn a clean message into a 500.

Verified per file: `php -l` clean, and gate-66's lookup check reports **zero** remaining findings for each file changed.

gate-66 for this app: **236 → 10**.