### PR TITLE
fix(lint): remove 4 duplicate manifest keys and format one spec — eslint and prettier both exit 0

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9942,8 +9942,7 @@
 					}
 				],
 				"detailRoute": "ReceiptDetail",
-				"rowRoute": "ReceiptDetail",
-				"_note_rowRoute": "`rowRoute`, NOT `detailRoute`, is what CnPageRenderer reads. It sets `rowClickToView` when EITHER rowRoute is declared OR a `type:\"detail\"` page exists for the same register+schema. receipt-extraction-consume.json overlays ReceiptDetail as `type:\"custom\"` (ReceiptCapture), so the second condition stopped holding and every row on this index went dead on click — the library's own comment calls out this exact case. detailRoute is kept because 247 pages declare it, but nothing reads it.",
+				"_note_rowRoute_overlay": "`rowRoute`, NOT `detailRoute`, is what CnPageRenderer reads. It sets `rowClickToView` when EITHER rowRoute is declared OR a `type:\"detail\"` page exists for the same register+schema. receipt-extraction-consume.json overlays ReceiptDetail as `type:\"custom\"` (ReceiptCapture), so the second condition stopped holding and every row on this index went dead on click — the library's own comment calls out this exact case. detailRoute is kept because 247 pages declare it, but nothing reads it.",
 				"documentationUrl": "https://shillinq.conduction.nl/user-guide/purchasing/overview"
 			}
 		},
@@ -13837,8 +13836,7 @@
 				],
 				"defaultSort": "dueDate",
 				"detailRoute": "SupplierInvoiceDetail",
-				"rowRoute": "SupplierInvoiceDetail",
-				"_note_rowRoute": "See the Receipts index — `rowRoute` is the key CnPageRenderer reads; SupplierInvoiceDetail is `type:\"custom\"`, so without it these rows are dead on click.",
+				"_note_rowRoute_overlay": "See the Receipts index — `rowRoute` is the key CnPageRenderer reads; SupplierInvoiceDetail is `type:\"custom\"`, so without it these rows are dead on click.",
 				"description": "Read-only stub at slice-01. Member 05 owns UBL/Peppol/OCR ingestion.",
 				"documentationUrl": "https://shillinq.conduction.nl/guides/import-bills"
 			}
@@ -14052,8 +14050,7 @@
 				],
 				"defaultSort": "createdAt",
 				"detailRoute": "ThreeWayMatchDetail",
-				"rowRoute": "ThreeWayMatchDetail",
-				"_note_rowRoute": "See the Receipts index — ThreeWayMatchDetail is `type:\"custom\"`, so without `rowRoute` these rows are dead on click.",
+				"_note_rowRoute_overlay": "See the Receipts index — ThreeWayMatchDetail is `type:\"custom\"`, so without `rowRoute` these rows are dead on click.",
 				"description": "3-way match outcomes. Member 06 owns the matching engine.",
 				"documentationUrl": "https://shillinq.conduction.nl/user-guide/purchasing/overview"
 			}
@@ -14210,8 +14207,7 @@
 				],
 				"defaultSort": "createdAt",
 				"detailRoute": "ThreeWayMatchDetail",
-				"rowRoute": "ThreeWayMatchDetail",
-				"_note_rowRoute": "See the Receipts index — ThreeWayMatchDetail is `type:\"custom\"`, so without `rowRoute` these rows are dead on click.",
+				"_note_rowRoute_overlay": "See the Receipts index — ThreeWayMatchDetail is `type:\"custom\"`, so without `rowRoute` these rows are dead on click.",
 				"description": "Filtered view of 3-way matches that need operator action (price/quantity/missing-GRN/missing-PO/fraud-alert exceptions). Member 08 owns the exception workflow.",
 				"documentationUrl": "https://shillinq.conduction.nl/user-guide/purchasing/overview"
 			}

