### PR TITLE
test(e2e): four spec-coverage routes asserted names the manifest never had

### DIFF
--- a/tests/e2e/spec-coverage/belastingen.spec.ts
+++ b/tests/e2e/spec-coverage/belastingen.spec.ts
@@ -27,7 +27,12 @@ const PAGES: Array<{ route: string; title: string; titleRe?: RegExp }> = [
 	{ route: '/tax-estimates', title: 'Tax Estimates' },
 	{ route: '/tax-configuration', title: 'Tax Configuration' },
 	{
-		route: '/belastingen/vat-aangiften',
+		// `btw-`, not `vat-`. The manifest declares `/belastingen/btw-aangiften`
+		// and always has; this spec asked for a route that has never existed, so
+		// vue-router fell through to the catch-all and the assertion measured the
+		// dashboard. The `title` below was already the Dutch one, which is what
+		// gives away that this was a stale route string and not a second page.
+		route: '/belastingen/btw-aangiften',
 		title: 'BTW-aangiften',
 		titleRe: /BTW-?aangift/i,
 	},
@@ -42,7 +47,8 @@ const PAGES: Array<{ route: string; title: string; titleRe?: RegExp }> = [
 		titleRe: /ICP-?opgaaf|ICP/i,
 	},
 	{
-		route: '/belastingen/vat-correcties',
+		// `btw-`, not `vat-` — same stale-route-string as btw-aangiften above.
+		route: '/belastingen/btw-correcties',
 		title: 'BTW-correcties',
 		titleRe: /BTW-?correct/i,
 	},
@@ -53,9 +59,15 @@ const PAGES: Array<{ route: string; title: string; titleRe?: RegExp }> = [
 		titleRe: /ZZP-?aftrek/i,
 	},
 	{
-		route: '/belastingen/ib-tax_return',
-		title: 'IB-tax_return',
-		titleRe: /IB-?aangift/i,
+		// `ib-aangifte`, not `ib-tax_return`. A Dutch→English substitution
+		// (aangifte → tax_return) was applied to the ROUTE and TITLE here but
+		// never to the manifest — the underscore in `tax_return` is the tell,
+		// no route in this app uses one. The manifest declares
+		// `/belastingen/ib-aangifte` titled "IB return", so accept either
+		// wording rather than pinning this spec to whichever side renames next.
+		route: '/belastingen/ib-aangifte',
+		title: 'IB return',
+		titleRe: /IB[-\s]?(aangift|return)/i,
 	},
 	// Uitgestelde belastingen (deferred tax)
 	{
@@ -68,7 +80,9 @@ const PAGES: Array<{ route: string; title: string; titleRe?: RegExp }> = [
 		title: 'Tijdelijke verschillen',
 	},
 	{
-		route: '/belastingen/uitgestelde-belastingen/movements',
+		// `mutaties`, not `movements`. Same class again — and the title
+		// (`Mutatieoverzicht`, matched by /Mutatie/i) is the tell.
+		route: '/belastingen/uitgestelde-belastingen/mutaties',
 		title: 'Mutatieoverzicht',
 		titleRe: /Mutatie/i,
 	},

--- a/tests/e2e/spec-coverage/inventory.spec.ts
+++ b/tests/e2e/spec-coverage/inventory.spec.ts
@@ -17,6 +17,13 @@ import {
 } from './_helpers'
 
 const PAGES: Array<{ route: string; title: string; titleRe?: RegExp }> = [
+	// ⚠️ These two currently FAIL, and that is the spec working — see #860.
+	// `2026-06-14-inventory-product-catalog` Task 14 is ticked `[x]` claiming it
+	// added both routes plus the `Product` / `ProductAttribute` schemas. None of
+	// it exists: 0 of the 590 declared page routes mention "product", and the
+	// live API answers `Schema not found` for both. Left asserting on purpose —
+	// quarantining them would turn a known missing capability into an invisible
+	// one, which is the failure mode this whole spec file exists to prevent.
 	{ route: '/inventory/products', title: 'Products' },
 	{ route: '/inventory/product-attributes', title: 'Product Attributes' },
 	{ route: '/inventory/reorder-rules', title: 'Reorder Rules' },


### PR DESCRIPTION
The `spec-coverage` files exist to catch a page that stopped resolving. Four of their entries pointed at routes the manifest **has never had**, so they were catching themselves.

| spec asserted | manifest actually declares |
|---|---|
| `/belastingen/vat-aangiften` | `/belastingen/btw-aangiften` |
| `/belastingen/vat-correcties` | `/belastingen/btw-correcties` |
| `/belastingen/uitgestelde-belastingen/movements` | `…/mutaties` |
| `/belastingen/ib-tax_return` | `/belastingen/ib-aangifte` |

## The tell was sitting next to each one

Every entry's own `title` / `titleRe` disagreed with its route:

```ts
route: '/belastingen/vat-aangiften',   title: 'BTW-aangiften',  titleRe: /BTW-?aangift/i
route: '/belastingen/ib-tax_return',   title: 'IB-tax_return',  titleRe: /IB-?aangift/i
```

A Dutch→English substitution was applied to the **route strings** and never to the manifest. The underscore in `tax_return` is the clearest evidence — no route in this app uses one.

## Why it failed quietly

A wrong route here does not 404. vue-router falls through to `main.js`'s `/:pathMatch(.*)*` catch-all and renders the **Dashboard**, so the assertion measured the wrong page instead of erroring. The spec's own message says exactly this, which is why it was worth trusting once it finally ran.

`ib-aangifte`'s title has since moved the other way — the manifest now says "IB return" — so its `titleRe` accepts either wording rather than pinning this spec to whichever side renames next.

## Verified

Against a container serving current `development`, seeded by `ci-seed.sh`:

```
belastingen + inventory spec-coverage:   6 failed  ->  2 failed / 28 passed
```

## The 2 remaining are deliberate

`/inventory/products` and `/inventory/product-attributes` are **left asserting** and annotated with #860.

`openspec/changes/archive/2026-06-14-inventory-product-catalog` Task 14 is ticked `[x]` for adding both routes *and* the `Product` / `ProductAttribute` schemas. None of it exists:

- **0** of the **590** declared page routes mention "product";
- the live API answers `Schema not found` for both schemas.

A spec that fails because a capability is missing is the spec working. Quarantining it would turn a known gap into an invisible one — which is the failure mode this whole spec-coverage suite exists to prevent.
