### PR TITLE
ci: run every npm job on Node 24

### DIFF
--- a/.github/workflows/pull-request-lint-check.yaml
+++ b/.github/workflows/pull-request-lint-check.yaml
@@ -17,6 +17,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      # This job had NO setup-node at all, so it inherited the runner default —
+      # currently Node 22, which bundles npm 10. npm 10 cannot install from the
+      # npm 11 lockfile this repo now ships: it exits EUSAGE with
+      # "Missing: <pkg> from lock file". Node 24 bundles npm 11.
+      #
+      # Nothing in this file named a Node version, so nothing looked wrong.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## What

Points every workflow in this repo that runs `npm ci` at Node 24.

## Why

The shared `quality.yml` moved to Node 24 (ConductionNL/.github#469) because **npm 10 cannot install from an npm 11 lockfile** — it exits `EUSAGE` with `Missing: <pkg> from lock file`. The fleet's lockfiles are now npm 11.

This repo's **own** workflows did not move with it, and they run `npm ci` too. Measured on the cooldown PR: every shared-workflow job passed while `Lint Check` and `Spec Validation` went red on exactly that error.

| file | before | why it was missed |
|---|---|---|
| `pull-request-lint-check.yaml` | **no `setup-node` at all** | nothing in the file named a Node version, so nothing looked wrong — it silently inherited the runner default (22, npm 10) |
| `spec-validation.yml` | `node-version: '20'` | explicit, but below the npm 11 floor |

Node 24.19 bundles npm 11.17. Every Node 22 release — including the latest, 22.23.2 — bundles npm 10.9.8, so no value in the 22 line can work.

## Not changed, deliberately

- `l10n.yml` — its only `npm ci` is inside a comment saying it needs none.
- `api-test-coverage.yml` — runs `npm install -g newman`, a global tool install with no lockfile, so the npm major is irrelevant.

Both were checked rather than swept.
