### PR TITLE
fix(gate-1): add the missing @copyright to RenameDutchColumnsMap

### DIFF
--- a/lib/Repair/RenameDutchColumnsMap.php
+++ b/lib/Repair/RenameDutchColumnsMap.php
@@ -12,11 +12,12 @@
  * The LEFT side is the original Dutch COLUMN name — what the repair step looks
  * for in the database — and must never be renamed.
  *
- * @category Repair
- * @package  OCA\\Shillinq\\Repair
- * @author   Conduction B.V. <info@conduction.nl>
- * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
- * @link     https://www.conduction.nl
+ * @category  Repair
+ * @package   OCA\\Shillinq\\Repair
+ * @author    Conduction B.V. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://www.conduction.nl
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2


### PR DESCRIPTION
## gate-1 spdx-headers: 1 -> 0

`lib/Repair/RenameDutchColumnsMap.php` was the single file under `lib/` with no
`@copyright` PHPDoc tag.

### The value is checked, not guessed

gate-1 checks **presence**; gate-28 license-triangle checks the **value**. This
fleet has already shipped six files that passed gate-1 while declaring
`AGPL-3.0` inside a EUPL-1.2 app, so the licence was verified against three
independent sources before writing it:

| source | says |
|---|---|
| `composer.json` `"license"` | `EUPL-1.2` |
| `appinfo/info.xml` `<licence>` | `EUPL-1.2` |
| the file's own `SPDX-License-Identifier` | `EUPL-1.2` |

`@copyright 2026 Conduction B.V.` is the form **673 of the app's 680** `lib/`
PHP files already use, and matches the file's own
`SPDX-FileCopyrightText: 2026 Conduction B.V.`

The surrounding tags are re-padded because `@copyright` is now the longest tag
in the block. gate-28 stays `PASS`.

### Evidence — the gate's own script

`ConductionNL/.github@main`, `hydra-gates/scripts/run-hydra-gates.sh --full`
(the version CI runs — the copy vendored in this repo's tree is older).
Base measured in a clone pinned to the exact base sha, branch measured in the
worktree.

| | base `49968ce0` | this branch |
|---|---|---|
| `[gate-1] spdx-headers` | **FAIL** — 0 missing @license, 1 missing @copyright | **PASS** |
| files inspected | 680 tracked PHP under `lib/` | 680 |
| gates reporting | 72 | 72 |
| failing gates (exit code) | **12** | **11** |

Verdict-by-verdict diff of the two runs: `gate-1` FAIL→PASS and nothing else
regressed. `gate-16` and `gate-47` appear only on the branch because they are
delta gates — on the base run `HEAD == base`, so they correctly report NOT
APPLICABLE rather than PASS.

### ⚠️ A re-measurement that mattered

An earlier run of this PR showed `gate-16 spec-coverage: FAIL — 2 changed
method(s) missing @spec`, naming two `.vue` files this branch never touches.
**They were not mine.** `development` moved under the branch, and the delta
gates use the **two-dot** diff (`git diff <base>`), which compares the working
tree against the *current* tip — so every file `development` gained after the
branch point is attributed to the PR. The two-dot diff showed 10 files where
`origin/development...HEAD` showed 1. Rebasing onto the current tip cleared it.
Worth knowing for any PR measured while the fleet is merging.

### Quality on the changed file

`php -l` clean. phpcs 0 errors, phpmd clean (run under `php:8.3-cli`; the host
PHP is 8.2 and this repo's `vendor/` requires >= 8.3, which aborts the linters
with a fatal error and **exit 255** — not a clean run). Positive-controlled: a
deliberately malformed file reports 1 error + 2 warnings, so the green is not
vacuous.

One pre-existing phpcs **warning** remains (`Class RenameDutchColumnsMap is
missing @spec`). Not fixed deliberately: `openspec/specs/` has no requirement
describing this column map, and inventing an anchor would manufacture false
traceability. phpcs exits 0.

### Not claimed

This repo's `Hydra Gates` job is **cancelled** on the base run, so its gate
state cannot be judged from CI at all — a cancelled check is not a pass and not
a failure. All gate evidence above is from the gate's own script, run locally,
which is why both sides are quoted with their file counts.
