### PR TITLE
refactor(ui): NcActions type → variant — shillinq's last deprecated-library-props site

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,9 +1,4 @@
 {
-  "src/components/AdministratieSwitcher.vue": {
-    "@nextcloud/no-deprecated-library-props": {
-      "count": 1
-    }
-  },
   "src/components/BudgetBBVMapping/BudgetBBVMappingDetail.vue": {
     "@typescript-eslint/no-unused-vars": {
       "count": 2

--- a/src/components/AdministratieSwitcher.vue
+++ b/src/components/AdministratieSwitcher.vue
@@ -33,7 +33,7 @@
 			:title="t('shillinq', 'Switch administration')"
 			:disabled="loading"
 			:forceName="true"
-			type="tertiary"
+			variant="tertiary"
 			:aria-label="t('shillinq', 'Switch administration')">
 			<template #icon>
 				<OfficeBuilding :size="20" />


### PR DESCRIPTION
Clears shillinq's **last** `@nextcloud/no-deprecated-library-props` suppression (ConductionNL/.github#455).

## This one really is the straight rename

Unlike the two before it, both of which turned out to be live bugs:

| app | deprecation | shape |
|---|---|---|
| openconnector#1267 | `closeOnSelect` → `keepOpen` | **inverted** — multi-select closed on every pick |
| openbuild#223 | `canClose` → `noClose` | **inverted** — 4 dialogs dismissible mid-work |
| **this PR** | `type` → `variant` on `NcActions` | **straight rename**, value unchanged (`tertiary`) |

`NcActions` in `@nextcloud/vue` 9 declares `variant`; there is no polarity to get wrong here.

## The hazard #455 flags, checked first

#455 warns this rule's fix changes rendered DOM, and that **openbuild lost 10 tests** to `button[data-nc-button-type="primary"]` assertions. So I checked before editing:

```
grep -rn "data-nc-button-type\|AdministratieSwitcher" tests/   →  no matches
```

Nothing asserts on the rendered attribute or on this component, so there is no assertion to update.

## Verified

- Suppressions **1 → 0**, and `--prune-suppressions` removed the entry. The `eslint-suppressions.json` diff is **exactly those 5 lines** and nothing else.
- eslint on `src`: **165 errors / 98 warnings both before and after** — measured by stashing the change, not assumed. Those 165 are the repo's pre-existing Vue lint debt (`vue/attribute-hyphenation` and friends), unrelated to this and already red on `development`.
- vitest: **16 files, 177 tests passed**.
