### PR TITLE
fix(innovatiebox): the validator factory still passed the $container ADR-084 removed

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -385,8 +385,15 @@ class Application extends App implements IBootstrap {
 			DoorsnijdingsVerbodValidator::class,
 			static function (ContainerInterface $c): DoorsnijdingsVerbodValidator {
 				return new DoorsnijdingsVerbodValidator(
-					container: $c,
 					appConfig: $c->get(IAppConfig::class),
+					// ADR-084 replaced the `$container` parameter with the
+					// published contract. This factory bypasses autowiring, so
+					// it does not follow a constructor automatically: passing
+					// `container:` here was `Error: Unknown named parameter
+					// $container` on every request that resolved the service —
+					// i.e. every InnovatieboxController route. See
+					// tests/Unit/AppInfo/CompositionRootArgumentsTest.php.
+					objectService: $c->get(ObjectServiceInterface::class),
 					auditLogger: $c->get(InnovatieboxAuditEventLogger::class),
 				);
 			}

--- a/tests/Unit/AppInfo/CompositionRootArgumentsTest.php
+++ b/tests/Unit/AppInfo/CompositionRootArgumentsTest.php
@@ -1,0 +1,587 @@
+<?php
+
+/**
+ * Composition-root argument tests.
+ *
+ * `lib/AppInfo/Application.php` registers a number of services with a
+ * hand-written factory closure — `return new Foo(bar: $c->get(...))` —
+ * instead of letting Nextcloud autowire them. That is a deliberate choice
+ * (several of these need an argument the container cannot infer, or must stay
+ * a string reference so a disabled OpenRegister does not fatal bootstrap), but
+ * it has one dangerous property:
+ *
+ *   **A manual `new Foo(...)` that no longer matches `Foo::__construct()` is
+ *   invisible to every static check we run.** `php -l` passes, phpcs, phpmd,
+ *   psalm and phpstan pass, and the class's own unit test passes too, because
+ *   the unit test constructs it directly and never goes through the factory.
+ *   The first thing that notices is a **request**.
+ *
+ * That is exactly what happened when ADR-084 replaced
+ * `DoorsnijdingsVerbodValidator`'s `$container` parameter with the published
+ * `ObjectServiceInterface` contract. The factory in `Application.php` kept
+ * passing `container: $c` — a parameter that no longer exists — so resolving
+ * the service threw `Error: Unknown named parameter $container`, and
+ * `InnovatieboxController` requires that service, so **every Innovatiebox
+ * route returned 500**. `tests/Unit/Service/DoorsnijdingsVerbodValidatorTest`
+ * was green throughout: it builds the validator itself, correctly.
+ *
+ * These tests close that hole. They read `Application.php`'s own source,
+ * extract every `new <Class>(...)` in it, and compare the call against the
+ * target class's real constructor via reflection.
+ *
+ * @category  Test
+ * @package   OCA\Shillinq\Tests\Unit\AppInfo
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://github.com/ConductionNL/shillinq
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\AppInfo;
+
+use OCA\Shillinq\Service\DoorsnijdingsVerbodValidator;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Every hand-written factory in the composition root must still match the
+ * constructor it calls.
+ */
+class CompositionRootArgumentsTest extends TestCase {
+
+	/**
+	 * Absolute path to the composition root.
+	 *
+	 * @var string
+	 */
+	private string $applicationPhp;
+
+	/**
+	 * Parsed `new <Class>(...)` call sites found in the composition root.
+	 *
+	 * Each entry: ['class' => FQN, 'line' => int, 'named' => string[],
+	 * 'positional' => int].
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $callSites;
+
+
+	/**
+	 * Parse the composition root once per test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->applicationPhp = dirname(__DIR__, 3) . '/lib/AppInfo/Application.php';
+		self::assertFileExists($this->applicationPhp, 'the composition root must exist');
+
+		$source = file_get_contents($this->applicationPhp);
+		$this->callSites = $this->parseNewCalls(
+			$source,
+			$this->buildUseMap($source),
+			$this->currentNamespace($source)
+		);
+
+	}//end setUp()
+
+
+	/**
+	 * The parser must actually have found the factories.
+	 *
+	 * Without this, a parsing regression would make every other test in this
+	 * file pass over an empty list — a check that did not run looks exactly
+	 * like one that passed.
+	 *
+	 * @return void
+	 */
+	public function testTheParserFindsTheFactoriesItIsSupposedToCheck(): void {
+		self::assertGreaterThanOrEqual(
+			20,
+			count($this->callSites),
+			'Expected the composition root to contain at least 20 `new X(...)` '
+			. 'call sites; found ' . count($this->callSites) . '. Either the '
+			. 'factories were removed (update this floor deliberately) or this '
+			. "file's parser broke and every other assertion here is vacuous."
+		);
+
+		$classes = array_column($this->callSites, 'class');
+		self::assertContains(
+			DoorsnijdingsVerbodValidator::class,
+			$classes,
+			'The DoorsnijdingsVerbodValidator factory must be among the parsed '
+			. 'call sites; it is the one this test file exists for.'
+		);
+
+	}//end testTheParserFindsTheFactoriesItIsSupposedToCheck()
+
+
+	/**
+	 * Every manual factory supplies every argument its constructor requires.
+	 *
+	 * @return void
+	 */
+	public function testEveryManualFactorySuppliesAllRequiredConstructorArguments(): void {
+		$checked  = 0;
+		$problems = [];
+
+		foreach ($this->callSites as $site) {
+			if (class_exists($site['class']) === false) {
+				// Classes from other apps (OpenRegister, OCP) are not
+				// autoloadable in a unit-test run. Reported by
+				// testUnresolvableFactoryTargetsAreDeclared() rather than
+				// silently skipped here.
+				continue;
+			}
+
+			$reflection  = new ReflectionClass($site['class']);
+			$constructor = $reflection->getConstructor();
+			if ($constructor === null) {
+				continue;
+			}
+
+			$checked++;
+			$parameters = $constructor->getParameters();
+			$names      = array_map(
+				static fn ($parameter) => $parameter->getName(),
+				$parameters
+			);
+
+			foreach (array_count_values($site['named']) as $name => $times) {
+				if ($times > 1) {
+					$problems[] = sprintf(
+						'%s:%d new %s — named argument $%s is passed %d times '
+						. '(PHP fatals with "Named parameter $%s overwrites '
+						. 'previous argument")',
+						basename($this->applicationPhp),
+						$site['line'],
+						$reflection->getShortName(),
+						$name,
+						$times,
+						$name
+					);
+				}
+
+				if (in_array($name, $names, true) === false) {
+					$problems[] = sprintf(
+						'%s:%d new %s — named argument $%s does not exist on '
+						. '%s::__construct() (it takes: %s). PHP fatals with '
+						. '"Unknown named parameter $%s".',
+						basename($this->applicationPhp),
+						$site['line'],
+						$reflection->getShortName(),
+						$name,
+						$reflection->getShortName(),
+						implode(', ', array_map(static fn ($n) => '$' . $n, $names)),
+						$name
+					);
+				}
+			}
+
+			foreach ($parameters as $index => $parameter) {
+				if ($index < $site['positional']) {
+					// Supplied positionally.
+					continue;
+				}
+
+				if ($parameter->isOptional() === true || $parameter->isVariadic() === true) {
+					continue;
+				}
+
+				if (in_array($parameter->getName(), $site['named'], true) === true) {
+					continue;
+				}
+
+				$problems[] = sprintf(
+					'%s:%d new %s — required constructor parameter $%s is not '
+					. 'supplied (%d of %d arguments given). Every request that '
+					. 'resolves this service will die with ArgumentCountError.',
+					basename($this->applicationPhp),
+					$site['line'],
+					$reflection->getShortName(),
+					$parameter->getName(),
+					(count($site['named']) + $site['positional']),
+					count($parameters)
+				);
+			}
+		}//end foreach
+
+		self::assertGreaterThanOrEqual(
+			5,
+			$checked,
+			'Expected to reflect at least 5 factory targets; reflected '
+			. $checked . '. A run that checks nothing must not report success.'
+		);
+
+		self::assertSame(
+			[],
+			$problems,
+			"The composition root disagrees with a constructor it calls:\n  - "
+			. implode("\n  - ", $problems)
+		);
+
+	}//end testEveryManualFactorySuppliesAllRequiredConstructorArguments()
+
+
+	/**
+	 * The Innovatiebox validator's factory, named explicitly.
+	 *
+	 * This is the regression that made every `InnovatieboxController` route a
+	 * 500. It is asserted on its own so that the failure message names the
+	 * service rather than a list.
+	 *
+	 * @return void
+	 */
+	public function testInnovatieboxValidatorFactoryMatchesItsConstructor(): void {
+		$sites = array_values(
+			array_filter(
+				$this->callSites,
+				static fn ($site) => $site['class'] === DoorsnijdingsVerbodValidator::class
+			)
+		);
+
+		self::assertCount(
+			1,
+			$sites,
+			'Application.php must register exactly one hand-written '
+			. 'DoorsnijdingsVerbodValidator factory.'
+		);
+
+		$constructor = (new ReflectionClass(DoorsnijdingsVerbodValidator::class))->getConstructor();
+		self::assertNotNull($constructor);
+
+		$names = array_map(
+			static fn ($parameter) => $parameter->getName(),
+			$constructor->getParameters()
+		);
+
+		$unknown = array_values(array_diff($sites[0]['named'], $names));
+		self::assertSame(
+			[],
+			$unknown,
+			'The DoorsnijdingsVerbodValidator factory passes named argument(s) '
+			. '$' . implode(', $', $unknown) . ' that its constructor does not '
+			. 'have. Resolving the service throws "Unknown named parameter", '
+			. 'and InnovatieboxController requires it — so every Innovatiebox '
+			. 'route returns 500.'
+		);
+
+		$required = [];
+		foreach ($constructor->getParameters() as $index => $parameter) {
+			if ($index < $sites[0]['positional']) {
+				continue;
+			}
+
+			if ($parameter->isOptional() === true || $parameter->isVariadic() === true) {
+				continue;
+			}
+
+			$required[] = $parameter->getName();
+		}
+
+		$missing = array_values(array_diff($required, $sites[0]['named']));
+		self::assertSame(
+			[],
+			$missing,
+			'The DoorsnijdingsVerbodValidator factory does not pass: $'
+			. implode(', $', $missing) . '. Resolving the service throws '
+			. 'ArgumentCountError.'
+		);
+
+	}//end testInnovatieboxValidatorFactoryMatchesItsConstructor()
+
+
+	/**
+	 * Record which factory targets could not be reflected.
+	 *
+	 * An unloadable class is "I could not tell", not a pass. This test keeps
+	 * that set visible, so a future factory for a foreign class does not
+	 * quietly disappear from the check above.
+	 *
+	 * @return void
+	 */
+	public function testUnresolvableFactoryTargetsAreDeclared(): void {
+		$unresolvable = [];
+		foreach ($this->callSites as $site) {
+			if (class_exists($site['class']) === false) {
+				$unresolvable[] = $site['class'];
+			}
+		}
+
+		$unresolvable = array_values(array_unique($unresolvable));
+		sort($unresolvable);
+
+		self::assertSame(
+			$this->unreflectableTargets(),
+			$unresolvable,
+			'Composition-root factory targets that cannot be reflected in a '
+			. 'unit-test run have changed. Unreflectable targets are unchecked, '
+			. "not clean — add a stub, or accept the new entry deliberately.\n"
+			. '  now: ' . implode(', ', $unresolvable) . "\n"
+			. '  expected: ' . implode(', ', $this->unreflectableTargets())
+		);
+
+	}//end testUnresolvableFactoryTargetsAreDeclared()
+
+
+	/**
+	 * Factory targets that a unit-test autoloader cannot resolve.
+	 *
+	 * These belong to other apps or to PHP itself. Kept sorted, so the
+	 * assertion above compares like with like.
+	 *
+	 * @return string[]
+	 */
+	private function unreflectableTargets(): array {
+		return [];
+
+	}//end unreflectableTargets()
+
+
+	/**
+	 * The namespace the composition root is declared in.
+	 *
+	 * An unqualified class name in a namespaced file resolves to the current
+	 * namespace, not to the global one. Without this, a factory for a class
+	 * that is simply a neighbour of `Application` looks unresolvable — and
+	 * unresolvable reads as unchecked.
+	 *
+	 * @param string $source The PHP source of the composition root.
+	 *
+	 * @return string
+	 */
+	private function currentNamespace(string $source): string {
+		if (preg_match('/^namespace\s+([A-Za-z0-9_\\\\]+)\s*;/m', $source, $match) === 1) {
+			return $match[1];
+		}
+
+		return '';
+
+	}//end currentNamespace()
+
+
+	/**
+	 * Build alias => fully-qualified-class-name from the file's `use` list.
+	 *
+	 * @param string $source The PHP source of the composition root.
+	 *
+	 * @return array<string, string>
+	 */
+	private function buildUseMap(string $source): array {
+		$map = [];
+		preg_match_all(
+			'/^use\s+([A-Za-z0-9_\\\\]+)(?:\s+as\s+([A-Za-z0-9_]+))?\s*;/m',
+			$source,
+			$matches,
+			PREG_SET_ORDER
+		);
+
+		foreach ($matches as $match) {
+			$fqn   = $match[1];
+			$parts = explode('\\', $fqn);
+			$alias = ($match[2] ?? '');
+			if ($alias === '') {
+				$alias = end($parts);
+			}
+
+			$map[$alias] = $fqn;
+		}
+
+		return $map;
+
+	}//end buildUseMap()
+
+
+	/**
+	 * Extract every `new <Class>(...)` call site from PHP source.
+	 *
+	 * Uses PHP's own tokeniser, so comments and string literals cannot be
+	 * mistaken for code.
+	 *
+	 * @param string                $source    The PHP source of the composition root.
+	 * @param array<string, string> $useMap    Alias => FQN, from buildUseMap().
+	 * @param string                $namespace The file's own namespace.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function parseNewCalls(string $source, array $useMap, string $namespace): array {
+		$tokens = token_get_all($source);
+		$sites  = [];
+		$count  = count($tokens);
+
+		for ($i = 0; $i < $count; $i++) {
+			if (is_array($tokens[$i]) === false || $tokens[$i][0] !== T_NEW) {
+				continue;
+			}
+
+			$line = $tokens[$i][2];
+
+			// The class name: skip whitespace, then take a name token.
+			$j = ($i + 1);
+			while ($j < $count && is_array($tokens[$j]) === true
+				&& in_array($tokens[$j][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true) === true
+			) {
+				$j++;
+			}
+
+			if ($j >= $count || is_array($tokens[$j]) === false) {
+				continue;
+			}
+
+			$nameTokens = [T_STRING, T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED];
+			if (in_array($tokens[$j][0], $nameTokens, true) === false) {
+				// `new class`, `new $var`, `new self`, ... — not a factory
+				// for a named class.
+				continue;
+			}
+
+			$name       = $tokens[$j][1];
+			$isAbsolute = (str_starts_with($name, '\\') === true);
+			$name       = ltrim($name, '\\');
+
+			// The argument list must open immediately.
+			$k = ($j + 1);
+			while ($k < $count && is_array($tokens[$k]) === true
+				&& $tokens[$k][0] === T_WHITESPACE
+			) {
+				$k++;
+			}
+
+			if ($k >= $count || $tokens[$k] !== '(') {
+				continue;
+			}
+
+			[$named, $positional, $end] = $this->readArgumentList($tokens, $k);
+
+			// Resolve `use ... as Alias` FIRST, then take the short name from
+			// the fully-qualified name. The other way round makes an aliased
+			// class look unresolvable, which reads as "not checked".
+			$head = explode('\\', $name)[0];
+			$fqn  = $name;
+			if (isset($useMap[$head]) === true) {
+				$fqn = $useMap[$head] . substr($name, strlen($head));
+			} else if ($isAbsolute === false && $namespace !== '') {
+				// Not imported and not fully qualified: PHP resolves it
+				// relative to the file's own namespace.
+				$fqn = $namespace . '\\' . $name;
+			}
+
+			$sites[] = [
+				'class'      => ltrim($fqn, '\\'),
+				'line'       => $line,
+				'named'      => $named,
+				'positional' => $positional,
+			];
+
+			$i = $end;
+		}//end for
+
+		return $sites;
+
+	}//end parseNewCalls()
+
+
+	/**
+	 * Read one argument list starting at the `(` token.
+	 *
+	 * @param array<int, mixed> $tokens The full token stream.
+	 * @param int               $open   Index of the opening parenthesis.
+	 *
+	 * @return array{0: string[], 1: int, 2: int} Named argument names, the
+	 *                                            number of positional
+	 *                                            arguments, and the index of
+	 *                                            the closing parenthesis.
+	 */
+	private function readArgumentList(array $tokens, int $open): array {
+		$depth      = 0;
+		$named      = [];
+		$positional = 0;
+		$sawToken   = false;
+		$count      = count($tokens);
+		$i          = $open;
+
+		for (; $i < $count; $i++) {
+			$token = $tokens[$i];
+
+			if (is_array($token) === true) {
+				if ($token[0] === T_WHITESPACE || $token[0] === T_COMMENT
+					|| $token[0] === T_DOC_COMMENT
+				) {
+					continue;
+				}
+
+				if ($depth === 1) {
+					// A named argument is `name:` at the top level of this
+					// list. `::` is its own token (T_DOUBLE_COLON), so
+					// `Foo::class` cannot be mistaken for one.
+					if ($token[0] === T_STRING) {
+						$next = ($i + 1);
+						while ($next < $count && is_array($tokens[$next]) === true
+							&& $tokens[$next][0] === T_WHITESPACE
+						) {
+							$next++;
+						}
+
+						if ($next < $count && $tokens[$next] === ':') {
+							$named[]  = $token[1];
+							$sawToken = true;
+							$i        = $next;
+							continue;
+						}
+					}
+
+					$sawToken = true;
+				}
+
+				continue;
+			}//end if
+
+			if ($token === '(' || $token === '[' || $token === '{') {
+				$depth++;
+				if ($depth > 1) {
+					$sawToken = true;
+				}
+
+				continue;
+			}
+
+			if ($token === ')' || $token === ']' || $token === '}') {
+				$depth--;
+				if ($depth === 0) {
+					// PHP requires positional arguments before named ones, so
+					// a final segment only counts as positional while no named
+					// argument has been seen.
+					if ($sawToken === true && count($named) === 0) {
+						$positional++;
+					}
+
+					break;
+				}
+
+				continue;
+			}
+
+			if ($token === ',' && $depth === 1) {
+				if ($sawToken === true && count($named) === 0) {
+					$positional++;
+				}
+
+				$sawToken = false;
+				continue;
+			}
+
+			if ($depth === 1) {
+				$sawToken = true;
+			}
+		}//end for
+
+		return [$named, $positional, $i];
+
+	}//end readArgumentList()
+
+
+}//end class


### PR DESCRIPTION
## The defect — a second live 500, found by sweeping every composition root in the fleet

`Application.php:387` registers `DoorsnijdingsVerbodValidator` with a hand-written factory that passes `container: $c`. ADR-084 (#556) **replaced that constructor parameter** with the published `ObjectServiceInterface` contract:

```php
public function __construct(
    private readonly IAppConfig $appConfig,
    private readonly ObjectServiceInterface $objectService,
    private readonly ?InnovatieboxAuditEventLogger $auditLogger = null,
) {
```

So resolving the service throws `Error: Unknown named parameter $container` — and `$objectService`, which replaced it, is never passed at all. `InnovatieboxController::__construct()` requires the validator (`lib/Controller/InnovatieboxController.php:78`), so this is not one endpoint: **every Innovatiebox route is a 500**.

**Nothing we run notices this.** `php -l` passes. phpcs, phpmd, psalm and phpstan pass. `tests/Unit/Service/DoorsnijdingsVerbodValidatorTest` passes — it constructs the validator itself, with the *correct* two arguments, and never goes through the factory. The first thing that notices is a request.

⚠️ And this repo had **no CI at all** between ~09:32 and #856, so there was nothing to notice it with either. A repo that cannot be measured cannot report what broke in it.

## How it was found

Not by grep. Every `new <Class>(...)` in all 18 repos' `lib/AppInfo/Application.php` was compared against the target class's real `__construct()`, parsed from that repo's own tree — **260 call sites, 18 repos, each at its `origin/development` tip**. Two repos had a mismatch: softwarecatalog (`/me`, PR #531) and this one.

## The test

`tests/Unit/AppInfo/CompositionRootArgumentsTest.php` closes the hole for **every** hand-written factory here, not only this one. It tokenises `Application.php` (so comments and strings cannot be mistaken for code), resolves each class name the way PHP does — imports first, then the file's own namespace — and reflects the target constructor.

**Shown to fail against the unfixed composition root** (`git stash` of the one hunk, same command, same container):

```
1) CompositionRootArgumentsTest::testEveryManualFactorySuppliesAllRequiredConstructorArguments
  - Application.php:387 new DoorsnijdingsVerbodValidator — named argument $container
    does not exist on DoorsnijdingsVerbodValidator::__construct() (it takes:
    $appConfig, $objectService, $auditLogger). PHP fatals with "Unknown named
    parameter $container".
  - Application.php:387 new DoorsnijdingsVerbodValidator — required constructor
    parameter $objectService is not supplied (3 of 3 arguments given).

2) CompositionRootArgumentsTest::testInnovatieboxValidatorFactoryMatchesItsConstructor
The DoorsnijdingsVerbodValidator factory passes named argument(s) $container that
its constructor does not have. Resolving the service throws "Unknown named
parameter", and InnovatieboxController requires it — so every Innovatiebox route
returns 500.

Tests: 4, Assertions: 14, Failures: 2.
```

With the fix: `OK (4 tests, 15 assertions)`.

It refuses to report a vacuous pass — a check that did not run looks exactly like one that passed:

- a **floor of 20 parsed call sites**, and `DoorsnijdingsVerbodValidator` must be among them;
- a **floor of 5 reflected constructors**;
- `testUnresolvableFactoryTargetsAreDeclared` keeps the set of targets that cannot be reflected in a unit-test run **explicit**. It is currently **empty** — all 28 call sites are actually checked — and a new entry appearing there fails the test rather than silently shrinking the check.

(That last guard earned its place during development: the first version of the parser did not resolve unqualified names against the file's own namespace, and reported `OpdrachtUitvoeringGateRegistration` and `SigningDelegationRegistration` as unreflectable when both are simply neighbours of `Application`. Unresolvable reads as unchecked, and unchecked reads as clean.)

## Before / after

| measurement | before | after |
|---|---|---|
| composition-root argument mismatches in `lib/AppInfo/Application.php` | **2** | **0** |
| `new <Class>(...)` call sites scanned, both sides | 28 | 28 |
| factory targets that could not be reflected | 0 | 0 |
| `CompositionRootArgumentsTest` | 2 failures | 4 tests, 15 assertions, **OK** |

Instrument output redirected to a file and line-counted — never piped, so no exit code is read off the last stage of a pipe. Run identically on both sides; the only difference is the one hunk.

## Quality legs, on the changed files

- `phpcs --standard=phpcs.xml lib/AppInfo/Application.php` — **rc 0**, 0 errors, 3 pre-existing `@spec` warnings on `Application`/`register()`/`boot()` (untouched by this PR).
- `phpstan analyse lib/AppInfo/Application.php tests/Unit/AppInfo/CompositionRootArgumentsTest.php` — **`[OK] No errors`, 2 files.** Positive control in the same container: `phpstan analyse lib/Lifecycle` reports **15 errors**, so the instrument can say no here.
- `php -l` clean on both files.

Container: `hermiq-llm-runner:gates` (PHP 8.3.33) — the host is PHP 8.2, and `php:8.3-cli` ships neither `python3` nor `git`.

## Parity

Base `6bd201f0`, which is the first commit after **#856 repaired this repo's CI** (a duplicate key in one `with:` mapping meant GitHub could not parse `code-quality.yml`; those runs reported `failure` with **zero jobs**). Any shillinq run created between ~09:32 and #856 means nothing — **count the jobs before believing this PR's run, and before believing any base you compare it to.**

The repo's inherited red on this base is the ADR-084 fallout measured elsewhere: 4 PHP Quality legs and **506 failing tests** (`Tests: 4133, Errors: 162, Failures: 344`, measured by S4 on a detached worktree at the base sha). This PR touches one factory and adds one test file; it cannot reduce that set, and it does not add to it.

## Not done here, deliberately

- The **506 broken tests** and the phpcs/phpstan `$objectService` docblock family are service-layer and call-site work, a different change from the composition root. Keeping this PR to the runtime fatal makes it safe to merge immediately, which is the point — it is live right now.
- `DoorsnijdingsVerbodValidator`'s constructor docblock still carries the orphaned fragment left when `$container`'s `@param` was removed, and has no `@param` for `$objectService`. Left alone: it is one instance of a repo-wide phpcs family that belongs to whoever takes that sweep, and touching it here would blur what this PR is.

---

## Added after opening: the base measured, S7's way

`origin/development` at `6bd201f0`, extracted read-only into a detached tree, unit suite run locally against this repo's own `vendor/` in `hermiq-llm-runner:gates`:

```
Tests: 4133, Assertions: 42219, Errors: 162, Failures: 346,
Warnings: 32, Deprecations: 1, Skipped: 1
```

That independently reproduces S4's `4133 / 162 / 344` at its branch base (the two extra failures are the merges since), so **508 broken tests are inherited on this base and none of them is this PR's.** Dominant error signatures, all ADR-084 call-site fallout:

| count | signature |
|---:|---|
| 20 | `Named parameter $objectService overwrites previous argument` |
| 16 | `Unknown named parameter $container` |
| 16 | `Argument ... must be of type Psr\Container\ContainerInterface, null given` |
| 9 | `Return value must be of type array, null returned` |

⚠️ This is the **unit** layer (`phpunit-unit.xml`, outside Nextcloud), not the six PHPUnit matrix cells CI runs. It isolates the ADR-084 damage; it is not a substitute for CI's verdict.
