### PR TITLE
ci: run the 53 Playwright specs this repo has never executed

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -113,6 +113,26 @@ jobs:
       enable-frontend: true
       enable-eslint: true
       enable-phpunit: true
+
+      # ── E2E browser tests ────────────────────────────────────────────────
+      # `enable-playwright` defaults to FALSE and was never set here, so the
+      # "E2E Tests (Playwright)" job has reported `skipped` on every run this
+      # repo has ever produced — while the tree ships a root
+      # `playwright.config.ts` and 53 spec files under `tests/e2e/`. A skipped
+      # job is not a pass: it is the absence of a measurement, and the Quality
+      # Report renders it identically to a green one.
+      #
+      # `playwright-test-path` does double duty in the shared workflow: it is
+      # both the test directory AND the first place it looks for a config
+      # (`${playwright-test-path}/playwright.config.ts`, falling back to the
+      # repo root). We ship tests/e2e/playwright.config.ts precisely so that
+      # lookup hits it — the workflow passes no `--project`, so if the ROOT
+      # config were picked it would also run `docs-capture` (re-shooting every
+      # journeydoc screenshot, which has its own job) and `visual` (pixel
+      # baselines that cannot byte-match a CI runner). See that file's header.
+      enable-playwright: true
+      playwright-test-path: tests/e2e
+
       enable-newman: true
       # Shillinq delegates ALL object CRUD to OpenRegister (@conduction/nextcloud-vue
       # store factories hit /apps/openregister/api/objects), so a Nextcloud without

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Shillinq Contributors
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * CI regression config for the shared `E2E Tests (Playwright)` job.
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * `enable-playwright` defaults to FALSE in the shared workflow and was never
+ * set for this repo, so the "E2E Tests (Playwright)" job has reported
+ * **skipped** on every run shillinq has ever produced — while the tree ships a
+ * root `playwright.config.ts` and 53 spec files under `tests/e2e/`. A skipped
+ * job is not a pass; it is the absence of a measurement, and it looks exactly
+ * like a green one in the PR rollup.
+ *
+ * WHY A SECOND CONFIG RATHER THAN JUST FLIPPING THE FLAG
+ * -----------------------------------------------------
+ * The shared workflow runs the suite as:
+ *
+ *     CONFIG="${{ inputs.playwright-test-path }}/playwright.config.ts"
+ *     if [ ! -f "$CONFIG" ] && [ -f "playwright.config.ts" ]; then
+ *       CONFIG="playwright.config.ts"
+ *     fi
+ *     npx playwright test --config="$CONFIG"
+ *
+ * Note what is missing: `--project`. So whichever config it picks, EVERY
+ * project in it runs. The root config declares three:
+ *
+ *   chromium     — the regression suite. This is the one CI wants.
+ *   docs-capture — journeydoc screenshot capture (ADR-030); re-shoots every
+ *                  tutorial screenshot, and has its own dedicated job.
+ *   visual       — pixel-diff baselines, which are host-font/GPU specific and
+ *                  will not byte-match on a CI Linux runner.
+ *
+ * Letting the root config be picked would therefore run two projects that
+ * cannot pass on a runner, on top of the one that can. `playwright-test-path:
+ * tests/e2e` in the caller makes the workflow's FIRST lookup hit this file,
+ * which declares only the regression project. The root config is untouched and
+ * stays the entry point for local runs and `npm run test:e2e:docs`.
+ *
+ * The report/output paths deliberately point at the APP ROOT: the workflow
+ * uploads `<app>/playwright-report/` and `<app>/test-results/`, so with the
+ * root config's relative paths the upload step would match nothing and
+ * silently produce an empty artifact — a failing run with no report to read.
+ */
+
+import { defineConfig, devices } from '@playwright/test'
+import * as path from 'path'
+
+import { BASE_URL } from './base-url'
+
+const APP_ROOT = path.resolve(__dirname, '..', '..')
+
+export default defineConfig({
+	testDir: __dirname,
+	globalSetup: path.resolve(__dirname, 'global-setup.ts'),
+
+	// The shared workflow caps this job at `timeout-minutes: 45`, and a job the
+	// runner kills at its cap reports **cancelled** — which is NO VERDICT: not a
+	// pass, not a failure, no information. `globalTimeout` below sits inside
+	// that cap so Playwright stops first and exits non-zero WITH a tally.
+	//
+	// This suite has never run in CI, so there is no measured slowest-pass to
+	// size against. The values start at decidesk's proven settings and should be
+	// re-derived from the first green run rather than left as a guess:
+	// `retries: 0` because a retry only ever converts red to green, and a first
+	// run needs to show what is actually flaky.
+	timeout: 20_000,
+	expect: { timeout: 10_000 },
+	globalTimeout: 38 * 60_000,
+	fullyParallel: false,
+	retries: 0,
+	workers: 1,
+
+	// `github` is what makes a killed run legible: it emits a ::error::
+	// annotation per failure AS IT HAPPENS. `list` alone prints failure bodies
+	// only in an end-of-run summary, so a run cut off at the cap shows a column
+	// of ✘ marks and not one error message.
+	reporter: process.env.CI
+		? [
+				['github'],
+				['list'],
+				[
+					'html',
+					{
+						open: 'never',
+						outputFolder: path.join(APP_ROOT, 'playwright-report'),
+					},
+				],
+			]
+		: [
+				[
+					'html',
+					{
+						open: 'never',
+						outputFolder: path.join(APP_ROOT, 'playwright-report'),
+					},
+				],
+				['list'],
+			],
+	outputDir: path.join(APP_ROOT, 'test-results'),
+
+	use: {
+		// Single source of truth — tests/e2e/base-url.ts. The specs import the
+		// same resolver, so `page.goto()` (which uses this baseURL) and the
+		// specs' own `page.request` calls cannot address different hosts.
+		baseURL: BASE_URL,
+		storageState: path.resolve(__dirname, '.auth', 'admin.json'),
+		trace: 'retain-on-failure',
+		screenshot: 'only-on-failure',
+		video: 'off',
+	},
+
+	projects: [
+		{
+			name: 'chromium',
+			// Same exclusions the root config's regression project uses: the
+			// screenshot-capture specs belong to the Journeydoc job and the
+			// pixel baselines cannot match on a runner.
+			testIgnore: [
+				'**/docs-screenshots.spec.ts',
+				'**/bookings-screenshots.spec.ts',
+				'**/visual/**',
+			],
+			use: {
+				...devices['Desktop Chrome'],
+			},
+		},
+	],
+})

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -47,7 +47,13 @@
 import { defineConfig, devices } from '@playwright/test'
 import * as path from 'path'
 
