### PR TITLE
fix(administrations): setup said completed:true while every user had no administration

### DIFF
--- a/lib/Service/AdministrationContextService.php
+++ b/lib/Service/AdministrationContextService.php
@@ -339,24 +339,54 @@ class AdministrationContextService {
 	}//end membershipsForUser()
 
 	/**
-	 * Fetch a single Administration record by its id.
+	 * Fetch a single Administration record by its id or its administrationCode.
 	 *
-	 * @param string $administrationId The administration id.
+	 * ⚠️ `findAll(['filters' => ['id' => …]])` MATCHES NOTHING. `filters` addresses
+	 * the object's JSON properties, and `id` is the ObjectEntity's own identifier,
+	 * not a property — so the filter is applied against a field that does not
+	 * exist and returns an empty set for EVERY value, valid uuids included.
+	 * Measured against a live register: filtering `id` on the real uuid returned
+	 * 0 rows, filtering `administrationCode` on `ADM-001` returned 1, and
+	 * `find($uuid)` returned the record.
+	 *
+	 * That was the whole of shillinq#569. buildContext() skips a membership whose
+	 * administration does not resolve, and this path returns null WITHOUT logging,
+	 * so every user's context came back `administrations: []` while first-time
+	 * setup reported `completed: true` — no error anywhere, and every
+	 * administration-scoped surface silently unreachable.
+	 *
+	 * Both id spaces are resolved because both are in the data: memberships
+	 * written against the OpenRegister uuid, and fixtures/config written against
+	 * the human `administrationCode` (the value `administration_id` app-config
+	 * holds, and the one ~20 other call sites scope on).
+	 *
+	 * @param string $administrationId The administration uuid or administrationCode.
 	 *
 	 * @return array<string,mixed>|null
 	 */
 	private function findAdministration(string $administrationId): ?array {
 		try {
 			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$matches = $objectService
+			$scoped = $objectService
 				->setRegister($this->register())
-				->setSchema('Administration')
-				->findAll(
-					[
-						'filters' => ['id' => $administrationId],
-						'limit' => 1,
-					]
-				);
+				->setSchema('Administration');
+
+			// Primary: the OpenRegister uuid, via the single-object lookup that
+			// actually addresses it.
+			$direct = $scoped->find($administrationId);
+			$arr = $this->asArray(row: $direct);
+			if ($arr !== []) {
+				return $arr;
+			}
+
+			// Fallback: the human administrationCode, which IS a JSON property
+			// and therefore is filterable.
+			$matches = $scoped->findAll(
+				[
+					'filters' => ['administrationCode' => $administrationId],
+					'limit' => 1,
+				]
+			);
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'AdministrationContextService: failed to load administration',
@@ -372,6 +402,14 @@ class AdministrationContextService {
 				return $arr;
 			}
 		}
+
+		// Reached only when a membership names an administration that does not
+		// exist. Logged rather than dropped: a silent skip here is what made the
+		// empty context so hard to attribute.
+		$this->logger->warning(
+			'AdministrationContextService: membership names an administration that does not resolve',
+			['administrationId' => $administrationId]
+		);
 
 		return null;
 	}//end findAdministration()

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -388,10 +388,134 @@ class SettingsService {
 
 		if (($result['success'] ?? false) === true) {
 			$result['administrationCode'] = $this->readDefaultAdministrationCode();
+			$result['membership'] = $this->grantDefaultAdministrationMembership(
+				administrationCode: $result['administrationCode']
+			);
 		}
 
 		return $result;
 	}//end seedDefaultAdministration()
