### PR TITLE
fix(lookups): repair the 11 non-guard findAll(filters.id) lookups that matched nothing

### DIFF
--- a/l10n/en.json
+++ b/l10n/en.json
@@ -162,7 +162,6 @@
         "Allocation %": "Allocation %",
         "Allocation Key": "Allocation Key",
         "Allocation Key Ratio": "Allocation Key Ratio",
-        "Allocation must be between 0 % and 100 %.": "Allocation must be between 0 % and 100 %.",
         "Allocation range": "Allocation range",
         "Allocation Rule": "Allocation Rule",
         "Allocation Rules": "Allocation Rules",
@@ -2754,7 +2753,22 @@
         "Zelfstandigenaftrek": "Self-employed deduction",
         "ZZP Deduction": "ZZP Deduction",
         "ZZP-aftrek": "Self-employed deductions",
-        "Δ": "Δ"
+        "Δ": "Δ",
+        "Creating…": "Creating…",
+        "Declare which accounting and reporting frameworks this administration follows, and drag them into order of precedence. When frameworks disagree on a treatment (revenue, leases, inventory, …), business logic follows the highest-ranked enabled framework.": "Declare which accounting and reporting frameworks this administration follows, and drag them into order of precedence. When frameworks disagree on a treatment (revenue, leases, inventory, …), business logic follows the highest-ranked enabled framework.",
+        "Evaluating…": "Evaluating…",
+        "Loading goods receipt note…": "Loading goods receipt note…",
+        "Loading match…": "Loading match…",
+        "Loading purchase order…": "Loading purchase order…",
+        "Loading receipt…": "Loading receipt…",
+        "Loading scorecard…": "Loading scorecard…",
+        "Loading scorecards…": "Loading scorecards…",
+        "Loading supplier invoice…": "Loading supplier invoice…",
+        "Loading three-way matches…": "Loading three-way matches…",
+        "Search account or programme…": "Search account or programme…",
+        "Sending PDF…": "Sending PDF…",
+        "Sending Peppol…": "Sending Peppol…",
+        "Sending…": "Sending…"
     },
     "plurals": ""
 }

--- a/lib/Controller/ExtractionRequestController.php
+++ b/lib/Controller/ExtractionRequestController.php
@@ -56,6 +56,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Util\ObjectIdentifier;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\Extraction\ChartOfAccountsCandidateService;
 use OCA\Shillinq\Service\Extraction\DocudeskExtractionClient;
