### PR TITLE
fix(build): compare the sibling nc-vue to the declared range, not its major

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,16 +52,34 @@ webpackConfig.entry = {
 const localLib = path.resolve(__dirname, '../nextcloud-vue/src')
 const localLibPkg = path.resolve(__dirname, '../nextcloud-vue/package.json')
 let useLocalLib = process.env.USE_LOCAL_LIB === 'true' && fs.existsSync(localLib)
-if (useLocalLib && fs.existsSync(localLibPkg)) {
-	const localVersion = String(
-		JSON.parse(fs.readFileSync(localLibPkg, 'utf8')).version || '',
-	)
-	const localMajor = parseInt(localVersion, 10)
-	if (!Number.isNaN(localMajor) && localMajor < 2) {
+if (useLocalLib) {
+	// The `localMajor < 2` test this replaces was blind to the skew it was
+	// written for: nc-vue's Vue 2 line and its Vue 3 line are BOTH major 2. The
+	// sibling is 2.0.5 (Vue 2) against a declared ^2.3.0 (Vue 3), so `2 < 2` was
+	// false and the Vue 2 checkout was accepted. Compare against the declared
+	// RANGE instead, and fail CLOSED if the check cannot run.
+	let localVersion = 'unreadable'
+	let satisfied = false
+	try {
+		// eslint-disable-next-line n/no-extraneous-require
+		const semver = require('semver')
+		const required =
+			require('./package.json').dependencies['@conduction/nextcloud-vue']
+		localVersion = String(
+			JSON.parse(fs.readFileSync(localLibPkg, 'utf8')).version || '',
+		)
+		satisfied = semver.satisfies(localVersion, required, {
+			includePrerelease: true,
+		})
+	} catch (e) {
+		satisfied = false
+	}
+
+	if (!satisfied) {
 		// eslint-disable-next-line no-console
 		console.warn(
 			`[shillinq] IGNORING sibling @conduction/nextcloud-vue@${localVersion} — `
-				+ 'that is the Vue 2 line and this app is Vue 3. Building against the npm dist.',
+				+ "it does not satisfy this app's declared range. Building against the npm dist.",
 		)
 		useLocalLib = false
 	}


### PR DESCRIPTION
The guard here was already opt-in, which is the important half. The version
check behind it, though, could not see the skew it was written to stop.

It tested `localMajor < 2` — i.e. "is the sibling on the Vue 2 line?" — but
nc-vue's Vue 2 line and its Vue 3 line are BOTH major 2. The sibling checkout
is 2.0.5 (Vue 2) while this app declares ^2.3.0 (Vue 3), so `2 < 2` was false
and a developer who set USE_LOCAL_LIB=true got Vue 2 library sources compiled
into this Vue 3 app — silently, with a clean build.

Comparing against the declared RANGE with semver asks the question that
matches the failure: not "which line is this?" but "is this the version this
app asked for?". The check fails CLOSED — if semver or the sibling's
package.json cannot be read, the sibling is refused rather than trusted.

Measured: USE_LOCAL_LIB unset builds clean with the sibling unused;
USE_LOCAL_LIB=true builds clean AND prints
`IGNORING sibling @conduction/nextcloud-vue@2.0.5`. The opt-in run is the
positive control — the guard is shown refusing, not merely staying silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)