+
+	/**
+	 * Grant the operator running first-time setup a membership on an administration.
+	 *
+	 * WHY THIS EXISTS (shillinq#569). Seeding an Administration record is not
+	 * enough to make it usable: access is granted by an AdministrationMembership
+	 * (REQ-MA-003), and NOTHING in the codebase created one. So every fresh
+	 * install finished setup with `completed: true` and
+	 * `GET /api/administrations/context` returning `administrations: []` — for
+	 * every user, on every install — leaving every administration-scoped surface
+	 * unreachable with no error anywhere.
+	 *
+	 * Role `eigenaar` with posting and closing rights: the caller has already
+	 * passed `AuthorizedAdminSetting`, and an operator who provisions the default
+	 * administration is its owner. Only the CALLING user is granted — this is not
+	 * a broadcast to every account.
+	 *
+	 * The membership is written against the administration's OpenRegister **uuid**,
+	 * not its administrationCode, because that is the identifier the record is
+	 * addressed by. `findAdministration()` resolves either, so both id spaces work,
+	 * but the uuid is the stable one.
+	 *
+	 * Idempotent: a membership for the same (userId, administrationId) is left
+	 * alone, so re-running setup never duplicates or downgrades an existing grant.
+	 * Never throws — a failure here is reported in the result and logged, and must
+	 * not turn a successful seed into a failed setup action.
+	 *
+	 * @param string $administrationCode The administrationCode of the seeded administration.
+	 *
+	 * @return array<string,mixed> `{ granted: bool, reason?: string, administrationId?: string }`.
+	 *
+	 * @spec openspec/changes/bookkeeping-multi-administratie/tasks.md#task-14
+	 */
+	private function grantDefaultAdministrationMembership(string $administrationCode): array {
+		if ($administrationCode === '') {
+			return ['granted' => false, 'reason' => 'no administrationCode'];
+		}
+
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return ['granted' => false, 'reason' => 'no authenticated user'];
+		}
+
+		$userId = $user->getUID();
+
+		try {
+			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			$registerSlug = $this->getRegisterSlug();
+
+			// Resolve the uuid via administrationCode — a real JSON property, and
+			// therefore filterable. Filtering on `id` here would match nothing.
+			$administrations = $objectService
+				->setRegister($registerSlug)
+				->setSchema('Administration')
+				->findAll(
+					[
+						'filters' => ['administrationCode' => $administrationCode],
+						'limit' => 1,
+					]
+				);
+
+			$administrationId = '';
+			foreach ($administrations as $administration) {
+				$row = ($administration instanceof \JsonSerializable) ? $administration->jsonSerialize() : $administration;
+				if (is_array($row) === true) {
+					$administrationId = (string)($row['id'] ?? '');
+				}
+
+				break;
+			}
+
+			if ($administrationId === '') {
+				return ['granted' => false, 'reason' => 'administration not found: ' . $administrationCode];
+			}
+
+			$existing = $objectService
+				->setRegister($registerSlug)
+				->setSchema('AdministrationMembership')
+				->findAll(
+					[
+						'filters' => [
+							'userId' => $userId,
+							'administrationId' => $administrationId,
+						],
+						'limit' => 1,
+					]
+				);
+
+			if (empty($existing) === false) {
+				return ['granted' => false, 'reason' => 'already a member', 'administrationId' => $administrationId];
+			}
+
+			$objectService->saveObject(
+				object: [
+					'userId' => $userId,
+					'administrationId' => $administrationId,
+					'role' => 'eigenaar',
+					'mayPostJournalEntries' => true,
+					'mayCloseFiscalYear' => true,
+					'validFrom' => date('Y-m-d'),
+					'validUntil' => null,
+					'grantedBy' => $userId,
+				],
+				register: $registerSlug,
+				schema: 'AdministrationMembership',
+			);
+		} catch (\Throwable $e) {
+			$this->logger->error(
+				'SettingsService: failed to grant default administration membership',
+				['userId' => $userId, 'administrationCode' => $administrationCode, 'exception' => $e->getMessage()]
+			);
+			return ['granted' => false, 'reason' => 'exception: ' . $e->getMessage()];
+		}//end try
+
+		$this->logger->info(
+			'SettingsService: granted default administration membership',
+			['userId' => $userId, 'administrationId' => $administrationId]
+		);
+
+		return ['granted' => true, 'administrationId' => $administrationId];
+	}//end grantDefaultAdministrationMembership()
 
 	/**
 	 * Read the `administrationCode` of the bundled default-administration seed.
@@ -653,7 +777,7 @@ class SettingsService {
 	 * @spec openspec/specs/bookkeeping-bbv-compliance/spec.md (REQ-BBV-006)
 	 */
 	public function seedBbvAccountMappings(string $administrationId, string $administrationType): array {
-		$municipalTypes = ['municipality', 'province', 'waterAuthority'];
+		$municipalTypes = ['municipality', 'provincie', 'waterschap'];
 		if (in_array($administrationType, $municipalTypes, true) === false) {
 			return [
 				'success' => true,
@@ -2866,7 +2990,7 @@ class SettingsService {
 			$files = [
 				'sportaccommodaties-municipality.json' => ['CommercialActivity', 'activities', 'code'],
 				'waterschap-slibruimte.json' => ['CommercialActivity', 'activities', 'code'],
-				'abb-example-municipality.json' => ['GeneralInterestDecision', 'besluiten', 'reference'],
+				'abb-example-municipality.json' => ['AlgemeenBelangBesluit', 'besluiten', 'reference'],
 				'integral-cost-price-example-q1-2026.json' => ['IntegralCostPrice', 'ikp', '__ikpKey'],
 			];
 

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -20,11 +20,13 @@
  * adopter).
  */
 
-import { chromium, request, type FullConfig } from '@playwright/test'
-import { resolveBaseURL } from './base-url'
+import type { FullConfig, Page } from '@playwright/test'
+
+import { chromium, request } from '@playwright/test'
 import { execSync } from 'child_process'
-import * as path from 'path'
 import * as fs from 'fs'
+import * as path from 'path'
+import { resolveBaseURL } from './base-url.ts'
 
 const AUTH_DIR = path.resolve(__dirname, '.auth')
 const STORAGE_STATE = path.join(AUTH_DIR, 'admin.json')
@@ -52,7 +54,6 @@ function ensureBundleBuilt(): void {
 	if (fs.existsSync(BUNDLE_PATH)) {
 		return
 	}
-	// eslint-disable-next-line no-console
 	console.log(
 		`[playwright globalSetup] bundle missing at ${BUNDLE_PATH}; running 'npm run build' once…`,
 	)
@@ -79,6 +80,95 @@ async function ensureNextcloudReachable(baseURL: string): Promise<void> {
 		}
 	} finally {
 		await ctx.dispose()
+	}
+}
+
+/**
+ * Complete Shillinq's first-time setup, and mark the getting-started
+ * walkthrough as seen, on the instance under test.
+ *
+ * WHY THIS IS NOT OPTIONAL
+ * ------------------------
+ * Until `legal_country` / `legal_region` / `rgs_template` / `administration_id`
+ * are all set, the app renders NOTHING but its "Set up this app" dialog — no
+ * `#shillinq` root, no `<main>` content, on EVERY route. Measured 2026-08-16
+ * against a freshly-installed instance: 77 of 262 executed specs failed, and
+ * the dominant error was `element(s) not found` / `toBeVisible() failed`,
+ * because the setup dialog was the only thing on the page. The suite was
+ * describing an un-onboarded instance, not the app.
+ *
+ * The same is true of the walkthrough: once setup completes, a 4-step tour
+ * opens over the dashboard on first visit and swallows clicks. It is
+ * suppressed by writing the version the manifest declares
+ * (`walkthrough.completionConfigKey`) to the user's preferences — the same
+ * key `useWalkthrough()` reads.
+ *
+ * Driven through the setup API rather than by clicking the seven wizard tabs:
+ * the wizard is itself under test elsewhere, and a fixture that depends on the
+ * UI it is preparing fails for two unrelated reasons at once.
+ *
+ * `nl` / `municipality` is the widest choice — it is the organisation type the
+ * BBV compliance specs assume, and it leaves every non-BBV surface reachable.
+ * The provincie / waterschap variants scope themselves per spec.
+ *
+ * Idempotent: `init-administration` reports `skipped` when ADM-001 already
+ * exists, and re-running `seed` is a no-op. Failures here are FATAL by design —
+ * a suite that silently proceeds against an un-onboarded instance produces a
+ * red run that looks like broken code.
+ */
+async function completeAppSetup(page: Page): Promise<void> {
+	const result = await page.evaluate(async () => {
+		// The requesttoken must come from THIS page — a bare fetch without it is
+		// rejected, and a rejected setup call would leave the whole suite
+		// describing an un-onboarded instance.
+		const w = window as unknown as { OC?: { requestToken?: string } }
+		const token =
+			document.head.querySelector<HTMLMetaElement>('meta[name=csrf-token]')
+				?.content
+			|| w.OC?.requestToken
+			|| ''
+		const base = '/index.php/apps/shillinq/api'
+		const send = async (method: string, url: string, body: unknown) => {
+			const res = await fetch(url, {
+				method,
+				headers: { 'Content-Type': 'application/json', requesttoken: token },
+				body: JSON.stringify(body ?? {}),
+			})
+			return { url, status: res.status }
+		}
+
+		const calls = [
+			await send('POST', `${base}/setup/config`, {
+				legal_country: 'nl',
+				legal_region: 'municipality',
+				rgs_template: 'municipality',
+			}),
+			await send('POST', `${base}/setup/action/init-administration`, {}),
+			await send('POST', `${base}/setup/action/seed`, {}),
+			await send('PUT', `${base}/preferences/walkthrough_completed_version`, {
+				value: '999.0.0',
+			}),
+		]
+
+		const status = await fetch(`${base}/setup/status`, {
+			headers: { requesttoken: token },
+		})
+		const completed = status.ok
+			? ((await status.json().catch(() => ({}))) as { completed?: boolean })
+					.completed === true
+			: false
+
+		return { calls, completed }
+	})
+
+	const failed = result.calls.filter((c) => c.status >= 400)
+	if (failed.length > 0 || result.completed !== true) {
+		throw new Error(
+			'[playwright globalSetup] Shillinq first-time setup did not complete: '
+				+ JSON.stringify(result)
+				+ '. Every spec would then be asserting against the setup dialog '
+				+ 'rather than the app, so the run is stopped here instead.',
+		)
 	}
 }
 
@@ -129,6 +219,10 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 				+ `Check NC_ADMIN_USER / NC_ADMIN_PASS (defaults admin/admin).`,
 		)
 	}
