### PR TITLE
fix(e2e): de-race all 17 remaining test.skip() gates on the non-waiting isVisible()

### DIFF
--- a/tests/e2e/AccountantPortalDashboard.spec.js
+++ b/tests/e2e/AccountantPortalDashboard.spec.js
@@ -30,6 +30,7 @@
  */
 
 import { test, expect } from '@playwright/test'
+import { becomesVisible } from './becomes-visible.js'
 
 const APP = '/apps/shillinq'
 const ROUTE = '/accountant-portal'
@@ -55,11 +56,11 @@ test.describe('accountant-portal — scoped multi-client dashboard (REQ-ACP-001/
 		await dismissWizard(page)
 
 		const heading = page.getByRole('heading', { name: 'Accountant portal' })
-		const deployed = await heading.isVisible().catch(() => false)
+		const deployed = await becomesVisible(heading)
 		test.skip(!deployed, 'accountant-portal page not deployed on this build')
 
 		const card = page.getByTestId('accountant-client-card').first()
-		const hasCard = await card.isVisible().catch(() => false)
+		const hasCard = await becomesVisible(card)
 		if (!hasCard) {
 			// A user with no AdministrationMembership sees the empty state, not an error.
 			await expect(page.getByText('No client administrations')).toBeVisible()
@@ -78,7 +79,7 @@ test.describe('accountant-portal — scoped multi-client dashboard (REQ-ACP-001/
 		await dismissWizard(page)
 
 		const button = page.getByTestId('accountant-handover-pack-button').first()
-		const hasButton = await button.isVisible().catch(() => false)
+		const hasButton = await becomesVisible(button)
 		test.skip(
 			!hasButton,
 			'no client administration available to test the handover-pack action against',

--- a/tests/e2e/DeadlineCalendarSettings.spec.js
+++ b/tests/e2e/DeadlineCalendarSettings.spec.js
@@ -31,6 +31,7 @@
  */
 
 import { test, expect } from '@playwright/test'
+import { becomesVisible } from './becomes-visible.js'
 
 const APP = '/apps/shillinq'
 const ROUTE = '/settings/deadline-calendar'
@@ -56,7 +57,7 @@ test.describe('compliance-deadline-calendar — per-user category toggles (REQ-C
 		await dismissWizard(page)
 
 		const filing = page.getByTestId('deadline-category-filing')
-		const deployed = await filing.isVisible().catch(() => false)
+		const deployed = await becomesVisible(filing)
 		test.skip(
 			!deployed,
 			'deadline-calendar settings page not deployed on this build',
@@ -80,7 +81,7 @@ test.describe('compliance-deadline-calendar — per-user category toggles (REQ-C
 		await dismissWizard(page)
 
 		const toggle = page.getByTestId('deadline-toggle-payment-run')
-		const deployed = await toggle.isVisible().catch(() => false)
+		const deployed = await becomesVisible(toggle)
 		test.skip(
 			!deployed,
 			'deadline-calendar settings page not deployed on this build',

--- a/tests/e2e/bank-statement-wizard.spec.ts
+++ b/tests/e2e/bank-statement-wizard.spec.ts
@@ -27,6 +27,7 @@
  */
 
 import { test, expect, type Page } from '@playwright/test'
+import { becomesVisible } from './becomes-visible.js'
 
 const APP = '/apps/shillinq'
 const ROUTE_BANK_IMPORT = '/configuratie/bank-import'
@@ -75,10 +76,18 @@ async function openWizard(page: Page): Promise<boolean> {
 	// that no longer exists anywhere in the app. The wizard now lives on the
 	// Configuratie page that hosts it (src/registry.js: BankImportPage,
 	// src/manifest.d/bank-import-settings.json).
+	//
+	// ⚠️ THE SELECTOR WAS REPAIRED; THE RACE WAS NOT. `isVisible()` does not
+	// wait — its `timeout` option is ignored — so this probe still asked "is
+	// the launcher here on this tick", one tick after a `goto`. It happens to
+	// answer yes on the current runner, which is why all eleven tests pass
+	// today; a slower runner silently returns all eleven to the same false
+	// "not available for this administration" skip, with no code change and no
+	// signal. `becomesVisible` polls, so the answer stops depending on timing.
 	await page.goto(`${APP}${ROUTE_BANK_IMPORT}`)
 	await dismissWizard(page)
 	const importBank = page.locator('[data-testid="bank-import-launch"]')
-	if (!(await importBank.isVisible().catch(() => false))) {
+	if (!(await becomesVisible(importBank))) {
 		return false
 	}
 	await importBank.click()

--- a/tests/e2e/becomes-visible.js
+++ b/tests/e2e/becomes-visible.js
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * A POLLING visibility probe, for use as a `test.skip()` condition.
+ *
+ * ⚠️ WHY THIS FILE EXISTS — `locator.isVisible()` DOES NOT WAIT.
+ * ------------------------------------------------------------------
+ * `Locator.isVisible()` is an *immediate* predicate: it answers "is this
+ * element visible on this tick". Its `timeout` option is **ignored** — passing
+ * `{ timeout: 10_000 }` buys nothing at all, which is why Playwright
+ * deprecated the option. Only `expect(...).toBeVisible()` and
+ * `locator.waitFor()` poll.
+ *
+ * So this shape asks the question before the SPA has issued a single XHR:
+ *
+ *     await page.goto(url)
+ *     const has = await thing.isVisible().catch(() => false)
+ *     test.skip(!has, 'not present in this fixture')
+ *
+ * It answers "no" essentially always, and the test skips **with a reason that
+ * is false**. This app has already paid for it twice:
+ *
+ *   - `receipt-extraction-consume.spec.ts` skipped three tests with *"Import
+ *     bill action not visible in this fixture"* while `import-bill` was a
+ *     declared, working `type:"open-modal"` header action (fixed in #867);
+ *   - `bank-statement-wizard.spec.ts` reported all ELEVEN of its tests as
+ *     *"Import bank action not available for this administration"*, blaming the
+ *     instance for a selector that had simply moved.
+ *
+ * 🔑 A SKIP WHOSE STATED REASON IS UNTRUE IS AN INVISIBLE PASS — worse than a
+ * stub assertion, because it renders as "not applicable" rather than as a gap,
+ * the reason looks investigated, and it inflates the skip count, which is the
+ * number that separates a flake from a regression.
+ *
+ * `waitFor` polls. **The skip that survives it is a real one.**
+ *
+ * The `test.skip()` calls are deliberately KEPT: the fix is not to unskip, it
+ * is to make the gate tell the truth.
+ *
+ * ℹ️ Written as `.js` with JSDoc types on purpose — this suite has both `.js`
+ * and `.ts` specs, and both import it.
+ */
+
+/**
+ * Wait up to `timeout` for a locator to become visible; return whether it did.
+ *
+ * @param {import('@playwright/test').Locator} locator The locator to poll.
+ *        `.first()` is applied so a strict-mode violation on a multi-match
+ *        selector cannot masquerade as an absence.
+ * @param {number} [timeout] Milliseconds to poll for. Default 10s — enough for
+ *        a Nextcloud SPA route to mount and fetch.
+ * @return {Promise<boolean>} `true` when the element became visible within
+ *         `timeout`, else `false`. Never throws.
+ */
+export async function becomesVisible(locator, timeout = 10_000) {
+	return await locator
+		.first()
+		.waitFor({ state: 'visible', timeout })
+		.then(() => true)
+		.catch(() => false)
+}

--- a/tests/e2e/budget-line-commitments.spec.ts
+++ b/tests/e2e/budget-line-commitments.spec.ts
@@ -32,6 +32,7 @@
  */
 
 import { test, expect, type Page } from '@playwright/test'
+import { becomesVisible } from './becomes-visible.js'
 
 const APP = '/apps/shillinq'
 const ROUTE = '/verplichtingen/budget-lines'
@@ -57,7 +58,7 @@ test.describe('verplichtingen-commitment-accounting — budget-line committed-vs
 		await dismissWizard(page)
 
 		const row = page.getByTestId('budget-line-row').first()
-		const opened = await row.isVisible().catch(() => false)
+		const opened = await becomesVisible(row)
 		test.skip(!opened, 'no Verplichtingsregel seeded in this administration')
 
 		// The four BBV columns are text-labelled, not colour-coded only
@@ -81,8 +82,15 @@ test.describe('verplichtingen-commitment-accounting — budget-line committed-vs
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
 
+		// ⚠️ INVERTED GATE — this one skips when rows ARE present, so the
+		// non-waiting probe failed in the direction that RUNS the test. On a
+		// seeded administration it therefore asserted "No budget lines" against
+		// a table that was merely still loading, and failed with a confusing
+		// message instead of skipping honestly. Polling makes the skip correct.
+		// 5s rather than the 10s default: the no-rows case is the common one and
+		// this wait is paid in full every time it holds.
 		const row = page.getByTestId('budget-line-row').first()
-		const hasRows = await row.isVisible().catch(() => false)
+		const hasRows = await becomesVisible(row, 5_000)
 		test.skip(
 			hasRows,
 			'administration has seeded budget lines — empty-state assertion not applicable',


### PR DESCRIPTION
Follow-up to #867, which fixed six of these in receipt-extraction-consume and
recorded the other seventeen for a later slot.

`locator.isVisible()` is an IMMEDIATE predicate — its `timeout` option is
ignored. Called on the tick after a `goto`, it asks "is this here right now",
before the SPA has issued an XHR, and a `test.skip()` built on it skips with a
reason that is FALSE. A skip whose stated reason is untrue is an invisible pass,
and a worse one than a stub assertion: it renders as "not applicable" rather
than as a gap, and it inflates the skip count — the number that separates a
flake from a regression.

Adds `tests/e2e/becomes-visible.js`, a polling probe built on `waitFor`, shared
by the `.js` and `.ts` specs alike. The `test.skip()` calls are KEPT: the fix is
not to unskip, it is to make the gate tell the truth.

Gates de-raced (17):
- bank-statement-wizard  11, ALL through one `openWizard()` helper
- AccountantPortalDashboard 2 (+ the client-card branch probe)
- DeadlineCalendarSettings  2
- budget-line-commitments   2

🔑 bank-statement-wizard is the instructive one. Its selector was already
repaired — the launcher moved to the Configuratie page and the helper was
updated to match — but the RACE was left in place, and all eleven tests pass
today only because the probe happens to win on the current runner. A slower
runner returns all eleven to the same false "Import bank action not available
for this administration" skip, with no code change and no signal. This is a
latent eleven-test invisible pass, not an active one, and that is exactly why
it was invisible.

⚠️ `budget-line-commitments:79` is an INVERTED gate — it skips when rows ARE
present, so the non-waiting probe failed in the direction that RUNS the test,
asserting "No budget lines" against a table that was still loading. Polling
turns a confusing failure into an honest skip. Given a 5s rather than 10s
budget because the no-rows case is the common one and the wait is paid in full
whenever it holds.

Deliberately NOT deduplicated: receipt-extraction-consume.spec.ts keeps its own
local `becomesVisible` from #867. Rewriting a file that landed hours ago is
refactoring outside this workstream and a needless conflict with #495.

Verified locally: `--list` collects 292 tests in 55 files on BOTH sides, with
only line-number shifts in the diff — no test added, removed or renamed.
eslint on the four changed specs + the new helper: base 8 errors, branch 8.
Zero introduced.

---

## Measurement

Follow-up to **#867**, which fixed 6 of these and explicitly listed the rest for a follow-up slot.

Local, both sides:
- `playwright --list`: **292 tests in 55 files** on base and branch; the diff of the collected list is **line-number shifts only**. No test added, removed or renamed.
- `eslint` on the 4 changed specs + the new helper: **8 → 8 problems, zero introduced**.

## 🔑 The eleven-test latent case
`bank-statement-wizard.spec.ts` is the instructive one and the reason this needed measuring per test rather than fixing in bulk.

Its selector was **already repaired** — the launcher moved off the Financial overview to the Configuratie page, and the helper was updated to match. But the **race was left in**, and in the baseline run **all eleven of its tests PASS**. So there is no live invisible pass here at all; the probe simply happens to win on the current runner.

A slower runner returns all eleven to the same false *"Import bank action not available for this administration"* skip — no code change, no signal, and the file's own comment records that this is exactly what happened before. **That is a latent eleven-test invisible pass, and its latency is why nobody found it.**

## ⚠️ One inverted gate
`budget-line-commitments:79` skips when rows **are** present, so the non-waiting probe failed in the direction that *runs* the test — asserting "No budget lines" against a table that was merely still loading. Polling converts a confusing failure into an honest skip. Given a 5s rather than 10s budget because the no-rows case is the common one and the wait is paid in full whenever it holds.

Its sibling at `:54` skipped in the baseline with *"no Verplichtingsregel seeded in this administration"*. S37 traced that to **DECISION-3** (the seed reports `"success": true` while dropping 71 objects). **I expect it to still skip after this change, and that is the correct outcome** — a genuinely absent fixture with a now-truthful reason.

## What this does NOT do
- **It does not unskip anything.** Every `test.skip()` is kept.
- It does not deduplicate `receipt-extraction-consume.spec.ts`'s local `becomesVisible` from #867 — rewriting a file that landed hours ago is refactoring outside this workstream and a needless textual conflict with #495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)