### PR TITLE
fix(deps): gate-66 ADR-083 — the twelve OpenRegister lookups #556 left behind, two of them fatal

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -385,8 +385,8 @@ class Application extends App implements IBootstrap {
 			DoorsnijdingsVerbodValidator::class,
 			static function (ContainerInterface $c): DoorsnijdingsVerbodValidator {
 				return new DoorsnijdingsVerbodValidator(
-					container: $c,
 					appConfig: $c->get(IAppConfig::class),
+					objectService: $c->get(ObjectServiceInterface::class),
 					auditLogger: $c->get(InnovatieboxAuditEventLogger::class),
 				);
 			}

--- a/lib/Guard/StatementVerifyGuard.php
+++ b/lib/Guard/StatementVerifyGuard.php
@@ -47,9 +47,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Guard;
 
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -70,22 +70,20 @@ use Psr\Log\LoggerInterface;
  */
 class StatementVerifyGuard {
 	/**
-	 * Construct the guard with lazy DI of OR's ObjectService.
+	 * Construct the guard with OR's ObjectService injected (ADR-083 rule 1).
 	 *
-	 * @param ContainerInterface $container DI container — OR's ObjectService
-	 *                                      is fetched lazily so this class
-	 *                                      stays usable without a hard
-	 *                                      compile-time dependency on
-	 *                                      OpenRegister.
 	 * @param IAppConfig $appConfig App config for dynamic register
 	 *                              slug resolution.
 	 * @param LoggerInterface $logger Nextcloud logger for fail-closed
 	 *                                diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's published
+	 *                                             object surface (ADR-084),
+	 *                                             aliased in Application.php.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectServiceInterface $objectService,
 	) {
 	}//end __construct()
 
@@ -300,8 +298,6 @@ class StatementVerifyGuard {
 			return 0;
 		}
 
-		$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
-
 		// Page through GLLine entries filtered by accountNumber + entryDate
 		// window. We use accountNumber == bankAccountId by convention; T4
 		// expects bank accounts to share their IBAN/identifier with the GL
@@ -312,7 +308,7 @@ class StatementVerifyGuard {
 		$page = 1;
 		$batchSize = 0;
 		do {
-			$batch = $objectService
+			$batch = $this->objectService
 				->setRegister($this->getRegisterSlug())
 				->setSchema('GLLine')
 				->findAll(
@@ -366,8 +362,7 @@ class StatementVerifyGuard {
 	 */
 	private function persistVarianceFields(string $id, int $expectedCents, int $varianceCents): void {
 		try {
-			$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
-			$objectService
+			$this->objectService
 				->setRegister($this->getRegisterSlug())
 				->setSchema('BankReconciliation')
 				->updateObject(
@@ -398,14 +393,12 @@ class StatementVerifyGuard {
 	 * @return array<int, array<string, mixed>> The match object arrays.
 	 */
 	private function findMatches(string $reconId): array {
-		$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
-
 		$matches = [];
 		$pageSize = 500;
 		$page = 1;
 		$batchSize = 0;
 		do {
-			$batch = $objectService
+			$batch = $this->objectService
 				->setRegister($this->getRegisterSlug())
 				->setSchema('ReconciliationMatch')
 				->findAll(

--- a/lib/Listener/ACMReportSignTransitionListener.php
+++ b/lib/Listener/ACMReportSignTransitionListener.php
@@ -52,13 +52,13 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Listener;
 
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\SettingsService;
 use OCA\Shillinq\Service\Signing\SigningDelegationService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -96,21 +96,22 @@ class ACMReportSignTransitionListener implements IEventListener {
 	/**
 	 * Constructor.
 	 *
-	 * @param ContainerInterface $container DI container — OR ObjectService pulled
-	 *                                      lazily (avoids a circular DI edge).
 	 * @param SettingsService $settingsService Shillinq settings (register slug).
 	 * @param SigningDelegationService $signingService The document-signing request service.
 	 * @param ListenerSchemaResolver $schemaResolver Resolves the entity's schema id to its slug.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's published object
+	 *                                              surface (ADR-084), aliased in
+	 *                                              Application.php.
 	 *
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly SettingsService $settingsService,
 		private readonly SigningDelegationService $signingService,
 		private readonly ListenerSchemaResolver $schemaResolver,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectServiceInterface $objectService,
 	) {
 	}//end __construct()
 
@@ -217,8 +218,7 @@ class ACMReportSignTransitionListener implements IEventListener {
 	 * @return void
 	 */
 	private function persist(string $id, array $updates): void {
-		$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
-		$objectService
+		$this->objectService
 			->setRegister($this->settingsService->getRegisterSlug())
 			->setSchema(self::SCHEMA)
 			->updateObject($id, $updates);

--- a/lib/Listener/AnnualReportSignoffRequestListener.php
+++ b/lib/Listener/AnnualReportSignoffRequestListener.php
@@ -51,12 +51,12 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Listener;
 
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Service\SettingsService;
 use OCA\Shillinq\Service\Signing\SignoffDecisionService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -88,17 +88,18 @@ final class AnnualReportSignoffRequestListener implements IEventListener {
 	/**
 	 * Constructor.
 	 *
-	 * @param ContainerInterface $container DI container — OR ObjectService pulled
-	 *                                      lazily.
 	 * @param SettingsService $settingsService Shillinq settings (register slug).
 	 * @param SignoffDecisionService $signoffService The sign-off request service.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's published object
+	 *                                              surface (ADR-084), aliased in
+	 *                                              Application.php.
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly SettingsService $settingsService,
 		private readonly SignoffDecisionService $signoffService,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectServiceInterface $objectService,
 	) {
 	}//end __construct()
 
@@ -203,8 +204,7 @@ final class AnnualReportSignoffRequestListener implements IEventListener {
 	 * @return void
 	 */
 	private function persist(string $id, array $updates): void {
-		$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
-		$objectService
+		$this->objectService
 			->setRegister($this->settingsService->getRegisterSlug())
 			->setSchema(self::TARGET_SCHEMA)
 			->updateObject($id, $updates);

--- a/lib/Listener/ContractObligationTaskListener.php
+++ b/lib/Listener/ContractObligationTaskListener.php
@@ -55,6 +55,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Listener;
 
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
 use OCA\Shillinq\Service\ListenerSchemaResolver;
@@ -62,7 +63,6 @@ use OCA\Shillinq\Service\ObligationTaskBridge;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -93,21 +93,22 @@ class ContractObligationTaskListener implements IEventListener {
 	/**
 	 * Constructor.
 	 *
-	 * @param ContainerInterface $container DI container — OR ObjectService pulled
-	 *                                      lazily (avoids a circular DI edge).
 	 * @param SettingsService $settingsService Shillinq settings (register slug).
 	 * @param ObligationTaskBridge $bridge NC Tasks / Deck glue.
 	 * @param ListenerSchemaResolver $schemaResolver Resolves the entity's schema id to its slug.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's published object
+	 *                                              surface (ADR-084), aliased in
+	 *                                              Application.php.
 	 *
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly SettingsService $settingsService,
 		private readonly ObligationTaskBridge $bridge,
 		private readonly ListenerSchemaResolver $schemaResolver,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectServiceInterface $objectService,
 	) {
 	}//end __construct()
 
@@ -229,8 +230,7 @@ class ContractObligationTaskListener implements IEventListener {
 			$updates['taskUri'] = (string)$result['taskUri'];
 		}
 
-		$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
-		$objectService
+		$this->objectService
 			->setRegister($this->settingsService->getRegisterSlug())
 			->setSchema(self::SCHEMA)
 			->updateObject($id, $updates);

--- a/lib/Listener/ReconciliationMatchToReportListener.php
+++ b/lib/Listener/ReconciliationMatchToReportListener.php
@@ -60,11 +60,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Listener;
 
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -80,17 +80,18 @@ final class ReconciliationMatchToReportListener implements IEventListener {
 	/**
 	 * Constructor.
 	 *
-	 * @param ContainerInterface $container DI container — OR ObjectService
-	 *                                      pulled lazily.
 	 * @param IAppConfig $appConfig App config for register slug.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's published object
+	 *                                              surface (ADR-084), aliased in
+	 *                                              Application.php.
 	 *
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectServiceInterface $objectService,
 	) {
 	}//end __construct()
 
@@ -258,8 +259,7 @@ final class ReconciliationMatchToReportListener implements IEventListener {
 			$updates['bankLineId'] = $bankLineId;
 		}
 
-		$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
-		$objectService
+		$this->objectService
 			->setRegister($this->getRegisterSlug())
 			->setSchema('ReconciliationMatch')
 			->updateObject($matchId, $updates);
@@ -305,8 +305,7 @@ final class ReconciliationMatchToReportListener implements IEventListener {
 				return '';
 			}
 
-			$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
-			$line = $objectService
+			$line = $this->objectService
 				->setRegister($this->getRegisterSlug())
 				->setSchema('BankStatementLine')
 				->find($lineId);
@@ -320,7 +319,7 @@ final class ReconciliationMatchToReportListener implements IEventListener {
 				return '';
 			}
 
-			$statement = $objectService
+			$statement = $this->objectService
 				->setRegister($this->getRegisterSlug())
 				->setSchema('BankStatement')
 				->find($statementId);
@@ -335,7 +334,7 @@ final class ReconciliationMatchToReportListener implements IEventListener {
 				return '';
 			}
 
-			$sessions = $objectService
+			$sessions = $this->objectService
 				->setRegister($this->getRegisterSlug())
 				->setSchema('BankReconciliation')
 				->findAll(

--- a/lib/Listener/SigningConcludedListener.php
+++ b/lib/Listener/SigningConcludedListener.php
@@ -43,11 +43,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Listener;
 
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\SettingsService;
 use OCA\Shillinq\Service\Signing\SigningDelegationService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -91,19 +91,20 @@ final class SigningConcludedListener implements IEventListener {
 	/**
 	 * Constructor.
 	 *
-	 * @param ContainerInterface $container DI container — OR ObjectService pulled
-	 *                                      lazily.
 	 * @param SettingsService $settingsService Shillinq settings (register slug).
 	 * @param SigningDelegationService $signingService The document-signing consumer service.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's published object
+	 *                                              surface (ADR-084), aliased in
+	 *                                              Application.php.
 	 *
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly SettingsService $settingsService,
 		private readonly SigningDelegationService $signingService,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectServiceInterface $objectService,
 	) {
 	}//end __construct()
 
@@ -344,8 +345,7 @@ final class SigningConcludedListener implements IEventListener {
 	 */
 	private function findObject(string $schema, string $id): ?array {
 		try {
-			$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->settingsService->getRegisterSlug())
 				->setSchema($schema)
 				->find($id);
@@ -367,8 +367,7 @@ final class SigningConcludedListener implements IEventListener {
 	 * @return void
 	 */
 	private function persist(string $schema, string $id, array $updates): void {
-		$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
-		$objectService
+		$this->objectService
 			->setRegister($this->settingsService->getRegisterSlug())
 			->setSchema($schema)
 			->updateObject($id, $updates);

--- a/lib/Listener/SignoffDecisionConcludedListener.php
+++ b/lib/Listener/SignoffDecisionConcludedListener.php
@@ -42,11 +42,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Listener;
 
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\SettingsService;
 use OCA\Shillinq\Service\Signing\SignoffDecisionService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -82,19 +82,20 @@ final class SignoffDecisionConcludedListener implements IEventListener {
 	/**
 	 * Constructor.
 	 *
-	 * @param ContainerInterface $container DI container — OR ObjectService pulled
-	 *                                      lazily.
 	 * @param SettingsService $settingsService Shillinq settings (register slug).
 	 * @param SignoffDecisionService $signoffService The sign-off consumer service.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's published object
+	 *                                              surface (ADR-084), aliased in
+	 *                                              Application.php.
 	 *
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly SettingsService $settingsService,
 		private readonly SignoffDecisionService $signoffService,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectServiceInterface $objectService,
 	) {
 	}//end __construct()
 
@@ -321,8 +322,7 @@ final class SignoffDecisionConcludedListener implements IEventListener {
 	 */
 	private function findObject(string $schema, string $id): ?array {
 		try {
-			$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
-			$result = $objectService
+			$result = $this->objectService
 				->setRegister($this->settingsService->getRegisterSlug())
 				->setSchema($schema)
 				->find($id);
@@ -344,8 +344,7 @@ final class SignoffDecisionConcludedListener implements IEventListener {
 	 * @return void
 	 */
 	private function persist(string $schema, string $id, array $updates): void {
-		$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
-		$objectService
+		$this->objectService
 			->setRegister($this->settingsService->getRegisterSlug())
 			->setSchema($schema)
 			->updateObject($id, $updates);

--- a/lib/Service/AansluitingService.php
+++ b/lib/Service/AansluitingService.php
@@ -103,16 +103,18 @@ class AansluitingService {
 	private const FILED_VAT_RETURN_STATUSES = ['submitted', 'verified', 'filed'];
 
 	/**
-	 * Construct the service with lazy DI of OpenRegister's ObjectService and
-	 * direct dependencies on the two services whose computation this class
-	 * reuses rather than duplicating (REQ-AANS-002).
+	 * Construct the service with OpenRegister's ObjectService injected
+	 * (ADR-083 rule 1) and direct dependencies on the two services whose
+	 * computation this class reuses rather than duplicating (REQ-AANS-002).
 	 *
-	 *                                      lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for diagnostics.
 	 * @param AansluitingCalculator $calculator Pure-logic tolerance/diff helper.
 	 * @param VATReturnService $vatReturnService The BTW ledger-derivation engine this service diffs against.
 	 * @param AansluitingResolutionGuard $resolutionGuard The ADR-031 exception guard for explained -> resolved.
+	 * @param ObjectServiceInterface $objectService OpenRegister's published object
+	 *                                              surface (ADR-084), aliased in
+	 *                                              Application.php.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,
@@ -678,8 +680,7 @@ class AansluitingService {
 	 * @return array<string,mixed>|null
 	 */
 	private function fetchExistingResult(string $reconciliationId, string $periodId): ?array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$results = $objectService
+		$results = $this->objectService
 			->setRegister($this->register())
 			->setSchema('AansluitingResult')
 			->findAll(['filters' => ['reconciliationId' => $reconciliationId, 'periodId' => $periodId]]);

--- a/lib/Service/DoorsnijdingsVerbodValidator.php
+++ b/lib/Service/DoorsnijdingsVerbodValidator.php
@@ -50,10 +50,13 @@ use OCA\OpenRegister\Contract\ObjectServiceInterface;
  */
 class DoorsnijdingsVerbodValidator {
 	/**
-	 * Construct the validator with lazy DI of OpenRegister's ObjectService.
+	 * Construct the validator with OpenRegister's ObjectService injected
+	 * (ADR-083 rule 1).
 	 *
-	 *                                      lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
+	 * @param ObjectServiceInterface $objectService OpenRegister's published object
+	 *                                              surface (ADR-084), aliased in
+	 *                                              Application.php.
 	 * @param InnovatieboxAuditEventLogger|null $auditLogger Optional audit-event logger. When
 	 *                                                       provided, every validateNoDuplication
 	 *                                                       run emits a DoorsnijdingsVerbod.check_run
@@ -227,8 +230,7 @@ class DoorsnijdingsVerbodValidator {
 	 * @return array<int,array<string,mixed>> GL lines carrying accountNumber + kostenplaats.
 	 */
 	private function fetchGlDeductions(string $administrationId, int $financialYear): array {
-		$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-		$rows = $objectService
+		$rows = $this->objectService
 			->setRegister($this->register())
 			->setSchema('GLLine')
 			->findAll(['filters' => ['administrationId' => $administrationId, 'financialYear' => $financialYear]]);

--- a/lib/Service/IcpFilingService.php
+++ b/lib/Service/IcpFilingService.php
@@ -47,12 +47,16 @@ use OCA\OpenRegister\Contract\ObjectServiceInterface;
  */
 class IcpFilingService {
 	/**
-	 * Construct the service with lazy DI of OpenRegister's ObjectService.
+	 * Construct the service with OpenRegister's ObjectService injected
+	 * (ADR-083 rule 1).
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param IcpCalculator $calculator Pure-logic ICP helper.
 	 * @param IcpService $icp Read-side ICP service (period-window supplies).
 	 * @param ViesService $vies VIES validation / evidence-reuse helper.
+	 * @param ObjectServiceInterface $objectService OpenRegister's published object
+	 *                                              surface (ADR-084), aliased in
+	 *                                              Application.php.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,
@@ -300,8 +304,7 @@ class IcpFilingService {
 	 */
 	private function saveReturn(array $return): bool {
 		try {
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$objectService->saveObject(
+			$this->objectService->saveObject(
 				object: $return,
 				register: $this->register(),
 				schema: 'IcpOpgaaf',

--- a/lib/Service/ReconciliationResolutionService.php
+++ b/lib/Service/ReconciliationResolutionService.php
@@ -31,10 +31,10 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Service;
 
 use DomainException;
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
 use OutOfBoundsException;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -47,19 +47,18 @@ class ReconciliationResolutionService {
 	/**
 	 * Constructor.
 	 *
-	 * @param ContainerInterface $container DI container — OR ObjectService
-	 *                                      pulled lazily so the service
-	 *                                      stays usable without a
-	 *                                      compile-time OR dependency.
 	 * @param IAppConfig $appConfig App config for register slug.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's published
+	 *                                             object surface (ADR-084),
+	 *                                             aliased in Application.php.
 	 *
 	 * @return void
 	 */
 	public function __construct(
-		private readonly ContainerInterface $container,
 		private readonly IAppConfig $appConfig,
 		private readonly LoggerInterface $logger,
+		private readonly ObjectServiceInterface $objectService,
 	) {
 	}//end __construct()
 
@@ -91,12 +90,11 @@ class ReconciliationResolutionService {
 		string $resolutionReason,
 		string $actor,
 	): array {
-		$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');
 		$register = $this->getRegisterSlug();
 
 		// Load + validate the parent reconciliation.
 		try {
-			$parent = $objectService
+			$parent = $this->objectService
 				->setRegister($register)
 				->setSchema('BankReconciliation')
 				->find($reconId);
@@ -122,7 +120,7 @@ class ReconciliationResolutionService {
 
 		// Load + validate the match record.
 		try {
-			$match = $objectService
+			$match = $this->objectService
 				->setRegister($register)
 				->setSchema('ReconciliationMatch')
 				->find($matchId);
@@ -147,7 +145,7 @@ class ReconciliationResolutionService {
 			);
 		}
 
-		$updated = $objectService
+		$updated = $this->objectService
 			->setRegister($register)
 			->setSchema('ReconciliationMatch')
 			->updateObject(

--- a/tests/Unit/Guard/StatementVerifyGuardVarianceTest.php
+++ b/tests/Unit/Guard/StatementVerifyGuardVarianceTest.php
@@ -30,24 +30,18 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Guard;
 
+use OCA\OpenRegister\Contract\ObjectEntityInterface;
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Guard\StatementVerifyGuard;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
  * Tests that StatementVerifyGuard flags a bank statement that does not tie out.
  */
 class StatementVerifyGuardVarianceTest extends TestCase {
-
-	/**
-	 * Mock ContainerInterface.
-	 *
-	 * @var ContainerInterface&MockObject
-	 */
-	private ContainerInterface&MockObject $container;
 
 	/**
 	 * Mock IAppConfig.
@@ -64,11 +58,18 @@ class StatementVerifyGuardVarianceTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 
 	/**
-	 * Recording ObjectService stub shared with the guard.
+	 * Recording ObjectService mock injected into the guard (ADR-083 rule 1).
 	 *
-	 * @var object
+	 * @var ObjectServiceInterface&MockObject
 	 */
-	private object $objectService;
+	private ObjectServiceInterface&MockObject $objectService;
+
+	/**
+	 * Every updateObject() payload the guard persisted, keyed by object id.
+	 *
+	 * @var array<string, array<string, mixed>>
+	 */
+	private array $updates = [];
 
 	/**
 	 * Set up test fixtures.
@@ -79,63 +80,24 @@ class StatementVerifyGuardVarianceTest extends TestCase {
 		parent::setUp();
 
 		// phpcs:disable CustomSniffs.Functions.NamedParameters
-		$this->container = $this->createMock(ContainerInterface::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
+
+		// A fluent ObjectService: no GL lines (net activity 0), recording every
+		// updateObject() so the test can read the persisted variance back.
+		$this->updates = [];
+		$this->objectService = $this->createMock(ObjectServiceInterface::class);
+		$this->objectService->method('setRegister')->willReturnSelf();
+		$this->objectService->method('setSchema')->willReturnSelf();
+		$this->objectService->method('findAll')->willReturn([]);
+		$this->objectService->method('updateObject')->willReturnCallback(
+			function (string $objectId, array $data): ObjectEntityInterface {
+				$this->updates[$objectId] = $data;
+				return $this->createMock(ObjectEntityInterface::class);
+			}
+		);
 		// phpcs:enable CustomSniffs.Functions.NamedParameters
-
-		// A fluent ObjectService stub: no GL lines (net activity 0), recording
-		// every updateObject() so the test can read the persisted variance.
-		$this->objectService = new class {
-
-			/**
-			 * Captured updateObject payloads keyed by id.
-			 *
-			 * @var array<string, array<string, mixed>>
-			 */
-			public array $updates = [];
-
-			/**
-			 * @param string $register Register slug.
-			 *
-			 * @return static
-			 */
-			public function setRegister(string $register): static {
-				return $this;
-			}
-
-			/**
-			 * @param string $schema Schema slug.
-			 *
-			 * @return static
-			 */
-			public function setSchema(string $schema): static {
-				return $this;
-			}
-
-			/**
-			 * @param array<string, mixed> $params Query params (unused).
-			 *
-			 * @return array<int, mixed> No GL lines — net activity is zero.
-			 */
-			public function findAll(array $params = []): array {
-				return [];
-			}
-
-			/**
-			 * @param string $id Object id.
-			 * @param array<string, mixed> $data Fields to persist.
-			 *
-			 * @return array<string, mixed>
-			 */
-			public function updateObject(string $id, array $data): array {
-				$this->updates[$id] = $data;
-				return $data;
-			}
-		};
-
-		$this->container->method('get')->willReturn($this->objectService);
 
 	}//end setUp()
 
@@ -146,16 +108,16 @@ class StatementVerifyGuardVarianceTest extends TestCase {
 	 */
 	private function guard(): StatementVerifyGuard {
 		return new StatementVerifyGuard(
-			container: $this->container,
 			appConfig: $this->appConfig,
 			logger: $this->logger,
+			objectService: $this->objectService,
 		);
 	}//end guard()
 
 	/**
 	 * A statement whose closing balance does NOT tie to GL flags a non-zero variance.
 	 *
-	 * opening 5000.00 + GL net activity 0.00 = expected 5000.00; the statement
+	 * Opening 5000.00 + GL net activity 0.00 = expected 5000.00; the statement
 	 * closes at 5100.00, so the tie-out fails by 100.00 and that variance is
 	 * persisted (flagged) onto the reconciliation.
 	 *
@@ -174,11 +136,16 @@ class StatementVerifyGuardVarianceTest extends TestCase {
 		);
 
 		// REQ-REC-002: variance surfaces a warning but does not block.
-		self::assertTrue($result, 'A variance surfaces a warning but does not block the transition');
-		self::assertArrayHasKey('rec-1', $this->objectService->updates);
-		self::assertEqualsWithDelta(100.00, $this->objectService->updates['rec-1']['variance'], 0.001, 'The non-tying balance must flag a 100.00 variance');
-		self::assertNotSame(0, $this->objectService->updates['rec-1']['variance'], 'A non-tying balance must not flag a zero variance');
-		self::assertEqualsWithDelta(5000.00, $this->objectService->updates['rec-1']['expectedGLBalance'], 0.001);
+		self::assertTrue(condition: $result, message: 'A variance surfaces a warning but does not block the transition');
+		self::assertArrayHasKey(key: 'rec-1', array: $this->updates);
+		self::assertEqualsWithDelta(
+			expected: 100.00,
+			actual: $this->updates['rec-1']['variance'],
+			delta: 0.001,
+			message: 'The non-tying balance must flag a 100.00 variance'
+		);
+		self::assertNotSame(expected: 0, actual: $this->updates['rec-1']['variance'], message: 'A non-tying balance must not flag a zero variance');
+		self::assertEqualsWithDelta(expected: 5000.00, actual: $this->updates['rec-1']['expectedGLBalance'], delta: 0.001);
 
 	}//end testNonTyingBalanceIsFlagged()
 
@@ -199,8 +166,13 @@ class StatementVerifyGuardVarianceTest extends TestCase {
 			]
 		);
 
-		self::assertTrue($result);
-		self::assertEqualsWithDelta(0.00, $this->objectService->updates['rec-2']['variance'], 0.001, 'A tying balance must flag a zero variance');
+		self::assertTrue(condition: $result);
+		self::assertEqualsWithDelta(
+			expected: 0.00,
+			actual: $this->updates['rec-2']['variance'],
+			delta: 0.001,
+			message: 'A tying balance must flag a zero variance'
+		);
 
 	}//end testTyingBalanceFlagsZeroVariance()
 }//end class

--- a/tests/Unit/Listener/ACMReportSignTransitionListenerTest.php
+++ b/tests/Unit/Listener/ACMReportSignTransitionListenerTest.php
@@ -31,6 +31,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Listener;
 
+use OCA\OpenRegister\Contract\ObjectEntityInterface;
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Listener\ACMReportSignTransitionListener;
@@ -39,7 +41,6 @@ use OCA\Shillinq\Service\SettingsService;
 use OCA\Shillinq\Service\Signing\SigningDelegationService;
 use OCP\EventDispatcher\GenericEvent;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 
@@ -51,11 +52,11 @@ use RuntimeException;
 final class ACMReportSignTransitionListenerTest extends TestCase {
 
 	/**
-	 * Recording fake ObjectService: captures updateObject() writes.
+	 * Every updateObject() write the listener issued, as ['id' => …] + payload.
 	 *
-	 * @var object
+	 * @var array<int,array<string,mixed>>
 	 */
-	private object $objectService;
+	private array $updates = [];
 
 	/**
 	 * Captured requestSignature() invocations: each entry is
@@ -84,29 +85,17 @@ final class ACMReportSignTransitionListenerTest extends TestCase {
 		string $schemaSlug = 'ACMReport',
 	): ACMReportSignTransitionListener {
 		$this->signingCalls = [];
+		$this->updates = [];
 
-		$this->objectService = new class {
-
-			/**
-			 * @var array<int,array<string,mixed>>
-			 */
-			public array $updates = [];
-
-			public function setRegister(string $r): self {
-				return $this;
-			}//end setRegister()
-
-			public function setSchema(string $s): self {
-				return $this;
-			}//end setSchema()
-
-			/**
-			 * @param array<string,mixed> $updates
-			 */
-			public function updateObject(string $id, array $updates): void {
-				$this->updates[] = ['id' => $id] + $updates;
-			}//end updateObject()
-		};
+		$objectService = $this->createMock(ObjectServiceInterface::class);
+		$objectService->method('setRegister')->willReturnSelf();
+		$objectService->method('setSchema')->willReturnSelf();
+		$objectService->method('updateObject')->willReturnCallback(
+			function (string $objectId, array $data): ObjectEntityInterface {
+				$this->updates[] = ['id' => $objectId] + $data;
+				return new ObjectEntity();
+			}
+		);
 
 		$signingService = $this->createMock(SigningDelegationService::class);
 		$signingService->method('requestSignature')->willReturnCallback(
@@ -126,24 +115,6 @@ final class ACMReportSignTransitionListenerTest extends TestCase {
 			}
 		);
 
-		$objectSvc = $this->objectService;
-		$container = new class($objectSvc) implements ContainerInterface {
-
-			private object $svc;
-
-			public function __construct(object $svc) {
-				$this->svc = $svc;
-			}//end __construct()
-
-			public function get(string $id): mixed {
-				return $this->svc;
-			}//end get()
-
-			public function has(string $id): bool {
-				return true;
-			}//end has()
-		};
-
 		$settings = $this->createMock(SettingsService::class);
 		$settings->method('getRegisterSlug')->willReturn('shillinq');
 
@@ -151,11 +122,11 @@ final class ACMReportSignTransitionListenerTest extends TestCase {
 		$schemaResolver->method('schemaSlug')->willReturn($schemaSlug);
 
 		return new ACMReportSignTransitionListener(
-			$container,
 			$settings,
 			$signingService,
 			$schemaResolver,
 			new NullLogger(),
+			$objectService,
 		);
 
 	}//end makeListener()
@@ -218,10 +189,10 @@ final class ACMReportSignTransitionListenerTest extends TestCase {
 		self::assertSame('ACMReport', $subjectSchema);
 		self::assertSame('acm-report', $documentClass);
 
-		self::assertCount(1, $this->objectService->updates);
-		self::assertSame('acm-42', $this->objectService->updates[0]['id']);
-		self::assertSame('requested', $this->objectService->updates[0]['signingStatus']);
-		self::assertSame('ds-req-42', $this->objectService->updates[0]['signingRequestRef']);
+		self::assertCount(1, $this->updates);
+		self::assertSame('acm-42', $this->updates[0]['id']);
+		self::assertSame('requested', $this->updates[0]['signingStatus']);
+		self::assertSame('ds-req-42', $this->updates[0]['signingRequestRef']);
 
 	}//end testSignTransitionCallsRequestSignatureAndPersists()
 
@@ -236,7 +207,7 @@ final class ACMReportSignTransitionListenerTest extends TestCase {
 		$listener->handle($this->makeEvent(['id' => 'acm-42'], action: 'submit'));
 
 		self::assertCount(0, $this->signingCalls);
-		self::assertCount(0, $this->objectService->updates);
+		self::assertCount(0, $this->updates);
 
 	}//end testNonSignActionIsIgnored()
 
@@ -253,7 +224,7 @@ final class ACMReportSignTransitionListenerTest extends TestCase {
 		);
 
 		self::assertCount(0, $this->signingCalls);
-		self::assertCount(0, $this->objectService->updates);
+		self::assertCount(0, $this->updates);
 
 	}//end testNonAcmReportSchemaIsIgnored()
 
@@ -271,7 +242,7 @@ final class ACMReportSignTransitionListenerTest extends TestCase {
 		);
 
 		self::assertCount(0, $this->signingCalls);
-		self::assertCount(0, $this->objectService->updates);
+		self::assertCount(0, $this->updates);
 
 	}//end testAlreadyRequestedStatusSkipsDuplicateRequest()
 
@@ -287,7 +258,7 @@ final class ACMReportSignTransitionListenerTest extends TestCase {
 		$listener->handle($this->makeEvent(['id' => 'acm-42']));
 
 		self::assertCount(1, $this->signingCalls, 'requestSignature() must still have been invoked.');
-		self::assertCount(0, $this->objectService->updates, 'A fail-closed request must not persist a mirror.');
+		self::assertCount(0, $this->updates, 'A fail-closed request must not persist a mirror.');
 
 	}//end testFailSoftWhenRequestSignatureThrows()
 
@@ -302,7 +273,7 @@ final class ACMReportSignTransitionListenerTest extends TestCase {
 		$listener->handle(new GenericEvent());
 
 		self::assertCount(0, $this->signingCalls);
-		self::assertCount(0, $this->objectService->updates);
+		self::assertCount(0, $this->updates);
 
 	}//end testNonMatchingEventTypeIsIgnored()
 }//end class

--- a/tests/Unit/Listener/AnnualReportSignoffRequestListenerTest.php
+++ b/tests/Unit/Listener/AnnualReportSignoffRequestListenerTest.php
@@ -33,6 +33,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Listener;
 
+use OCA\OpenRegister\Contract\ObjectEntityInterface;
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Listener\AnnualReportSignoffRequestListener;
@@ -40,7 +42,6 @@ use OCA\Shillinq\Service\SettingsService;
 use OCA\Shillinq\Service\Signing\SignoffDecisionService;
 use OCP\EventDispatcher\GenericEvent;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 
@@ -52,11 +53,11 @@ use RuntimeException;
 final class AnnualReportSignoffRequestListenerTest extends TestCase {
 
 	/**
-	 * Recording fake ObjectService: captures updateObject() writes.
+	 * Every updateObject() write the listener issued, as ['id' => …] + payload.
 	 *
-	 * @var object
+	 * @var array<int,array<string,mixed>>
 	 */
-	private object $objectService;
+	private array $updates = [];
 
 	/**
 	 * Captured requestSignoff() invocations: each entry is
@@ -80,29 +81,17 @@ final class AnnualReportSignoffRequestListenerTest extends TestCase {
 	 */
 	private function makeListener(?array $requestResult): AnnualReportSignoffRequestListener {
 		$this->signoffCalls = [];
+		$this->updates = [];
 
-		$this->objectService = new class {
-
-			/**
-			 * @var array<int,array<string,mixed>>
-			 */
-			public array $updates = [];
-
-			public function setRegister(string $r): self {
-				return $this;
-			}//end setRegister()
-
-			public function setSchema(string $s): self {
-				return $this;
-			}//end setSchema()
-
-			/**
-			 * @param array<string,mixed> $updates
-			 */
-			public function updateObject(string $id, array $updates): void {
-				$this->updates[] = ['id' => $id] + $updates;
-			}//end updateObject()
-		};
+		$objectService = $this->createMock(ObjectServiceInterface::class);
+		$objectService->method('setRegister')->willReturnSelf();
+		$objectService->method('setSchema')->willReturnSelf();
+		$objectService->method('updateObject')->willReturnCallback(
+			function (string $objectId, array $data): ObjectEntityInterface {
+				$this->updates[] = ['id' => $objectId] + $data;
+				return new ObjectEntity();
+			}
+		);
 
 		$signoffService = $this->createMock(SignoffDecisionService::class);
 		$signoffService->method('requestSignoff')->willReturnCallback(
@@ -122,32 +111,14 @@ final class AnnualReportSignoffRequestListenerTest extends TestCase {
 			}
 		);
 
-		$objectSvc = $this->objectService;
-		$container = new class($objectSvc) implements ContainerInterface {
-
-			private object $svc;
-
-			public function __construct(object $svc) {
-				$this->svc = $svc;
-			}//end __construct()
-
-			public function get(string $id): mixed {
-				return $this->svc;
-			}//end get()
-
-			public function has(string $id): bool {
-				return true;
-			}//end has()
-		};
-
 		$settings = $this->createMock(SettingsService::class);
 		$settings->method('getRegisterSlug')->willReturn('shillinq');
 
 		return new AnnualReportSignoffRequestListener(
-			$container,
 			$settings,
 			$signoffService,
 			new NullLogger(),
+			$objectService,
 		);
 
 	}//end makeListener()
@@ -206,10 +177,10 @@ final class AnnualReportSignoffRequestListenerTest extends TestCase {
 		self::assertSame('AnnualReport', $subjectSchema);
 		self::assertSame('adoption', $decisionType);
 
-		self::assertCount(1, $this->objectService->updates);
-		self::assertSame('ar-42', $this->objectService->updates[0]['id']);
-		self::assertSame('pending', $this->objectService->updates[0]['decisionOutcome']);
-		self::assertSame('dec-42', $this->objectService->updates[0]['decisionRef']);
+		self::assertCount(1, $this->updates);
+		self::assertSame('ar-42', $this->updates[0]['id']);
+		self::assertSame('pending', $this->updates[0]['decisionOutcome']);
+		self::assertSame('dec-42', $this->updates[0]['decisionRef']);
 
 	}//end testOpgemaaktTransitionCallsRequestSignoffAndPersists()
 
@@ -224,7 +195,7 @@ final class AnnualReportSignoffRequestListenerTest extends TestCase {
 		$listener->handle($this->makeEvent(['id' => 'ar-42'], to: 'determined', from: 'in-review'));
 
 		self::assertCount(0, $this->signoffCalls);
-		self::assertCount(0, $this->objectService->updates);
+		self::assertCount(0, $this->updates);
 
 	}//end testNonOpgemaaktTargetIsIgnored()
 
@@ -239,7 +210,7 @@ final class AnnualReportSignoffRequestListenerTest extends TestCase {
 		$listener->handle($this->makeEvent(['id' => 'other-1'], schema: 'ACMReport'));
 
 		self::assertCount(0, $this->signoffCalls);
-		self::assertCount(0, $this->objectService->updates);
+		self::assertCount(0, $this->updates);
 
 	}//end testNonAnnualReportSchemaIsIgnored()
 
@@ -258,7 +229,7 @@ final class AnnualReportSignoffRequestListenerTest extends TestCase {
 		);
 
 		self::assertCount(0, $this->signoffCalls);
-		self::assertCount(0, $this->objectService->updates);
+		self::assertCount(0, $this->updates);
 
 	}//end testExistingDecisionOutcomeSkipsDuplicateRequest()
 
@@ -275,7 +246,7 @@ final class AnnualReportSignoffRequestListenerTest extends TestCase {
 		$listener->handle($this->makeEvent(['id' => 'ar-42']));
 
 		self::assertCount(1, $this->signoffCalls, 'requestSignoff() must still have been invoked.');
-		self::assertCount(0, $this->objectService->updates, 'A fail-closed request must not persist a mirror.');
+		self::assertCount(0, $this->updates, 'A fail-closed request must not persist a mirror.');
 
 	}//end testFailSoftWhenRequestSignoffThrows()
 
@@ -290,7 +261,7 @@ final class AnnualReportSignoffRequestListenerTest extends TestCase {
 		$listener->handle(new GenericEvent());
 
 		self::assertCount(0, $this->signoffCalls);
-		self::assertCount(0, $this->objectService->updates);
+		self::assertCount(0, $this->updates);
 
 	}//end testNonMatchingEventTypeIsIgnored()
 }//end class

--- a/tests/Unit/Listener/SignoffDecisionConcludedListenerTest.php
+++ b/tests/Unit/Listener/SignoffDecisionConcludedListenerTest.php
@@ -82,12 +82,14 @@ if (class_exists(\OCA\Decidesk\Event\DecisionConcludedEvent::class, false) === f
 namespace OCA\Shillinq\Tests\Unit\Listener;
 
 use OCA\Decidesk\Event\DecisionConcludedEvent;
+use OCA\OpenRegister\Contract\ObjectEntityInterface;
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
+use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\Shillinq\Listener\SignoffDecisionConcludedListener;
 use OCA\Shillinq\Service\SettingsService;
 use OCA\Shillinq\Service\Signing\SignoffDecisionService;
 use OCP\EventDispatcher\IEventDispatcher;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;
 
 /**
@@ -98,12 +100,11 @@ use Psr\Log\NullLogger;
 final class SignoffDecisionConcludedListenerTest extends TestCase {
 
 	/**
-	 * Recording fake ObjectService: captures find() lookups and updateObject()
-	 * writes, and returns a configured object for the matching id.
+	 * Every updateObject() write the listener issued, as ['id' => …] + payload.
 	 *
-	 * @var object
+	 * @var array<int,array<string,mixed>>
 	 */
-	private object $objectService;
+	private array $updates = [];
 
 	/**
 	 * Build the SUT wired to the recording ObjectService.
@@ -113,75 +114,35 @@ final class SignoffDecisionConcludedListenerTest extends TestCase {
 	 * @return SignoffDecisionConcludedListener
 	 */
 	private function makeListener(?array $found): SignoffDecisionConcludedListener {
-		$this->objectService = new class($found) {
+		$this->updates = [];
 
-			/**
-			 * @var array<string,mixed>|null
-			 */
-			private ?array $found;
+		$objectService = $this->createMock(ObjectServiceInterface::class);
+		$objectService->method('setRegister')->willReturnSelf();
+		$objectService->method('setSchema')->willReturnSelf();
+		$objectService->method('find')->willReturnCallback(
+			static function () use ($found): ?ObjectEntityInterface {
+				if ($found === null) {
+					return null;
+				}
 
-			/**
-			 * @var array<int,array<string,mixed>>
-			 */
-			public array $updates = [];
-
-			/**
-			 * @param array<string,mixed>|null $found
-			 */
-			public function __construct(?array $found) {
-				$this->found = $found;
-			}//end __construct()
-
-			public function setRegister(string $r): self {
-				return $this;
-			}//end setRegister()
-
-			public function setSchema(string $s): self {
-				return $this;
-			}//end setSchema()
-
-			/**
-			 * @return array<string,mixed>|null
-			 */
-			public function find(string $id): ?array {
-				return $this->found;
-			}//end find()
-
-			/**
-			 * @param array<string,mixed> $updates
-			 */
-			public function updateObject(string $id, array $updates): void {
-				$this->updates[] = ['id' => $id] + $updates;
-			}//end updateObject()
-		};
-
-		$svc = $this->objectService;
-
-		$container = new class($svc) implements ContainerInterface {
-
-			private object $svc;
-
-			public function __construct(object $svc) {
-				$this->svc = $svc;
-			}//end __construct()
-
-			public function get(string $id): mixed {
-				return $this->svc;
-			}//end get()
-
-			public function has(string $id): bool {
-				return true;
-			}//end has()
-		};
+				return (new ObjectEntity())->setObject($found);
+			}
+		);
+		$objectService->method('updateObject')->willReturnCallback(
+			function (string $objectId, array $data): ObjectEntityInterface {
+				$this->updates[] = ['id' => $objectId] + $data;
+				return new ObjectEntity();
+			}
+		);
 
 		$settings = $this->createMock(SettingsService::class);
 		$settings->method('getRegisterSlug')->willReturn('shillinq');
 
 		return new SignoffDecisionConcludedListener(
-			$container,
 			$settings,
 			new SignoffDecisionService($settings, $this->createMock(IEventDispatcher::class), new NullLogger()),
 			new NullLogger(),
+			$objectService,
 		);
 
 	}//end makeListener()
@@ -205,7 +166,7 @@ final class SignoffDecisionConcludedListenerTest extends TestCase {
 			)
 		);
 
-		$this->assertCount(0, $this->objectService->updates);
+		$this->assertCount(0, $this->updates);
 
 	}//end testForeignSourceAppIsIgnored()
 
@@ -228,10 +189,10 @@ final class SignoffDecisionConcludedListenerTest extends TestCase {
 			)
 		);
 
-		$this->assertCount(1, $this->objectService->updates);
-		$this->assertSame('approved', $this->objectService->updates[0]['decisionOutcome']);
-		$this->assertSame('dec-1', $this->objectService->updates[0]['decisionRef']);
-		$this->assertTrue($this->objectService->updates[0]['signoffGateOpen']);
+		$this->assertCount(1, $this->updates);
+		$this->assertSame('approved', $this->updates[0]['decisionOutcome']);
+		$this->assertSame('dec-1', $this->updates[0]['decisionRef']);
+		$this->assertTrue($this->updates[0]['signoffGateOpen']);
 
 	}//end testApprovedProjectsOutcomeAndOpensGate()
 
@@ -254,9 +215,9 @@ final class SignoffDecisionConcludedListenerTest extends TestCase {
 			)
 		);
 
-		$this->assertCount(1, $this->objectService->updates);
-		$this->assertSame('rejected', $this->objectService->updates[0]['decisionOutcome']);
-		$this->assertArrayNotHasKey('signoffGateOpen', $this->objectService->updates[0]);
+		$this->assertCount(1, $this->updates);
+		$this->assertSame('rejected', $this->updates[0]['decisionOutcome']);
+		$this->assertArrayNotHasKey('signoffGateOpen', $this->updates[0]);
 
 	}//end testRejectedProjectsOutcomeWithoutGate()
 
@@ -279,7 +240,7 @@ final class SignoffDecisionConcludedListenerTest extends TestCase {
 			)
 		);
 
-		$this->assertCount(0, $this->objectService->updates);
+		$this->assertCount(0, $this->updates);
 
 	}//end testWithdrawnStatusIsIgnored()
 
@@ -302,7 +263,7 @@ final class SignoffDecisionConcludedListenerTest extends TestCase {
 			)
 		);
 
-		$this->assertCount(0, $this->objectService->updates);
+		$this->assertCount(0, $this->updates);
 
 	}//end testMissingObjectIsSkippedFailSoft()
 }//end class

--- a/tests/Unit/Service/ReconciliationResolutionServiceTest.php
+++ b/tests/Unit/Service/ReconciliationResolutionServiceTest.php
@@ -22,17 +22,24 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
+use OCA\OpenRegister\Contract\ObjectEntityInterface;
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
+use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\Shillinq\Service\ReconciliationResolutionService;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
- * Stand-in for OCA\\OpenRegister\\Service\\ObjectService — fluent
- * setRegister()/setSchema() chain, configurable find() / updateObject()
- * behaviours per schema.
+ * Behaviour holder behind the ObjectServiceInterface mock — a per-schema
+ * find() / updateObject() map plus a recording of every update issued.
+ *
+ * It returns ObjectEntityInterface values, not arrays, because that is what
+ * the real contract returns; the service normalises them through its own
+ * toArray(). Before ADR-083 this fake was handed to the service through an
+ * untyped `ContainerInterface::get()`, so nothing enforced the return shape
+ * and the fake could answer with a plain array the real service never emits.
  *
  * @phpstan-type FindMap array<string, array<string, array<string,mixed>|\Throwable|null>>
  */
@@ -75,23 +82,27 @@ final class FakeObjectService {
 	}//end setSchema()
 
 	/**
-	 * @return array<string,mixed>|null
+	 * @return ObjectEntityInterface|null
 	 */
-	public function find(string $id): ?array {
+	public function find(string $id): ?ObjectEntityInterface {
 		$rec = $this->finds[$this->schema][$id] ?? null;
 		if ($rec instanceof \Throwable) {
 			throw $rec;
 		}
 
-		return $rec;
+		if (is_array($rec) === false) {
+			return null;
+		}
+
+		return (new ObjectEntity())->setObject($rec);
 	}//end find()
 
 	/**
 	 * @param array<string,mixed> $payload Update payload.
 	 *
-	 * @return array<string,mixed>
+	 * @return ObjectEntityInterface
 	 */
-	public function updateObject(string $id, array $payload): array {
+	public function updateObject(string $id, array $payload): ObjectEntityInterface {
 		$this->updates[] = ['schema' => $this->schema, 'id' => $id, 'payload' => $payload];
 
 		$existing = $this->finds[$this->schema][$id] ?? [];
@@ -99,7 +110,7 @@ final class FakeObjectService {
 			$existing = [];
 		}
 
-		return array_merge(['id' => $id], $existing, $payload);
+		return (new ObjectEntity())->setObject(array_merge(['id' => $id], $existing, $payload));
 	}//end updateObject()
 }//end class
 
@@ -113,13 +124,6 @@ final class FakeObjectService {
  * @spec openspec/changes/bookkeeping-reconciliation-reports/specs/bookkeeping-reconciliation-reports/spec.md (REQ-REC-004)
  */
 final class ReconciliationResolutionServiceTest extends TestCase {
-
-	/**
-	 * Mock container.
-	 *
-	 * @var ContainerInterface&MockObject
-	 */
-	private ContainerInterface&MockObject $container;
 
 	/**
 	 * Mock app config.
@@ -141,7 +145,6 @@ final class ReconciliationResolutionServiceTest extends TestCase {
 	 * @return void
 	 */
 	protected function setUp(): void {
-		$this->container = $this->createMock(ContainerInterface::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 
@@ -150,18 +153,30 @@ final class ReconciliationResolutionServiceTest extends TestCase {
 	}//end setUp()
 
 	/**
-	 * Build the subject with a FakeObjectService wired into the container.
+	 * Build the subject with an injected ObjectServiceInterface (ADR-083 rule 1)
+	 * that delegates to the FakeObjectService behaviour holder.
 	 *
-	 * @param FakeObjectService $fake Stand-in for OR ObjectService.
+	 * @param FakeObjectService $fake Stand-in behaviour for OR ObjectService.
 	 *
 	 * @return ReconciliationResolutionService
 	 */
 	private function svc(FakeObjectService $fake): ReconciliationResolutionService {
-		$this->container->method('get')
-			->with('OCA\\OpenRegister\\Service\\ObjectService')
-			->willReturn($fake);
+		$objectService = $this->createMock(ObjectServiceInterface::class);
+		$objectService->method('setRegister')->willReturnSelf();
+		$objectService->method('setSchema')->willReturnCallback(
+			static function (string|int $schema) use ($fake, $objectService): ObjectServiceInterface {
+				$fake->setSchema((string)$schema);
+				return $objectService;
+			}
+		);
+		$objectService->method('find')->willReturnCallback(
+			static fn (int|string $id): ?ObjectEntityInterface => $fake->find((string)$id)
+		);
+		$objectService->method('updateObject')->willReturnCallback(
+			static fn (string $objectId, array $data): ObjectEntityInterface => $fake->updateObject($objectId, $data)
+		);
 
-		return new ReconciliationResolutionService($this->container, $this->appConfig, $this->logger);
+		return new ReconciliationResolutionService($this->appConfig, $this->logger, $objectService);
 	}//end svc()
 
 	/**


### PR DESCRIPTION
## gate-66 `openregister-dependency-shape` (ADR-083) — 12 → 0

### What this is, and what the "236" in the fleet board was

The gate matrix lists shillinq at **236 ADR-083 violations**. That number was
real, and it was measured against a tree that `development` has since left
behind. Same checker, four trees:

| tree | FAIL lines |
|---|---:|
| `16e27e4f` — the sha behind the §1 baseline run 31926367937 | **236** |
| `191156f8` — corrected-baseline run 31937325844 | 12 |
| `49968ce0` — this PR's base | **12** |

**224 of the 236 were already fixed by #556** (`refactor/adr-084-type-hint-the-contract`,
merged 08:46:48), which converted 148 files under `lib/` to constructor
injection. This PR is the residue #556 left behind — and part of that residue
is a live defect, not a style finding.

### The systemic pattern — one shape, two sub-shapes

**A — `$this->container` survived a constructor that no longer has a container.**
#556 removed `ContainerInterface $container` from three services and converted
their call sites, but missed one site in each. Those classes now declare **no
container property and no `use Psr\Container\ContainerInterface`**, so
`$this->container->get(...)` is `Error: Call to a member function get() on null`
the moment the method runs:

| site | reachable |
|---|---|
| `lib/Service/AansluitingService.php:681` | gate-reported |
| `lib/Service/DoorsnijdingsVerbodValidator.php:230` | gate-reported |
| `lib/Service/IcpFilingService.php:303` | **not gate-reported — see below** |

`IcpFilingService::saveReturn()` is the one that matters. Its dangling lookup
sits inside `catch (\Throwable) { return false; }`, so **the method has been
returning `false` on every call — an ICP correction filing is accepted and
silently never persisted.** gate-66 correctly does not report it: a degrading
`catch` is precisely ADR-083 rule 1's optional-capability exception. **The catch
that makes the lookup legal is the same catch that swallows the fatal.** It was
found by sweeping `lib/` for `$this->container` in files that declare no
container, which is a check gate-66 does not and should not perform:

```sh
for f in $(grep -rl 'this->container' lib/); do
  grep -qE '(ContainerInterface|IAppContainer|ContainerBuilder)\s+\$container|\$container;' "$f" \
    || echo "DANGLING: $f"
done
```

The sweep returns four files on this repo; the fourth,
`lib/Reporting/Generator/ReportDataTrait.php`, is a legitimate trait contract —
all seven generators that `use` it do declare `$container` — and is untouched.

**B — eight classes #556 never visited** (10 of the 12 findings). They still take
`private readonly ContainerInterface $container` and pull ObjectService
mid-method. In every one of the eight, **that lookup is the container's only
use**, so the parameter comes out and `ObjectServiceInterface $objectService`
goes in, matching the 148 classes already converted and the
`registerServiceAlias(ObjectServiceInterface::class, 'OCA\OpenRegister\Service\ObjectService')`
already in `lib/AppInfo/Application.php:186`.

All eight are autowired (`registerEventListener(listener: X::class)` /
container-resolved), so no registration closure changes.

### Not applicable here

- **Rule 2** (OpenRegister type in a class header): no findings.
- **Rule 3** (default route): the checker prints
  `NOTE: no default route found in appinfo/routes.php and no #[FrontpageRoute] attribute, so rule 3 inspected nothing.`
- **The `class_exists()`-in-`register()` hazard** flagged on hermiq does not
  exist here: `Application.php:186` aliases **two strings**, so nothing
  autoloads at registration and the plumbing cannot silently skip.

### Evidence

**gate-66**, run exactly as CI runs it — `run-hydra-gates.sh:10099` invokes
`python3 lib/check_openregister_dependency_shape.py .` from the repo root and
counts `^FAIL ` lines. shillinq's `code-quality.yml` deliberately sets **no
`hydra-gates-ref`**, so CI uses `.github@main`; the checker was fetched from
there by `download_url` + `curl` and verified as blob **`8db55c4c…`, 18 979
bytes, 453 lines** against both `contents/…?ref=main` and an independent
`git clone --depth 1 --branch main`.

| | findings | files | exit |
|---|---:|---:|---:|
| **before** (`49968ce0`) | **12** | 680 | 1 |
| **after** | **0** | 680 | 0 |

gate-66 is **full-scope by construction** — its own runner block says *"NOT
diff-scoped. The shape of a dependency is a property of the tree, not of a
diff"* — so before and after are the same 680 files and are directly
comparable. The checker demonstrably can fail: the pre-`.github#458` generation
of it reports 206 on this same tree.

**PHP quality**, PHP 8.3 container, on the 16 files this PR touches, base
(`49968ce0`) vs head:

| tool | base | head |
|---|---:|---:|
| `composer lint` (php -l, whole repo) | pass | **pass** |
| `phpcs --standard=phpcs.xml` | 96 errors / 1 warning | **52 errors / 1 warning** |
| `phpmd` (both configs) | 0 | **0** |

All **eleven `lib/` files are now phpcs-clean (0 errors)** — that includes
clearing the docblock debt #556 left behind: three constructors missing
`@param $objectService`, plus the orphaned continuation lines of the deleted
`@param ContainerInterface` (`*    lazily.`), which tripped
`Generic.Commenting.DocComment.LongNotCapital`.

The residual 52 are **pre-existing and unchanged in count**, in two test files:
`ReconciliationResolutionServiceTest` 42 (base 42) and
`SignoffDecisionConcludedListenerTest` 8 (base 20 — improved), all
`CustomSniffs.Functions.NamedParameters` on PHPUnit assertions and missing
docblocks on a `class_exists` polyfill stub. They are untouched deliberately:
`PHP Quality` is red on this base for the ADR-084 rollout, that leg is another
slot's, and rewriting 42 assertion call sites here would collide with it.

**Tests.** The five unit classes that construct the changed classes:

```
StatementVerifyGuardVarianceTest            2/2
ReconciliationResolutionServiceTest         8/8
ACMReportSignTransitionListenerTest         6/6
AnnualReportSignoffRequestListenerTest    ) 11/11
SignoffDecisionConcludedListenerTest      )
```

Two of them were handing the service a **plain array where the real contract
returns `?ObjectEntityInterface`**. The untyped `ContainerInterface::get()` was
what let that shape through — nothing enforced the return type of a fake pulled
out of a container. Injecting the typed contract makes those doubles honest, and
they now return `ObjectEntity` stubs the service normalises through its own
`toArray()`, exactly as it does in production.

### Parity

`Hydra Gates` is **`cancelled`** in this base's run (31937325844), and
`GET /actions/runs/<id>/jobs?per_page=100` currently returns `total_count: 0`
for every recent shillinq run — unreadable, which is not green. Gate parity is
therefore asserted from the gate's own script locally, on both the base commit
and this head, at the same 680-file scope.

The four `PHP Quality` legs (phpcs, phpmd, psalm, phpstan) are red on this base
from the ADR-084 rollout and are not this PR's; this PR adds no new failing job.

### A third residue, in the one file gate-66 skips on purpose

`lib/AppInfo/Application.php:387` still constructed `DoorsnijdingsVerbodValidator`
with `container: $c` — a **named argument for a parameter #556 deleted**. That is
`Error: Unknown named parameter $container` on every resolution, and it never
passed the `ObjectServiceInterface` the constructor now requires: the
doorsnijdingsverbod check (REQ-IBA-004) could not be constructed at all.

gate-66 cannot report this, correctly — its checker skips the composition root
by name (*"`lib/AppInfo/Application.php` is the COMPOSITION ROOT … Rule 1 has
nothing to say about it. 16 of 435 findings sat here"*). That exclusion is right
for rule 1, and it is why a constructor-signature change needs a separate check
of the wiring layer:

```sh
grep -n "container: \$c\|container: \$container" lib/AppInfo/*.php
```

Three hits here; the other two (`FourEyesPaymentRunGuard`,
`PaymentRunDuplicateGuard`) are consistent — both classes still declare
`ContainerInterface $container` — and are untouched. **The named argument is what
made it silent**: positionally PHP would have thrown a type error on argument #1;
by name it fails only on the name, at resolution time, on a path no unit test
constructs.

### One measured red → less red, and one that is honestly still red

`IcpFilingServiceTest::testCreateCorrectionReattachesEvidence` fails on the base
at line 252, `assertTrue($result['saved'])` — *"Failed asserting that false is
true"* — which is the `saveReturn()` defect above, pinned by a test that has been
red. On this head it gets past 252 (8 → 9 assertions) and fails later, at line
254, on a **different** cause: `buildService()` wires its recording stub into
`$this->container->method('get')`, which nothing consumes any more, and hands each
service a bare `createMock(ObjectServiceInterface::class)` instead. The fixture is
disconnected from the code under test.

That is a fourth shape of the same refactor's fallout — **a test double orphaned
from its subject** — and it is deliberately *not* fixed here: it belongs to the
ADR-084 test fallout being worked in another PR, and 224 test files in this repo
still stub `container->method('get')`, so it wants one owner and one pass, not a
drive-by. This PR neither fixes nor worsens those three assertions; the two tests
that fail identically on base and head are untouched.