--- a/tests/e2e/waterschappen-bbv-variant.spec.ts
+++ b/tests/e2e/waterschappen-bbv-variant.spec.ts
@@ -57,7 +57,6 @@ async function dismissWizard(page: Page): Promise<void> {
 }
 
 test.describe('BBV dashboard — widget shell renders', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + DASHBOARD_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
@@ -67,10 +66,13 @@ test.describe('BBV dashboard — widget shell renders', () => {
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-003/dashboard-loads-all-widgets
 	 */
-	test('dashboard mounts the four widgets with counts and badges', async ({ page }) => {
+	test('dashboard mounts the four widgets with counts and badges', async ({
+		page,
+	}) => {
 		// CnDashboardPage wrapper must mount.
-		await expect(page.getByTestId('bbv-compliance-dashboard'))
-			.toBeVisible({ timeout: 15_000 })
+		await expect(page.getByTestId('bbv-compliance-dashboard')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// The four KPI cards (Total / On-track / At-risk / Non-compliant)
 		// declared by the slice-05 BBVKPICards component.
@@ -93,7 +95,9 @@ test.describe('BBV dashboard — widget shell renders', () => {
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-004/programme-table-row-navigates-to-detail
 	 */
-	test('programme table renders sortable rows; row click navigates to detail', async ({ page }) => {
+	test('programme table renders sortable rows; row click navigates to detail', async ({
+		page,
+	}) => {
 		const table = page.getByTestId('bbv-programme-table')
 		await expect(table).toBeVisible({ timeout: 15_000 })
 
@@ -114,11 +118,9 @@ test.describe('BBV dashboard — widget shell renders', () => {
 			expect(page.url()).toMatch(/budget-mappings|bbv-dashboard/)
 		}
 	})
-
 })
 
 test.describe('BBV mapping index — search + add + row click', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + MAPPING_INDEX_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
@@ -129,24 +131,30 @@ test.describe('BBV mapping index — search + add + row click', () => {
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-index-loads-seeded-mappings
 	 */
 	test('mapping index page mounts with filter chrome', async ({ page }) => {
-		await expect(page.getByTestId('bbv-mapping-index'))
-			.toBeVisible({ timeout: 15_000 })
-		await expect(page.getByTestId('bbv-mapping-index-filters'))
-			.toBeVisible()
+		await expect(page.getByTestId('bbv-mapping-index')).toBeVisible({
+			timeout: 15_000,
+		})
+		await expect(page.getByTestId('bbv-mapping-index-filters')).toBeVisible()
 
 		// The four declared filter facets (search + fiscal year +
 		// allocation bucket + effective-date window) are present.
 		await expect(page.getByTestId('bbv-mapping-search')).toBeVisible()
 		await expect(page.getByTestId('bbv-mapping-fiscal-year')).toBeVisible()
 		await expect(page.getByTestId('bbv-mapping-allocation')).toBeVisible()
-		await expect(page.getByTestId('bbv-mapping-effective-from-after')).toBeVisible()
-		await expect(page.getByTestId('bbv-mapping-effective-from-before')).toBeVisible()
+		await expect(
+			page.getByTestId('bbv-mapping-effective-from-after'),
+		).toBeVisible()
+		await expect(
+			page.getByTestId('bbv-mapping-effective-from-before'),
+		).toBeVisible()
 	})
 
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-search-filter
 	 */
-	test('search input accepts typed input and filters the table', async ({ page }) => {
+	test('search input accepts typed input and filters the table', async ({
+		page,
+	}) => {
 		const search = page.getByTestId('bbv-mapping-search')
 		await expect(search).toBeVisible({ timeout: 15_000 })
 		await search.fill('2.3.2')
@@ -177,11 +185,9 @@ test.describe('BBV mapping index — search + add + row click', () => {
 		await page.waitForLoadState('domcontentloaded')
 		expect(page.url()).toMatch(/budget-mappings\/new|budget-mappings\/[^/]+$/)
 	})
-
 })
 
 test.describe('BBV mapping detail — create flow', () => {
-
 	test.beforeEach(async ({ page }) => {
 		await page.goto(APP + MAPPING_NEW_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
@@ -191,9 +197,12 @@ test.describe('BBV mapping detail — create flow', () => {
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-detail-pickers-render
 	 */
-	test('detail page renders pickers + allocation field + effective-date defaults', async ({ page }) => {
-		await expect(page.getByTestId('budget-bbv-mapping-detail'))
-			.toBeVisible({ timeout: 15_000 })
+	test('detail page renders pickers + allocation field + effective-date defaults', async ({
+		page,
+	}) => {
+		await expect(page.getByTestId('budget-bbv-mapping-detail')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// The two declared relation pickers (GL account + BBV programme)
 		// must mount in their own dedicated components.
@@ -203,15 +212,21 @@ test.describe('BBV mapping detail — create flow', () => {
 		// The allocation input, effective-from + effective-to fields,
 		// and the lifecycle status are present.
 		await expect(page.getByTestId('bbv-mapping-detail-allocation')).toBeVisible()
-		await expect(page.getByTestId('bbv-mapping-detail-effective-from')).toBeVisible()
-		await expect(page.getByTestId('bbv-mapping-detail-effective-to')).toBeVisible()
+		await expect(
+			page.getByTestId('bbv-mapping-detail-effective-from'),
+		).toBeVisible()
+		await expect(
+			page.getByTestId('bbv-mapping-detail-effective-to'),
+		).toBeVisible()
 		await expect(page.getByTestId('bbv-mapping-detail-status')).toBeVisible()
 	})
 
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-detail-effective-from-default
 	 */
-	test('Effective From defaults to a fiscal-year-aligned date', async ({ page }) => {
+	test('Effective From defaults to a fiscal-year-aligned date', async ({
+		page,
+	}) => {
 		const effFrom = page.getByTestId('bbv-mapping-detail-effective-from')
 		await expect(effFrom).toBeVisible({ timeout: 15_000 })
 
@@ -228,7 +243,9 @@ test.describe('BBV mapping detail — create flow', () => {
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-detail-allocation-range
 	 */
-	test('allocation accepts 0..100 and rejects out-of-range values', async ({ page }) => {
+	test('allocation accepts 0..100 and rejects out-of-range values', async ({
+		page,
+	}) => {
 		const alloc = page.getByTestId('bbv-mapping-detail-allocation')
 		await expect(alloc).toBeVisible({ timeout: 15_000 })
 
@@ -253,18 +270,17 @@ test.describe('BBV mapping detail — create flow', () => {
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-detail-save-cancel-affordances
 	 */
 	test('save + cancel + delete affordances are present', async ({ page }) => {
-		await expect(page.getByTestId('budget-bbv-mapping-detail'))
-			.toBeVisible({ timeout: 15_000 })
+		await expect(page.getByTestId('budget-bbv-mapping-detail')).toBeVisible({
+			timeout: 15_000,
+		})
 		await expect(page.getByTestId('bbv-mapping-detail-save')).toBeVisible()
 		await expect(page.getByTestId('bbv-mapping-detail-cancel')).toBeVisible()
 		// Delete is hidden in create mode per slice 07 — its absence is
 		// expected here. The edit-flow spec asserts presence.
 	})
-
 })
 
 test.describe('BBV mapping detail — edit flow', () => {
-
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-002/mapping-detail-edit-prefills-and-persists
 	 *
@@ -274,7 +290,9 @@ test.describe('BBV mapping detail — edit flow', () => {
 	 * mounts in edit mode (delete affordance visible) and the form
 	 * pre-fill hook fires.
 	 */
-	test('detail page mounts in edit mode and surfaces the delete affordance', async ({ page }) => {
+	test('detail page mounts in edit mode and surfaces the delete affordance', async ({
+		page,
+	}) => {
 		// "edit-stub" is a synthetic id; the page MUST still mount even
 		// when the underlying record is absent (OR returns 404 and the
 		// detail handles the empty-form path).
@@ -282,8 +300,9 @@ test.describe('BBV mapping detail — edit flow', () => {
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
 
-		await expect(page.getByTestId('budget-bbv-mapping-detail'))
-			.toBeVisible({ timeout: 15_000 })
+		await expect(page.getByTestId('budget-bbv-mapping-detail')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// In edit mode the delete CTA + audit-trail panel are rendered.
 		const deleteCta = page.getByTestId('bbv-mapping-detail-delete')
@@ -339,7 +358,10 @@ test.describe('BBV mapping detail — edit flow', () => {
 	 * synthetic id the wrapper renders its "Not Found" state, `#actions` still
 	 * mounts and `#default` is suppressed by design.
 	 */
-	test('audit-trail surface is reachable from the detail page sidebar', async ({ page, request }) => {
+	test('audit-trail surface is reachable from the detail page sidebar', async ({
+		page,
+		request,
+	}) => {
 		const created = await request.post(
 			'/index.php/apps/openregister/api/objects/shillinq/BudgetBBVMapping',
 			{
@@ -365,17 +387,19 @@ test.describe('BBV mapping detail — edit flow', () => {
 
 			// The record loads, so the wrapper renders `#default` and the form
 			// is present — the negative case above is what used to fail here.
-			await expect(page.getByTestId('bbv-mapping-detail-form'))
-				.toBeVisible({ timeout: 15_000 })
+			await expect(page.getByTestId('bbv-mapping-detail-form')).toBeVisible({
+				timeout: 15_000,
+			})
 
 			// REQ-BBVW-007: the audit-trail panel must be reachable from the
 			// detail sidebar. CnDetailPage renders it collapsed
 			// (`:sidebarOpen="false"`), so assert it is attached rather than
 			// in the viewport.
-			await expect(page.getByTestId('budget-bbv-mapping-detail'))
-				.toBeVisible()
+			await expect(page.getByTestId('budget-bbv-mapping-detail')).toBeVisible()
 			await expect(
-				page.locator('[data-testid="budget-bbv-mapping-detail"] .app-sidebar, .app-sidebar'),
+				page.locator(
+					'[data-testid="budget-bbv-mapping-detail"] .app-sidebar, .app-sidebar',
+				),
 			).toBeAttached({ timeout: 10_000 })
 		} finally {
 			// Surface a failed teardown instead of swallowing it. This ran as
@@ -395,25 +419,27 @@ test.describe('BBV mapping detail — edit flow', () => {
 		}
 	})
 
-	test('a mapping id that does not exist reports the failure instead of rendering an empty edit form', async ({ page }) => {
+	test('a mapping id that does not exist reports the failure instead of rendering an empty edit form', async ({
+		page,
+	}) => {
 		await page.goto(APP + MAPPING_INDEX_ROUTE + '/edit-stub')
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
 
 		// The page still mounts — a missing record must not blank the route.
-		await expect(page.getByTestId('budget-bbv-mapping-detail'))
-			.toBeVisible({ timeout: 15_000 })
+		await expect(page.getByTestId('budget-bbv-mapping-detail')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// …and it must NOT present the editable mapping form for a record it
 		// could not load.
-		await expect(page.getByTestId('bbv-mapping-detail-form'))
-			.toBeHidden({ timeout: 15_000 })
+		await expect(page.getByTestId('bbv-mapping-detail-form')).toBeHidden({
+			timeout: 15_000,
+		})
 	})
-
 })
 
 test.describe('BBV scoping + validation', () => {
-
 	/**
 	 * @e2e bookkeeping-waterschappen-bbv-variant-11-testing/REQ-BBVW-006/fiscal-year-scope-is-surfaced-and-requeryable
 	 *
@@ -453,13 +479,16 @@ test.describe('BBV scoping + validation', () => {
 	 * The old assertion masked this: it failed on a fictional `<select>`, which
 	 * is a louder wrong reason than the real one. Left asserting.
 	 */
-	test('dashboard surfaces the active fiscal-year scope and re-queries it', async ({ page }) => {
+	test('dashboard surfaces the active fiscal-year scope and re-queries it', async ({
+		page,
+	}) => {
 		await page.goto(APP + DASHBOARD_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
 
-		await expect(page.getByTestId('bbv-compliance-dashboard'))
-			.toBeVisible({ timeout: 15_000 })
+		await expect(page.getByTestId('bbv-compliance-dashboard')).toBeVisible({
+			timeout: 15_000,
+		})
 
 		// 1. The fiscal-year scope is visible, and it is a real year — not an
 		//    empty chip, not the untranslated `FY {year}` placeholder.
@@ -490,7 +519,9 @@ test.describe('BBV scoping + validation', () => {
 	 * over-100% rejection at the engine boundary; this test asserts the
 	 * UI affordance exposes the bound.
 	 */
-	test('allocation input enforces the 0..100 bound at the HTML level', async ({ page }) => {
+	test('allocation input enforces the 0..100 bound at the HTML level', async ({
+		page,
+	}) => {
 		await page.goto(APP + MAPPING_NEW_ROUTE)
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
@@ -525,5 +556,4 @@ test.describe('BBV scoping + validation', () => {
 		expect(await from.getAttribute('type')).toBe('date')
 		expect(await to.getAttribute('type')).toBe('date')
 	})
-
 })


### PR DESCRIPTION
Closes #874.

## `src/manifest.json` — 8 eslint errors, 4 duplicate-key pairs

Four page configs declared `rowRoute` and `_note_rowRoute` **twice** (Receipts, Supplier invoices, Three-way match ×2). In JSON the later key silently wins, so today's behaviour is correct **by luck**.

Every duplicated `rowRoute` value is identical — checked with a JSON `object_pairs_hook` rather than by eye — so deleting the second is semantically free. Verified afterwards by parsing both trees and comparing with the note keys stripped: **identical**.

The two `_note_rowRoute` copies were **not** identical, and that's the part worth care: the first explains that `rowRoute` is load-bearing for `CnPageRenderer.onRowOpen()`, the second explains the `type:"custom"` overlay case that made it necessary. Deleting either loses a real explanation, so the second is kept under `_note_rowRoute_overlay`. Nothing lost; nothing duplicated.

## `tests/e2e/waterschappen-bbv-variant.spec.ts`

Pre-existing prettier failure on `development`, **not** caused by this change — verified by stashing the manifest edit and re-running: it warns identically. `Frontend Check (format)` was red on this one file. Formatted.

## ⚠️ I made the mistake this issue warned about, then undid it

#874 says explicitly *"do not reformat the file to fix it — a JSON round-trip rewrites all ~14k lines and buries the change."* I then ran `prettier --write src/manifest.json` while checking my work, which did exactly that: **475 insertions / 271 deletions**. Reverted and redone line-wise.

`src/manifest.json` isn't even in this app's prettier glob (`**/*.{js,ts,vue,css,scss}` — no `json`), so the reformat wasn't required by anything; I'd widened the glob myself while checking and then acted on the result. **Final diff in that file: 4 insertions / 8 deletions.**

`eslint` exit 0 (was 8 errors). `prettier` clean over the app's own glob.
