### PR TITLE
fix(lint): clear both tranche-A suppressions — one was a stale disable, one a real API

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -173,16 +173,8 @@
     }
   },
   "src/composables/useBarcodeScanner.js": {
-    "import/no-unresolved": {
-      "count": 1
-    },
     "no-unused-vars": {
       "count": 5
-    }
-  },
-  "src/main.js": {
-    "no-undef": {
-      "count": 1
     }
   },
   "src/modals/BankStatementWizard.vue": {

--- a/src/composables/useBarcodeScanner.js
+++ b/src/composables/useBarcodeScanner.js
@@ -129,7 +129,11 @@ export async function decodeWithJsQrFallback(imageData) {
 		return null
 	}
 	try {
-		// eslint-disable-next-line import/no-unresolved
+		// No `eslint-disable` for `import/no-unresolved` here: the flat config
+		// does not register that rule, so the disable comment was itself the
+		// error ("Definition for rule 'import/no-unresolved' was not found").
+		// `webpackIgnore` keeps this a real runtime import rather than a bundled
+		// one, which is why the specifier is not resolvable at lint time.
 		const mod = await import(/* webpackIgnore: true */ 'jsqr')
 		const jsQR = mod && mod.default ? mod.default : mod
 		if (typeof jsQR !== 'function') {

--- a/src/main.js
+++ b/src/main.js
@@ -143,6 +143,12 @@ const pageFragmentIndex = buildPageFragmentIndex(mergedManifest.pages)
 // `fragmentCtx(key)` returns a Promise instead of eagerly bundling every
 // fragment's full content into `main` (contrast the shell generator above,
 // which reads the SAME directory at build time via plain `fs`, not webpack).
+// `require.context` is a WEBPACK build-time API, not CommonJS `require`: the
+// bundler rewrites this call at compile time and no `require` exists at
+// runtime. eslint's browser globals therefore report `no-undef` correctly —
+// the code is right and the linter is right. Scoped to this one identifier so
+// a genuinely undefined name elsewhere in the file still fails.
+/* global require */
 const lazyFragmentCtx = require.context('./manifest.d/', false, /\.json$/, 'lazy')
 const loadedFragments = new Set()
 


### PR DESCRIPTION
## What

Clears both of this repo's **tranche A** eslint suppressions. Tranche A is the set where a suppression can be hiding a real defect (`no-undef`, unresolved imports, `preserve-caught-error`, unused expressions) — ~125 sites fleet-wide, and the plan calls it the place any real bug in the fleet's JS most likely sits.

Both of shillinq's two were worth reading, and neither was what the rule name suggested.

## 1. A disable comment for a rule that does not exist

```js
// eslint-disable-next-line import/no-unresolved
const mod = await import(/* webpackIgnore: true */ 'jsqr')
```

The flat config does not register `import/no-unresolved`, so the disable comment was **itself** the error: *"Definition for rule 'import/no-unresolved' was not found"*. Removed, and replaced with a note explaining why the specifier is deliberately unresolvable — `webpackIgnore` keeps it a real runtime import rather than a bundled one.

## 2. A real build-time API under a blanket suppression

```js
const lazyFragmentCtx = require.context('./manifest.d/', false, /\.json$/, 'lazy')
```

`require.context` is a **webpack** API that the bundler rewrites at compile time; no `require` exists at runtime. So eslint is right that it is undefined, and the code is right as written — the two are not in conflict.

The old fix was a file-wide `no-undef` suppression, which also switches the rule off for every other identifier in a 200-line entrypoint. Replaced with a scoped `/* global require */`, so a genuinely undefined name elsewhere in the file still fails.

## Verification

| check | result |
|---|---|
| `npx eslint src` | **0 errors** (96 pre-existing warnings, unchanged) |
| `npm run build` | exit 0 |
| `npm run test:unit` | **171 passed**, 15 files |
| suppressions | 148 → **146**, pruned |
