### PR TITLE
fix(security): widget availability leaked services the business never published

### DIFF
--- a/lib/Controller/WidgetApiController.php
+++ b/lib/Controller/WidgetApiController.php
@@ -201,6 +201,21 @@ class WidgetApiController extends Controller {
 			return $this->badRequest(message: 'date must be ISO YYYY-MM-DD.');
 		}
 
+		// The #491 gate, third door. services() filters the catalogue to
+		// `isPublic` and appointments() refuses to book a service that is not,
+		// but availability was readable for ANY serviceId of this tenant.
+		// guard() only proves the caller holds the widget API key — which is
+		// shipped in a PUBLIC widget, so everyone who can see the page has it.
+		//
+		// 404 rather than 403, matching WidgetService: a 403 would confirm the
+		// service exists, which is the fact being withheld.
+		if ($this->widgetService->isPubliclyBookable(serviceId: $serviceId) === false) {
+			return new JSONResponse(
+				data: ['error' => 'service_not_found'],
+				statusCode: Http::STATUS_NOT_FOUND
+			);
+		}
+
 		$result = $this->slots->getAvailableSlots(
 			serviceId: $serviceId,
 			resourceId: $resourceId,

--- a/lib/Service/WidgetService.php
+++ b/lib/Service/WidgetService.php
@@ -424,6 +424,46 @@ class WidgetService {
 	}//end createAppointment()
 
 	/**
+	 * Whether a serviceId names a service the business actually published.
+	 *
+	 * The same #491 gate as findPublicService(), exposed for callers that need
+	 * to ASK the question rather than resolve the row — currently
+	 * WidgetApiController::slots().
+	 *
+	 * Why slots() needs it: `guard()` proves the caller holds a widget API key,
+	 * and that key is by definition shipped in a PUBLIC booking widget, so
+	 * anyone who can view the widget holds it. listPublicServices() filters the
+	 * catalogue down to `isPublic` entries precisely so a business can keep
+	 * internal services out of it — but availability was readable for ANY
+	 * serviceId of that tenant, published or not. Booking was gated (#491) and
+	 * listing was gated; reading availability was the third door.
+	 *
+	 * Fail-closed: an unresolvable catalogue denies rather than permits.
+	 *
+	 * @param string $serviceId The service to check.
+	 *
+	 * @return bool True when the service is public and active.
+	 *
+	 * @psalm-return   bool
+	 * @phpstan-return bool
+	 *
+	 * @spec openspec/specs/bookings-self-service-widget/spec.md
+	 */
+	public function isPubliclyBookable(string $serviceId): bool {
+		$objectService = $this->getObjectService();
+		if ($objectService === null) {
+			return false;
+		}
+
+		return $this->findPublicService(
+			objectService: $objectService,
+			serviceId: $serviceId
+		) !== null;
+
+	}//end isPubliclyBookable()
+
+
+	/**
 	 * Resolve a bookable public Service by its serviceId, or null.
 	 *
 	 * Fail-closed in every direction: an unresolvable catalogue, a missing

--- a/tests/Unit/Controller/WidgetApiControllerTest.php
+++ b/tests/Unit/Controller/WidgetApiControllerTest.php
@@ -225,6 +225,89 @@ class WidgetApiControllerTest extends TestCase {
 	}//end testSlotsRejectsInvalidDateFormat()
 
 	/**
+	 * THE #491 GATE, THIRD DOOR — availability is refused for a service the
+	 * business never published, and the slot engine is never reached.
+	 *
+	 * guard() only proves the caller holds the widget API key, and that key
+	 * ships inside a PUBLIC booking widget — so every visitor has it.
+	 * services() hides non-public services and appointments() refuses to book
+	 * them; before this, availability answered for any serviceId of the tenant.
+	 *
+	 * Deleting the gate makes this test red.
+	 *
+	 * @return void
+	 */
+	public function testSlotsRefusesAServiceTheBusinessNeverPublished(): void {
+		$this->request->method('getParam')->willReturnMap([['businessId', '', 'salon-001']]);
+		$this->request->method('getHeader')->willReturnMap(
+			[
+				['Authorization', 'Bearer bk_live_valid'],
+				['If-None-Match', ''],
+			]
+		);
+
+		$this->auth->method('validateApiKey')->willReturn(['valid' => true, 'key' => ['rateLimit' => 100]]);
+		$this->auth->method('consumeRateLimit')->willReturn(
+			['allowed' => true, 'remaining' => 99, 'retryAfter' => 60]
+		);
+
+		$this->widgetService->method('isPubliclyBookable')->willReturn(false);
+
+		// The engine must not run at all: computing availability and then
+		// discarding it would still leak through timing and cache population.
+		$this->slots->expects(self::never())->method('getAvailableSlots');
+
+		$response = $this->makeController()->slots(
+			serviceId: 'svc-internal-001',
+			resourceId: 'res-001',
+			date: '2026-05-22'
+		);
+
+		// 404, not 403 — a 403 confirms the service exists, which is the very
+		// fact being withheld.
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame(['error' => 'service_not_found'], $response->getData());
+
+	}//end testSlotsRefusesAServiceTheBusinessNeverPublished()
+
+	/**
+	 * THE POSITIVE CONTROL — a published service still returns its slots.
+	 *
+	 * Without this, a gate that refused everything would satisfy the test
+	 * above while taking the whole booking widget offline.
+	 *
+	 * @return void
+	 */
+	public function testSlotsStillServesAPublishedService(): void {
+		$this->request->method('getParam')->willReturnMap([['businessId', '', 'salon-001']]);
+		$this->request->method('getHeader')->willReturnMap(
+			[
+				['Authorization', 'Bearer bk_live_valid'],
+				['If-None-Match', ''],
+			]
+		);
+
+		$this->auth->method('validateApiKey')->willReturn(['valid' => true, 'key' => ['rateLimit' => 100]]);
+		$this->auth->method('consumeRateLimit')->willReturn(
+			['allowed' => true, 'remaining' => 99, 'retryAfter' => 60]
+		);
+
+		$this->widgetService->method('isPubliclyBookable')->willReturn(true);
+		$this->slots->expects(self::once())
+			->method('getAvailableSlots')
+			->willReturn(['slots' => [], 'etag' => 'W/"abc"', 'cached' => false]);
+
+		$response = $this->makeController()->slots(
+			serviceId: 'svc-001',
+			resourceId: 'res-001',
+			date: '2026-05-22'
+		);
+
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+
+	}//end testSlotsStillServesAPublishedService()
+
+	/**
 	 * POST /appointments rejects malformed ISO timestamps with 400.
 	 *
 	 * @return void


### PR DESCRIPTION
## What

`WidgetApiController::slots()` returned availability for **any** `serviceId` of a tenant, including services the business never published. It now refuses them.

## The third door

The `isPublic` gate exists in two of three widget endpoints:

| endpoint | gate |
|---|---|
| `services()` | filters the catalogue to `isPublic` entries |
| `appointments()` | refuses to book a non-public service (the **#491** gate) |
| `slots()` | **nothing** |

`guard()` does not close it. It proves the caller holds a **widget API key** — and that key is by definition shipped inside a *public* booking widget, so every visitor to the page holds it. A caller who knows or guesses an internal `serviceId` could read **when that service is busy and when it is free**, which is exactly the information `services()` filters out.

`WidgetService` already carries the right reasoning, in its own words:

> The #491 gate: a caller who knows any serviceId must not be able to **book** a service the business never published.

The same sentence with *read availability of* in place of *book* is this PR.

## The fix

`WidgetService::isPubliclyBookable()` — a public wrapper over the existing private `findPublicService()`, so the rule has **one implementation**, not a third copy. The controller calls it before any availability is computed.

Two choices worth stating:

- **404, not 403** — matching `WidgetService`. A 403 confirms the service exists, which is the fact being withheld.
- **The slot engine never runs.** Computing availability and then discarding it would still leak through cache population and timing; a test asserts `getAvailableSlots` is never called.
- **Fail-closed:** an unresolvable catalogue denies rather than permits.

## Relationship to #484

#484 (open since 09-08) proposed a broader change to the same area. It is **partly superseded**: `services()` and `appointments()` have since been gated, but `slots()` was left, and #484 has been sitting unmerged with three failing checks. This PR closes only the remaining hole, in 2 files. #484 should be re-scoped or closed against it.

## Verification

- **Negative control:** deleting the gate makes `testSlotsRefusesAServiceTheBusinessNeverPublished` fail. Restored, green.
- **Positive control:** a published service still returns its slots — without it, a gate that refused *everything* would pass the refusal test while taking the booking widget offline.
- `php -l` clean; **full unit suite: 4107 tests, 43,278 assertions, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
