### PR TITLE
fix(spec): make the reporting exclusion legible to gate-46 and correct the OSS/BTW capability name

### DIFF
--- a/src/components/reporting/GeneratedReportsIndex.vue
+++ b/src/components/reporting/GeneratedReportsIndex.vue
@@ -26,14 +26,25 @@
  `index` page type (ADR-024 / ADR-036). The manifest fragment
  src/manifest.d/reporting-compliance.json declares the route.
 
- @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ @spec exclude The reporting capability has no canonical spec. This tag pointed at
+       openspec/changes/reporting-compliance-consolidation (a change directory that
+       exists neither under changes nor under changes/archive), and no canonical
+       reporting capability exists under openspec/specs either. Tracked in #525.
+       Deliberately NOT resolved by writing that spec — authoring the requirement
+       a tag is checked against turns the gate green over an unspecified capability.
 
- KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
- The change directory it names was never committed, and the `reporting`
+ KNOWINGLY DANGLING — do not repoint this tag at a spec (gate-46, shillinq#499).
+ The change directory it named was never committed, and the `reporting`
  capability has NO canonical spec. One was drafted during gate remediation and
  withdrawn: a spec written to fit the code, by the process whose job is to
  check the code against a spec, is not a specification anyone agreed to.
  Authoring it is the capability owner's decision, not a gate fix.
+
+ The dangling path is replaced by the reason-bearing `@spec exclude` above —
+ the same declaration lib/Controller/ReportingController.php already carries for
+ the same capability. The prose note alone did not say this to gate-46, which
+ reads the tag and not the paragraph under it, so the two halves of the same
+ decision disagreed and only the PHP half was legible.
 -->
 <template>
 	<div class="generated-reports" data-testid="generated-reports">

--- a/src/components/reporting/ReportingComplianceOverview.vue
+++ b/src/components/reporting/ReportingComplianceOverview.vue
@@ -43,14 +43,25 @@
  (ADR-024 / ADR-036). The manifest fragment
  src/manifest.d/reporting-compliance.json declares the route.
 
- @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ @spec exclude The reporting capability has no canonical spec. This tag pointed at
+       openspec/changes/reporting-compliance-consolidation (a change directory that
+       exists neither under changes nor under changes/archive), and no canonical
+       reporting capability exists under openspec/specs either. Tracked in #525.
+       Deliberately NOT resolved by writing that spec — authoring the requirement
+       a tag is checked against turns the gate green over an unspecified capability.
 
- KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
- The change directory it names was never committed, and the `reporting`
+ KNOWINGLY DANGLING — do not repoint this tag at a spec (gate-46, shillinq#499).
+ The change directory it named was never committed, and the `reporting`
  capability has NO canonical spec. One was drafted during gate remediation and
  withdrawn: a spec written to fit the code, by the process whose job is to
  check the code against a spec, is not a specification anyone agreed to.
  Authoring it is the capability owner's decision, not a gate fix.
+
+ The dangling path is replaced by the reason-bearing `@spec exclude` above —
+ the same declaration lib/Controller/ReportingController.php already carries for
+ the same capability. The prose note alone did not say this to gate-46, which
+ reads the tag and not the paragraph under it, so the two halves of the same
+ decision disagreed and only the PHP half was legible.
 -->
 <template>
 	<div class="reporting-overview" data-testid="reporting-overview">

--- a/src/modals/GenerateReportDialog.vue
+++ b/src/modals/GenerateReportDialog.vue
@@ -20,14 +20,25 @@
  fileName) so the parent can toast a download link; on failure it surfaces
  the error inline and stays open.
 
- @spec openspec/changes/reporting-compliance-consolidation/specs/reporting/spec.md
+ @spec exclude The reporting capability has no canonical spec. This tag pointed at
+       openspec/changes/reporting-compliance-consolidation (a change directory that
+       exists neither under changes nor under changes/archive), and no canonical
+       reporting capability exists under openspec/specs either. Tracked in #525.
+       Deliberately NOT resolved by writing that spec — authoring the requirement
+       a tag is checked against turns the gate green over an unspecified capability.
 
- KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
- The change directory it names was never committed, and the `reporting`
+ KNOWINGLY DANGLING — do not repoint this tag at a spec (gate-46, shillinq#499).
+ The change directory it named was never committed, and the `reporting`
  capability has NO canonical spec. One was drafted during gate remediation and
  withdrawn: a spec written to fit the code, by the process whose job is to
  check the code against a spec, is not a specification anyone agreed to.
  Authoring it is the capability owner's decision, not a gate fix.
+
+ The dangling path is replaced by the reason-bearing `@spec exclude` above —
+ the same declaration lib/Controller/ReportingController.php already carries for
+ the same capability. The prose note alone did not say this to gate-46, which
+ reads the tag and not the paragraph under it, so the two halves of the same
+ decision disagreed and only the PHP half was legible.
 -->
 
 <template>

--- a/tests/e2e/workflows/fin-oss-vat-rate.spec.ts
+++ b/tests/e2e/workflows/fin-oss-vat-rate.spec.ts
@@ -25,7 +25,11 @@
  * enters the OSS pipeline), so the destination-country case (DE 19%) is used
  * here and the gross/VAT identity is asserted explicitly.
  *
- * @spec openspec/changes/bookkeeping-vat-oss-eu/specs/bookkeeping-vat-oss-eu/spec.md
+ * The capability is spelled with the Dutch statutory term for the tax — `btw`,
+ * not `vat` — so the canonical spec is `bookkeeping-btw-oss-eu`. The path this
+ * tag used to name has never existed in any form.
+ *
+ * @spec openspec/specs/bookkeeping-btw-oss-eu/spec.md#REQ-OSS-001
  */
 
 import { test, expect, request as pwRequest } from '@playwright/test'


### PR DESCRIPTION
## What

gate-46 spec-anchor-existence: **4 unresolved `@spec` findings from 2 distinct targets → 0 from 0.**

They are two different problems, and only one of them is a mistake.

### 1. `bookkeeping-vat-oss-eu` — a naming slip (1 finding)

`tests/e2e/workflows/fin-oss-vat-rate.spec.ts` pointed at
`openspec/changes/bookkeeping-vat-oss-eu/specs/bookkeeping-vat-oss-eu/spec.md`, which has never
existed in any form. The capability is spelled with the Dutch statutory term for the tax — `btw`,
not `vat` — so the canonical spec is `openspec/specs/bookkeeping-btw-oss-eu/spec.md`, and the
test's own header already names the requirement it proves. Repointed at
`openspec/specs/bookkeeping-btw-oss-eu/spec.md#REQ-OSS-001`.

### 2. `reporting-compliance-consolidation` — NOT a mistake; do not repoint it (3 findings)

The decision is already recorded in this repository, in **issue #525** and in the
`KNOWINGLY DANGLING` note the three reporting components carry: the change directory was never
committed, the `reporting` capability has **no canonical spec**, one was drafted during a
previous gate-remediation pass and withdrawn, and authoring the requirement a tag is checked
against would turn the gate green over an unspecified capability. `ReportingController.php`
already declares exactly that with a reason-bearing `@spec exclude`.

**What was wrong is that the three Vue files said it only in PROSE.** gate-46 reads the tag, not
the paragraph under it — so one decision had a PHP half the gate could read and a Vue half it
could not, and the unreadable half kept the gate red. They now carry the same `@spec exclude`
the controller does, verbatim, with the prose retained underneath.

Nothing is newly excluded. The exclusion is simply written where the gate can see it, no spec was
invented, and **#525 stays open**.

## Evidence

Instrument: `hydra-gates/scripts/lib/check_spec_anchors.py` from **`ConductionNL/.github@main`**
(the vendored `v1.7.3` copy differs from what CI runs), invoked exactly as `run-hydra-gates.sh`
does — `find lib src tests` for `*.php|*.vue|*.js|*.ts|*.md`, excluding `vendor/`,
`node_modules/`, `dist/`, `build/`. Findings are read from the log the helper writes; it always
exits 0, so its exit code proves nothing.

| | findings | distinct targets | files measured |
|---|---|---|---|
| base `origin/development` @ `13e47531` | **4** | 2 | **1511** |
| this branch (merged with that base) | **0** | 0 | **1511** |

⚠️ shillinq's `Hydra Gates` job is **cancelled** on the current base run (`31937325844`), so gate
parity **cannot** be judged from CI here. Every number above is from the gate's own script run
locally against both the base commit and this head.

### No gate is made worse

- **gate-19 e2e-coverage**: 290 on the base, **290 on this head** (full-repo).
- **gate-16 spec-coverage**: passes on both — `@spec exclude` is reason-bearing, which is what
  gate-16 requires.
- **eslint**: clean on all three components.
- **No PHP is touched by this change**, so the four `PHP Quality` failures that landed on
  `development` with `refactor/adr-084-type-hint-the-contract` (phpcs, phpmd, psalm, phpstan) are
  inherited from the base and are being handled elsewhere in the programme.

## Risk

Comment-only changes in three `.vue` files and one header comment in a Playwright spec.
No executable behaviour changes.