-import { BASE_URL } from './base-url'
+// `resolveBaseURL()`, NOT `BASE_URL`. base-url.ts exports the FUNCTION and
+// `BASE_URL_ENV_NAMES`; there is no `BASE_URL` const. Playwright transpiles
+// this config without type-checking, so importing a name that does not exist
+// is not an error — it is `undefined`, and `baseURL: undefined` makes every
+// relative `page.goto('/apps/...')` a "Cannot navigate to invalid URL".
+// That is what failed 169 of 271 tests on this suite's first ever CI run.
+import { resolveBaseURL } from './base-url'
 
 const APP_ROOT = path.resolve(__dirname, '..', '..')
 
@@ -104,7 +110,7 @@ export default defineConfig({
 		// Single source of truth — tests/e2e/base-url.ts. The specs import the
 		// same resolver, so `page.goto()` (which uses this baseURL) and the
 		// specs' own `page.request` calls cannot address different hosts.
-		baseURL: BASE_URL,
+		baseURL: resolveBaseURL(),
 		storageState: path.resolve(__dirname, '.auth', 'admin.json'),
 		trace: 'retain-on-failure',
 		screenshot: 'only-on-failure',


### PR DESCRIPTION
`enable-playwright` defaults to **FALSE** in the shared workflow and was never set here, so **"E2E Tests (Playwright)" has reported `skipped` on every run shillinq has ever produced** — while the tree ships a root `playwright.config.ts` and **53 spec files** under `tests/e2e/`.

A skipped job is not a pass. It is the absence of a measurement, and the Quality Report renders it identically to a green one. This is the same shape as `enable-hydra-gates`, two comments further down in the same file, which was fixed for exactly this reason.

I found it while checking that the e2e evidence behind the vocabulary PRs was real: #560's Playwright check reads `skipping`, and the job log is 215 bytes.

## Why a second config, not just the flag

The shared workflow runs `npx playwright test --config=$CONFIG` with **no `--project`**, so whichever config it picks, *every* project in it runs. The root config declares three, and two cannot pass on a runner:

| project | |
|---|---|
| `chromium` | the regression suite — the one CI wants |
| `docs-capture` | re-shoots every journeydoc screenshot; has its own dedicated job |
| `visual` | pixel baselines, host-font/GPU specific, will not byte-match a CI runner |

`playwright-test-path: tests/e2e` makes the workflow's first config lookup hit the new file, which declares only the regression project. The root config is untouched and stays the entry point for local runs and `npm run test:e2e:docs`.

Report paths point at the **app root** deliberately: the workflow uploads `<app>/playwright-report/`, so with the root config's relative paths the upload step matches nothing and silently produces an empty artifact — a failing run with no report to read.

## ⚠️ Expect red on the first run

These 53 specs have never executed in CI. Whatever they report is a **finding, not a regression from this commit**. Two settings are chosen so that first run is informative:

- `retries: 0` — a retry only ever converts red to green; the first run should show what is genuinely broken rather than what is merely flaky.
- `globalTimeout: 38m` inside the job's 45-minute cap — a job the runner kills reports **cancelled**, which is no verdict at all. Playwright stops first and exits non-zero with a tally.

The timeouts start at decidesk's proven values because there is no measured slowest-pass for this suite yet; they should be re-derived from the first green run rather than left as a guess.

I am **not** merging this one without you: unlike the other PRs tonight it can only make the pipeline redder, and the right response to its output is triage, not a rubber stamp.