### PR TITLE
ci: Code Quality has not run at all — duplicate keys reject the workflow file

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -115,23 +115,10 @@ jobs:
       enable-phpunit: true
 
       # ── E2E browser tests ────────────────────────────────────────────────
-      # `enable-playwright` defaults to FALSE and was never set here, so the
-      # "E2E Tests (Playwright)" job has reported `skipped` on every run this
-      # repo has ever produced — while the tree ships a root
-      # `playwright.config.ts` and 53 spec files under `tests/e2e/`. A skipped
-      # job is not a pass: it is the absence of a measurement, and the Quality
-      # Report renders it identically to a green one.
-      #
-      # `playwright-test-path` does double duty in the shared workflow: it is
-      # both the test directory AND the first place it looks for a config
-      # (`${playwright-test-path}/playwright.config.ts`, falling back to the
-      # repo root). We ship tests/e2e/playwright.config.ts precisely so that
-      # lookup hits it — the workflow passes no `--project`, so if the ROOT
-      # config were picked it would also run `docs-capture` (re-shooting every
-      # journeydoc screenshot, which has its own job) and `visual` (pixel
-      # baselines that cannot byte-match a CI runner). See that file's header.
-      enable-playwright: true
-      playwright-test-path: tests/e2e
+      # `enable-playwright` / `playwright-test-path` are set ONCE, further down
+      # next to `playwright-seed-command` — the three belong together. They
+      # were briefly declared here as well; YAML allows no duplicate keys, and
+      # GitHub rejected the whole file for it (see the note on that block).
 
       enable-newman: true
       # Shillinq delegates ALL object CRUD to OpenRegister (@conduction/nextcloud-vue


### PR DESCRIPTION
**shillinq's Code Quality pipeline has not run at all** — not on `development`, not on any PR — since the second declaration landed. This restores it.

## What's wrong

`enable-playwright` and `playwright-test-path` are each declared **twice** in the same `with:` block. YAML forbids duplicate keys, so GitHub rejects the file and the run dies before a single job is created:

> ✗ This run likely failed because of a workflow file issue.

## How to see it without guessing

The **run name** is the tell. A healthy run is titled `Code Quality`. These are titled `.github/workflows/code-quality.yml` — GitHub falls back to the file path when it cannot load the workflow far enough to read `name:`. And the run carries **zero jobs**.

```
shillinq       .github/workflows/code-quality.yml   completed/failure   ← broken
opencatalogi   Code Quality                         completed/failure   ← ran, jobs failed
decidesk       Code Quality                         completed/failure   ← ran, jobs failed
openbuild      Code Quality                         in_progress
```

A job that fails and a workflow that never starts look very different once you know to look at the name — and identical if you don't. In the checks list it simply *isn't there*, which reads as "not required" rather than "broken".

## How it happened

#564 and #440 both enabled Playwright, independently, in the same block. Each carries a long comment explaining that `enable-playwright` "was never set here" — written by two changes that could not see each other, then merged one after the other. Neither was wrong on its own.

## The fix

One declaration, kept beside `playwright-seed-command` because the three belong together. **No value changed** — `true` / `tests/e2e` either way.

## Verified

- Duplicate-key scan of the file: **NONE**. Control: the same scanner flags a planted `a: 1 / a: 3` pair, so a clean result is a measurement rather than a silent pass.
- Resolved inputs unchanged: `enable-playwright=True`, `playwright-test-path=tests/e2e`, `playwright-seed-command` present.
- Swept **all 17 other apps'** `code-quality.yml` on `development` for the same defect — all clean, so this is not a fleet pattern.

## Note

Until this merges, no PR in this repo has a meaningful Code Quality verdict, including #855 and #570. That is worth knowing before reading any recent green or red here.
