### PR TITLE
fix(lint): burn the eslint error backlog down 165 → 59, by hand

### DIFF
--- a/src/components/BudgetBBVMapping/BudgetBBVMappingDetail.vue
+++ b/src/components/BudgetBBVMapping/BudgetBBVMappingDetail.vue
@@ -213,6 +213,7 @@ export default {
 		BBVProgrammePicker,
 		DeleteBudgetMappingDialog,
 	},
+
 	props: {
 		/**
 		 * Object id from the route (`:id`). Pass "new" or leave undefined
@@ -222,6 +223,7 @@ export default {
 			type: String,
 			default: 'new',
 		},
+
 		/**
 		 * Optional administration scope override. When omitted the page
 		 * derives it from the loaded record (edit) or the first GL
@@ -232,6 +234,7 @@ export default {
 			default: '',
 		},
 	},
+
 	data() {
 		return {
 			loading: false,
@@ -250,6 +253,7 @@ export default {
 				status: 'active',
 				administrationId: this.administrationId || '',
 			},
+
 			selectedAccount: null,
 			selectedProgramme: null,
 			allocationFeedback: { message: '', severity: 'info' },
@@ -257,13 +261,16 @@ export default {
 			existingAllocationTotal: 0,
 		}
 	},
+
 	computed: {
 		isCreate() {
 			return !this.id || this.id === 'new'
 		},
+
 		recordId() {
 			return this.isCreate ? '' : String(this.id)
 		},
+
 		pageTitle() {
 			if (this.isCreate) {
 				return this.t('shillinq', 'New Budget Mapping')
@@ -276,12 +283,14 @@ export default {
 			}
 			return this.t('shillinq', 'Budget Mapping')
 		},
+
 		pageDescription() {
 			return this.t(
 				'shillinq',
 				'Link a GL account to a BBV programme with an allocation share for the selected fiscal-year window.',
 			)
 		},
+
 		saveLabel() {
 			if (this.saving) {
 				return this.t('shillinq', 'Saving…')
@@ -290,6 +299,7 @@ export default {
 				? this.t('shillinq', 'Create')
 				: this.t('shillinq', 'Save')
 		},
+
 		canSave() {
 			if (this.saving) {
 				return false
@@ -315,6 +325,7 @@ export default {
 			}
 			return true
 		},
+
 		fiscalYearOfMapping() {
 			const from = this.form.effectiveFrom
 			if (typeof from === 'string' && from.length >= 4) {
@@ -325,6 +336,7 @@ export default {
 			}
 			return new Date().getFullYear()
 		},
+
 		glAccountSummary() {
 			const a = this.selectedAccount
 			if (!a) {
@@ -339,6 +351,7 @@ export default {
 			const parts = [name, type, balance].filter(Boolean)
 			return parts.join(' · ')
 		},
+
 		programmeSummary() {
 			const p = this.selectedProgramme
 			if (!p) {
@@ -348,6 +361,7 @@ export default {
 			return parts.join(' · ')
 		},
 	},
+
 	watch: {
 		id: {
 			immediate: true,
@@ -356,17 +370,20 @@ export default {
 			},
 		},
 	},
+
 	beforeUnmount() {
 		if (this.allocationCheckTimer) {
 			clearTimeout(this.allocationCheckTimer)
 		}
 	},
+
 	methods: {
 		t,
 		defaultEffectiveFrom() {
 			const year = new Date().getFullYear()
 			return `${year}-01-01`
 		},
+
 		async loadRecord() {
 			if (this.isCreate) {
 				this.record = null
@@ -399,6 +416,7 @@ export default {
 				this.loading = false
 			}
 		},
+
 		onGlAccountSelected(account) {
 			this.selectedAccount = account || null
 			if (account?.administrationId && !this.form.administrationId) {
@@ -406,12 +424,14 @@ export default {
 			}
 			this.scheduleAllocationCheck()
 		},
+
 		onProgrammeSelected(programme) {
 			this.selectedProgramme = programme || null
 			if (programme?.administrationId && !this.form.administrationId) {
 				this.form.administrationId = programme.administrationId
 			}
 		},
+
 		scheduleAllocationCheck() {
 			// The 0..100 RANGE check runs IMMEDIATELY; only the cross-mapping
 			// projection (which costs a network round-trip) is debounced. They
@@ -458,6 +478,7 @@ export default {
 			}
 			return true
 		},
+
 		async refreshAllocationProjection() {
 			const gl = this.form.glAccountNumber
 			const fiscalYear = this.fiscalYearOfMapping
@@ -532,6 +553,7 @@ export default {
 				this.allocationFeedback = { message: '', severity: 'info' }
 			}
 		},
+
 		overlapsFiscalYear(row, fiscalYear) {
 			const yearStart = `${fiscalYear}-01-01`
 			const yearEnd = `${fiscalYear}-12-31`
@@ -545,6 +567,7 @@ export default {
 			}
 			return true
 		},
+
 		buildPayload() {
 			const payload = {
 				glAccountNumber: this.form.glAccountNumber,
@@ -561,6 +584,7 @@ export default {
 			}
 			return payload
 		},
+
 		async onSave() {
 			if (!this.canSave) {
 				return
@@ -593,15 +617,18 @@ export default {
 				this.saving = false
 			}
 		},
+
 		openDeleteDialog() {
 			if (this.isCreate) {
 				return
 			}
 			this.deleteDialogOpen = true
 		},
+
 		closeDeleteDialog() {
 			this.deleteDialogOpen = false
 		},
+
 		async onDelete() {
 			if (this.isCreate || !this.recordId) {
 				this.deleteDialogOpen = false
@@ -625,9 +652,11 @@ export default {
 				this.deleting = false
 			}
 		},
+
 		onCancel() {
 			this.returnToIndex()
 		},
+
 		returnToIndex() {
 			if (this.$router) {
 				try {
@@ -639,6 +668,7 @@ export default {
 			}
 			this.$emit('navigate', { name: 'BudgetBBVMappings' })
 		},
+
 		formatEuro(cents) {
 			const numeric = Number(cents)
 			if (!Number.isFinite(numeric)) {

--- a/src/components/BudgetBBVMapping/BudgetBBVMappingDetail.vue
+++ b/src/components/BudgetBBVMapping/BudgetBBVMappingDetail.vue
@@ -43,15 +43,15 @@
 			:description="pageDescription"
 			:loading="loading"
 			:error="!!loadError"
-			:error-message="loadError"
+			:errorMessage="loadError"
 			icon="LinkVariant"
 			:object="record"
-			:max-width="'1100px'"
+			maxWidth="1100px"
 			:sidebar="true"
-			:sidebar-open="false"
-			object-type="bbv-budget-mapping"
-			:object-id="recordId || ''"
-			:sidebar-props="{ register: 'shillinq', schema: 'BudgetBBVMapping', title: t('shillinq', 'Mapping audit trail') }">
+			:sidebarOpen="false"
+			objectType="bbv-budget-mapping"
+			:objectId="recordId || ''"
+			:sidebarProps="{ register: 'shillinq', schema: 'BudgetBBVMapping', title: t('shillinq', 'Mapping audit trail') }">
 			<template #actions>
 				<button
 					type="button"
@@ -97,7 +97,7 @@
 					<div class="bbv-mapping-detail__row" data-testid="bbv-mapping-detail-gl">
 						<GlAccountPicker
 							v-model="form.glAccountNumber"
-							:administration-id="form.administrationId"
+							:administrationId="form.administrationId"
 							@selected="onGlAccountSelected" />
 						<p v-if="selectedAccount" class="bbv-mapping-detail__hint" data-testid="bbv-mapping-detail-gl-hint">
 							{{ glAccountSummary }}
@@ -108,8 +108,8 @@
 					<div class="bbv-mapping-detail__row" data-testid="bbv-mapping-detail-programme">
 						<BBVProgrammePicker
 							v-model="form.programmeCode"
-							:administration-id="form.administrationId"
-							:fiscal-year="fiscalYearOfMapping"
+							:administrationId="form.administrationId"
+							:fiscalYear="fiscalYearOfMapping"
 							@selected="onProgrammeSelected" />
 						<p v-if="selectedProgramme" class="bbv-mapping-detail__hint" data-testid="bbv-mapping-detail-programme-hint">
 							{{ programmeSummary }}
@@ -193,13 +193,12 @@
 <script>
 import { CnDetailPage } from '@conduction/nextcloud-vue'
 import axios from '@nextcloud/axios'
-import { generateUrl } from '@nextcloud/router'
-import { translate as t } from '@nextcloud/l10n'
 import { showError, showSuccess } from '@nextcloud/dialogs'
-
-import GlAccountPicker from './GlAccountPicker.vue'
-import BBVProgrammePicker from './BBVProgrammePicker.vue'
+import { translate as t } from '@nextcloud/l10n'
+import { generateUrl } from '@nextcloud/router'
 import DeleteBudgetMappingDialog from '../../modals/DeleteBudgetMappingDialog.vue'
+import BBVProgrammePicker from './BBVProgrammePicker.vue'
+import GlAccountPicker from './GlAccountPicker.vue'
 
 const REGISTER_SLUG = 'shillinq'
 const SCHEMA_SLUG = 'BudgetBBVMapping'

--- a/src/components/BudgetBBVMapping/BudgetBBVMappingIndex.vue
+++ b/src/components/BudgetBBVMapping/BudgetBBVMappingIndex.vue
@@ -37,24 +37,43 @@
 -->
 <template>
 	<div class="bbv-mapping-index" data-testid="bbv-mapping-index">
+		<!--
+			🔴 `:empty-title`, `:empty-action-label` and `@empty-action` below are
+			LEFT KEBAB-CASED ON PURPOSE — do not "fix" them to camelCase to clear
+			`vue/attribute-hyphenation` / `vue/v-on-event-hyphenation`.
+
+			None of the three is part of CnIndexPage's API: nc-vue 2.3.0 declares
+			`emptyText` (default the untranslated string `'No items found'`) and
+			its `emits` list has no `empty-action`. So all three are INERT — the
+			two attributes fall through onto the root DOM element and the listener
+			is never called. Renaming them to camelCase changes the rendered DOM
+			attribute names and leaves them exactly as inert, which is why the
+			rewrite was withheld rather than applied.
+
+			The real defect is a BEHAVIOUR one: this index shows CnIndexPage's
+			untranslated default empty text, and its empty-state action does
+			nothing. Fixing it means `:empty-text` plus an `#empty` slot (or an
+			nc-vue change), and it needs verifying through the UI — it is not a
+			lint fix and is deliberately out of this change's scope.
+		-->
 		<CnIndexPage
 			:title="t('shillinq', 'Budget Mapping')"
 			:description="t('shillinq', 'Allocations of GL accounts to BBV programmes (REQ-BBVW-002 / REQ-BBVW-004).')"
 			:objects="filteredObjects"
 			:loading="loading"
 			:pagination="pagination"
-			:include-columns="visibleColumns"
-			:column-overrides="columnOverrides"
+			:includeColumns="visibleColumns"
+			:columnOverrides="columnOverrides"
 			:empty-title="t('shillinq', 'No mappings recorded yet')"
 			:empty-action-label="t('shillinq', 'Add mapping')"
-			:add-label="t('shillinq', 'Add mapping')"
-			:row-key="rowKey"
+			:addLabel="t('shillinq', 'Add mapping')"
+			:rowKey="rowKey"
 			data-testid="bbv-mapping-index-page"
 			@add="onAdd"
 			@empty-action="onAdd"
 			@refresh="loadMappings"
-			@row-click="onRowClick"
-			@page-changed="onPageChange">
+			@rowClick="onRowClick"
+			@pageChanged="onPageChange">
 			<!--
 				`below-header`, NOT `header-actions`. CnIndexPage 2.2.0-vue3.2
 				declares below-header / mass-actions / action-items / actions /

--- a/src/components/BudgetBBVMapping/BudgetBBVMappingIndex.vue
+++ b/src/components/BudgetBBVMapping/BudgetBBVMappingIndex.vue
@@ -215,10 +215,12 @@ export default {
 	components: {
 		CnIndexPage,
 	},
+
 	setup() {
 		const store = useBudgetBBVMappingStore()
 		return { store }
 	},
+
 	data() {
 		return {
 			objects: [],
@@ -239,6 +241,7 @@ export default {
 				startDate: null,
 				endDate: null,
 			},
+
 			// Live-updates handle for the
 			// or-collection-{register-slug}-{schema-slug} subscription of
 			// the budgetBBVMapping collection (nc-vue beta.212,
@@ -253,6 +256,7 @@ export default {
 			liveUnwatch: null,
 		}
 	},
+
 	computed: {
 		/**
 		 * Columns rendered by CnIndexPage, in render order (REQ-BBVW-004).
@@ -269,6 +273,7 @@ export default {
 				'lifecycleState',
 			]
 		},
+
 		/**
 		 * Per-column labels + flags. Pass through to CnIndexPage so the
 		 * BBV-specific spec language ("Programme", "Allocation %") wins
@@ -286,6 +291,7 @@ export default {
 				lifecycleState: { label: this.t('shillinq', 'Status'), sortable: true },
 			}
 		},
+
 		/**
 		 * Fiscal-year option list — three years either side of "now" so the
 		 * dropdown stays bounded without a server round-trip.
@@ -300,6 +306,7 @@ export default {
 			}
 			return list
 		},
+
 		/**
 		 * Server-derived "FY YYYY" label so the index header always reflects
 		 * the active fiscal year inherited from the Administration context
@@ -313,6 +320,7 @@ export default {
 			}
 			return this.t('shillinq', 'FY {year}', { year: this.scope.fiscalYear })
 		},
+
 		/**
 		 * In-memory filter pipeline. Server-side scoping by administration
 		 * arrives in slice 09; until then the index reads the fiscal-year
@@ -375,17 +383,20 @@ export default {
 			})
 		},
 	},
+
 	async created() {
 		await this.loadScope()
 		await this.loadMappings()
 		this.syncLiveSubscription()
 	},
+
 	beforeUnmount() {
 		if (this.searchDebounce) {
 			clearTimeout(this.searchDebounce)
 		}
 		this.releaseLiveSubscription()
 	},
+
 	methods: {
 		/**
 		 * Subscribe to live updates for the budgetBBVMapping collection
@@ -434,6 +445,7 @@ export default {
 				console.warn('[BudgetBBVMappingIndex] live subscription failed:', e?.message ?? e)
 			}
 		},
+
 		/**
 		 * Release the live collection subscription and its cache watcher,
 		 * and invalidate any in-flight subscribe (its resolution
@@ -454,6 +466,7 @@ export default {
 			}
 			this.liveHandle = null
 		},
+
 		/**
 		 * Load the active administration + fiscal-year scope from the
 		 * slice-04 envelope so the page header surfaces "FY YYYY" and the
@@ -498,6 +511,7 @@ export default {
 				}
 			}
 		},
+
 		/**
 		 * Load BudgetBBVMapping objects from the OpenRegister API via the
 		 * slice-06 store. Errors surface as the inline `error` banner so the
@@ -531,6 +545,7 @@ export default {
 				this.loading = false
 			}
 		},
+
 		/**
 		 * Debounce the search term so type-into-the-search-box does not
 		 * trigger a re-filter on every keystroke.
@@ -544,6 +559,7 @@ export default {
 				this.searchDebounce = null
 			}, SEARCH_DEBOUNCE_MS)
 		},
+
 		/**
 		 * Navigate to the detail view in create mode (id=new). Slice 07
 		 * builds the bespoke detail Vue; until then the manifest detail
@@ -555,6 +571,7 @@ export default {
 				params: { id: 'new' },
 			})
 		},
+
 		/**
 		 * Navigate to a mapping's detail view.
 		 *
@@ -569,6 +586,7 @@ export default {
 				params: { id: String(row.id) },
 			})
 		},
+
 		/**
 		 * Pagination change handler — re-fetch via the store. The OR
 		 * endpoint paginates; CnIndexPage emits 1-based page numbers.
@@ -597,6 +615,7 @@ export default {
 				this.loading = false
 			}
 		},
+
 		/**
 		 * Parse the allocation-bucket select value into a {min,max} range.
 		 *
@@ -618,6 +637,7 @@ export default {
 			}
 			return { min, max }
 		},
+
 		/**
 		 * Lifecycle-status palette key.
 		 *
@@ -631,6 +651,7 @@ export default {
 			}
 			return value.replace(/[^a-z0-9_-]/g, '-')
 		},
+
 		/**
 		 * Localised lifecycle-status label. Falls back to the raw value
 		 * when the state is not in the known palette (e.g. a future state
@@ -649,6 +670,7 @@ export default {
 			}
 			return labels[value] || row.lifecycleState || '—'
 		},
+
 		/**
 		 * Format an allocation percentage as "n %".
 		 *
@@ -665,6 +687,7 @@ export default {
 			}
 			return `${num} %`
 		},
+
 		/**
 		 * Format an ISO-8601 date for display. Empty / null values render
 		 * as an en-dash so the column reads cleanly.

--- a/src/components/Dashboard/BBVComplianceDashboard.vue
+++ b/src/components/Dashboard/BBVComplianceDashboard.vue
@@ -120,6 +120,7 @@ export default {
 		BBVTrendChart,
 		BBVProgrammeTable,
 	},
+
 	data() {
 		return {
 			programmes: [],
@@ -137,6 +138,7 @@ export default {
 			},
 		}
 	},
+
 	computed: {
 		widgets() {
 			return [
@@ -146,6 +148,7 @@ export default {
 				{ id: 'bbv-table', title: this.t('shillinq', 'Programme utilization'), type: 'custom' },
 			]
 		},
+
 		layout() {
 			return [
 				{ id: 'layout-kpis', widgetId: 'bbv-kpis', gridX: 0, gridY: 0, gridWidth: 12, gridHeight: 2, showTitle: false },
@@ -154,12 +157,14 @@ export default {
 				{ id: 'layout-table', widgetId: 'bbv-table', gridX: 0, gridY: 6, gridWidth: 12, gridHeight: 5 },
 			]
 		},
+
 		fyLabel() {
 			if (!this.scope.fiscalYear) {
 				return ''
 			}
 			return this.t('shillinq', 'FY {year}', { year: this.scope.fiscalYear })
 		},
+
 		scopeDescription() {
 			if (!this.scope.fiscalYear) {
 				return this.t('shillinq', 'Fiscal-year overview of programme utilization and compliance status.')
@@ -171,10 +176,12 @@ export default {
 			)
 		},
 	},
+
 	async created() {
 		await this.loadAdministrationContext()
 		await this.loadProgrammes()
 	},
+
 	methods: {
 		t,
 		async loadAdministrationContext() {
@@ -193,12 +200,14 @@ export default {
 				this.error = this.t('shillinq', 'Failed to load administration context')
 			}
 		},
+
 		async onAdministrationChange() {
 			// Server-side scope is derived from the session, but explicitly
 			// passing administrationId lets a multi-admin user pivot the
 			// view without a session-switch round-trip (REQ-BBVW-006).
 			await this.loadProgrammes()
 		},
+
 		/**
 		 * Load the BBV compliance envelope (widgets, programmes, mappings,
 		 * counts, summary) for the active administration and render the
@@ -248,6 +257,7 @@ export default {
 				this.loading = false
 			}
 		},
+
 		onProgrammeClick(row) {
 			// The table component handles router.push itself; this hook is
 			// kept so embedders (e.g. tests, parent shells) can intercept

--- a/src/components/Dashboard/BBVComplianceDashboard.vue
+++ b/src/components/Dashboard/BBVComplianceDashboard.vue
@@ -42,9 +42,9 @@
 			:widgets="widgets"
 			:layout="layout"
 			:loading="loading"
-			:cell-height="80"
-			:grid-margin="16"
-			:empty-label="t('shillinq', 'No widgets configured.')">
+			:cellHeight="80"
+			:gridMargin="16"
+			:emptyLabel="t('shillinq', 'No widgets configured.')">
 			<template #header-actions>
 				<span
 					v-if="scope.fiscalYear"
@@ -91,7 +91,7 @@
 				<BBVProgrammeTable
 					:programmes="programmes"
 					:loading="loading"
-					@row-click="onProgrammeClick" />
+					@rowClick="onProgrammeClick" />
 			</template>
 		</CnDashboardPage>
 
@@ -103,14 +103,13 @@
 
 <script>
 import { CnDashboardPage } from '@conduction/nextcloud-vue'
-import { generateUrl } from '@nextcloud/router'
-import { translate as t } from '@nextcloud/l10n'
 import axios from '@nextcloud/axios'
-
-import BBVKPICards from './BBVKPICards.vue'
+import { translate as t } from '@nextcloud/l10n'
+import { generateUrl } from '@nextcloud/router'
 import BBVComplianceChart from './BBVComplianceChart.vue'
-import BBVTrendChart from './BBVTrendChart.vue'
+import BBVKPICards from './BBVKPICards.vue'
 import BBVProgrammeTable from './BBVProgrammeTable.vue'
+import BBVTrendChart from './BBVTrendChart.vue'
 
 export default {
 	name: 'BBVComplianceDashboard',

--- a/src/views/bookings/BookingForm.vue
+++ b/src/views/bookings/BookingForm.vue
@@ -105,8 +105,8 @@
 </template>
 
 <script>
-import { NcButton } from '@nextcloud/vue'
 import { generateUrl } from '@nextcloud/router'
+import { NcButton } from '@nextcloud/vue'
 import BookingConflictDialog from '../../modals/BookingConflictDialog.vue'
 
 const MIN_DURATION_MS = 15 * 60 * 1000

--- a/src/views/bookings/BookingForm.vue
+++ b/src/views/bookings/BookingForm.vue
@@ -127,6 +127,7 @@ export default {
 			type: String,
 			required: true,
 		},
+
 		/**
 		 * `datetime-local` value to pre-fill the start field with — the host
 		 * passes the clicked slot's window so the operator does not retype it.
@@ -135,6 +136,7 @@ export default {
 			type: String,
 			default: '',
 		},
+
 		/**
 		 * `datetime-local` value to pre-fill the end field with.
 		 */
@@ -155,6 +157,7 @@ export default {
 				attendee: '',
 				status: 'pending',
 			},
+
 			validationError: '',
 			submitting: false,
 			showConflictDialog: false,

--- a/src/views/bookings/CalendarPage.vue
+++ b/src/views/bookings/CalendarPage.vue
@@ -32,7 +32,7 @@
 		<CalendarView
 			ref="grid"
 			:key="gridKey"
-			:calendar-id="calendarId"
+			:calendarId="calendarId"
 			@booking:selected="onBookingSelected"
 			@slot:clicked="onSlotClicked" />
 
@@ -41,9 +41,9 @@
 			class="bookings-calendar-page__form"
 			data-testid="booking-form-panel">
 			<BookingForm
-				:calendar-id="calendarId"
-				:initial-start="formStart"
-				:initial-end="formEnd"
+				:calendarId="calendarId"
+				:initialStart="formStart"
+				:initialEnd="formEnd"
 				@booking:created="onBookingCreated"
 				@cancel="formOpen = false" />
 		</aside>
@@ -51,8 +51,8 @@
 </template>
 
 <script>
-import CalendarView from './CalendarView.vue'
 import BookingForm from './BookingForm.vue'
+import CalendarView from './CalendarView.vue'
 
 export default {
 	name: 'CalendarPage',

--- a/src/views/bookings/CalendarView.vue
+++ b/src/views/bookings/CalendarView.vue
@@ -122,6 +122,7 @@ export default {
 			type: String,
 			required: true,
 		},
+
 		/**
 		 * Initial view mode.
 		 */
@@ -130,6 +131,7 @@ export default {
 			default: 'month',
 			validator: (v) => ['month', 'week', 'day'].includes(v),
 		},
+
 		/**
 		 * Initial date (ISO-8601) to display; defaults to today.
 		 */
@@ -137,6 +139,7 @@ export default {
 			type: String,
 			default: '',
 		},
+
 		/**
 		 * Optional pre-loaded bookings (used by tests / parent-driven data).
 		 * When empty the component fetches from the API on mount.
@@ -225,6 +228,7 @@ export default {
 		view(v) {
 			this.currentView = v
 		},
+
 		initialBookings(v) {
 			this.bookings = [...v]
 		},


### PR DESCRIPTION
## What this is

shillinq's `lint-check` and `quality / Vue Quality (eslint)` are both permanently
red on the same findings, so neither protects anything. This burns **165 → 59**
errors, entirely by hand except for one class that is *proven* whitespace-only.

**⚠️ This does NOT turn the job green**, and it deliberately does not. The
remaining 59 are one file plus three bindings that must not be rewritten, both
explained below. Everything left is a decision, not work.

## Before / after — the jobs' own command

Node 24 / npm 11 (matching `pull-request-lint-check.yaml`), `npm ci` from the
committed lock, at `origin/development` `c8cb6e9b`:

| | problems | **errors** | warnings | files linted | exit |
|---|---:|---:|---:|---:|---:|
| before | 263 | **165** | 98 | 201 | 1 |
| after  | 157 | **59** | 98 | 201 | 1 |

🔑 **eslint exits non-zero on ERRORS only.** The "263 problems" figure overstates
the blocking backlog: the 98 warnings never failed anything, and they are
untouched here.

| rule | before | after | how |
|---|---:|---:|---|
| `vue/new-line-between-multi-line-property` | 70 | **0** | fixer, per file, proven whitespace-only |
| `perfectionist/sort-imports` | 68 | **56** | 12 by hand; **56 withheld** (`src/registry.js`) |
| `vue/attribute-hyphenation` | 22 | **2** | 20 by hand after prop verification; **2 withheld** |
| `vue/v-on-event-hyphenation` | 4 | **1** | 3 by hand; **1 withheld** |
| `vue/no-useless-v-bind` | 1 | **0** | by hand |

## `vue/attribute-hyphenation` is not cosmetic, and was not treated as such

The rule is configured `never`, i.e. **kebab → camelCase**. Compiled with the
project's own `@vue/compiler-dom`, `:row-key="k"` and `:rowKey="k"` produce
**different** render code (`{"row-key": k}` vs `{rowKey: k}`). They are
equivalent only because Vue normalises **declared** props at runtime — for an
**undeclared** attribute the value falls through to the DOM, where the two
spellings are two different attributes.

So every one of the 22 was checked against the target component's declared
`props` before being touched:

| component | props | verdict |
|---|---|---|
| `CnDetailPage` | errorMessage, maxWidth, sidebarOpen, objectType, objectId, sidebarProps | all DECLARED |
| `CnDashboardPage` | cellHeight, gridMargin, emptyLabel | all DECLARED |
| `CnIndexPage` | includeColumns, columnOverrides, addLabel, rowKey | all DECLARED |
| **`CnIndexPage`** | **emptyTitle, emptyActionLabel** | **🔴 NOT DECLARED** |
| local components | administrationId, fiscalYear, calendarId, initialStart, initialEnd | all DECLARED |

The checker carries a negative control (a made-up prop name reports NOT
DECLARED against a component with 92 real props).

`vue/v-on-event-hyphenation` was proven safe at the compiler level rather than
argued: `@row-click`/`@rowClick`, `@page-changed`/`@pageChanged` and
`@empty-action`/`@emptyAction` each compile **byte-identically**, and the
comparator can say no (`:row-key` vs `:row-keyX` compares DIFFERENT).

`vue/no-useless-v-bind`: `:max-width="'1100px'"` → `maxWidth="1100px"`, safe
because `CnDetailPage` declares `maxWidth: { type: String, default: '1200px' }`.
Called out explicitly because this fleet already gained a gate-35 finding from
an autofix rewriting `:alt="''"` (bound, unjudged) into `alt=""` (judged).

## 🔴 A real defect this surfaced — not a lint issue

`emptyTitle` / `emptyActionLabel` are **not part of CnIndexPage's API**. nc-vue
2.3.0 declares **`emptyText`**, defaulting to the untranslated literal
`'No items found'`, and its `emits` list contains no `empty-action`.

So on `BudgetBBVMappingIndex.vue`, all three of `:empty-title`,
`:empty-action-label` and `@empty-action` are **inert**: the two attributes fall
through onto the root DOM element and the listener is never called. **The BBV
Budget Mapping index shows the wrong, untranslated empty state, and its
empty-state action does nothing.**

Renaming them to camelCase would change the rendered DOM attribute names and
leave them *exactly as inert*. **All three are withheld**, with the reason
written into the template above the component so nobody "fixes" them, and the
rules stay on and still report them. The real fix (`:empty-text` plus an
`#empty` slot, or an nc-vue change) is a behaviour change needing a UI check.

## 🔴 `src/registry.js` — 56 errors withheld, and why

It is the ADR-036 5-kind component registry, and its own header says an entry
"requires an explicit justification in the design doc of the change that
introduces it". In practice **the multi-paragraph comments in this file are that
justification record.**

The fixer was trialled on it and the result read in full. It **orphans comments
from the imports they describe**:

- the `invoice-from-time-and-expense` comment says "drafting form + admin list +
  detail page" and originally covered three imports; after sorting only
  `InvoiceGenerator` follows it and the other two move elsewhere;
- `GoodsReceiptNoteDetail` is hoisted *above* the comment explaining it, leaving
  that comment attached to `GoodsReceiptNoteForm` alone;
- the file-header `inventory-mobile-scanner exception` paragraph ends up
  introducing an unrelated `AREInvoiceActions` import.

That is a change to a compliance record, not a layout change. Sorting it
honestly means rewriting ~6 grouped justifications into per-import ones —
authoring new ADR-036 documentation — which is **a decision above a lint slot**.

The **CSS-order** objection, by contrast, was measured away rather than
asserted: all **48** imported SFCs use `<style scoped>`, **0** have a global
style block and **0** use `:deep()`/`::v-deep`, so no two of them can interact
through the cascade.

**Remaining options, for whoever owns this:** (a) restructure the file so each
import carries its own comment, then sort; (b) a documented file-scoped
`perfectionist/sort-imports` exemption — the eslint config's own header names
"file-scoped exemptions" as a sanctioned app-specific block. Not chosen here.

## The fixer overreached three times, and the invariant caught all three

`vue/new-line-between-multi-line-property` is 70 hunks of "+1 blank line", so it
was run per file (never across the repo) with a machine-checkable invariant:

```
git diff --ignore-blank-lines --ignore-all-space   ->   EMPTY   (all five files)
git diff --numstat  ->  30/23/10/3/4 insertions, ZERO deletions
```

It was **not** empty three times, and each would have shipped silently:

1. It rewrote the three `empty-*` bindings I had deliberately withheld, overriding
   a judgement documented in the template directly above them.
2. `@nextcloud/l10n-enforce-ellipsis` rewrote
   `t('shillinq', 'Search account or programme...')` to use `…`. That string is a
   **live msgid translated in every locale file under `l10n/`** — the rewrite
   orphans all of them and drops the UI back to English in every language.
   🔑 **That violation is already in `eslint-suppressions.json` (count 1).** So
   `--fix` fixes *suppressed* violations too: a suppression parks a finding, it
   does not protect the code from the autofixer.
3. On `CalendarView.vue` it emitted broken indentation, putting
   `v-for="day in monthDays"` at column 0. Reverted; those 4 blank lines are
   hand-written.

## Verification

- 201 files linted on both sides; warnings **98 → 98** (unchanged).
- `prettier --check "src/**"` reports **7 files before and 7 after** —
  `Frontend Check (format)` is inherited-red and is not made worse.
- Full vitest suite green on the branch: **16 files, 177 tests**.
- No rule disabled, downgraded, excluded, or added to a suppressions file.
- No PHP, no workflow, no config touched — this cannot affect PHPUnit, PHP
  Quality, Hydra Gates, Newman or E2E.
