### PR TITLE
test(e2e): disable Nextcloud's firstrunwizard — 84 of 90 click timeouts were its modal

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -175,13 +175,34 @@ jobs:
       # these specs need for the same reason the Newman leg does: shillinq
       # delegates all object CRUD to /apps/openregister/api/objects.
       #
-      # ⚠️ `enable-playwright` / `playwright-test-path` are NOT repeated here.
-      # They are set once above (with the reasoning for the config-path choice),
-      # and a merge on 2026-08-16 re-introduced them at this point. YAML forbids
-      # duplicate keys in one mapping, so GitHub could not parse this file: it
-      # created a run, marked it `failure`, and ran ZERO jobs — which on every
-      # dashboard is indistinguishable from the red this repo already had.
-      # Set each input exactly once, in the block above.
+      # ⚠️ SET EXACTLY ONCE — here, and nowhere else in this file.
+      #
+      # These two keys have now been lost twice in one day, in opposite
+      # directions, by changes that could not see each other:
+      #
+      #   1. #564 and #440 each ADDED them to this block independently. YAML
+      #      forbids duplicate keys, so GitHub could not parse the file at all:
+      #      it created a run, marked it `failure`, and ran ZERO jobs. Fixed by
+      #      #856, which removed the copy further up.
+      #   2. #853 had branched before that fix, hit the same duplicate, and
+      #      resolved it by removing THIS copy instead. Net result: zero
+      #      declarations, `enable-playwright` fell back to its `false` default,
+      #      and `E2E Tests (Playwright)` reported **skipped** on development.
+      #
+      # Case 2 is the more dangerous one. A workflow that will not parse is at
+      # least loudly red; a skipped job renders in the Quality Report exactly
+      # like a passing one, so the 53 specs silently stopped running again with
+      # nothing on any dashboard to say so.
+      #
+      # `playwright-test-path` does double duty in the shared workflow: it is
+      # both the spec directory AND the first place the run step looks for a
+      # config (`${playwright-test-path}/playwright.config.ts`, falling back to
+      # the repo root). We ship tests/e2e/playwright.config.ts precisely so that
+      # lookup hits it — the run step passes no `--project`, so the ROOT config
+      # would additionally run `visual` (pixel baselines a CI runner cannot
+      # byte-match) and `docs-capture` (screenshot re-shoots with their own job).
+      enable-playwright: true
+      playwright-test-path: tests/e2e
       # Runs after `php -S` is up and before the first spec, with cwd set to the
       # Nextcloud server ROOT (hence the `apps/shillinq/` prefix).
       #

--- a/tests/e2e/ci-seed.sh
+++ b/tests/e2e/ci-seed.sh
@@ -166,6 +166,43 @@ else
 	echo "[ci-seed] no ./occ in $(pwd) — skipping the pretty-URL config step."
 fi
 
+# ── 0b. Disable Nextcloud's own first-run wizard ─────────────────────────────
+# `firstrunwizard` is a STOCK Nextcloud app, enabled by default, and on a fresh
+# profile it renders a full-viewport opaque modal over the SPA:
+#
+#     <div role="dialog" aria-modal="true" id="firstrunwizard"
+#          class="first-run-wizard modal-mask modal-mask--opaque">
+#
+# It is the single largest cause of spec failure on a clean instance. Measured
+# 2026-08-16 against a container serving current `development`, seeded by this
+# script: of 90 `locator.click: Test timeout` failures, **84** logged
+# `#firstrunwizard … subtree intercepts pointer events`.
+#
+# ⚠️ The symptom does NOT look like an overlay. Playwright reports the target as
+# "visible, enabled and stable" and then retries the click until the test times
+# out — so it presents as a dozen unrelated flaky-click defects, not one cause.
+#
+# 33 spec files carry a `dismissWizard()` helper for exactly this, but a helper
+# that runs inside the test races the modal's own mount, and cannot help a spec
+# whose first action is a click. Removing the app removes the race.
+#
+# Test-environment setup, not a product change: nothing in shillinq depends on
+# `firstrunwizard`, and it is disabled only on the instance under test.
+#
+# Effect, nothing else changed between the runs:
+#
+#     three worst spec files   26 failed  ->  9 failed / 17 passed
+#     FULL chromium suite      200 passed / 71 failed / 3 skipped
+#                         ->   213 passed / 49 failed / 7 skipped
+#
+if [ -f "./occ" ]; then
+	if php ./occ app:disable firstrunwizard >/dev/null 2>&1; then
+		echo "[ci-seed] disabled Nextcloud's firstrunwizard (its modal intercepts pointer events)."
+	else
+		echo "[ci-seed] firstrunwizard not present or already disabled."
+	fi
+fi
+
 # ── 1. Import the Shillinq configuration ─────────────────────────────────────
 # Shillinq's `appinfo/routes.php` returns
 # `\OCA\OpenRegister\AppHost\Routes::standard()`, whose canonical table ships


### PR DESCRIPTION
The single largest cause of spec failure on a clean instance — and it isn't shillinq's code.

## What's happening

`firstrunwizard` is a **stock Nextcloud app**, enabled by default. On a fresh profile it renders a full-viewport opaque modal over the SPA:

```html
<div role="dialog" aria-modal="true" id="firstrunwizard"
     class="first-run-wizard modal-mask modal-mask--opaque">
```

Of the **90** `locator.click: Test timeout` failures in a full run, **84** logged `#firstrunwizard … subtree intercepts pointer events`.

⚠️ **The symptom does not look like an overlay.** Playwright reports the target as *"visible, enabled and stable"* and then retries the click until the test times out — so it reads as a dozen unrelated flaky-click defects rather than one cause. That is why it has survived this long.

33 spec files already carry a `dismissWizard()` helper for exactly this. But a helper that runs *inside* the test races the modal's own mount, and cannot help a spec whose first action is a click. Removing the app removes the race.

This is test-environment setup, not a product change: nothing in shillinq depends on `firstrunwizard`, and it is disabled only on the instance under test.

## Measured

Container serving current `development`, seeded by this same script, nothing else changed between runs:

| | passed | failed | skipped |
|---|---:|---:|---:|
| three worst spec files, wizard enabled | 0 | 26 | — |
| three worst spec files, wizard disabled | **17** | **9** | — |
| **full chromium suite, wizard enabled** | 200 | **71** | 3 |
| **full chromium suite, wizard disabled** | **213** | **49** | 7 |

Both full runs **completed** (274 tests, no `did not run`), so these are totals rather than the floor a truncated run reports.

## Why the earlier numbers on this repo were wrong

Every shillinq e2e figure I posted before today described a container mounting a worktree **101 commits behind `development`**, on which the API route `GET /bbv-dashboard` still shadowed the SPA page route of the same name and returned `412 CSRF check failed` on any deep link. I have retracted those on #564 and closed #618.

This measurement is from a **fresh container serving current `development`**, with both apps deployed at that ref and the register seeded by `ci-seed.sh`.

## What's left after this

49 failures remain, and they look like real work rather than environment:

- 5 are genuinely missing manifest routes, correctly caught: `/inventory/products`, `/inventory/product-attributes`, `/belastingen/vat-aangiften`, `/belastingen/vat-correcties`, `/belastingen/uitgestelde-belastingen/movements` — verified absent from all 590 declared page routes.
- the rest cluster in `bookings-resource-calendar`, `bank-statement-wizard`, `provincies-/waterschappen-bbv-variant`, `receipt-extraction-consume`.

I have not touched those — they need reading one at a time, not a sweep.
