### PR TITLE
fix(spec): finish the exclude decision this repo already made, and fix a typo

### DIFF
--- a/lib/Reporting/GeneratedFile.php
+++ b/lib/Reporting/GeneratedFile.php
@@ -16,7 +16,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/Generator/AbstractDocumentReportGenerator.php
+++ b/lib/Reporting/Generator/AbstractDocumentReportGenerator.php
@@ -34,7 +34,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/Generator/AnnualAccountsReportGenerator.php
+++ b/lib/Reporting/Generator/AnnualAccountsReportGenerator.php
@@ -19,7 +19,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/Generator/BalanceSheetReportGenerator.php
+++ b/lib/Reporting/Generator/BalanceSheetReportGenerator.php
@@ -20,7 +20,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/Generator/BbvJaarstukkenReportGenerator.php
+++ b/lib/Reporting/Generator/BbvJaarstukkenReportGenerator.php
@@ -20,7 +20,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/Generator/GeneralLedgerReportGenerator.php
+++ b/lib/Reporting/Generator/GeneralLedgerReportGenerator.php
@@ -17,7 +17,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/Generator/Iv3ReportGenerator.php
+++ b/lib/Reporting/Generator/Iv3ReportGenerator.php
@@ -19,7 +19,16 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
+ *       NOTE: this generator is one of the three that CONTRADICT their domain
+ *       capability (REQ-IV3-004 — "not a PHP renderer"), so retagging it at
+ *       bookkeeping-iv3-reporting would make the gate pass against a requirement
+ *       the code breaks. That contradiction is the substance of #525.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/Generator/ManagementLetterReportGenerator.php
+++ b/lib/Reporting/Generator/ManagementLetterReportGenerator.php
@@ -20,7 +20,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/Generator/ProfitLossReportGenerator.php
+++ b/lib/Reporting/Generator/ProfitLossReportGenerator.php
@@ -20,7 +20,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/Generator/ReportDataTrait.php
+++ b/lib/Reporting/Generator/ReportDataTrait.php
@@ -19,7 +19,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/Generator/RuleAuditReportGenerator.php
+++ b/lib/Reporting/Generator/RuleAuditReportGenerator.php
@@ -19,7 +19,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/Generator/SaftReportGenerator.php
+++ b/lib/Reporting/Generator/SaftReportGenerator.php
@@ -20,7 +20,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/Generator/TrialBalanceReportGenerator.php
+++ b/lib/Reporting/Generator/TrialBalanceReportGenerator.php
@@ -19,7 +19,16 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
+ *       NOTE: this generator is one of the three that CONTRADICT their domain
+ *       capability (REQ-TB-001 — "not a PHP report builder"), so retagging it at
+ *       bookkeeping-trial-balance would make the gate pass against a requirement
+ *       the code breaks. That contradiction is the substance of #525.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/Generator/VatReturnReportGenerator.php
+++ b/lib/Reporting/Generator/VatReturnReportGenerator.php
@@ -21,7 +21,16 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
+ *       NOTE: this generator is one of the three that CONTRADICT their domain
+ *       capability (REQ-VBTW-004 — the ADR-031 aggregation anti-pattern), so
+ *       retagging it at bookkeeping-vat-btw-filing would make the gate pass
+ *       against a requirement the code breaks. That contradiction is #525.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/ReportCatalogue.php
+++ b/lib/Reporting/ReportCatalogue.php
@@ -24,7 +24,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Reporting/ReportGeneratorInterface.php
+++ b/lib/Reporting/ReportGeneratorInterface.php
@@ -29,7 +29,12 @@
  *
  * @link https://conduction.nl
  *
- * @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ * @spec exclude The reporting capability has no canonical spec. This tag pointed at
+ *       openspec/changes/reporting-compliance-consolidation (a change directory that
+ *       exists neither under changes nor under changes/archive), and no canonical
+ *       reporting capability exists under openspec/specs either. Tracked in #525.
+ *       Deliberately NOT resolved by writing that spec — authoring the requirement
+ *       a tag is checked against turns the gate green over an unspecified capability.
  *
  * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
  * The change directory it names was never committed, and the `reporting`

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -428,7 +428,7 @@ class SettingsService {
 	 *
 	 * @return array<string,mixed> Result with success flag, seeded count, skipped count.
 	 *
-	 * @spec openspec/specs/bookkeeping-vat-vat-filing/spec.md
+	 * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
 	 */
 	public function seedBtwTariffs(): array {
 		return $this->seedGenericFile(


### PR DESCRIPTION
## What

Finishes a decision this repo already made, and fixes one typo. gate-46 on shillinq: **17 → 0**.

## The reporting cluster (16 files)

`development` already resolved this — for **two** files. `ReportingController` and `ReportGenerationService` carry an `@spec exclude` block whose reasoning is exact:

> The reporting capability has no canonical spec. This tag pointed at `openspec/changes/reporting-compliance-consolidation` (a change directory that exists neither under `changes` nor under `changes/archive`)… **Deliberately NOT resolved by writing that spec — authoring the requirement a tag is checked against turns the gate green over an unspecified capability.** Tracked in #525.

**Sixteen more files were never given the same treatment** and still point at that never-existing path. This applies the identical block to them. It adds no new judgement; it finishes applying one already recorded in the tree.

### Three files get an extra sentence

`TrialBalanceReportGenerator`, `Iv3ReportGenerator` and `VatReturnReportGenerator` are the three that **contradict** their domain capability — REQ-TB-001 ("not a PHP report builder"), REQ-IV3-004 ("not a PHP renderer"), REQ-VBTW-004 (the ADR-031 aggregation anti-pattern). Their exclude says so, because the obvious "fix" — retagging them at their domain spec — would make gate-46 **pass against requirements the code breaks**. That is the substance of #525 and it should be findable from the code, not only from an issue.

## The typo (1 file)

`SettingsService::seedBtwTariffs()` tagged `bookkeeping-vat-vat-filing` — a path that has never existed. The real capability is `bookkeeping-vat-btw-filing`, and **REQ-VBTW-003 covers this exact behaviour**: "BTW rate seed data SHALL be loaded as a register, not hard-coded as enums", with a `VatTariff` register, idempotent re-run, and operator-added tariffs preserved — which is what the method does.

I checked coverage rather than just resolution: a tag that resolves to a spec not covering the code is the failure mode this gate exists to catch.

> Worth a follow-up: REQ-VBTW-003 names the seed file `btw-tariffs-2026.json`, the code loads `vat-tariffs-2026.json`. Spec and code disagree on the filename. Out of scope here.

## Supersedes #514

#514 proposed the opposite resolution — *writing* `openspec/specs/reporting/spec.md`. It is now **34 commits behind** and conflicts with the exclude blocks development has since adopted. Since the tree has taken a documented position, the consistent move is to apply that position rather than reverse it in a stale branch. #514 should be closed; #525 keeps the architectural question open, which is where it belongs.

## Verification

- `php -l` clean on all 17 changed files.
- gate-46: **17 findings on `development` → 0 on this branch**, run with the current canonical gate package.
- Docblock-only change: no executable line is touched (`+109 / −17`, all comment lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