@@ -475,26 +476,20 @@ class ExtractionRequestController extends Controller {
 	 */
 	private function findById(string $schema, string $id): ?array {
 		try {
+			// NOT findAll(['filters' => ['id' => …]]) — `filters` addresses
+			// JSON properties and the entity's `id` is not one, so that shape
+			// matched nothing for every value and this resolver returned null
+			// for every object it was asked for.
 			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
-				->setRegister(self::REGISTER_SLUG)
-				->setSchema($schema)
-				->findAll(['filters' => ['id' => $id]]);
+			return ObjectIdentifier::findOne(
+				scoped: $objectService
+					->setRegister(self::REGISTER_SLUG)
+					->setSchema($schema),
+				id: $id
+			);
 		} catch (Throwable $e) {
 			return null;
 		}
-
-		if (is_array($rows) === false) {
-			return null;
-		}
-
-		foreach ($rows as $row) {
-			if (is_array($row) === true) {
-				return $row;
-			}
-		}
-
-		return null;
 	}//end findById()
 
 	/**

--- a/lib/Controller/NotificationController.php
+++ b/lib/Controller/NotificationController.php
@@ -52,6 +52,7 @@ namespace OCA\Shillinq\Controller;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\SettingsService;
+use OCA\Shillinq\Util\ObjectIdentifier;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
@@ -496,10 +497,23 @@ class NotificationController extends Controller {
 	private function requireAccessibleBooking(string $bookingId): ?JSONResponse {
 		try {
 			$service = $this->resolveObjectService();
-			$rows = $service
-				->setRegister($this->settings->getRegisterSlug())
-				->setSchema('Booking')
-				->findAll(['filters' => ['id' => $bookingId]]);
+			// NOT findAll(['filters' => ['id' => …]]) — `filters` addresses JSON
+			// properties and `id` is the entity's own column, so that shape
+			// matched nothing for every value and this guard refused every
+			// booking addressed by uuid. findOne() resolves the uuid via find()
+			// and falls back to the `bookingId` property, which is the other
+			// identifier the loop below already accepts.
+			$booking = ObjectIdentifier::findOne(
+				scoped: $service
+					->setRegister($this->settings->getRegisterSlug())
+					->setSchema('Booking'),
+				id: $bookingId,
+				fallbackProperty: 'bookingId'
+			);
+			$rows = [];
+			if ($booking !== null) {
+				$rows = [$booking];
+			}
 		} catch (Throwable $e) {
 			$this->logger->warning('shillinq.notification.booking.unavailable', ['error' => $e->getMessage()]);
 			return new JSONResponse(data: ['message' => 'Booking unavailable'], statusCode: Http::STATUS_SERVICE_UNAVAILABLE);

--- a/lib/Controller/PayrollWebhookController.php
+++ b/lib/Controller/PayrollWebhookController.php
@@ -34,6 +34,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Util\ObjectIdentifier;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AnonRateLimit;
@@ -215,18 +216,16 @@ class PayrollWebhookController extends Controller {
 	private function applyEvent(string $eventId, string $payrollId, array $data): ?array {
 		$register = $this->resolveRegister();
 
-		$payrolls = $this->objectService
-			->setRegister($register)
-			->setSchema('Payroll')
-			->findAll(['filters' => ['id' => $payrollId]]);
-
-		$payroll = null;
-		foreach ($payrolls as $candidate) {
-			if (is_array($candidate) === true) {
-				$payroll = $candidate;
-				break;
-			}
-		}
+		// NOT findAll(['filters' => ['id' => …]]) — `filters` addresses JSON
+		// properties and the entity's `id` is not one, so that shape matched
+		// nothing for every value and every inbound payroll webhook was
+		// treated as referencing an unknown Payroll.
+		$payroll = ObjectIdentifier::findOne(
+			scoped: $this->objectService
+				->setRegister($register)
+				->setSchema('Payroll'),
+			id: $payrollId
+		);
 
 		if ($payroll === null) {
 			return null;

--- a/lib/Service/AccountantsdossierExportService.php
+++ b/lib/Service/AccountantsdossierExportService.php
@@ -69,6 +69,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Util\ObjectIdentifier;
 use OCP\IAppConfig;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -883,19 +884,17 @@ class AccountantsdossierExportService {
 	 * @return array<string,mixed>|null
 	 */
 	private function loadOne(string $schema, string $id): ?array {
-		$found = $this->objects()
-			->setRegister($this->register())
-			->setSchema($schema)
-			->findAll(['filters' => ['id' => $id]]);
-
-		foreach ($found as $candidate) {
-			$candidateId = (string)($candidate['id'] ?? ($candidate['@self']['id'] ?? ''));
-			if ($candidateId === $id) {
-				return $candidate;
-			}
-		}
-
-		return ($found[0] ?? null);
+		// NOT findAll(['filters' => ['id' => …]]) — `filters` addresses JSON
+		// properties and the entity's `id` is not one, so that shape matched
+		// nothing for every value and this loader returned null for every
+		// record the export asked for. find() answers the uuid directly,
+		// making the id-comparison loop that followed redundant.
+		return ObjectIdentifier::findOne(
+			scoped: $this->objects()
+				->setRegister($this->register())
+				->setSchema($schema),
+			id: $id
+		);
 	}//end loadOne()
 
 	/**

--- a/lib/Service/AdministrationArchivalService.php
+++ b/lib/Service/AdministrationArchivalService.php
@@ -38,6 +38,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Util\ObjectIdentifier;
 use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -252,16 +253,20 @@ class AdministrationArchivalService {
 	 */
 	private function findAdministration(string $administrationId): ?array {
 		try {
+			// NOT findAll(['filters' => ['id' => …]]) — that addresses JSON
+			// properties, and the entity's `id` is not one, so it matched
+			// nothing for every value and this method reported every
+			// administration as absent. An administration is addressed by its
+			// administrationCode ('ADM-001') throughout the app, which is why
+			// findOne() needs the fallback.
 			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$matches = $objectService
-				->setRegister($this->resolveRegister())
-				->setSchema('Administration')
-				->findAll(
-					[
-						'filters' => ['id' => $administrationId],
-						'limit' => 1,
-					]
-				);
+			return ObjectIdentifier::findOne(
+				scoped: $objectService
+					->setRegister($this->resolveRegister())
+					->setSchema('Administration'),
+				id: $administrationId,
+				fallbackProperty: 'administrationCode'
+			);
 		} catch (Throwable $e) {
 			$this->logger->error(
 				'AdministrationArchivalService: failed to load administration',
@@ -269,21 +274,6 @@ class AdministrationArchivalService {
 			);
 			return null;
 		}
-
-		foreach ($matches as $match) {
-			if (is_array($match) === true) {
-				return $match;
-			}
-
-			if (is_object($match) === true && method_exists($match, 'getObject') === true) {
-				$data = $match->getObject();
-				if (is_array($data) === true) {
-					return $data;
-				}
-			}
-		}
-
-		return null;
 	}//end findAdministration()
 
 	/**

--- a/lib/Service/AppointmentConfirmationService.php
+++ b/lib/Service/AppointmentConfirmationService.php
@@ -33,6 +33,7 @@ namespace OCA\Shillinq\Service;
 
 use DateTimeImmutable;
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Util\ObjectIdentifier;
 use OCA\Shillinq\Util\TokenValidator;
 use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
@@ -417,20 +418,19 @@ class AppointmentConfirmationService {
 	 */
 	private function findAppointment(object $objectService, string $register, string $appointmentId): ?array {
 		try {
-			$byId = $objectService
-				->setRegister($register)
-				->setSchema('Appointment')
-				->findAll(['filters' => ['id' => $appointmentId], 'limit' => 1]);
-			if (empty($byId) === false) {
-				return $byId[0];
-			}
-
-			$byNumber = $objectService
-				->setRegister($register)
-				->setSchema('Appointment')
-				->findAll(['filters' => ['appointmentNumber' => $appointmentId], 'limit' => 1]);
-			if (empty($byNumber) === false) {
-				return $byNumber[0];
+			// The by-id arm used to be findAll(['filters' => ['id' => …]]),
+			// which matches NOTHING — `filters` addresses JSON properties and
+			// `id` is the entity's own column — so every lookup fell through to
+			// the appointmentNumber arm and an appointment addressed by uuid
+			// was reported absent. ObjectIdentifier::findOne() does the uuid
+			// lookup through find(), then the same appointmentNumber fallback.
+			$appointment = ObjectIdentifier::findOne(
+				scoped: $objectService->setRegister($register)->setSchema('Appointment'),
+				id: $appointmentId,
+				fallbackProperty: 'appointmentNumber'
+			);
+			if ($appointment !== null) {
+				return $appointment;
 			}
 		} catch (Throwable $e) {
 			$this->logger->error('Shillinq: failed to load appointment: ' . $e->getMessage());

--- a/lib/Service/BadoControleprotocolService.php
+++ b/lib/Service/BadoControleprotocolService.php
@@ -42,6 +42,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Util\ObjectIdentifier;
 use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
 use OCA\OpenRegister\Contract\ObjectServiceInterface;
@@ -624,19 +625,17 @@ class BadoControleprotocolService {
 			return null;
 		}
 
-		$found = $this->objects()
-			->setRegister($this->register())
-			->setSchema($schema)
-			->findAll(['filters' => ['id' => $id]]);
-
-		foreach ($found as $candidate) {
-			$candidateId = (string)($candidate['id'] ?? ($candidate['@self']['id'] ?? ''));
-			if ($candidateId === $id) {
-				return $candidate;
-			}
-		}
-
-		return ($found[0] ?? null);
+		// NOT findAll(['filters' => ['id' => …]]) — `filters` addresses JSON
+		// properties and the entity's `id` is not one, so that shape matched
+		// nothing for every value and this resolver returned null for every
+		// object it was asked for. find() answers the uuid directly, which
+		// makes the id-comparison loop that followed redundant.
+		return ObjectIdentifier::findOne(
+			scoped: $this->objects()
+				->setRegister($this->register())
+				->setSchema($schema),
+			id: $id
+		);
 	}//end resolveObject()
 
 	/**

--- a/lib/Service/PaymentReconciliationService.php
+++ b/lib/Service/PaymentReconciliationService.php
@@ -53,6 +53,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Service;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Util\ObjectIdentifier;
 use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -358,15 +359,20 @@ class PaymentReconciliationService {
 		}
 
 		try {
-			$invoices = $objectService
-				->setRegister($registerSlug)
-				->setSchema('ARInvoice')
-				->findAll(
-					[
-						'filters' => ['id' => $invoiceRef],
-						'limit' => 1,
-					]
-				);
+			// The by-id arm was findAll(['filters' => ['id' => …]]), which
+			// matches NOTHING — `filters` addresses JSON properties and the
+			// entity's `id` is not one — so every reference fell through to
+			// the slug arm and an invoice referenced by uuid never reconciled.
+			$byId = ObjectIdentifier::findOne(
+				scoped: $objectService
+					->setRegister($registerSlug)
+					->setSchema('ARInvoice'),
+				id: $invoiceRef
+			);
+			$invoices = [];
+			if ($byId !== null) {
+				$invoices = [$byId];
+			}
 
 			if (empty($invoices) === true) {
 				$invoices = $objectService

--- a/lib/Service/PeriodCloseService.php
+++ b/lib/Service/PeriodCloseService.php
@@ -40,6 +40,7 @@ namespace OCA\Shillinq\Service;
 use DateTimeImmutable;
 use DateTimeInterface;
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Util\ObjectIdentifier;
 use OCP\IAppConfig;
 use OCP\IGroupManager;
 use Psr\Log\LoggerInterface;
@@ -462,13 +463,17 @@ class PeriodCloseService {
 		}
 
 		// Fall back to the record-id lookup, still scoped to the administration.
-		$byId = $this->objectService
-			->setRegister($register)
-			->setSchema('FiscalPeriod')
-			->findAll(['filters' => ['id' => $periodId], 'limit' => 1]);
+		// NOT findAll(['filters' => ['id' => …]]) — `filters` addresses JSON
+		// properties and the entity's `id` is not one, so this arm matched
+		// nothing for every value and the fallback never actually fell back.
+		$record = ObjectIdentifier::findOne(
+			scoped: $this->objectService
+				->setRegister($register)
+				->setSchema('FiscalPeriod'),
+			id: $periodId
+		);
 
-		if (is_array($byId) === true && $byId !== []) {
-			$record = $this->normaliseRow(row: $byId[0]);
+		if ($record !== null) {
 			$recordAdmin = (string)($record['administrationId'] ?? '');
 			if ($administrationId === '' || $recordAdmin === '' || $recordAdmin === $administrationId) {
 				return $record;

--- a/lib/Service/Treasury/FxRevaluationService.php
+++ b/lib/Service/Treasury/FxRevaluationService.php
@@ -49,6 +49,7 @@ namespace OCA\Shillinq\Service\Treasury;
 use DateTimeImmutable;
 use DateTimeInterface;
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Util\ObjectIdentifier;
 use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -425,15 +426,18 @@ class FxRevaluationService {
 	 */
 	private function functionalCurrencyFor(string $administrationId): string {
 		try {
-			$found = $this->objectService
-				->setRegister($this->register())
-				->setSchema('Administration')
-				->findAll(
-					[
-						'filters' => ['id' => $administrationId],
-						'limit' => 1,
-					]
-				);
+			// NOT findAll(['filters' => ['id' => …]]) — that addresses JSON
+			// properties and the entity's `id` is not one, so it matched
+			// nothing for every administration and this method silently
+			// returned the EUR default for all of them, ignoring whatever
+			// functionalCurrency was actually configured.
+			$admin = ObjectIdentifier::findOne(
+				scoped: $this->objectService
+					->setRegister($this->register())
+					->setSchema('Administration'),
+				id: $administrationId,
+				fallbackProperty: 'administrationCode'
+			);
 		} catch (Throwable $e) {
 			$this->logger->warning(
 				'FxRevaluationService: failed to resolve Administration.functionalCurrency — defaulting to EUR',
@@ -442,11 +446,10 @@ class FxRevaluationService {
 			return self::DEFAULT_FUNCTIONAL_CURRENCY;
 		}
 
-		if (is_array($found) === false || $found === []) {
+		if ($admin === null) {
 			return self::DEFAULT_FUNCTIONAL_CURRENCY;
 		}
 
-		$admin = $this->asArray(row: $found[0]);
 		$currency = (string)($admin['functionalCurrency'] ?? '');
 		if ($currency === '') {
 			return self::DEFAULT_FUNCTIONAL_CURRENCY;

--- a/lib/Service/Treasury/RealisedFxSettlementService.php
+++ b/lib/Service/Treasury/RealisedFxSettlementService.php
@@ -53,6 +53,7 @@ namespace OCA\Shillinq\Service\Treasury;
 use DateTimeImmutable;
 use DateTimeInterface;
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Util\ObjectIdentifier;
 use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -539,16 +540,19 @@ class RealisedFxSettlementService {
 		}
 
 		try {
+			// NOT findAll(['filters' => ['id' => …]]) — that addresses JSON
+			// properties and the entity's `id` is not one, so it matched
+			// nothing for every administration and this method silently
+			// returned the EUR default for all of them, ignoring whatever
+			// functionalCurrency was actually configured.
 			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$found = $objectService
-				->setRegister($this->register())
-				->setSchema('Administration')
-				->findAll(
-					[
-						'filters' => ['id' => $administrationId],
-						'limit' => 1,
-					]
-				);
+			$admin = ObjectIdentifier::findOne(
+				scoped: $objectService
+					->setRegister($this->register())
+					->setSchema('Administration'),
+				id: $administrationId,
+				fallbackProperty: 'administrationCode'
+			);
 		} catch (Throwable $e) {
 			$this->logger->warning(
 				'RealisedFxSettlementService: failed to resolve Administration.functionalCurrency — defaulting to EUR',
@@ -557,11 +561,10 @@ class RealisedFxSettlementService {
 			return self::DEFAULT_FUNCTIONAL_CURRENCY;
 		}
 
-		if (is_array($found) === false || $found === []) {
+		if ($admin === null) {
 			return self::DEFAULT_FUNCTIONAL_CURRENCY;
 		}
 
-		$admin = $this->asArray(row: $found[0]);
 		$currency = strtoupper((string)($admin['functionalCurrency'] ?? ''));
 		if ($currency === '') {
 			return self::DEFAULT_FUNCTIONAL_CURRENCY;

--- a/lib/Util/ObjectIdentifier.php
+++ b/lib/Util/ObjectIdentifier.php
@@ -171,6 +171,103 @@ final class ObjectIdentifier {
 	}//end accessor()
 
 	/**
+	 * Look one object up by identifier, the way that actually works.
+	 *
+	 * ⚠️ DO NOT reach for `findAll(['filters' => ['id' => $id]])` instead.
+	 *
+	 * `filters` addresses the object's JSON PROPERTIES. The ObjectEntity's `id`
+	 * is the entity's own column, merged into the serialised output afterwards
+	 * — so it is not a property the filter can see, and that shape matches
+	 * ZERO rows for every value, uuids included. It returns an empty array
+	 * rather than raising, so the caller reads a record that plainly exists as
+	 * "not found", with no exception and nothing in the log. The HTTP list API
+	 * DOES answer `?id=…` (it maps that onto the entity column), so the same
+	 * lookup looks healthy when probed with curl and returns nothing in PHP.
+	 *
+	 * `find()` is the single-object lookup and it THROWS DoesNotExistException
+	 * on a miss rather than returning null — including for any identifier that
+	 * is not a uuid — so it needs its own catch. Cross-references in this app
+	 * join on the uuid, so `find()` answers most lookups on its own.
+	 *
+	 * `$fallbackProperty` covers the identifiers that are NOT uuids: an
+	 * administration is addressed by its `administrationCode` ('ADM-001')
+	 * throughout the app, because buildContext() echoes the code back as
+	 * `activeAdministrationId` and ci-seed.sh stamps fixtures with it.
+	 *
+	 * @param object      $scoped           ObjectService with register + schema already set.
+	 * @param string      $id               The uuid, or the fallback property's value.
+	 * @param string|null $fallbackProperty JSON property to match when $id is not a uuid.
+	 *
+	 * @return array<string,mixed>|null The record, or null when genuinely absent.
+	 *
+	 * @spec openspec/specs/inventory-cycle-count/spec.md
+	 */
+	public static function findOne(object $scoped, string $id, ?string $fallbackProperty = null): ?array {
+		if ($id === '') {
+			return null;
+		}
+
+		// Its own try/catch, deliberately — find() throws rather than
+		// returning null, so a shared catch would swallow the fallback.
+		try {
+			$record = self::record(candidate: $scoped->find($id));
+			if ($record !== null) {
+				return $record;
+			}
+		} catch (Throwable $notAUuid) {
+			// Fall through to the property lookup below.
+		}
+
+		if ($fallbackProperty === null) {
+			return null;
+		}
+
+		try {
+			$matches = $scoped->findAll(['filters' => [$fallbackProperty => $id], 'limit' => 1]);
+		} catch (Throwable $e) {
+			return null;
+		}
+
+		foreach ($matches as $match) {
+			$record = self::record(candidate: $match);
+			if ($record !== null) {
+				return $record;
+			}
+		}
+
+		return null;
+	}//end findOne()
+
+	/**
+	 * Normalise an ObjectService result entry to a plain record array.
+	 *
+	 * Results arrive as either plain arrays or ObjectEntity instances
+	 * depending on the call shape.
+	 *
+	 * @param mixed $candidate Result entry or single object.
+	 *
+	 * @return array<string,mixed>|null The record, or null when not usable.
+	 */
+	private static function record(mixed $candidate): ?array {
+		if (is_array($candidate) === true) {
+			if ($candidate === []) {
+				return null;
+			}
+
+			return $candidate;
+		}
+
+		if (is_object($candidate) === true && method_exists($candidate, 'getObject') === true) {
+			$payload = $candidate->getObject();
+			if (is_array($payload) === true && $payload !== []) {
+				return $payload;
+			}
+		}
+
+		return null;
+	}//end record()
+
+	/**
 	 * Render a scalar identifier as a non-empty string.
 	 *
 	 * @param mixed $value The candidate identifier.

--- a/tests/Unit/Controller/ExtractionRequestControllerTest.php
+++ b/tests/Unit/Controller/ExtractionRequestControllerTest.php
@@ -29,6 +29,7 @@ use OCA\Shillinq\Service\Extraction\ChartOfAccountsCandidateService;
 use OCA\Shillinq\Service\Extraction\DocudeskExtractionClient;
 use OCA\Shillinq\Service\Extraction\ExtractionPrefillService;
 use OCA\Shillinq\Service\Extraction\GlAccountSuggestionClient;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
 use OCP\IUser;
@@ -219,7 +220,37 @@ final class ExtractionRequestControllerTest extends TestCase {
 			}//end setSchema()
 
 			/**
+			 * Single-object lookup by uuid.
+			 *
+			 * ⚠️ THROWS on a miss — it does not return null, so a caller
+			 * wanting a fallback must wrap it in its own try/catch. The double
+			 * had no find() at all, so the lookup path the controller actually
+			 * takes was never exercised here.
+			 *
+			 * @param string $id Object uuid.
+			 *
+			 * @return array<string,mixed>
+			 *
+			 * @throws DoesNotExistException When no object matches.
+			 */
+			public function find(string $id): array {
+				foreach (($this->test->stubRows[$this->schema] ?? []) as $row) {
+					if ((string)($row['id'] ?? '') === $id) {
+						return $row;
+					}
+				}
+
+				throw new DoesNotExistException(
+					sprintf("Object with identifier '%s' not found in any magic table", $id)
+				);
+			}//end find()
+
+			/**
 			 * Filter the schema's stub rows by the given equality filters.
+			 *
+			 * ⚠️ `filters` addresses JSON PROPERTIES only — the ObjectEntity's
+			 * `id` is its own column, so real OpenRegister matches ZERO rows
+			 * for `['filters' => ['id' => …]]` at every value, silently.
 			 *
 			 * @param array<string,mixed> $params Query params.
 			 *
@@ -228,6 +259,10 @@ final class ExtractionRequestControllerTest extends TestCase {
 			public function findAll(array $params = []): array {
 				$rows = ($this->test->stubRows[$this->schema] ?? []);
 				$filters = ($params['filters'] ?? []);
+				if (array_key_exists('id', $filters) === true) {
+					return [];
+				}
+
 				return array_values(
 					array_filter(
 						$rows,

--- a/tests/Unit/Service/AdministrationArchivalServiceLookupTest.php
+++ b/tests/Unit/Service/AdministrationArchivalServiceLookupTest.php
@@ -109,10 +109,30 @@ class AdministrationArchivalServiceLookupTest extends TestCase {
 				return $this;
 			}
 
+			// ⚠️ THROWS on a miss, like the real one — it never returns null,
+			// so a caller wanting a fallback needs its own try/catch. No row
+			// here is addressed by uuid, so this always throws and the
+			// administrationCode fallback is what answers. The double had no
+			// find() at all, which is why it could not see that the service's
+			// by-id lookup never worked.
+			public function find(string $id): array {
+				throw new \OCP\AppFramework\Db\DoesNotExistException(
+					sprintf("Object with identifier '%s' not found in any magic table", $id)
+				);
+			}
+
+			// ⚠️ `filters` addresses JSON PROPERTIES only. Real OpenRegister
+			// matches ZERO rows for ['filters' => ['id' => …]] at every value,
+			// because the entity's `id` is its own column — mirrored here so
+			// this double cannot bless that shape again.
 			public function findAll(array $config): array {
 				$this->seenConfig = $config;
 				if ($this->throws === true) {
 					throw new \RuntimeException('findAll exploded');
+				}
+
+				if (array_key_exists('id', ($config['filters'] ?? [])) === true) {
+					return [];
 				}
 
 				return $this->matches;
@@ -166,7 +186,9 @@ class AdministrationArchivalServiceLookupTest extends TestCase {
 	 * @return void
 	 */
 	public function testArrayRowForActiveAdministrationIsWritable(): void {
-		$fake = $this->fakeObjectService([['id' => 'adm-1', 'status' => 'actief']]);
+		$fake = $this->fakeObjectService(
+			[['id' => 'adm-1', 'administrationCode' => 'adm-1', 'status' => 'actief']]
+		);
 		$service = $this->buildService($fake);
 
 		$service->assertWritableById('adm-1');
@@ -174,7 +196,13 @@ class AdministrationArchivalServiceLookupTest extends TestCase {
 		// The lookup must be tenant-targeted and bounded.
 		self::assertSame('shillinq', $fake->seenRegister);
 		self::assertSame('Administration', $fake->seenSchema);
-		self::assertSame(['id' => 'adm-1'], $fake->seenConfig['filters']);
+
+		// ⚠️ `administrationCode`, NOT `id`. This assertion used to pin
+		// ['id' => 'adm-1'] — the shape real OpenRegister answers with zero
+		// rows for every value, because `filters` addresses JSON properties
+		// and the entity's `id` is its own column. The test was holding the
+		// broken lookup in place as though it were the contract.
+		self::assertSame(['administrationCode' => 'adm-1'], $fake->seenConfig['filters']);
 		self::assertSame(1, $fake->seenConfig['limit']);
 
 	}//end testArrayRowForActiveAdministrationIsWritable()

--- a/tests/Unit/Service/AppointmentConfirmationServiceTest.php
+++ b/tests/Unit/Service/AppointmentConfirmationServiceTest.php
@@ -26,6 +26,7 @@ namespace OCA\Shillinq\Tests\Unit\Service;
 
 use OCA\Shillinq\Service\AppointmentConfirmationService;
 use OCA\Shillinq\Service\ConfirmationMailer;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -94,7 +95,40 @@ final class AppointmentConfirmationServiceTest extends TestCase {
 			}
 
 			/**
+			 * Single-object lookup by uuid.
+			 *
+			 * ⚠️ THROWS on a miss — it does not return null. Real
+			 * ObjectService raises DoesNotExistException for any identifier it
+			 * cannot resolve, so a caller wanting a fallback must wrap this in
+			 * its own try/catch. The double had no find() at all, which made it
+			 * blind to the lookup path the service actually takes.
+			 *
+			 * @param string $id Object uuid.
+			 *
+			 * @return array<string,mixed>
+			 *
+			 * @throws DoesNotExistException When no object matches.
+			 */
+			public function find(string $id): array {
+				foreach (($this->records[$this->schema] ?? []) as $row) {
+					if ((string)($row['id'] ?? '') === $id) {
+						return $row;
+					}
+				}
+
+				throw new DoesNotExistException(
+					sprintf("Object with identifier '%s' not found in any magic table", $id)
+				);
+			}
+
+			/**
 			 * Filter the selected schema's records.
+			 *
+			 * ⚠️ `filters` addresses JSON PROPERTIES only — the ObjectEntity's
+			 * `id` is its own column, so real OpenRegister matches ZERO rows
+			 * for `['filters' => ['id' => …]]` at every value, silently.
+			 * Mirrored here so this double cannot bless a lookup the engine
+			 * would answer with nothing.
 			 *
 			 * @param array<string,mixed> $query Query with optional filters/limit.
 			 *
@@ -102,6 +136,10 @@ final class AppointmentConfirmationServiceTest extends TestCase {
 			 */
 			public function findAll(array $query = []): array {
 				$filters = ($query['filters'] ?? []);
+				if (array_key_exists('id', $filters) === true) {
+					return [];
+				}
+
 				$rows = array_values($this->records[$this->schema] ?? []);
 				$out = array_filter(
 					$rows,


### PR DESCRIPTION
Part of #871. Fixes the 11 **non-guard** call sites; the 38 lifecycle guards are deliberately left for a separate decision (see the end).

## The bug

Every one of these queried `findAll(['filters' => ['id' => $someId]])`. OpenRegister's `filters` addresses the object's **JSON properties**; the ObjectEntity's `id` is its own column, merged into the serialised output afterwards. That shape matches **zero rows for every value**, uuids included, and returns an empty array rather than raising — so each of these reported a record that plainly exists as absent, with no exception and nothing in the log.

Measured in-container, filtering each schema by its own real id:

```
Receipt            total=1    filters.id(4c2c0d82…)=0
Administration     total=1    filters.id(1c13b57b…)=0
BudgetBBVMapping   total=1    filters.id(d8cb5294…)=0
```

The trap that hides it: the **HTTP list API does answer `?id=…`** — it maps that onto the entity column — so the identical lookup looks healthy when probed with curl and returns nothing in PHP.

## What was actually broken

- **`FxRevaluationService` and `RealisedFxSettlementService`** resolve an administration's `functionalCurrency` and fall back to EUR when not found. The lookup never succeeded, so **both silently returned EUR for every administration**, ignoring whatever currency was configured.
- **`AppointmentConfirmationService`** and **`PaymentReconciliationService`** each try by-id first and fall back to `appointmentNumber` / `slug`. The by-id arm never matched, so anything addressed by uuid only ever resolved if it also carried the fallback property.
- **`NotificationController::requireAccessibleBooking()`** refused every booking addressed by uuid.
- **`PayrollWebhookController`** treated every inbound webhook as referencing an unknown Payroll.
- **`AccountantsdossierExportService::loadOne`**, **`BadoControleprotocolService::resolveObject`** and **`ExtractionRequestController::findById`** returned null for everything asked of them.
- **`PeriodCloseService`**'s id fallback never fell back.
- **`AdministrationArchivalService`** reported every administration absent.

## The fix

Adds `ObjectIdentifier::findOne()`, which does the lookup the way that works: `find()` first — in **its own** try/catch, because it *throws* `DoesNotExistException` rather than returning null, so a shared catch swallows the fallback — then an optional fallback property.

Cross-references in this app join on the uuid (as `ObjectIdentifier`'s existing docblock already documents), so `find()` answers most of these on its own. The three `Administration` lookups pass `administrationCode`, which is the id space the app actually uses: `buildContext()` echoes the code back as `activeAdministrationId` and `ci-seed.sh` stamps fixtures with it.

Verified against live data, negatives included:

```
findOne(Receipt, uuid)                                -> record(30 keys)
findOne(Receipt, garbage)                             -> NULL (correct)
findOne(Receipt, empty)                               -> NULL (correct)
findOne(Administration, ADM-001, administrationCode)  -> FOUND (fallback works)
findOne(Administration, ADM-001, no fallback)         -> NULL (correct — not a uuid)
```

## The test doubles could not have caught any of this

Four are corrected here. Each matched `filters` against plain array keys — treating `id` as filterable exactly like the broken code assumed — and **none implemented `find()` at all**, so the lookup path the code really takes was never exercised. They now throw `DoesNotExistException` on a miss and return nothing for a filter containing `id`.

`AdministrationArchivalServiceLookupTest` went further: it asserted `['id' => 'adm-1']` as the expected query, holding the broken shape in place as though it were the contract.

This is the same correction already applied to `FiscalYearContextServiceTest` and `AdministrationContextServiceTest` in #870.

## Verification

Unit suite failures stay at the **2-failure baseline** — both `TimeIntakeServiceTest`, hitting the pre-existing `OCA\OpenRegister\Contract\ObjectServiceInterface does not exist` environment gap behind that run's 1184 errors.

The sequence is worth stating, because it is the evidence the fix is real: fixing the call sites first took failures **2 → 16**; all 14 new ones were the doubles; correcting the doubles returned it to **2**.

phpcs introduces **zero** new errors. The 41 in `AppointmentConfirmationServiceTest` are pre-existing and sit at lines 172+, below everything added here — verified by comparing the error line set against the added ranges, not just the count.

## Deliberately out of scope

The **38 remaining sites are lifecycle guards** and are not touched. Each currently takes its not-found branch on every call, so the rule it encodes is dead code. Restoring them makes dormant financial controls start enforcing again — where a guard fails closed that unblocks legitimate work, and where one fails open the consequence runs the other way. That is a behavioural change across bookkeeping flows and wants its own review rather than riding along here.

#871 carries the full inventory and reproduction command.