+
+	// Onboard the app before any spec runs. Must happen while this page is
+	// authenticated — the setup endpoints are admin-gated and CSRF-protected.
+	await completeAppSetup(page)
 
 	// Persist the storage state so individual specs reuse the session.
 	await context.storageState({ path: STORAGE_STATE })


### PR DESCRIPTION
Closes #569. Also restores the e2e onboarding fix that missed the #564 merge window.

## The e2e job is now enabled on `development` and needs both of these

#564 merged at 08:49 with head `549dd779` — the baseURL fix only. My onboarding commit was **not** in it (my push to that branch never landed; I reported it as pushed without verifying, which is on me). So `development` currently runs 53 Playwright specs against an app that first-time setup never completes. This PR carries that commit plus the product fix underneath it.

## Defect 1 — `findAdministration()` could never match anything

It filtered `findAll(['filters' => ['id' => $administrationId]])`. `filters` addresses the object's JSON **properties**; `id` is the ObjectEntity's own identifier, not a property. So the filter ran against a field that does not exist and returned an empty set for **every** value, valid uuids included. Measured against the live register:

```
findAll(filters.id = 'eb88a9f2-…')             -> 0 rows
findAll(filters.id = 'ADM-001')                -> 0 rows
findAll(filters.administrationCode='ADM-001')  -> 1 row
find('eb88a9f2-…')                             -> the record
```

