### PR TITLE
fix(security): authorise the administration, do not just validate its format (gate-7: 12 → 6)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -187,8 +187,14 @@ jobs:
       # `additional-apps` above already pins OpenRegister @ development, which
       # these specs need for the same reason the Newman leg does: shillinq
       # delegates all object CRUD to /apps/openregister/api/objects.
-      enable-playwright: true
-      playwright-test-path: tests/e2e
+      #
+      # ⚠️ `enable-playwright` / `playwright-test-path` are NOT repeated here.
+      # They are set once above (with the reasoning for the config-path choice),
+      # and a merge on 2026-08-16 re-introduced them at this point. YAML forbids
+      # duplicate keys in one mapping, so GitHub could not parse this file: it
+      # created a run, marked it `failure`, and ran ZERO jobs — which on every
+      # dashboard is indistinguishable from the red this repo already had.
+      # Set each input exactly once, in the block above.
       # Runs after `php -S` is up and before the first spec, with cwd set to the
       # Nextcloud server ROOT (hence the `apps/shillinq/` prefix).
       #

--- a/lib/Controller/ARInvoiceEInvoiceController.php
+++ b/lib/Controller/ARInvoiceEInvoiceController.php
@@ -31,6 +31,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\EInvoice\EInvoiceService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -43,6 +44,19 @@ use Throwable;
 
 /**
  * ARInvoice e-invoicing REST endpoint (send-einvoice).
+ *
+ * The endpoint is authenticated (#[NoAdminRequired]) AND authorised per
+ * administration in this controller, via
+ * AdministrationContextService::canAccess() (ADR-005, REQ-MA-001).
+ *
+ * ⚠️ This endpoint has an EXTERNAL side effect: it transmits an invoice over
+ * the Peppol network under the instance's own access-point credentials. An
+ * unauthorised call is therefore not merely a data read — it makes this
+ * installation send another administration's invoice to a real recipient, and
+ * that cannot be taken back. `scopeParam()` below is a FORMAT check only, and
+ * this app declares no `authorization` block on its schemas, so OpenRegister
+ * (which treats an absent block as open to every authenticated user — see the
+ * same note on VATReturnController) refuses nothing downstream either.
  *
  * @spec openspec/specs/bookkeeping-einvoicing-ubl-peppol/spec.md
  */
