### PR TITLE
fix(test): the Newman TenderNed collection still posted pre-rename enum values

### DIFF
--- a/tests/integration/TenderNedIntegratie.postman_collection.json
+++ b/tests/integration/TenderNedIntegratie.postman_collection.json
@@ -56,7 +56,7 @@
 				},
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"tenderId\": \"{{tender_aanbesteding_id}}\",\n  \"title\": \"Newman test tender — schoonmaak Utrecht\",\n  \"contractingService\": \"{{tender_aanbestedende_dienst}}\",\n  \"awardedSupplier\": \"{{tender_supplier}}\",\n  \"contractValue\": 50000.0,\n  \"assignmentType\": \"levering-in-fases\",\n  \"termStart\": \"2026-07-01\",\n  \"termEnd\": \"2027-06-30\",\n  \"administrationId\": \"{{administration_id}}\",\n  \"status\": \"open\",\n  \"tenderNedUrl\": \"https://www.tenderned.nl/aankondigingen/overzicht/{{tender_aanbesteding_id}}\"\n}"
+					"raw": "{\n  \"tenderId\": \"{{tender_aanbesteding_id}}\",\n  \"title\": \"Newman test tender — schoonmaak Utrecht\",\n  \"contractingService\": \"{{tender_aanbestedende_dienst}}\",\n  \"awardedSupplier\": \"{{tender_supplier}}\",\n  \"contractValue\": 50000.0,\n  \"assignmentType\": \"delivery-in-phases\",\n  \"termStart\": \"2026-07-01\",\n  \"termEnd\": \"2027-06-30\",\n  \"administrationId\": \"{{administration_id}}\",\n  \"status\": \"open\",\n  \"tenderNedUrl\": \"https://www.tenderned.nl/aankondigingen/overzicht/{{tender_aanbesteding_id}}\"\n}"
 				}
 			},
 			"event": [{
@@ -91,7 +91,7 @@
 				},
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"commitmentNumber\": \"V-NEWMAN-0001\",\n  \"description\": \"Newman concept obligation\",\n  \"source\": \"tenderned\",\n  \"sourceReference\": \"{{tender_aanbesteding_id}}\",\n  \"amount\": 50000.0,\n  \"termStart\": \"2026-07-01\",\n  \"termEnd\": \"2027-06-30\",\n  \"status\": \"concept\",\n  \"administrationId\": \"{{administration_id}}\",\n  \"milestones\": []\n}"
+					"raw": "{\n  \"commitmentNumber\": \"V-NEWMAN-0001\",\n  \"description\": \"Newman concept obligation\",\n  \"source\": \"tenderned\",\n  \"sourceReference\": \"{{tender_aanbesteding_id}}\",\n  \"amount\": 50000.0,\n  \"termStart\": \"2026-07-01\",\n  \"termEnd\": \"2027-06-30\",\n  \"status\": \"draft\",\n  \"administrationId\": \"{{administration_id}}\",\n  \"milestones\": []\n}"
 				}
 			},
 			"event": [{


### PR DESCRIPTION
## What was actually failing

`Integration Tests (Newman)` on `development` (baseline run [31926367937](https://github.com/ConductionNL/shillinq/actions/runs/31926367937), job `quality / Integration Tests (Newman)`) fails **one of four collections** — `TenderNedIntegratie` — with 3 of 5 assertions red:

```
→ REQ-001 — Import a concept TenderNed dossier
  POST …/api/objects/shillinq/TenderNedAanbesteding [400 Bad request]
→ REQ-001 — Create the linked concept Verplichting
  POST …/api/objects/shillinq/Verplichting          [400 Bad request]
→ REQ-008 — Mijn Contracten filter returns the tenderned-sourced row
  expected +0 to be at least 1                      (cascade of the above)
```

The other three collections (`VAT_Filings`, `bookings`, `shillinq`) are green: 22, 8 and 32 assertions, 0 failed. So the app's object API works — `VAT_Filings` POSTs an `AdministrationMembership` and gets `201 Created` in the same job.

**This is not the 74-unseedable-objects problem, and it is not "unseeded data".** There are two independent causes and they are named precisely below.

## Cause 1 — an enum rename that did not reach this boundary. **Fixed here.**

`#560` ("translate enum values to English, with the Dutch kept in l10n", `a149f6cc`, 2026-08-16 02:20) translated the enum values in `lib/Settings/register.d/*.json` **and** updated the seed objects in those same files — but not the Postman collection that POSTs them.

```diff
- "assignmentType": "levering-in-fases"      →  "delivery-in-phases"
- "status": "concept"                        →  "draft"
```

The drift is inside a single file: `20-bookkeeping-tenderned-integratie.json` already seeds `"assignmentType": "service-provision-continuous"` while the collection next door still sent the Dutch value.

**Bisected, not assumed:**

| run | commit | `POST TenderNedAanbesteding` |
|---|---|---|
| [94985993279](https://github.com/ConductionNL/shillinq/actions/runs/31873578672) 2026-08-15 08:04 — before #560 | `7160d73e` | **201 Created ✓** |
| [95114543545](https://github.com/ConductionNL/shillinq/actions/runs/31926367937) 2026-08-16 04:19 — after #560 | `16e27e4f` | **400 Bad request ✗** |

**Positive control — the enum really is enforced** (against the local dev instance, which still carries the *pre*-rename schema, so the polarity is reversed and the failure is visible):

```
POST …/objects/shillinq/TenderNedAanbesteding  {"assignmentType":"delivery-in-phases", …}
→ 400  "Property 'assignmentType' should be one of: , but is 'delivery-in-phases'."
```

### Before / after — measured with the schema, not by eye

The values are read from the **merged effective schema**, built by concatenating every `register.d` fragment the way the importer does, then validating every object-write request in every collection (`required` + `enum`):

| | invalid writes | writes measured | collections measured |
|---|---|---|---|
| **before** | **2** | 7 | 4 |
| **after** | **1** | 7 | 4 |

## Cause 2 — `Verplichting` is declared by two register fragments. **Deliberately NOT fixed here.**

The one remaining invalid write is `Verplichting`, `MISSING REQUIRED: ['kind']`, and it is a **product defect, not a test defect**.

Two fragments declare `components.schemas.Verplichting`:

* `bookkeeping-verplichtingenadministratie.json` → `required: [administrationId, commitmentNumber, kind, status]`
* `20-bookkeeping-tenderned-integratie.json` → `required: [commitmentNumber, description, source, amount, administrationId, status]`

The importer **concatenates** the arrays rather than unioning them. The live effective schema proves it — note the duplicates:

```
$ curl …/api/schemas/992 → required:
['commitmentNumber','description','source','amount','administrationId','status',
 'administrationId','commitmentNumber','kind','status']
```

They are not two views of one entity — they are two vocabularies for one name (`amount` vs `total_amount_excl_vat`, `termStart`/`termEnd` vs `term_from`/`term_to`), and both fragments even seed a `Verplichting` with the same `commitmentNumber: "VPL-2026-0001"`.

**Neither of the app's own writers can satisfy the merged schema:**

* `lib/Listener/TenderNedAwardDetectedListener.php:264` builds `$commitment` with **no `kind`** — and the `saveObject()` call is wrapped in a fail-soft `catch (Throwable)` that only logs a warning. So on a real TenderNed award **no Verplichting is ever created, silently.** The Newman test is correctly detecting this.
* `lib/Service/Commitment/CommitmentMaterialisationService.php:247` builds `$draft` with `kind` but **without `description`, `source`, `amount`**.

The same collision shows up in the seeds. Validating the 246 seed objects in `register.d` against the merged schemas:

```
Verplichting.description  3      Budget.financialYear     6
Verplichting.source       3      Budget.authorised_amount 6
Verplichting.amount       3      Budget.budgetName        2
Verplichting.kind         1      Budget.totalAmount       2
```

`Budget` is declared by two fragments too. **This is a mechanism behind the "74 seed objects cannot satisfy their own schema" report**, not a separate problem.

### Why this PR does not just add `"kind"` and go green

`kind` feeds `MandaatEnforcer::mandateApplies()`, which filters mandates by `kind_commitment` — it is an **authorisation-relevant** classification, and picking a value for a procurement award (`inkooporder` vs `frameworkAgreement` vs `other`) is a domain decision, not a test fix. Under the programme's rules a config you do not understand is not "completed" by guessing, and a green integration test bought by making the app write an arbitrary authorisation attribute would be worth less than the red one.

**So `Integration Tests (Newman)` stays red on this PR, with 2 of 5 assertions failing instead of 3, from one named root cause.** It is escalated on the fleet board as an input to DECISION-3 (fragment ownership), with the exact one-line change it needs once the classification is decided.

## Scope

`tests/integration/TenderNedIntegratie.postman_collection.json` only — two string values. No schema, no seed, no `lib/` change; nothing under `schemas/` or `seeds/` was touched (S4 is working those concurrently).