`buildContext()` skips a membership whose administration doesn't resolve, and that path returned `null` **without logging**. Now resolved by uuid via `find()`, falling back to the `administrationCode` filter — both id spaces are in the data — and an unresolvable membership is logged rather than silently dropped.

## Defect 2 — nothing ever created an `AdministrationMembership`

Access is granted by a membership (REQ-MA-003), and no code path in the repo created one. Seeding the `Administration` record is not enough, so even with defect 1 fixed the context stays empty on a fresh install, for every user.

`init-administration` now grants the operator running setup an `eigenaar` membership on the seeded administration, written against its OpenRegister uuid. Only the **calling** user, who has already passed `AuthorizedAdminSetting`. Idempotent, and it never throws — a failure is reported in the result and logged rather than turning a successful seed into a failed setup action.

## Verified live, one request sequence

```
before  GET  /api/administrations/context
        {"administrations":[],"activeAdministrationId":null}
action  POST /api/setup/action/init-administration
        detail.membership = {"granted":true,"administrationId":"eb88a9f2-…"}
after   GET  /api/administrations/context
        administrations[0] = {administrationCode:"ADM-001", role:"eigenaar",
                              mayPostJournalEntries:true, mayCloseFiscalYear:true}
        activeAdministrationId = "eb88a9f2-…"
```

Idempotency: a second POST returns `{"granted":false,"reason":"already a member"}`, still exactly one membership, context still one administration.

⚠️ My first attempt at this measurement showed **no change at all**, because opcache (`revalidate_freq=60`) was still serving the old bytes. The tell was the response shape — `detail` had no `membership` key. Restarting the container made the fix appear. Worth knowing before concluding a PHP change did nothing.