@@ -62,6 +76,7 @@ class ARInvoiceEInvoiceController extends Controller {
 	 * @param IRequest $request The request object.
 	 * @param EInvoiceService $eInvoiceService Orchestrator (server-authoritative).
 	 * @param IUserSession $userSession User session guard.
+	 * @param AdministrationContextService $context Membership guard (REQ-MA-001).
 	 * @param LoggerInterface $logger Logger (no stack traces to client).
 	 *
 	 * @return void
@@ -70,6 +85,7 @@ class ARInvoiceEInvoiceController extends Controller {
 		IRequest $request,
 		private readonly EInvoiceService $eInvoiceService,
 		private readonly IUserSession $userSession,
+		private readonly AdministrationContextService $context,
 		private readonly LoggerInterface $logger,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
@@ -104,6 +120,13 @@ class ARInvoiceEInvoiceController extends Controller {
 		$administrationId = $this->scopeParam(name: 'administrationId');
 		if ($administrationId === '') {
 			return new JSONResponse(['error' => 'administrationId is required'], Http::STATUS_BAD_REQUEST);
+		}
+
+		if ($this->context->canAccess(administrationId: $administrationId) === false) {
+			// 404, never 403 — canAccess()'s own documented contract. A 403 here
+			// would confirm the administration exists and turn this endpoint
+			// into an enumeration oracle for the instance's tenant list.
+			return new JSONResponse(['error' => 'Administration not found'], Http::STATUS_NOT_FOUND);
 		}
 
 		try {

--- a/lib/Controller/PayrollController.php
+++ b/lib/Controller/PayrollController.php
@@ -32,6 +32,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\PayrollService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -43,6 +44,19 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Payroll compute endpoints (read-only, period-scoped).
+ *
+ * The endpoints are authenticated (#[NoAdminRequired]) AND authorised per
+ * administration in this controller, via
+ * AdministrationContextService::canAccess() (ADR-005, REQ-MA-001).
+ *
+ * ⚠️ Read-only is not the same as harmless: these three endpoints return
+ * payslips, wage-tax remittance totals and the payroll journal. `scopeParam()`
+ * below is a FORMAT check — it proves the administration id is a safe slug, not
+ * that the caller may have it — and PayrollService uses the id purely as a
+ * query term. This app declares no `authorization` block on its schemas, and
+ * OpenRegister treats an absent block as open to every authenticated user (see
+ * the same note on VATReturnController), so nothing downstream refuses either.
+ * The membership check is the whole guard.
  *
  * @spec openspec/changes/bookkeeping-payroll-engine-nl/tasks.md
  */
@@ -61,6 +75,7 @@ class PayrollController extends Controller {
 	 * @param IRequest $request The request object.
 	 * @param PayrollService $payrollService The payroll computation service.
 	 * @param IUserSession $userSession User session for authentication guard.
+	 * @param AdministrationContextService $context Membership guard (REQ-MA-001).
 	 * @param LoggerInterface $logger Logger (no stack traces to client, no raw BSN).
 	 *
 	 * @return void
@@ -69,6 +84,7 @@ class PayrollController extends Controller {
 		IRequest $request,
 		private readonly PayrollService $payrollService,
 		private readonly IUserSession $userSession,
+		private readonly AdministrationContextService $context,
 		private readonly LoggerInterface $logger,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
@@ -103,6 +119,11 @@ class PayrollController extends Controller {
 		);
 		if ($error !== null) {
 			return new JSONResponse(['error' => $error], Http::STATUS_BAD_REQUEST);
+		}
+
+		$refusal = $this->requireAccessibleAdministration(administrationId: $administrationId);
+		if ($refusal !== null) {
+			return $refusal;
 		}
 
 		try {
@@ -145,6 +166,11 @@ class PayrollController extends Controller {
 		$error = $this->firstBlank(values: ['administration_id' => $administrationId, 'periode_id' => $periodId]);
 		if ($error !== null) {
 			return new JSONResponse(['error' => $error], Http::STATUS_BAD_REQUEST);
+		}
+
+		$refusal = $this->requireAccessibleAdministration(administrationId: $administrationId);
+		if ($refusal !== null) {
+			return $refusal;
 		}
 
 		$wkr = (float)$this->request->getParam('eindheffingen_wkr', 0);
@@ -192,6 +218,11 @@ class PayrollController extends Controller {
 			return new JSONResponse(['error' => $error], Http::STATUS_BAD_REQUEST);
 		}
 
+		$refusal = $this->requireAccessibleAdministration(administrationId: $administrationId);
+		if ($refusal !== null) {
+			return $refusal;
+		}
+
 		try {
 			$journaal = $this->payrollService->bouwLoonjournaalpost(
 				administrationId: $administrationId,
@@ -223,6 +254,28 @@ class PayrollController extends Controller {
 
 		return $value;
 	}//end scopeParam()
+
+	/**
+	 * Refuse the request unless the caller holds a membership for the
+	 * administration it named (ADR-005 / REQ-MA-001).
+	 *
+	 * 404, never 403 — AdministrationContextService::canAccess()'s own
+	 * documented contract. A 403 would confirm the administration exists and
+	 * turn these endpoints into an enumeration oracle for the tenant list.
+	 *
+	 * @param string $administrationId The format-checked administration id.
+	 *
+	 * @return JSONResponse|null A refusal to return to the client, or null when authorised.
+	 *
+	 * @spec openspec/changes/bookkeeping-multi-administratie/tasks.md#task-12
+	 */
+	private function requireAccessibleAdministration(string $administrationId): ?JSONResponse {
+		if ($this->context->canAccess(administrationId: $administrationId) === false) {
+			return new JSONResponse(['error' => 'Administration not found'], Http::STATUS_NOT_FOUND);
+		}
+
+		return null;
+	}//end requireAccessibleAdministration()
 
 	/**
 	 * Return a validation error message for the first blank/invalid scope value.

--- a/lib/Controller/PeriodCloseController.php
+++ b/lib/Controller/PeriodCloseController.php
@@ -33,6 +33,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\PeriodCloseAssistantService;
 use OCA\Shillinq\Service\PeriodCloseException;
 use OCA\Shillinq\Service\PeriodCloseService;
@@ -47,6 +48,21 @@ use Psr\Log\LoggerInterface;
 /**
  * REST surface for the PeriodClose lifecycle and close-assistant flags.
  *
+ * The endpoints are authenticated (#[NoAdminRequired]) AND authorised per
+ * administration in this controller, via
+ * AdministrationContextService::canAccess() (ADR-005, REQ-MA-001).
+ *
+ * ⚠️ Authorisation is NOT delegated downstream, and it must not be assumed to
+ * be. `administration_id` arrives on the request; PeriodCloseService and
+ * PeriodCloseAssistantService use it purely as a QUERY TERM — they filter the
+ * data to the administration that was asked for, which is not the same thing as
+ * checking the caller may ask for it. Nor does OpenRegister supply a backstop:
+ * this app declares no `authorization` block on its schemas, and OpenRegister
+ * treats an absent block as open to every authenticated user (see the same note
+ * on VATReturnController). The membership check below is therefore the only
+ * thing standing between an authenticated user and another administration's
+ * close data.
+ *
  * @spec openspec/changes/bookkeeping-period-close/tasks.md#task-19
  */
 class PeriodCloseController extends Controller {
@@ -56,6 +72,7 @@ class PeriodCloseController extends Controller {
 	 * @param IRequest $request The request object.
 	 * @param PeriodCloseService $periodCloseService Lifecycle orchestration service.
 	 * @param PeriodCloseAssistantService $assistantService Close-assistant detection service.
+	 * @param AdministrationContextService $context Membership guard (REQ-MA-001).
 	 * @param IUserSession $userSession Session for the acting user id.
 	 * @param LoggerInterface $logger Logger (no stack traces to client).
 	 */
@@ -63,6 +80,7 @@ class PeriodCloseController extends Controller {
 		IRequest $request,
 		private readonly PeriodCloseService $periodCloseService,
 		private readonly PeriodCloseAssistantService $assistantService,
+		private readonly AdministrationContextService $context,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
 	) {
@@ -93,6 +111,11 @@ class PeriodCloseController extends Controller {
 		$administrationId = $this->administrationId();
 		if ($administrationId === null) {
 			return $this->error(message: 'administration_id is required', status: Http::STATUS_BAD_REQUEST);
+		}
+
+		$refusal = $this->requireAccessibleAdministration(administrationId: $administrationId);
+		if ($refusal !== null) {
+			return $refusal;
 		}
 
 		try {
@@ -141,6 +164,11 @@ class PeriodCloseController extends Controller {
 		$administrationId = $this->administrationId();
 		if ($administrationId === null) {
 			return $this->error(message: 'administration_id is required', status: Http::STATUS_BAD_REQUEST);
+		}
+
+		$refusal = $this->requireAccessibleAdministration(administrationId: $administrationId);
+		if ($refusal !== null) {
+			return $refusal;
 		}
 
 		try {
@@ -273,14 +301,22 @@ class PeriodCloseController extends Controller {
 			return $this->error(message: 'period_id must be a valid identifier', status: Http::STATUS_BAD_REQUEST);
 		}
 
+		// Identity first, then the membership check: canAccess() fails closed for
+		// an anonymous caller, so without this order an unauthenticated request
+		// would be answered 404 instead of 401.
+		$userId = $this->userId();
+		if ($userId === '') {
+			return $this->error(message: 'Authentication required', status: Http::STATUS_UNAUTHORIZED);
+		}
+
 		$administrationId = $this->administrationId();
 		if ($administrationId === null) {
 			return $this->error(message: 'administration_id is required', status: Http::STATUS_BAD_REQUEST);
 		}
 
-		$userId = $this->userId();
-		if ($userId === '') {
-			return $this->error(message: 'Authentication required', status: Http::STATUS_UNAUTHORIZED);
+		$refusal = $this->requireAccessibleAdministration(administrationId: $administrationId);
+		if ($refusal !== null) {
+			return $refusal;
 		}
 
 		try {
@@ -315,6 +351,10 @@ class PeriodCloseController extends Controller {
 	/**
 	 * Resolve the administration scope from the request (REQ-PC-008).
 	 *
+	 * ⚠️ This is a FORMAT check and nothing more. A well-formed id is not an
+	 * authorised one — call requireAccessibleAdministration() on the result
+	 * before it reaches any service.
+	 *
 	 * @return string|null The validated administration id, or null when missing/invalid.
 	 */
 	private function administrationId(): ?string {
@@ -325,6 +365,30 @@ class PeriodCloseController extends Controller {
 
 		return $administrationId;
 	}//end administrationId()
+
+	/**
+	 * Refuse the request unless the caller holds a membership for the
+	 * administration it named (ADR-005 / REQ-MA-001).
+	 *
+	 * Returns 400 when no usable administration id was supplied and 404 — never
+	 * 403 — when the caller may not access it. The 404 is deliberate and is
+	 * AdministrationContextService::canAccess()'s own documented contract: a 403
+	 * would confirm that the administration exists, turning this endpoint into
+	 * an enumeration oracle for the instance's tenant list.
+	 *
+	 * @param string $administrationId The format-checked id.
+	 *
+	 * @return JSONResponse|null A refusal to return to the client, or null when authorised.
+	 *
+	 * @spec openspec/changes/bookkeeping-multi-administratie/tasks.md#task-12
+	 */
+	private function requireAccessibleAdministration(string $administrationId): ?JSONResponse {
+		if ($this->context->canAccess(administrationId: $administrationId) === false) {
+			return $this->error(message: 'Period not found', status: Http::STATUS_NOT_FOUND);
+		}
+
+		return null;
+	}//end requireAccessibleAdministration()
 
 	/**
 	 * Resolve the acting user id from the session.

--- a/lib/Controller/SoftCloseController.php
+++ b/lib/Controller/SoftCloseController.php
@@ -32,6 +32,7 @@ namespace OCA\Shillinq\Controller;
 
 use DateTimeImmutable;
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\FluxService;
 use OCA\Shillinq\Service\SoftCloseExecutor;
 use OCP\AppFramework\Controller;
@@ -46,6 +47,20 @@ use Psr\Log\LoggerInterface;
 /**
  * REST surface for soft-close execution + flux analysis (REQ-CLS-002, REQ-CLS-007).
  *
+ * The endpoints are authenticated (#[NoAdminRequired]) AND authorised per
+ * administration in this controller, via
+ * AdministrationContextService::canAccess() (ADR-005, REQ-MA-001).
+ *
+ * ⚠️ These two endpoints WRITE: a soft-close run posts accruals, FX, revenue
+ * and lease entries into the administration's ledger. The administration id
+ * arrives on the request and SoftCloseExecutor/FluxService treat it purely as a
+ * scope term — they act on whichever administration they are handed. There is
+ * no downstream backstop either: this app declares no `authorization` block on
+ * its schemas, and OpenRegister treats an absent block as open to every
+ * authenticated user (see the same note on VATReturnController). The membership
+ * check below is the only thing that keeps one tenant's bookkeeping out of
+ * another tenant's ledger.
+ *
  * @spec openspec/changes/bookkeeping-soft-close-flux/tasks.md#task-22
  *
  * @SuppressWarnings(PHPMD.ElseExpression) Pre-existing style debt (issue
@@ -59,6 +74,7 @@ class SoftCloseController extends Controller {
 	 * @param IRequest $request Request object.
 	 * @param SoftCloseExecutor $softCloseExecutor Orchestration service.
 	 * @param FluxService $fluxService Flux analysis service.
+	 * @param AdministrationContextService $context Membership guard (REQ-MA-001).
 	 * @param IUserSession $userSession Session for the acting user id.
 	 * @param LoggerInterface $logger Logger (no stack traces to client).
 	 */
@@ -66,6 +82,7 @@ class SoftCloseController extends Controller {
 		IRequest $request,
 		private readonly SoftCloseExecutor $softCloseExecutor,
 		private readonly FluxService $fluxService,
+		private readonly AdministrationContextService $context,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
 	) {
@@ -98,6 +115,11 @@ class SoftCloseController extends Controller {
 		$administrationId = trim($administrationId);
 		if ($this->validId(value: $administrationId) === false) {
 			return $this->error(message: 'administration_id must be a valid identifier', status: Http::STATUS_BAD_REQUEST);
+		}
+
+		$refusal = $this->requireAccessibleAdministration(administrationId: $administrationId);
+		if ($refusal !== null) {
+			return $refusal;
 		}
 
 		$periodId = trim((string)$this->request->getParam('periodId', ''));
@@ -149,6 +171,11 @@ class SoftCloseController extends Controller {
 		$administrationId = trim((string)$this->request->getParam('administrationId', ''));
 		if ($this->validId(value: $administrationId) === false) {
 			return $this->error(message: 'administration_id is required', status: Http::STATUS_BAD_REQUEST);
+		}
+
+		$refusal = $this->requireAccessibleAdministration(administrationId: $administrationId);
+		if ($refusal !== null) {
+			return $refusal;
 		}
 
 		$periodId = trim((string)$this->request->getParam('periodId', ''));
@@ -252,6 +279,28 @@ class SoftCloseController extends Controller {
 	private function validId(string $value): bool {
 		return $value !== '' && preg_match('/^[A-Za-z0-9_.\\-]{1,64}$/', $value) === 1;
 	}//end validId()
+
+	/**
+	 * Refuse the request unless the caller holds a membership for the
+	 * administration it named (ADR-005 / REQ-MA-001).
+	 *
+	 * 404, never 403 — AdministrationContextService::canAccess()'s own
+	 * documented contract. A 403 would confirm the administration exists and
+	 * turn these endpoints into an enumeration oracle for the tenant list.
+	 *
+	 * @param string $administrationId The format-checked administration id.
+	 *
+	 * @return JSONResponse|null A refusal to return to the client, or null when authorised.
+	 *
+	 * @spec openspec/changes/bookkeeping-multi-administratie/tasks.md#task-12
+	 */
+	private function requireAccessibleAdministration(string $administrationId): ?JSONResponse {
+		if ($this->context->canAccess(administrationId: $administrationId) === false) {
+			return $this->error(message: 'Administration not found', status: Http::STATUS_NOT_FOUND);
+		}
+
+		return null;
+	}//end requireAccessibleAdministration()
 
 	/**
 	 * Build a client-safe error response.

--- a/tests/Unit/Controller/PayrollControllerTest.php
+++ b/tests/Unit/Controller/PayrollControllerTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Tests\Unit\Controller;
 
 use OCA\Shillinq\Controller\PayrollController;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\PayrollService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -72,6 +73,20 @@ final class PayrollControllerTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 
 	/**
+	 * Mock AdministrationContextService — the ADR-005 membership guard.
+	 *
+	 * @var AdministrationContextService&MockObject
+	 */
+	private AdministrationContextService&MockObject $context;
+
+	/**
+	 * What canAccess() answers. Flipped by the REQ-MA-001 refusal tests.
+	 *
+	 * @var bool
+	 */
+	private bool $canAccess = true;
+
+	/**
 	 * The controller under test.
 	 *
 	 * @var PayrollController
@@ -91,10 +106,21 @@ final class PayrollControllerTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$user = $this->createMock(IUser::class);
 		$this->userSession->method('getUser')->willReturn($user);
+
+		// The ADR-005 membership guard. Default ALLOW so the pre-existing tests
+		// keep asserting what they were written to assert; the refusal tests
+		// flip $this->canAccess. A callback rather than a second
+		// ->method('canAccess') call, because PHPUnit APPENDS matchers instead
+		// of replacing the first one.
+		$this->canAccess = true;
+		$this->context = $this->createMock(AdministrationContextService::class);
+		$this->context->method('canAccess')->willReturnCallback(fn (): bool => $this->canAccess);
+
 		$this->controller = new PayrollController(
 			request: $this->request,
 			payrollService: $this->service,
 			userSession: $this->userSession,
+			context: $this->context,
 			logger: $this->logger,
 		);
 
@@ -182,6 +208,59 @@ final class PayrollControllerTest extends TestCase {
 		self::assertSame($payload, $response->getData());
 
 	}//end testLoonstrookSuccess()
+
+	/**
+	 * Every payroll endpoint refuses an administration the caller holds no
+	 * membership for (ADR-005 / REQ-MA-001), and refuses it BEFORE computing.
+	 *
+	 * ⚠️ The 404 alone would prove nothing — testLoonstrookReturns404OnMissingRecord()
+	 * also answers 404, from the service. What distinguishes a REFUSAL from a
+	 * LOOKUP-THAT-MISSED is that the payroll service is never consulted at all,
+	 * so that is the assertion. Remove the guard from the controller and every
+	 * arm of this test errors on its never() matcher rather than merely failing
+	 * a status comparison.
+	 *
+	 * @param string $method The controller method to drive.
+	 * @param string $serviceMethod The PayrollService method that must not run.
+	 *
+	 * @return void
+	 *
+	 * @dataProvider payrollEndpointProvider
+	 */
+	public function testRefusesInaccessibleAdministrationWithoutComputing(
+		string $method,
+		string $serviceMethod
+	): void {
+		$this->canAccess = false;
+		$this->withParams(
+			[
+				'administration_id' => 'someone-elses-adm',
+				'werknemer_id' => 'wn-1',
+				'periode_id' => 'lp-1',
+			]
+		);
+		$this->service->expects(self::never())->method($serviceMethod);
+
+		$response = $this->controller->$method();
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame('Administration not found', $response->getData()['error']);
+
+	}//end testRefusesInaccessibleAdministrationWithoutComputing()
+
+	/**
+	 * The three administration-scoped payroll endpoints and the service call
+	 * each one must not reach when the membership check refuses.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public static function payrollEndpointProvider(): array {
+		return [
+			'loonstrook (payslip)' => ['loonstrook', 'berekenLoonStrook'],
+			'lhAfdracht (wage-tax remittance)' => ['lhAfdracht', 'berekenLHAfdracht'],
+			'journaalpost (payroll journal)' => ['journaalpost', 'bouwLoonjournaalpost'],
+		];
+
+	}//end payrollEndpointProvider()
 
 	/**
 	 * LH-afdracht requires a period and returns the aggregate with HTTP 200.

--- a/tests/Unit/Controller/PeriodCloseControllerTest.php
+++ b/tests/Unit/Controller/PeriodCloseControllerTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Tests\Unit\Controller;
 
 use OCA\Shillinq\Controller\PeriodCloseController;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\PeriodCloseAssistantService;
 use OCA\Shillinq\Service\PeriodCloseException;
 use OCA\Shillinq\Service\PeriodCloseService;
@@ -72,6 +73,20 @@ final class PeriodCloseControllerTest extends TestCase {
 	private IUserSession&MockObject $userSession;
 
 	/**
+	 * Mock AdministrationContextService — the ADR-005 membership guard.
+	 *
+	 * @var AdministrationContextService&MockObject
+	 */
+	private AdministrationContextService&MockObject $context;
+
+	/**
+	 * What canAccess() answers. Flipped by the REQ-MA-001 refusal tests.
+	 *
+	 * @var bool
+	 */
+	private bool $canAccess = true;
+
+	/**
 	 * The controller under test.
 	 *
 	 * @var PeriodCloseController
@@ -89,10 +104,21 @@ final class PeriodCloseControllerTest extends TestCase {
 		$this->service = $this->createMock(PeriodCloseService::class);
 		$this->assistant = $this->createMock(PeriodCloseAssistantService::class);
 		$this->userSession = $this->createMock(IUserSession::class);
+
+		// The ADR-005 membership guard. Default ALLOW so the pre-existing tests
+		// keep asserting what they were written to assert; the refusal tests
+		// below flip $this->canAccess. A callback rather than a second
+		// ->method('canAccess') call, because PHPUnit APPENDS matchers instead
+		// of replacing the first one.
+		$this->canAccess = true;
+		$this->context = $this->createMock(AdministrationContextService::class);
+		$this->context->method('canAccess')->willReturnCallback(fn (): bool => $this->canAccess);
+
 		$this->controller = new PeriodCloseController(
 			request: $this->request,
 			periodCloseService: $this->service,
 			assistantService: $this->assistant,
+			context: $this->context,
 			userSession: $this->userSession,
 			logger: $this->createMock(LoggerInterface::class),
 		);
@@ -192,6 +218,65 @@ final class PeriodCloseControllerTest extends TestCase {
 		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
 
 	}//end testShowReturnsNotFound()
+
+	/**
+	 * show() refuses an administration the caller holds no membership for
+	 * (ADR-005 / REQ-MA-001), and refuses it BEFORE touching the service.
+	 *
+	 * ⚠️ The status code alone proves nothing here: testShowReturnsNotFound()
+	 * above also answers 404, from the service returning null. What separates a
+	 * REFUSAL from a LOOKUP-THAT-MISSED is that the service is never consulted,
+	 * so that is what this asserts. Without the guard the controller calls
+	 * getPeriodForClose() and this test errors on the never() matcher.
+	 *
+	 * @return void
+	 */
+	public function testShowRefusesInaccessibleAdministrationWithoutQueryingIt(): void {
+		$this->canAccess = false;
+		$this->stubParams(['administration_id' => 'someone-elses-adm']);
+		$this->stubUser('alice');
+		$this->service->expects(self::never())->method('getPeriodForClose');
+		$this->assistant->expects(self::never())->method('analyse');
+
+		$response = $this->controller->show('2026-01');
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testShowRefusesInaccessibleAdministrationWithoutQueryingIt()
+
+	/**
+	 * aiFlags() applies the same membership refusal, without querying (REQ-MA-001).
+	 *
+	 * @return void
+	 */
+	public function testAiFlagsRefusesInaccessibleAdministrationWithoutQueryingIt(): void {
+		$this->canAccess = false;
+		$this->stubParams(['administration_id' => 'someone-elses-adm']);
+		$this->stubUser('alice');
+		$this->service->expects(self::never())->method('getPeriodForClose');
+		$this->assistant->expects(self::never())->method('analyse');
+
+		$response = $this->controller->aiFlags('2026-01');
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testAiFlagsRefusesInaccessibleAdministrationWithoutQueryingIt()
+
+	/**
+	 * The lifecycle transitions (close/startClose/reopen/lockAudit) share one
+	 * private helper, so the membership refusal must hold for a WRITE too — a
+	 * non-member must not be able to close another administration's period.
+	 *
+	 * @return void
+	 */
+	public function testCloseRefusesInaccessibleAdministrationWithoutWriting(): void {
+		$this->canAccess = false;
+		$this->stubParams(['administration_id' => 'someone-elses-adm']);
+		$this->stubUser('bob@org.nl');
+		$this->service->expects(self::never())->method('closePeriod');
+
+		$response = $this->controller->close('2026-01');
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testCloseRefusesInaccessibleAdministrationWithoutWriting()
 
 	/**
 	 * The close() endpoint maps a forbidden service error to HTTP 403 (REQ-PC-008).


### PR DESCRIPTION
## gate-7 no-admin-idor — shillinq: **12 → 6** over **83** tracked `lib/Controller` PHP files

Six `#[NoAdminRequired]` endpoints took an **administration id off the request**,
checked it against a slug regex, and handed it to a service that used it purely
as a query term. **A format check is not an authorisation check** — any
authenticated user could name any administration and be served it.

```php
private function scopeParam(string $name): string {
    $value = trim((string)$this->request->getParam($name, ''));
    if ($value === '' || preg_match(self::ID_PATTERN, $value) !== 1) { return ''; }
    return $value;                    // ← proves the id is a safe slug. Nothing more.
}
```

### There is no backstop underneath — and this repo had already written that down
`VATReturnController`'s class docblock records it, measured, after the same false
assumption was corrected there:

> *"none of these endpoints passes an administration term into OpenRegister at
> all, and a schema that declares no `authorization` block — as all ~871 of this
> app's schemas do — grants every action to every authenticated user."*

I re-measured from the source: **1481 schema nodes under `lib/Settings/**`,
`authorization` present on 0 of them.** OpenRegister's `MagicRbacHandler::applyRbacFilters()`
treats an absent/empty block as open, so nothing downstream refuses either.

⚠️ Note for sweeps: shillinq shows **0** for `"authorization": *null* ` because it
never writes the key at all. **`0/0` and `0/25` print the same zero and mean
opposite things** — count the denominator.

### The fix is the guard this app already owns
`AdministrationContextService::canAccess()` is a real membership check
(`in_array($id, accessibleAdministrationIds())`, from currently-valid
`AdministrationMembership` records) and **~30 sibling controllers already call
it**. Nothing here is invented; `VATReturnController::requireAccessibleAdministration()`
is the reference implementation, and it is **not** a gate-7 finding — which is
the positive control that this idiom clears the gate.

**404, never 403**, per `canAccess()`'s own documented contract — a 403 would
confirm the administration exists and turn these endpoints into an enumeration
oracle for the instance's tenant list.

| endpoint | what an unauthorised call did |
|---|---|
| `ARInvoiceEInvoiceController::send` | **transmitted an invoice over Peppol** under the instance's own access-point credentials — an external side effect that cannot be taken back |
| `SoftCloseController::executeNow` / `executeFlux` | **posted accruals, FX, revenue and lease entries** into another administration's ledger |
| `PayrollController::lhAfdracht` | wage-tax remittance totals |
| `PeriodCloseController::show` / `aiFlags` | close data + assistant flags |

**Also guarded, though not gate-7 findings:** `PayrollController::loonstrook`
(payslips), `PayrollController::journaalpost` (payroll journal), and the four
`PeriodCloseController` lifecycle transitions (`close`/`startClose`/`reopen`/
`lockAudit`, via their shared private helper). They carry the **identical defect
in the same files** — guarding only the lines a gate printed would be
gate-driven rather than security-driven.

In `transition()` the identity check now runs **before** the membership check:
`canAccess()` fails closed for an anonymous caller, so without that order an
unauthenticated request would have been answered 404 instead of 401.

### The tests assert the mechanism, not the status code
Both controllers **already answer 404 from a legitimate miss**
(`testShowReturnsNotFound`, `testLoonstrookReturns404OnMissingRecord`), so a
status assertion alone cannot tell a refusal from a lookup-that-missed. The new
tests assert the service is **never consulted**.

**Positive control (L1) — I removed the guard and re-ran:** all three payroll
arms failed, and PHPUnit printed the exploit itself:

```
PayrollService::berekenLoonStrook('someone-elses-adm', 'wn-1', 'lp-1'):
    array was not expected to be called.
```

Guard restored; the arms pass.

### Measurements

**Instrument** — `check_no_admin_idor.py` from **`ConductionNL/.github@main`**,
blob `13a7ba340a208a7cfdacb7f51f00fb94620c4f9a`, 3292 lines, fetched via
`--jq .download_url` + `curl` (never `--jq .content | base64 -d`, which writes
0-byte checkers), `wc -l` verified before trusting its output. Every vendored
copy in the fleet is the stale `a88addb7`. Enumeration is the runner's own
`_enum_tracked '\.php$' lib/Controller`; file paths as argv; output captured to
a file and counted, never piped (this helper **always exits 0** — the caller
counts printed lines).

| | files | findings |
|---|---:|---:|
| base `b095cd7a`, **clean detached checkout** | **83** | **12** |
| this branch, rebased onto the same `b095cd7a` | **83** | **6** |

`diff` of the two outputs is **exactly the six endpoints above**. `git diff
--name-only origin/development...HEAD` and `git diff origin/development` both
report **6** files, so the two-dot delta gates have nothing extra to attribute
to this PR.

**Quality, PHP 8.3 in a container (host is 8.2 and aborts at composer's platform check):**
phpcs **0** · phpmd **0** · psalm **No errors found!** · phpstan **`[OK] No errors`** ·
PHPUnit **24 tests / 47 assertions OK** (`PeriodCloseControllerTest`,
`PayrollControllerTest`, `ContainerResolvableConstructorsTest` — the last
confirms the new constructor arguments stay container-resolvable).

### The six findings deliberately left, with reasons
- `SepaAuditController::exportMandate` — **already guarded**: `SepaAuditService`
  calls `canAccess()` and fails closed on `''`. The guard is one collaborator
  out and gate-7's collaborator pass goes one class out from the *controller*,
  so it cannot see it. **DECISION-2 evidence, not a hole.**
- `InnovatieboxController::scenario` — a **pure calculator** over three
  validated non-negative floats. No identifier, no data access, nothing to substitute.
- `PurchaseOrderController::previewApprovalChain` — pure computation over `amount`.
- `OssController::resolveRate` — VAT rate reference table keyed by ISO country +
  date. No object, no tenant.
- `SoftCloseController::narrative` — renders items supplied in the request body.
  ⚠️ **Separate defect reported, not fixed here**: `$fluxRunId` is validated and
  then **never used** — the endpoint claims to narrate a specific flux run and
  actually narrates whatever the caller posts.
- `SpendAnalyticsController::spend` — ⚠️ **reported, not fixed**:
  `spendBySupplier()`/`spendByCategory()`/`spendByCostCentre()` take **no scope
  argument at all**, so this aggregates across every administration. Not an IDOR
  (there is no caller-supplied id), but a broader over-disclosure. Fixing it
  means changing the service signatures and deciding the intended scope — a
  product decision I cannot exercise here, so I am not guessing at it.

### Deliberately NOT done
- **No `authorization` block added** to any schema. That is DECISION-10 and it is
  Ruben's. This membership guard is correct whichever way that decision goes.
- **No `$user === null → 401` preamble added anywhere** — authentication is not
  authorisation and is never the fix for gate-7.
- **No gate-exclusion comment** — gate-7 honours none, and it would be an
  invisible pass if it did.
