### PR TITLE
docs(phpcs): restore the docblocks ADR-083 dropped — 189 errors to 0

### DIFF
--- a/lib/BackgroundJob/BookingReminderJob.php
+++ b/lib/BackgroundJob/BookingReminderJob.php
@@ -70,6 +70,7 @@ class BookingReminderJob extends TimedJob {
 	 * @param BookingNotificationService $notificationService The notification service.
 	 * @param IAppConfig $appConfig The app config.
 	 * @param LoggerInterface $logger The logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Consolidation/ConsolidationGuard.php
+++ b/lib/Consolidation/ConsolidationGuard.php
@@ -50,6 +50,7 @@ class ConsolidationGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for register slug resolution.
 	 * @param LoggerInterface $logger Nextcloud logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Controller/BankStatementImportController.php
+++ b/lib/Controller/BankStatementImportController.php
@@ -84,6 +84,7 @@ class BankStatementImportController extends Controller {
 	 * @param AdministrationContextService $administrationContext Server-resolved tenant scope.
 	 * @param IUserSession $session User session.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		IRequest $request,

--- a/lib/Controller/BarcodeLookupController.php
+++ b/lib/Controller/BarcodeLookupController.php
@@ -104,12 +104,13 @@ class BarcodeLookupController extends Controller {
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/changes/inventory-barcode-sku/tasks.md#task-12
+	 * Rate limit: lookup against published product data — the code is a GTIN,
+	 * not a credential, so this is a volume ceiling and not a brute-force
+	 * counter. Loose, because a scanner in a stockroom fires these in rapid
+	 * succession.
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// Barcode lookup against published product data — the code is a GTIN, not
-	// a credential, so a volume ceiling and no brute-force counter. Loose,
-	// because a scanner in a stockroom fires these in rapid succession.
 	#[AnonRateLimit(limit: 240, period: 60)]
 	public function lookup(string $code, ?string $uomCode = null): JSONResponse {
 		$guardResponse = $this->guard();

--- a/lib/Controller/BookingNotificationController.php
+++ b/lib/Controller/BookingNotificationController.php
@@ -58,6 +58,7 @@ class BookingNotificationController extends Controller {
 	 * @param IUserSession $userSession The user session.
 	 * @param LoggerInterface $logger The logger.
 	 * @param AdministrationContextService $administrationContext The administration membership seam.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Controller/CBSSubmissionController.php
+++ b/lib/Controller/CBSSubmissionController.php
@@ -69,7 +69,6 @@ class CBSSubmissionController extends Controller {
 	 * Construct the controller.
 	 *
 	 * @param IRequest $request The request object.
-	 *                                      lazily.
 	 * @param CBSExportService $exportService The CBS export pipeline.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param IUserSession $userSession The session for the acting user id (auth body-guard).

--- a/lib/Controller/CBSSubmissionController.php
+++ b/lib/Controller/CBSSubmissionController.php
@@ -74,6 +74,7 @@ class CBSSubmissionController extends Controller {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param IUserSession $userSession The session for the acting user id (auth body-guard).
 	 * @param LoggerInterface $logger Logger for diagnostics (no stack traces to client).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Controller/ConfirmationApiController.php
+++ b/lib/Controller/ConfirmationApiController.php
@@ -117,6 +117,8 @@ class ConfirmationApiController extends Controller {
 	 * @param ConfirmationTokenService $tokens Token lifecycle +
 	 *                                         email dispatcher.
 	 * @param ITimeFactory $time Server clock.
+	 * @param IThrottler $throttler Brute-force throttler for
+	 *                              failed token attempts.
 	 * @param LoggerInterface $logger Logger for fail-closed
 	 *                                diagnostics.
 	 */

--- a/lib/Controller/DepositWebhookController.php
+++ b/lib/Controller/DepositWebhookController.php
@@ -82,12 +82,12 @@ class DepositWebhookController extends Controller {
 	 *                      or malformed payload, 404 when no deposit matches.
 	 *
 	 * @spec openspec/specs/bookings-deposits/spec.md (REQ-DP-006)
+	 * Rate limit: payment-gateway callback. The caller retries on its own
+	 * schedule and authenticates by its own signature. Generous ceiling —
+	 * dropping a deposit notification is worse than absorbing a burst.
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// Payment gateway callback: the caller retries on its own schedule and
-	// authenticates by its own signature. Generous ceiling — dropping a
-	// deposit notification is worse than absorbing a burst.
 	#[AnonRateLimit(limit: 300, period: 60)]
 	public function handle(string $gateway): JSONResponse {
 		$gateway = strtolower($gateway);

--- a/lib/Controller/IcpController.php
+++ b/lib/Controller/IcpController.php
@@ -70,6 +70,7 @@ class IcpController extends Controller {
 	 * @param ArInvoiceIcpPdfRenderer $pdfRenderer The ICP overlay PDF renderer (REQ-ICP-007).
 	 * @param IUserSession $userSession The session for the acting user id (auth body-guard).
 	 * @param LoggerInterface $logger Logger for diagnostics (no stack traces to client).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Controller/InvoiceApiController.php
+++ b/lib/Controller/InvoiceApiController.php
@@ -183,8 +183,8 @@ class InvoiceApiController extends Controller {
 				return new JSONResponse(['error' => 'Not found'], Http::STATUS_NOT_FOUND);
 			}
 
-			// find() hands back an entity; everything below this line reads the
-			// invoice as an array, so normalise once here rather than at each use.
+			// Normalise once: find() hands back an entity, and everything below
+			// this line reads the invoice as an array.
 			$invoice = $found->jsonSerialize();
 
 			if (((string)($invoice['administrationId'] ?? '')) !== $admin) {
@@ -237,8 +237,8 @@ class InvoiceApiController extends Controller {
 				return new JSONResponse(['error' => 'Not found'], Http::STATUS_NOT_FOUND);
 			}
 
-			// find() hands back an entity; everything below this line reads the
-			// invoice as an array, so normalise once here rather than at each use.
+			// Normalise once: find() hands back an entity, and everything below
+			// this line reads the invoice as an array.
 			$invoice = $found->jsonSerialize();
 
 			if (((string)($invoice['administrationId'] ?? '')) !== $admin) {
@@ -284,8 +284,8 @@ class InvoiceApiController extends Controller {
 				return new JSONResponse(['error' => 'Not found'], Http::STATUS_NOT_FOUND);
 			}
 
-			// find() hands back an entity; everything below this line reads the
-			// invoice as an array, so normalise once here rather than at each use.
+			// Normalise once: find() hands back an entity, and everything below
+			// this line reads the invoice as an array.
 			$invoice = $found->jsonSerialize();
 
 			if (((string)($invoice['administrationId'] ?? '')) !== $admin) {

--- a/lib/Controller/InvoiceApiController.php
+++ b/lib/Controller/InvoiceApiController.php
@@ -64,6 +64,7 @@ class InvoiceApiController extends Controller {
 	 * @param IUserSession $session User session.
 	 * @param AdministrationContextService $administrationContext Server-resolved tenant scope.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		IRequest $request,

--- a/lib/Controller/PaymentRunController.php
+++ b/lib/Controller/PaymentRunController.php
@@ -77,6 +77,7 @@ class PaymentRunController extends Controller {
 	 * @param AdministrationContextService $administrationContext Tenant scope (ADR-005 guard).
 	 * @param IUserSession $session User session.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		IRequest $request,

--- a/lib/Controller/PayrollWebhookController.php
+++ b/lib/Controller/PayrollWebhookController.php
@@ -67,6 +67,7 @@ class PayrollWebhookController extends Controller {
 	 * @param IRequest $request The request.
 	 * @param IAppConfig $appConfig App config (shared secret + register slug).
 	 * @param LoggerInterface $logger Logger for audit and fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		IRequest $request,

--- a/lib/Controller/PayrollWebhookController.php
+++ b/lib/Controller/PayrollWebhookController.php
@@ -84,10 +84,11 @@ class PayrollWebhookController extends Controller {
 	 * @return JSONResponse 501 — the webhook accepts POST only.
 	 *
 	 * @spec openspec/changes/bookkeeping-detachering-payroll-administratie/specs.md
+	 * Rate limit: payroll-provider integration surface — machine caller with
+	 * its own credential.
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// Payroll provider integration surface — machine caller, own credential.
 	#[AnonRateLimit(limit: 300, period: 60)]
 	public function info(): JSONResponse {
 		return new JSONResponse(

--- a/lib/Controller/PortalPaymentInitiationController.php
+++ b/lib/Controller/PortalPaymentInitiationController.php
@@ -99,12 +99,12 @@ class PortalPaymentInitiationController extends Controller {
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/specs/portal-payment-initiation/spec.md (REQ-SPPI-002)
+	 * Rate limit: citizen-facing, and it starts a payment. Tighter than the
+	 * receivers because a human clicks this, and each call creates a payment
+	 * intent at the provider — real work, and real cost, per request.
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// Citizen-facing: starts a payment. Tighter than the receivers because a
-	// human clicks this, and each call creates a payment intent at the
-	// provider — real work, and real cost, per request.
 	#[AnonRateLimit(limit: 20, period: 60)]
 	public function initiate(): JSONResponse {
 		// 1. Verify — the assertion is the ONLY credential (fail-closed 401).

--- a/lib/Controller/SupplierInvoiceImportController.php
+++ b/lib/Controller/SupplierInvoiceImportController.php
@@ -91,6 +91,7 @@ class SupplierInvoiceImportController extends Controller {
 	 * @param AdministrationContextService $administrationContext Server-resolved tenant scope (ADR-005).
 	 * @param IUserSession $session User session.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Controller/WidgetApiController.php
+++ b/lib/Controller/WidgetApiController.php
@@ -95,13 +95,14 @@ class WidgetApiController extends Controller {
 	 *
 	 * @return JSONResponse
 	 *
+	 * Rate limit: public booking widget. These back a citizen-facing embed —
+	 * services and slots are read repeatedly as someone picks a date, so the
+	 * ceiling is generous. No credential is in play, so no brute-force counter.
+	 *
 	 * @spec openspec/changes/bookings-self-service-widget/tasks.md#task-4
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// Public booking widget. These back a citizen-facing embed: services and
-	// slots are read repeatedly as someone picks a date, so the ceiling is
-	// generous. No credential in play, so no brute-force counter.
 	#[AnonRateLimit(limit: 120, period: 60)]
 	public function services(): JSONResponse {
 		$authResult = $this->guard();
@@ -263,11 +264,12 @@ class WidgetApiController extends Controller {
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/changes/bookings-self-service-widget/tasks.md#task-4
+	 * Rate limit: tighter than its siblings, because this one BOOKS.
+	 * `services` / `slots` are reads a visitor repeats while choosing; a
+	 * booking is a write and a commitment.
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	// Tighter than its siblings: this one BOOKS. services/slots are reads a
-	// visitor repeats while choosing; a booking is a write and a commitment.
 	#[AnonRateLimit(limit: 20, period: 60)]
 	public function appointments(
 		string $serviceId = '',

--- a/lib/Guard/AccountBalanceGuard.php
+++ b/lib/Guard/AccountBalanceGuard.php
@@ -45,10 +45,9 @@ class AccountBalanceGuard {
 	/**
 	 * Construct the guard with lazy DI of OR's ObjectService.
 	 *
-	 *                                      lazily so this class stays usable in T1
-	 *                                      before T2's GLLine register exists.
 	 * @param IAppConfig $appConfig App config for dynamic register slug resolution (C3).
 	 * @param LoggerInterface $logger Nextcloud logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Guard/BankReconciliationGuard.php
+++ b/lib/Guard/BankReconciliationGuard.php
@@ -50,10 +50,9 @@ class BankReconciliationGuard {
 	/**
 	 * Construct the guard with lazy DI of OR's ObjectService.
 	 *
-	 *                                      lazily so this class stays usable without a
-	 *                                      hard compile-time dependency on OpenRegister.
 	 * @param IAppConfig $appConfig App config for dynamic register slug resolution.
 	 * @param LoggerInterface $logger Nextcloud logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Guard/CreditLimitGuard.php
+++ b/lib/Guard/CreditLimitGuard.php
@@ -61,9 +61,9 @@ class CreditLimitGuard {
 	/**
 	 * Construct the guard with lazy DI of OR's ObjectService.
 	 *
-	 *                                      lazily so the class loads even when OR is absent.
 	 * @param IAppConfig $appConfig App config for dynamic register slug resolution.
 	 * @param LoggerInterface $logger Nextcloud logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Guard/RateScheduleOverlapGuard.php
+++ b/lib/Guard/RateScheduleOverlapGuard.php
@@ -62,6 +62,7 @@ class RateScheduleOverlapGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for register slug resolution.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/AnnualReportGuard.php
+++ b/lib/Lifecycle/AnnualReportGuard.php
@@ -66,6 +66,7 @@ class AnnualReportGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/AuditorStatementGuard.php
+++ b/lib/Lifecycle/AuditorStatementGuard.php
@@ -58,6 +58,7 @@ class AuditorStatementGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/BcfClaimGuard.php
+++ b/lib/Lifecycle/BcfClaimGuard.php
@@ -66,6 +66,7 @@ class BcfClaimGuard {
 	 * @param BcfClaimService $claimService Server-authoritative claim computation.
 	 * @param BcfCompensationCalculator $calculator Pure-logic submit-precondition helper.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/BegrotingswijzigingGuard.php
+++ b/lib/Lifecycle/BegrotingswijzigingGuard.php
@@ -54,6 +54,7 @@ class BegrotingswijzigingGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/BudgetOverrunGuard.php
+++ b/lib/Lifecycle/BudgetOverrunGuard.php
@@ -54,6 +54,7 @@ class BudgetOverrunGuard {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param BegrotingswijzigingStacker $stacker Computes the stacked authorized lasten.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/CbcrPillar2Guard.php
+++ b/lib/Lifecycle/CbcrPillar2Guard.php
@@ -74,6 +74,7 @@ class CbcrPillar2Guard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/CcmFindingGuard.php
+++ b/lib/Lifecycle/CcmFindingGuard.php
@@ -64,6 +64,7 @@ class CcmFindingGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/ComplianceValidator.php
+++ b/lib/Lifecycle/ComplianceValidator.php
@@ -57,6 +57,7 @@ class ComplianceValidator {
 	 *
 	 * @param IAppConfig $appConfig App config for dynamic register slug resolution.
 	 * @param LoggerInterface $logger Nextcloud logger for compliance audit logging.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/ConsolidationGuard.php
+++ b/lib/Lifecycle/ConsolidationGuard.php
@@ -99,6 +99,7 @@ class ConsolidationGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/CsrdEsrsGuard.php
+++ b/lib/Lifecycle/CsrdEsrsGuard.php
@@ -67,6 +67,7 @@ class CsrdEsrsGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/DBAComplianceGuard.php
+++ b/lib/Lifecycle/DBAComplianceGuard.php
@@ -115,6 +115,7 @@ class DBAComplianceGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug + VBAR override.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/DualGaapGuard.php
+++ b/lib/Lifecycle/DualGaapGuard.php
@@ -67,6 +67,7 @@ class DualGaapGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/DunningGuard.php
+++ b/lib/Lifecycle/DunningGuard.php
@@ -88,6 +88,7 @@ class DunningGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug + tunables.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/DunningRunExecuteGuard.php
+++ b/lib/Lifecycle/DunningRunExecuteGuard.php
@@ -58,6 +58,7 @@ class DunningRunExecuteGuard {
 	 *
 	 * @param IAppConfig $appConfig App config.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/EuExpenditureGuard.php
+++ b/lib/Lifecycle/EuExpenditureGuard.php
@@ -82,6 +82,7 @@ class EuExpenditureGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/ExpenseClaimGuard.php
+++ b/lib/Lifecycle/ExpenseClaimGuard.php
@@ -49,6 +49,7 @@ class ExpenseClaimGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/ExpenseReimbursementGuard.php
+++ b/lib/Lifecycle/ExpenseReimbursementGuard.php
@@ -71,6 +71,7 @@ class ExpenseReimbursementGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/FidoTreasuryGuard.php
+++ b/lib/Lifecycle/FidoTreasuryGuard.php
@@ -86,6 +86,7 @@ class FidoTreasuryGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/FrameworkAgreementDrawdownGuard.php
+++ b/lib/Lifecycle/FrameworkAgreementDrawdownGuard.php
@@ -51,6 +51,7 @@ class FrameworkAgreementDrawdownGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for register slug resolution.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/IntercompanyToleranceGuard.php
+++ b/lib/Lifecycle/IntercompanyToleranceGuard.php
@@ -58,6 +58,7 @@ class IntercompanyToleranceGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/InventoryPostingGuard.php
+++ b/lib/Lifecycle/InventoryPostingGuard.php
@@ -79,6 +79,7 @@ class InventoryPostingGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for register slug.
 	 * @param LoggerInterface $logger Logger for structured-warning + fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/InventoryValuationMethodGuard.php
+++ b/lib/Lifecycle/InventoryValuationMethodGuard.php
@@ -58,6 +58,7 @@ class InventoryValuationMethodGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/InvoiceGuard.php
+++ b/lib/Lifecycle/InvoiceGuard.php
@@ -67,6 +67,7 @@ class InvoiceGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/IrregularityReportGuard.php
+++ b/lib/Lifecycle/IrregularityReportGuard.php
@@ -67,6 +67,7 @@ class IrregularityReportGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/JournalEntryGuard.php
+++ b/lib/Lifecycle/JournalEntryGuard.php
@@ -60,6 +60,7 @@ class JournalEntryGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/KlantLadderOverrideApprovalGuard.php
+++ b/lib/Lifecycle/KlantLadderOverrideApprovalGuard.php
@@ -51,6 +51,7 @@ class KlantLadderOverrideApprovalGuard {
 	 *
 	 * @param IAppConfig $appConfig App config.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/ObjectionPeriodGuard.php
+++ b/lib/Lifecycle/ObjectionPeriodGuard.php
@@ -66,6 +66,7 @@ class ObjectionPeriodGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/PayrollGuard.php
+++ b/lib/Lifecycle/PayrollGuard.php
@@ -71,6 +71,7 @@ class PayrollGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug and statutory ceilings.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/PensionIas19Guard.php
+++ b/lib/Lifecycle/PensionIas19Guard.php
@@ -68,6 +68,7 @@ class PensionIas19Guard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/PeriodCloseGuard.php
+++ b/lib/Lifecycle/PeriodCloseGuard.php
@@ -88,6 +88,7 @@ class PeriodCloseGuard {
 	 * @param ContainerInterface $container DI container for lazy ObjectService resolution.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly ContainerInterface $container,

--- a/lib/Lifecycle/PeriodStatusGuard.php
+++ b/lib/Lifecycle/PeriodStatusGuard.php
@@ -82,6 +82,7 @@ class PeriodStatusGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/ProgrammabegrotingGuard.php
+++ b/lib/Lifecycle/ProgrammabegrotingGuard.php
@@ -78,6 +78,7 @@ final class ProgrammabegrotingGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/ProvisionGuard.php
+++ b/lib/Lifecycle/ProvisionGuard.php
@@ -102,6 +102,7 @@ class ProvisionGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/QuoteOrderInvoiceGuard.php
+++ b/lib/Lifecycle/QuoteOrderInvoiceGuard.php
@@ -88,6 +88,7 @@ class QuoteOrderInvoiceGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug + thresholds.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/RetainerGuard.php
+++ b/lib/Lifecycle/RetainerGuard.php
@@ -69,6 +69,7 @@ class RetainerGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/SegregatedLedgerGuard.php
+++ b/lib/Lifecycle/SegregatedLedgerGuard.php
@@ -55,6 +55,7 @@ class SegregatedLedgerGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/StockReservationGuard.php
+++ b/lib/Lifecycle/StockReservationGuard.php
@@ -69,6 +69,7 @@ class StockReservationGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for register slug.
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs the full payload.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/SubsidieVerantwoordingGuard.php
+++ b/lib/Lifecycle/SubsidieVerantwoordingGuard.php
@@ -70,6 +70,7 @@ class SubsidieVerantwoordingGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for register slug and threshold.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/SupplierQualificationGuard.php
+++ b/lib/Lifecycle/SupplierQualificationGuard.php
@@ -50,6 +50,7 @@ class SupplierQualificationGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for register slug resolution.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/SupportingDocumentGuard.php
+++ b/lib/Lifecycle/SupportingDocumentGuard.php
@@ -55,6 +55,7 @@ class SupportingDocumentGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/VatPreconditionGuard.php
+++ b/lib/Lifecycle/VatPreconditionGuard.php
@@ -66,6 +66,7 @@ class VatPreconditionGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/VpbAangifteGuard.php
+++ b/lib/Lifecycle/VpbAangifteGuard.php
@@ -85,6 +85,7 @@ class VpbAangifteGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/VpbBerekeningGuard.php
+++ b/lib/Lifecycle/VpbBerekeningGuard.php
@@ -62,6 +62,7 @@ class VpbBerekeningGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Lifecycle/WbsoMededelingGuard.php
+++ b/lib/Lifecycle/WbsoMededelingGuard.php
@@ -62,6 +62,7 @@ class WbsoMededelingGuard {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Listener/PosStockDecrementListener.php
+++ b/lib/Listener/PosStockDecrementListener.php
@@ -116,6 +116,7 @@ class PosStockDecrementListener implements IEventListener {
 	 * @param IGroupManager $groupManager Resolves the `admin` group for the audit surface.
 	 * @param IManager $notificationMgr Nextcloud notification manager for the audit surface.
 	 * @param LoggerInterface $logger Logger for fail-soft diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly SalesDispatchStockIssueService $dispatchService,

--- a/lib/Listener/StockMoveTransitionedListener.php
+++ b/lib/Listener/StockMoveTransitionedListener.php
@@ -77,6 +77,7 @@ class StockMoveTransitionedListener implements IEventListener {
 	 * @param CogsPosterService $cogs COGS poster.
 	 * @param IAppConfig $appConfig App config for register slug.
 	 * @param LoggerInterface $logger Logger for fail-soft diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly FifoValuationService $fifo,

--- a/lib/Repair/BackfillFiscalPeriods.php
+++ b/lib/Repair/BackfillFiscalPeriods.php
@@ -70,6 +70,7 @@ class BackfillFiscalPeriods implements IRepairStep {
 	 *
 	 * @param SettingsService $settingsService The settings service (register slug).
 	 * @param LoggerInterface $logger The logger interface.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private SettingsService $settingsService,

--- a/lib/Repair/FoldDunningWriteoffIntoArInvoice.php
+++ b/lib/Repair/FoldDunningWriteoffIntoArInvoice.php
@@ -74,6 +74,7 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep {
 	 * @param SettingsService $settingsService The settings service (register slug).
 	 * @param IGroupManager $groupManager The group manager (admin IUser resolution).
 	 * @param LoggerInterface $logger The logger interface.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private SettingsService $settingsService,

--- a/lib/Repair/FoldExpensesAndHoursIntoProject.php
+++ b/lib/Repair/FoldExpensesAndHoursIntoProject.php
@@ -64,6 +64,7 @@ class FoldExpensesAndHoursIntoProject implements IRepairStep {
 	 * @param SettingsService $settingsService The settings service (register slug).
 	 * @param IGroupManager $groupManager The group manager (resolve an admin IUser).
 	 * @param LoggerInterface $logger The logger interface.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private SettingsService $settingsService,

--- a/lib/Repair/PeriodCloseBackfill.php
+++ b/lib/Repair/PeriodCloseBackfill.php
@@ -79,6 +79,7 @@ class PeriodCloseBackfill implements IRepairStep {
 	 *
 	 * @param SettingsService $settingsService The settings service (register slug).
 	 * @param LoggerInterface $logger The logger interface.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private SettingsService $settingsService,

--- a/lib/Repair/RematerialiseConvertedCalculations.php
+++ b/lib/Repair/RematerialiseConvertedCalculations.php
@@ -113,6 +113,7 @@ class RematerialiseConvertedCalculations implements IRepairStep {
 	 * @param SettingsService $settingsService The settings service (register slug).
 	 * @param LoggerInterface $logger The logger interface.
 	 * @param ContainerInterface $container The DI container (lazy OR ObjectService resolution).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private SettingsService $settingsService,

--- a/lib/Service/AansluitingService.php
+++ b/lib/Service/AansluitingService.php
@@ -107,7 +107,6 @@ class AansluitingService {
 	 * direct dependencies on the two services whose computation this class
 	 * reuses rather than duplicating (REQ-AANS-002).
 	 *
-	 *                                      lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for diagnostics.
 	 * @param AansluitingCalculator $calculator Pure-logic tolerance/diff helper.

--- a/lib/Service/AansluitingService.php
+++ b/lib/Service/AansluitingService.php
@@ -113,6 +113,7 @@ class AansluitingService {
 	 * @param AansluitingCalculator $calculator Pure-logic tolerance/diff helper.
 	 * @param VATReturnService $vatReturnService The BTW ledger-derivation engine this service diffs against.
 	 * @param AansluitingResolutionGuard $resolutionGuard The ADR-031 exception guard for explained -> resolved.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/AccountantsdossierExportService.php
+++ b/lib/Service/AccountantsdossierExportService.php
@@ -173,6 +173,7 @@ class AccountantsdossierExportService {
 	 * @param IAppConfig $appConfig App config for the register slug + signer hand-off.
 	 * @param IUserSession $userSession Session for generatedBy attribution.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/BadoControleprotocolService.php
+++ b/lib/Service/BadoControleprotocolService.php
@@ -70,6 +70,7 @@ class BadoControleprotocolService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param BadoControleprotocolCalculator $calculator Pure-logic BADO decision helper.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics (no stack traces to client).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/BcfClaimService.php
+++ b/lib/Service/BcfClaimService.php
@@ -56,7 +56,6 @@ class BcfClaimService {
 	/**
 	 * Construct the service with lazy DI of OpenRegister's ObjectService.
 	 *
-	 *                                      lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param BcfCompensationCalculator $calculator Pure-logic compensable-VAT helper.
 	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.

--- a/lib/Service/BcfClaimService.php
+++ b/lib/Service/BcfClaimService.php
@@ -59,6 +59,7 @@ class BcfClaimService {
 	 *                                      lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param BcfCompensationCalculator $calculator Pure-logic compensable-VAT helper.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/BookingNotificationService.php
+++ b/lib/Service/BookingNotificationService.php
@@ -65,6 +65,7 @@ class BookingNotificationService {
 	 * @param ContainerInterface $container The DI container.
 	 * @param IAppConfig $appConfig The Nextcloud app config.
 	 * @param LoggerInterface $logger The logger interface.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Service/CBSExportService.php
+++ b/lib/Service/CBSExportService.php
@@ -99,6 +99,7 @@ class CBSExportService {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug + mapping overrides.
 	 * @param LoggerInterface $logger Logger for diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Service/CogsPosterService.php
+++ b/lib/Service/CogsPosterService.php
@@ -86,6 +86,7 @@ class CogsPosterService {
 	 *
 	 * @param IAppConfig $appConfig App config for account numbers + register slug.
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/Commitment/CommitmentMaterialisationService.php
+++ b/lib/Service/Commitment/CommitmentMaterialisationService.php
@@ -95,6 +95,7 @@ class CommitmentMaterialisationService {
 	 * @param BudgetBlocker $budget Reused budget-room guard (REQ-VPL-001).
 	 * @param IEventDispatcher $dispatcher NC event dispatcher (rechtmatigheid trigger transport).
 	 * @param LoggerInterface $logger Logger for fail-soft/fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/ComplianceDeadlineCalendarService.php
+++ b/lib/Service/ComplianceDeadlineCalendarService.php
@@ -233,6 +233,7 @@ class ComplianceDeadlineCalendarService {
 	 * @param ObligationTaskBridge $obligationTaskBridge The single home of the
 	 *                                                   contract-obligation path (REQ-CDC-005).
 	 * @param LoggerInterface $logger Logger for fail-soft diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly ContainerInterface $container,

--- a/lib/Service/CycleCountService.php
+++ b/lib/Service/CycleCountService.php
@@ -92,6 +92,7 @@ class CycleCountService {
 	 *                              slug.
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs payloads.
 	 * @param VarianceGate $varianceGate Pure helper for threshold + recalculation.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/DepositReconciliationService.php
+++ b/lib/Service/DepositReconciliationService.php
@@ -112,6 +112,7 @@ class DepositReconciliationService {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 * @param ?DepositPaymentAdapterInterface $adapter Optional DepositPayment lifecycle
 	 *                                                 adapter. When supplied, the scheduled
 	 *                                                 polling workflow (REQ-DP-007) can call
@@ -121,7 +122,6 @@ class DepositReconciliationService {
 	 *                                                 adapter at all. Optional so existing
 	 *                                                 call sites that pass an explicit
 	 *                                                 `pollPending($callable)` still work.
-	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Service/DepositReconciliationService.php
+++ b/lib/Service/DepositReconciliationService.php
@@ -121,6 +121,7 @@ class DepositReconciliationService {
 	 *                                                 adapter at all. Optional so existing
 	 *                                                 call sites that pass an explicit
 	 *                                                 `pollPending($callable)` still work.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Service/DoorsnijdingsVerbodValidator.php
+++ b/lib/Service/DoorsnijdingsVerbodValidator.php
@@ -52,7 +52,6 @@ class DoorsnijdingsVerbodValidator {
 	/**
 	 * Construct the validator with lazy DI of OpenRegister's ObjectService.
 	 *
-	 *                                      lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 * @param InnovatieboxAuditEventLogger|null $auditLogger Optional audit-event logger. When

--- a/lib/Service/DoorsnijdingsVerbodValidator.php
+++ b/lib/Service/DoorsnijdingsVerbodValidator.php
@@ -54,6 +54,7 @@ class DoorsnijdingsVerbodValidator {
 	 *
 	 *                                      lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 * @param InnovatieboxAuditEventLogger|null $auditLogger Optional audit-event logger. When
 	 *                                                       provided, every validateNoDuplication
 	 *                                                       run emits a DoorsnijdingsVerbod.check_run

--- a/lib/Service/DunningRunService.php
+++ b/lib/Service/DunningRunService.php
@@ -92,6 +92,7 @@ class DunningRunService {
 	 * @param ContainerInterface $container Lazy DI container.
 	 * @param IAppConfig $appConfig App config.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly ContainerInterface $container,

--- a/lib/Service/EInvoice/EInvoiceService.php
+++ b/lib/Service/EInvoice/EInvoiceService.php
@@ -82,7 +82,6 @@ final class EInvoiceService {
 	/**
 	 * Constructor.
 	 *
-	 *                                      lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope.
 	 * @param LoggerInterface $logger Logger (no PII/document bodies logged).

--- a/lib/Service/EInvoice/EInvoiceService.php
+++ b/lib/Service/EInvoice/EInvoiceService.php
@@ -90,6 +90,7 @@ final class EInvoiceService {
 	 * @param ArInvoiceUblMapper $ublMapper NLCIUS UBL 2.1 mapper (REQ-EINV-001).
 	 * @param InvoicePdfGenerator $pdfGenerator Hybrid PDF embed (REQ-EINV-002).
 	 * @param EInvoiceValidationService $validationService Pre-send validation (REQ-EINV-003).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 * @param PeppolTransmissionPortInterface|null $peppolPort Optional transmission port; defaults to
 	 *                                                         {@see LogPeppolTransmissionAdapter}.
 	 */

--- a/lib/Service/ExceptionResolutionService.php
+++ b/lib/Service/ExceptionResolutionService.php
@@ -225,6 +225,7 @@ class ExceptionResolutionService {
 	 *                                  authoritative, not body).
 	 * @param INotificationManager $notificationManager NC notification dispatcher.
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 * @param CreditNoteRequestAdapterInterface|null $creditNoteAdapter Optional UBL CreditNote
 	 *                                                                  dispatch port — defaults to
 	 *                                                                  {@see LogCreditNoteRequestAdapter}

--- a/lib/Service/FifoValuationService.php
+++ b/lib/Service/FifoValuationService.php
@@ -75,6 +75,7 @@ class FifoValuationService {
 	 *
 	 * @param IAppConfig $appConfig App config for the OR register slug.
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/FixedAssetDisposalService.php
+++ b/lib/Service/FixedAssetDisposalService.php
@@ -124,6 +124,7 @@ class FixedAssetDisposalService {
 	 * @param DisposalJournalEmitter $emitter The pure-logic disposal journal kernel.
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope (ADR-005).
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @SuppressWarnings(PHPMD.LongVariable) administrationContext is the
 	 * canonical name fleet-wide.

--- a/lib/Service/FluxService.php
+++ b/lib/Service/FluxService.php
@@ -73,6 +73,7 @@ class FluxService {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/GRIRClearingService.php
+++ b/lib/Service/GRIRClearingService.php
@@ -280,6 +280,7 @@ class GRIRClearingService {
 	 *                              register slug).
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope (ADR-005).
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @SuppressWarnings(PHPMD.LongVariable) administrationContext is the
 	 * canonical name fleet-wide.

--- a/lib/Service/GoodsReceiptNoteService.php
+++ b/lib/Service/GoodsReceiptNoteService.php
@@ -156,7 +156,6 @@ class GoodsReceiptNoteService {
 	/**
 	 * Constructor.
 	 *
-	 *                                      fetched lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope.
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).

--- a/lib/Service/GoodsReceiptNoteService.php
+++ b/lib/Service/GoodsReceiptNoteService.php
@@ -160,6 +160,7 @@ class GoodsReceiptNoteService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope.
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Service/IcpFilingService.php
+++ b/lib/Service/IcpFilingService.php
@@ -53,6 +53,7 @@ class IcpFilingService {
 	 * @param IcpCalculator $calculator Pure-logic ICP helper.
 	 * @param IcpService $icp Read-side ICP service (period-window supplies).
 	 * @param ViesService $vies VIES validation / evidence-reuse helper.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/IcpService.php
+++ b/lib/Service/IcpService.php
@@ -55,6 +55,7 @@ class IcpService {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param IcpCalculator $calculator Pure-logic ICP helper.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/InnovatieboxAggregationService.php
+++ b/lib/Service/InnovatieboxAggregationService.php
@@ -47,13 +47,13 @@ class InnovatieboxAggregationService {
 	/**
 	 * Construct the aggregation service.
 	 *
-	 *                                      fetched lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param CarryForwardLossService $lossService Loss-offset arithmetic helper.
 	 * @param QualifyingAssetValidator $validator Toegangsticket validator — re-runs the
 	 *                                            S&O / octrooi / combinatie rules at compute
 	 *                                            time to catch assets whose persisted
 	 *                                            status='valid' is now stale (REQ-IBA-001).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/IntercompanyLinkService.php
+++ b/lib/Service/IntercompanyLinkService.php
@@ -79,6 +79,7 @@ class IntercompanyLinkService {
 	 * @param IAppConfig $appConfig App config (register slug).
 	 * @param IntercompanyJournalService $journalService The pure-logic REQ-MA-004 kernel.
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/IntercompanyMatchingService.php
+++ b/lib/Service/IntercompanyMatchingService.php
@@ -57,6 +57,7 @@ class IntercompanyMatchingService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param IntercompanyMatchingCalculator $calculator Pure-logic arithmetic + classification helper.
 	 * @param LoggerInterface $logger Logger for diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/IntercompanyMatchingService.php
+++ b/lib/Service/IntercompanyMatchingService.php
@@ -53,7 +53,6 @@ class IntercompanyMatchingService {
 	/**
 	 * Construct the service with lazy DI of OpenRegister's ObjectService.
 	 *
-	 *                                      lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param IntercompanyMatchingCalculator $calculator Pure-logic arithmetic + classification helper.
 	 * @param LoggerInterface $logger Logger for diagnostics.

--- a/lib/Service/InventoryGlAdjustmentPoster.php
+++ b/lib/Service/InventoryGlAdjustmentPoster.php
@@ -63,6 +63,7 @@ class InventoryGlAdjustmentPoster {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/InventoryScanService.php
+++ b/lib/Service/InventoryScanService.php
@@ -60,6 +60,7 @@ class InventoryScanService {
 	 *
 	 * @param IAppConfig $appConfig App config for register slug resolution.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/InventoryValuationReportService.php
+++ b/lib/Service/InventoryValuationReportService.php
@@ -72,6 +72,7 @@ class InventoryValuationReportService {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/InvoiceGenerationService.php
+++ b/lib/Service/InvoiceGenerationService.php
@@ -53,6 +53,7 @@ class InvoiceGenerationService {
 	 * @param InvoiceDeduplicationService $deduper Source-id conflict scanner.
 	 * @param VATCalculationService $vat VAT totaller.
 	 * @param UsageRatingCalculator $usageRating Meter-quantity rating (usage model).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/KorMonitorService.php
+++ b/lib/Service/KorMonitorService.php
@@ -53,6 +53,7 @@ class KorMonitorService {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param KorThresholdCalculator $calculator Pure-logic KOR arithmetic helper.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/LandedCostAllocationService.php
+++ b/lib/Service/LandedCostAllocationService.php
@@ -90,6 +90,7 @@ class LandedCostAllocationService {
 	 * @param IAppConfig $appConfig App config for account numbers + register slug.
 	 * @param InventoryGlAdjustmentPoster $poster Shared balanced-posting adapter.
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/LeaseAuditPackGenerator.php
+++ b/lib/Service/LeaseAuditPackGenerator.php
@@ -56,7 +56,6 @@ class LeaseAuditPackGenerator {
 	/**
 	 * Construct the service with lazy DI of OpenRegister's ObjectService.
 	 *
-	 *                                      fetched lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LeasePaymentScheduleService $scheduleService Schedule rows for the pack.
 	 * @param LoggerInterface $logger Logger (no stack traces to client).

--- a/lib/Service/LeaseAuditPackGenerator.php
+++ b/lib/Service/LeaseAuditPackGenerator.php
@@ -60,6 +60,7 @@ class LeaseAuditPackGenerator {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LeasePaymentScheduleService $scheduleService Schedule rows for the pack.
 	 * @param LoggerInterface $logger Logger (no stack traces to client).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/LeaseDisclosureService.php
+++ b/lib/Service/LeaseDisclosureService.php
@@ -65,6 +65,7 @@ class LeaseDisclosureService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LeaseAmortizationCalculator $calculator Pure-logic IFRS 16 arithmetic helper.
 	 * @param LoggerInterface $logger Logger (no stack traces to client).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/LeasePaymentScheduleService.php
+++ b/lib/Service/LeasePaymentScheduleService.php
@@ -52,6 +52,7 @@ class LeasePaymentScheduleService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LeaseAmortizationCalculator $calculator Pure-logic IFRS 16 arithmetic helper.
 	 * @param LoggerInterface $logger Logger (no stack traces to client).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/LeaseReassessmentService.php
+++ b/lib/Service/LeaseReassessmentService.php
@@ -89,6 +89,7 @@ class LeaseReassessmentService {
 	 * @param LeaseAmortizationCalculator $calculator Pure-logic IFRS 16 arithmetic helper.
 	 * @param LoggerInterface $logger Logger (no stack traces to client).
 	 * @param LeaseDecideskWebhookService|null $decideskWebhook Optional decidesk webhook delivery service.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/LeaseReassessmentService.php
+++ b/lib/Service/LeaseReassessmentService.php
@@ -88,8 +88,8 @@ class LeaseReassessmentService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LeaseAmortizationCalculator $calculator Pure-logic IFRS 16 arithmetic helper.
 	 * @param LoggerInterface $logger Logger (no stack traces to client).
-	 * @param LeaseDecideskWebhookService|null $decideskWebhook Optional decidesk webhook delivery service.
 	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
+	 * @param LeaseDecideskWebhookService|null $decideskWebhook Optional decidesk webhook delivery service.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/MovingAverageValuationService.php
+++ b/lib/Service/MovingAverageValuationService.php
@@ -70,6 +70,7 @@ class MovingAverageValuationService {
 	 *
 	 * @param IAppConfig $appConfig App config for the OR register slug.
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/MultiPoConsolidationService.php
+++ b/lib/Service/MultiPoConsolidationService.php
@@ -182,6 +182,7 @@ class MultiPoConsolidationService {
 	 *                                                       SupplierInvoice document records its
 	 *                                                       per-line PO links inline (REQ-PO3W-007).
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Service/MultiPoConsolidationService.php
+++ b/lib/Service/MultiPoConsolidationService.php
@@ -172,8 +172,6 @@ class MultiPoConsolidationService {
 	/**
 	 * Constructor.
 	 *
-	 *                                      is fetched lazily so unit tests
-	 *                                      can swap an in-memory stub.
 	 * @param IAppConfig $appConfig App config for the OR register slug.
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope (ADR-005).
 	 * @param IUserSession $userSession Session for chosenBy attribution.

--- a/lib/Service/NrvWriteDownService.php
+++ b/lib/Service/NrvWriteDownService.php
@@ -86,6 +86,7 @@ class NrvWriteDownService {
 	 * @param IAppConfig $appConfig App config for account numbers + register slug.
 	 * @param InventoryGlAdjustmentPoster $poster Shared balanced-posting adapter.
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/ObligationTaskBridge.php
+++ b/lib/Service/ObligationTaskBridge.php
@@ -61,6 +61,7 @@ class ObligationTaskBridge {
 	 *
 	 * @param ContainerInterface $container DI container for lazy backend resolution.
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly ContainerInterface $container,

--- a/lib/Service/OssRateResolver.php
+++ b/lib/Service/OssRateResolver.php
@@ -91,6 +91,7 @@ class OssRateResolver {
 	 * Construct the resolver with lazy DI of OpenRegister's ObjectService.
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/OssRecordResolver.php
+++ b/lib/Service/OssRecordResolver.php
@@ -68,6 +68,7 @@ class OssRecordResolver {
 	 *
 	 * @param IAppConfig $appConfig App config (register slug).
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/OssReturnGenerator.php
+++ b/lib/Service/OssReturnGenerator.php
@@ -48,6 +48,7 @@ class OssReturnGenerator {
 	 * Construct the generator with lazy DI of OpenRegister's ObjectService.
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/PaymentReconciliationService.php
+++ b/lib/Service/PaymentReconciliationService.php
@@ -186,6 +186,7 @@ class PaymentReconciliationService {
 	 * @param ContainerInterface $container DI container — OR's ObjectService is fetched lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger (never receives raw payment data).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Service/PayrollJaaropgaveService.php
+++ b/lib/Service/PayrollJaaropgaveService.php
@@ -58,6 +58,7 @@ class PayrollJaaropgaveService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param PayrollCalculator $calculator Cents arithmetic helper (no IO).
 	 * @param LoggerInterface $logger Logger (no BSN / special-category data).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/PayrollLivLkvHandoffService.php
+++ b/lib/Service/PayrollLivLkvHandoffService.php
@@ -44,6 +44,7 @@ class PayrollLivLkvHandoffService {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param PayrollCalculator $calculator Cents arithmetic helper.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/PayrollService.php
+++ b/lib/Service/PayrollService.php
@@ -58,6 +58,7 @@ class PayrollService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param PayrollCalculator $calculator Pure-logic payroll arithmetic helper.
 	 * @param LoggerInterface $logger Logger (no BSN / special-category data).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/PayrollUpaHandoffService.php
+++ b/lib/Service/PayrollUpaHandoffService.php
@@ -48,6 +48,7 @@ class PayrollUpaHandoffService {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger (no BSN / special-category data).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/PayrollWkrHandoffService.php
+++ b/lib/Service/PayrollWkrHandoffService.php
@@ -48,6 +48,7 @@ class PayrollWkrHandoffService {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param PayrollCalculator $calculator Cents arithmetic helper.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/PeriodCloseAssistantService.php
+++ b/lib/Service/PeriodCloseAssistantService.php
@@ -60,6 +60,7 @@ class PeriodCloseAssistantService {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param SuspenseAgeingService $suspenseAgeing Aged suspense worklist source (REQ-PCG-002).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/PeriodCloseService.php
+++ b/lib/Service/PeriodCloseService.php
@@ -86,6 +86,7 @@ class PeriodCloseService {
 	 * @param IGroupManager $groupManager Group manager for role resolution.
 	 * @param SuspenseAgeingService $suspenseAgeing Suspense worklist ageing (close blocker, REQ-PCG-003).
 	 * @param LoggerInterface $logger Logger for diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/ProgrammabegrotingService.php
+++ b/lib/Service/ProgrammabegrotingService.php
@@ -45,7 +45,6 @@ class ProgrammabegrotingService {
 	/**
 	 * Construct the service with lazy DI of OpenRegister's ObjectService.
 	 *
-	 *                                      fetched lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param SluitendCalculator $sluitend Computes the sluitend-flags and toezichtregime.
 	 * @param ProgrammabegrotingExporter $exporter Produces iv3 / EMU / JSON export shapes.

--- a/lib/Service/ProgrammabegrotingService.php
+++ b/lib/Service/ProgrammabegrotingService.php
@@ -49,6 +49,7 @@ class ProgrammabegrotingService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param SluitendCalculator $sluitend Computes the sluitend-flags and toezichtregime.
 	 * @param ProgrammabegrotingExporter $exporter Produces iv3 / EMU / JSON export shapes.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/PurchaseOrderApprovalService.php
+++ b/lib/Service/PurchaseOrderApprovalService.php
@@ -124,6 +124,7 @@ class PurchaseOrderApprovalService {
 	 *                                  (server-authoritative).
 	 * @param LoggerInterface $logger Logger (no sensitive
 	 *                                payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 * @param ApprovalActivityEmitter|null $activityEmitter Optional emitter for
 	 *                                                      approval activity events.
 	 *

--- a/lib/Service/PurchaseOrderService.php
+++ b/lib/Service/PurchaseOrderService.php
@@ -162,6 +162,7 @@ class PurchaseOrderService {
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope.
 	 * @param INotificationManager $notificationManager NC notification dispatcher.
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 * @param PeppolTransmissionAdapterInterface|null $peppolAdapter Optional Peppol port (slice 03);
 	 *                                                               defaults to
 	 *                                                               LogPeppolTransmissionAdapter.

--- a/lib/Service/RequisitionConversionService.php
+++ b/lib/Service/RequisitionConversionService.php
@@ -60,6 +60,7 @@ class RequisitionConversionService {
 	 * @param RequisitionConversionGuard $guard Fail-closed status precondition.
 	 * @param PurchaseOrderService $purchaseOrderService Reused, unmodified PO creation.
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Service/RequisitionConversionService.php
+++ b/lib/Service/RequisitionConversionService.php
@@ -54,7 +54,6 @@ class RequisitionConversionService {
 	/**
 	 * Constructor.
 	 *
-	 *                                      is fetched lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope.
 	 * @param RequisitionConversionGuard $guard Fail-closed status precondition.

--- a/lib/Service/RequisitionService.php
+++ b/lib/Service/RequisitionService.php
@@ -56,7 +56,6 @@ class RequisitionService {
 	/**
 	 * Constructor.
 	 *
-	 *                                      is fetched lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope.
 	 * @param BudgetBlocker $budgetBlocker Reused, unmodified budget/mandate guard.

--- a/lib/Service/RequisitionService.php
+++ b/lib/Service/RequisitionService.php
@@ -61,6 +61,7 @@ class RequisitionService {
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope.
 	 * @param BudgetBlocker $budgetBlocker Reused, unmodified budget/mandate guard.
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Service/RevenueCutoffService.php
+++ b/lib/Service/RevenueCutoffService.php
@@ -62,6 +62,7 @@ class RevenueCutoffService {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param RevenueRecognitionCalculator $calculator Pure-logic IFRS 15 arithmetic helper.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/SalesDispatchStockIssueService.php
+++ b/lib/Service/SalesDispatchStockIssueService.php
@@ -94,6 +94,7 @@ class SalesDispatchStockIssueService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
 	 * @param LotSellabilityGuard $lotGuard Decides whether a line may be issued from its lots.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly ContainerInterface $container,

--- a/lib/Service/SepaAuditService.php
+++ b/lib/Service/SepaAuditService.php
@@ -51,6 +51,7 @@ class SepaAuditService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param AdministrationContextService $context RBAC guard — the caller's administration memberships.
 	 * @param LoggerInterface $logger Logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/ServiceReceiptService.php
+++ b/lib/Service/ServiceReceiptService.php
@@ -120,6 +120,7 @@ class ServiceReceiptService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope.
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Service/ServiceReceiptService.php
+++ b/lib/Service/ServiceReceiptService.php
@@ -116,7 +116,6 @@ class ServiceReceiptService {
 	/**
 	 * Constructor.
 	 *
-	 *                                      fetched lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope.
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).

--- a/lib/Service/SoftCloseExecutor.php
+++ b/lib/Service/SoftCloseExecutor.php
@@ -81,6 +81,7 @@ class SoftCloseExecutor {
 	 * @param ContainerInterface $container DI container for lazy ObjectService + delegate resolution.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for orchestration diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly ContainerInterface $container,

--- a/lib/Service/StockLedgerService.php
+++ b/lib/Service/StockLedgerService.php
@@ -64,6 +64,7 @@ class StockLedgerService {
 	 *
 	 * @param IAppConfig $appConfig App config for register slug.
 	 * @param LoggerInterface $logger Logger for diagnostics; never logs full payloads.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/SupplierInvoiceService.php
+++ b/lib/Service/SupplierInvoiceService.php
@@ -134,8 +134,6 @@ class SupplierInvoiceService {
 	/**
 	 * Constructor.
 	 *
-	 *                                      is fetched lazily so unit tests
-	 *                                      can swap an in-memory stub.
 	 * @param IAppConfig $appConfig App config for the OR register slug.
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope (ADR-005).
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).

--- a/lib/Service/SupplierInvoiceService.php
+++ b/lib/Service/SupplierInvoiceService.php
@@ -139,6 +139,7 @@ class SupplierInvoiceService {
 	 * @param IAppConfig $appConfig App config for the OR register slug.
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope (ADR-005).
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Service/SupplierQualificationService.php
+++ b/lib/Service/SupplierQualificationService.php
@@ -49,6 +49,7 @@ class SupplierQualificationService {
 	 * @param IAppConfig $appConfig App config for register slug resolution.
 	 * @param AdministrationContextService $administrationContext Tenant access/identity resolver.
 	 * @param LoggerInterface $logger Logger for diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/TaxCalculationService.php
+++ b/lib/Service/TaxCalculationService.php
@@ -60,6 +60,7 @@ class TaxCalculationService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param TaxCalculationHelper $helper Pure-logic helper (loss compensation, rate calc).
 	 * @param LoggerInterface $logger PSR-3 logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/TaxCalculationService.php
+++ b/lib/Service/TaxCalculationService.php
@@ -56,7 +56,6 @@ class TaxCalculationService {
 	/**
 	 * Construct the service.
 	 *
-	 *                                      fetched lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param TaxCalculationHelper $helper Pure-logic helper (loss compensation, rate calc).
 	 * @param LoggerInterface $logger PSR-3 logger.

--- a/lib/Service/TaxNotificationService.php
+++ b/lib/Service/TaxNotificationService.php
@@ -65,6 +65,7 @@ class TaxNotificationService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param IManager $notificationMgr Nextcloud notification manager.
 	 * @param LoggerInterface $logger Logger for diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/TaxPaymentReconciliationService.php
+++ b/lib/Service/TaxPaymentReconciliationService.php
@@ -50,6 +50,7 @@ class TaxPaymentReconciliationService {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param TaxReportCalculator $calculator Pure-logic cents helper (reused for precision).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/TaxReportService.php
+++ b/lib/Service/TaxReportService.php
@@ -55,7 +55,6 @@ class TaxReportService {
 	/**
 	 * Construct the service with lazy DI of OpenRegister's ObjectService.
 	 *
-	 *                                      lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param TaxReportCalculator $calculator Pure-logic aggregation helper.
 	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.

--- a/lib/Service/TaxReportService.php
+++ b/lib/Service/TaxReportService.php
@@ -58,6 +58,7 @@ class TaxReportService {
 	 *                                      lazily.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param TaxReportCalculator $calculator Pure-logic aggregation helper.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/ThreeWayMatchingEngine.php
+++ b/lib/Service/ThreeWayMatchingEngine.php
@@ -225,6 +225,7 @@ class ThreeWayMatchingEngine {
 	 *                                               matched invoice (received →
 	 *                                               matching → matched/exception).
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 * @param ExceptionResolutionService|null $exceptionResolution Raises the
 	 *                                                             crediteuren-administrateur
 	 *                                                             alert when a match is routed

--- a/lib/Service/TimeIntakeService.php
+++ b/lib/Service/TimeIntakeService.php
@@ -101,6 +101,7 @@ class TimeIntakeService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger.
 	 * @param InvoiceGenerationService $invoices Existing, unmodified draftInvoice() machinery.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/Treasury/FxRevaluationService.php
+++ b/lib/Service/Treasury/FxRevaluationService.php
@@ -103,6 +103,7 @@ class FxRevaluationService {
 	 * @param IAppConfig $appConfig App config for the register slug + GL account overrides.
 	 * @param TreasuryRateService $treasuryRateService Rate-lookup facade (REQ-MC-007).
 	 * @param LoggerInterface $logger Structured logger.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/TrialBalanceService.php
+++ b/lib/Service/TrialBalanceService.php
@@ -76,6 +76,7 @@ class TrialBalanceService {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param TrialBalanceCalculator $calculator Pure-logic arithmetic helper.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/VATReturnService.php
+++ b/lib/Service/VATReturnService.php
@@ -73,6 +73,7 @@ class VATReturnService {
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface $logger Logger for diagnostics.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/VatSuppletieDetectionService.php
+++ b/lib/Service/VatSuppletieDetectionService.php
@@ -117,7 +117,6 @@ class VatSuppletieDetectionService {
 	 * a direct dependency on VATReturnService, whose GL-derivation engine
 	 * this service re-uses rather than duplicating (REQ-VBTW-013).
 	 *
-	 *                                      lazily.
 	 * @param IAppConfig $appConfig App config for the register slug + clearing account.
 	 * @param LoggerInterface $logger Logger for diagnostics.
 	 * @param VATReturnService $vatReturnService The GL-derivation engine this service diffs against.

--- a/lib/Service/VatSuppletieDetectionService.php
+++ b/lib/Service/VatSuppletieDetectionService.php
@@ -121,6 +121,7 @@ class VatSuppletieDetectionService {
 	 * @param IAppConfig $appConfig App config for the register slug + clearing account.
 	 * @param LoggerInterface $logger Logger for diagnostics.
 	 * @param VATReturnService $vatReturnService The GL-derivation engine this service diffs against.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/VendorPerformanceAggregation.php
+++ b/lib/Service/VendorPerformanceAggregation.php
@@ -200,6 +200,7 @@ class VendorPerformanceAggregation {
 	 *
 	 * @param IAppConfig $appConfig App config for the OR register slug.
 	 * @param LoggerInterface $logger Logger (no sensitive payloads).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 *
 	 * @return void
 	 */

--- a/lib/Service/ViesService.php
+++ b/lib/Service/ViesService.php
@@ -84,6 +84,7 @@ class ViesService {
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param IClientService $clientService Nextcloud HTTP client factory.
 	 * @param LoggerInterface $logger Logger (no special-category data logged).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/WbsoAccountService.php
+++ b/lib/Service/WbsoAccountService.php
@@ -56,6 +56,7 @@ class WbsoAccountService {
 	 * Construct the service with lazy DI of OpenRegister's ObjectService.
 	 *
 	 * @param IAppConfig $appConfig App config (register slug).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/WbsoAdministratieService.php
+++ b/lib/Service/WbsoAdministratieService.php
@@ -51,6 +51,7 @@ class WbsoAdministratieService {
 	 * Construct the service with lazy DI of OpenRegister's ObjectService.
 	 *
 	 * @param IAppConfig $appConfig App config for the register slug.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/WbsoDocumentService.php
+++ b/lib/Service/WbsoDocumentService.php
@@ -75,6 +75,7 @@ class WbsoDocumentService {
 	 *
 	 * @param IAppConfig $appConfig App config (register slug).
 	 * @param IUserSession $userSession Authenticated session (createdBy).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,

--- a/lib/Service/WbsoTransactionService.php
+++ b/lib/Service/WbsoTransactionService.php
@@ -68,6 +68,7 @@ class WbsoTransactionService {
 	 *
 	 * @param IAppConfig $appConfig App config (register slug).
 	 * @param IUserSession $userSession Authenticated session (used to record createdBy).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
 	 */
 	public function __construct(
 		private readonly IAppConfig $appConfig,


### PR DESCRIPTION
Closes #852. `PHP Quality (phpcs)` is green on `lib/` again.

```
189 errors → 0
```

## Correction to the issue

I filed #852 saying **508 errors**. That was wrong — I got it from `grep -c ERROR` on the CI log, which also counts the `FOUND n ERRORS` summary lines. Measured with the tool itself, the real figure is **189**.

## Where it came from

`2c88358b` — *"fix: clear the docblocks and dead code ADR-083 left behind"*. ADR-083 injected `ObjectServiceInterface $objectService` into ~144 constructors; the docblocks did not follow, and in 19 files the deleted `@param ContainerInterface $container … resolved lazily.` line left its **wrapped tail behind**, dangling above the surviving params:

```php
 * Construct the guard with lazy DI of OR's ObjectService.
 *
 *                                      lazily so the class loads even when OR is absent.
 * @param IAppConfig $appConfig …
```

## What is in here

| count | shape |
|---:|---|
| 144 | missing `@param ObjectServiceInterface $objectService` |
| 19 | orphaned continuation lines (the tail above) |
| 5 | `//` rationale comments between the docblock and the attributes |
| 3 | inline comments opening on a lowercase `find()` |
| 1 | `IThrottler $throttler` never documented |

## Two things worth reviewing rather than skimming

**1. Position matters, and I got it wrong first.** phpcs checks `@param` **order** against the signature. In the 8 constructors where `$objectService` is followed by nullable params, appending the line at the end produced a *new* error class:

```
Doc comment for parameter $objectService does not match actual variable name $activityEmitter
```

Moving each line to its real position — immediately before the first nullable param — fixed those **and** 12 of the 13 pre-existing `does not match` errors, which were the same misalignment one row further down.

**2. One error was not the bulk pattern at all.** `ConfirmationApiController`'s constructor gained `IThrottler $throttler` with no `@param`, which phpcs surfaced as the *next* parameter mismatching (`$logger does not match actual variable name $throttler`). That is exactly why I kept the `does not match` class out of the mechanical sweep and read each one individually — a bulk edit would have "fixed" it by renaming `$logger`.

The 5 `//` comments were kept, not deleted: they explain each `AnonRateLimit` ceiling and that reasoning is worth having. They moved into the docblock so the attributes sit contiguous. **No rate limit was changed.**

## Verified

- `composer phpcs` — the command CI runs — **0 errors**.
- `php -l` on every changed file — **0 syntax errors**.
- Re-measured after every one of the nine batches; never assumed an edit landed.
