### PR TITLE
fix(adr-084): repair the call sites the contract migration left behind — two live 500s, three silent no-ops, phpmd 10→0, phpstan 66→2

### DIFF
--- a/lib/Controller/PaymentRunController.php
+++ b/lib/Controller/PaymentRunController.php
@@ -213,15 +213,9 @@ class PaymentRunController extends Controller {
 			return null;
 		}
 
-		if (is_object($run) === true && method_exists($run, 'jsonSerialize') === true) {
-			return (array)$run->jsonSerialize();
-		}
-
-		if (is_array($run) === true) {
-			return $run;
-		}
-
-		return null;
+		// ADR-084: find() is declared `: ?ObjectEntityInterface`, which extends
+		// JsonSerializable — the is_array() arm below it was unreachable by type.
+		return (array)$run->jsonSerialize();
 	}//end resolveRun()
 
 	/**

--- a/lib/Controller/SupplierInvoiceImportController.php
+++ b/lib/Controller/SupplierInvoiceImportController.php
@@ -354,11 +354,11 @@ class SupplierInvoiceImportController extends Controller {
 			->setSchema(self::SUPPLIER_INVOICE_SCHEMA)
 			->saveObject($record);
 
-		if (is_array($result) === true) {
-			return $result;
-		}
-
-		return $record;
+		// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+		// is_array() arm here was unreachable by type and this helper returned
+		// the INPUT record on every import — the stored invoice's id/uuid never
+		// reached the response.
+		return (array)$result->jsonSerialize();
 	}//end saveSupplierInvoice()
 
 	/**

--- a/lib/Guard/AccountBalanceGuard.php
+++ b/lib/Guard/AccountBalanceGuard.php
@@ -94,20 +94,18 @@ class AccountBalanceGuard {
 	 * @spec openspec/specs/bookkeeping-chart-of-accounts/spec.md (REQ-CoA-005)
 	 */
 	public function requireZeroBalance(array $account): bool {
-		// T1 probe: if ObjectService itself is unavailable (OR not installed), permit
-		// archive by default — no GLLine register can exist without OR (T1 state).
-		// This probe is intentionally separate from the computation resolution below
-		// so that "OR absent" (permit) and "computation failed" (deny, fail-closed)
-		// remain two distinct, independently observable outcomes.
-		try {
-		} catch (\Throwable) {
-			$this->logger->debug(
-				'AccountBalanceGuard: ObjectService not present (T1 state) — archive permitted by default',
-				['accountNumber' => ($account['accountNumber'] ?? 'unknown')]
-			);
-			return true;
-		}
-
+		// ADR-084 removed the T1 probe that used to live here: it resolved
+		// ObjectService from the container inside a try/catch so that "OR absent"
+		// (permit) stayed distinguishable from "computation failed" (deny). With
+		// the contract injected non-nullably that probe became an EMPTY try block
+		// whose catch could never fire — a dead branch that read like a live
+		// fail-open. It is deleted rather than left looking load-bearing.
+		//
+		// Consequence, stated rather than hidden: on an instance without
+		// OpenRegister the call below throws and the fail-closed catch DENIES the
+		// archive. That is the safe direction, but it is a behaviour change from
+		// the T1 permit, and it belongs to the ADR-084 migration, not to this fix.
+		//
 		// T2+ check: compute balance via GLLine records. Fail-closed on any error
 		// so a transient DB failure denies archive rather than silently permitting it.
 		// The ObjectService is resolved again inside this guarded block so a failure

--- a/lib/Guard/BankReconciliationGuard.php
+++ b/lib/Guard/BankReconciliationGuard.php
@@ -367,17 +367,15 @@ class BankReconciliationGuard {
 				->setSchema($schema)
 				->find($id);
 
-			if (is_array($result) === true) {
-				return $result;
+			// ADR-084: find() is declared `: ?ObjectEntityInterface`, which extends
+			// JsonSerializable — the is_array() arm above was unreachable by type.
+			if ($result === null) {
+				return null;
 			}
 
-			if (is_object($result) === true && method_exists($result, 'jsonSerialize') === true) {
-				$serialized = $result->jsonSerialize();
-				if (is_array($serialized) === true) {
-					return $serialized;
-				}
-
-				return null;
+			$serialized = $result->jsonSerialize();
+			if (is_array($serialized) === true) {
+				return $serialized;
 			}
 
 			return null;

--- a/lib/Lifecycle/BudgetOverrunGuard.php
+++ b/lib/Lifecycle/BudgetOverrunGuard.php
@@ -112,11 +112,11 @@ class BudgetOverrunGuard {
 			$register = $this->resolveRegister();
 
 			$basis = $this->toRows(
-				rows: $objectService->setRegister($register)->setSchema('Taakveld')
+				rows: $this->objectService->setRegister($register)->setSchema('Taakveld')
 					->findAll(['filters' => ['budgetId' => $budgetId]])
 			);
 			$wijzigingen = $this->toRows(
-				rows: $objectService->setRegister($register)->setSchema('Begrotingswijziging')
+				rows: $this->objectService->setRegister($register)->setSchema('Begrotingswijziging')
 					->findAll(['filters' => ['budgetId' => $budgetId]])
 			);
 
@@ -127,7 +127,7 @@ class BudgetOverrunGuard {
 			);
 
 			$glLines = $this->toRows(
-				rows: $objectService->setRegister($register)->setSchema('GLLine')
+				rows: $this->objectService->setRegister($register)->setSchema('GLLine')
 					->findAll(['filters' => ['taskFieldCode' => $taskFieldCode, 'side' => 'debit']])
 			);
 			$alreadyPostedCents = 0;

--- a/lib/Lifecycle/ExpenseReimbursementGuard.php
+++ b/lib/Lifecycle/ExpenseReimbursementGuard.php
@@ -356,10 +356,12 @@ class ExpenseReimbursementGuard {
 					continue;
 				}
 
-				$itemArray = (array)$item;
-				if (is_array($item) === true) {
-					$itemArray = $item;
-				}
+				// ADR-084: find() returns an ObjectEntityInterface, so the is_array()
+				// arm was unreachable and `(array)$item` cast the ENTITY — yielding
+				// its (mangled, private) property names rather than the stored
+				// payload, so `settlementMode` was never present and the mixed-mode
+				// rejection below could not fire.
+				$itemArray = (array)$item->jsonSerialize();
 
 				$itemMode = ($itemArray['settlementMode'] ?? null);
 
@@ -509,10 +511,10 @@ class ExpenseReimbursementGuard {
 					continue;
 				}
 
-				$itemArray = (array)$item;
-				if (is_array($item) === true) {
-					$itemArray = $item;
-				}
+				// ADR-084: see the note in the mixed-mode check above — `(array)$item`
+				// cast the ENTITY, not its payload, so no pass-through item was ever
+				// recognised and the cost total below always came out zero.
+				$itemArray = (array)$item->jsonSerialize();
 
 				if (($itemArray['settlementMode'] ?? null) !== 'pass-through') {
 					continue;
@@ -557,10 +559,10 @@ class ExpenseReimbursementGuard {
 			return false;
 		}
 
-		$txnArray = (array)$txn;
-		if (is_array($txn) === true) {
-			$txnArray = $txn;
-		}
+		// ADR-084: see the note in the mixed-mode check above — `(array)$txn` cast
+		// the ENTITY, so `status`/`isReversed` were never present and this guard
+		// read every transaction as neither posted nor reversed.
+		$txnArray = (array)$txn->jsonSerialize();
 
 		$status = ($txnArray['status'] ?? null);
 		$reversed = ($txnArray['isReversed'] ?? null);

--- a/lib/Lifecycle/RuleComplianceGuard.php
+++ b/lib/Lifecycle/RuleComplianceGuard.php
@@ -188,7 +188,8 @@ class RuleComplianceGuard {
 				->setSchema('GLLine')
 				->findAll(['filters' => ['transactionId' => $key]]);
 
-			foreach (($rows ?? []) as $row) {
+			// ADR-084: findAll() is declared `: array` — never null.
+			foreach ($rows as $row) {
 				$line = $row;
 				if (is_object($row) === true && method_exists($row, 'jsonSerialize') === true) {
 					$line = (array)$row->jsonSerialize();

--- a/lib/Lifecycle/StockReservationGuard.php
+++ b/lib/Lifecycle/StockReservationGuard.php
@@ -371,11 +371,11 @@ class StockReservationGuard {
 				return false;
 			}
 
-			if (is_array($current) === true) {
-				$currentArray = $current;
-			} else {
-				$currentArray = (array)$current;
-			}
+			// ADR-084: find() returns an ObjectEntityInterface, so the is_array()
+			// arm was unreachable and `(array)$current` cast the ENTITY — its
+			// `version` key was absent, so the compare-and-set below read every
+			// row as version 0 and reported a collision against any non-zero row.
+			$currentArray = (array)$current->jsonSerialize();
 
 			if ((int)($currentArray['version'] ?? 0) !== (int)($row['version'] ?? 0)) {
 				$this->logger->info('StockReservationGuard: CAS collision', ['id' => $id]);
@@ -383,10 +383,15 @@ class StockReservationGuard {
 			}
 
 			$merged = array_merge($currentArray, $patch);
+			// ADR-084: the contract declares updateObject(string $objectId, array $data,
+			// bool $_rbac, bool $_multitenancy). The register/schema scope is carried by
+			// the setRegister()/setSchema() chain above, so passing them here raised
+			// "Unknown named parameter $register" — swallowed by the catch below, which
+			// made every compare-and-set silently report a collision instead of writing.
 			$this->objectService
 				->setRegister($this->register())
 				->setSchema('InventoryStock')
-				->updateObject(id: $id, object: $merged, register: $this->register(), schema: 'InventoryStock');
+				->updateObject(objectId: $id, data: $merged);
 
 			return true;
 		} catch (\Throwable $e) {

--- a/lib/Repair/FoldDunningWriteoffIntoArInvoice.php
+++ b/lib/Repair/FoldDunningWriteoffIntoArInvoice.php
@@ -131,7 +131,7 @@ class FoldDunningWriteoffIntoArInvoice implements IRepairStep {
 				// Load the linked ARInvoice. factuurId is the ARInvoice UUID.
 				$invoice = null;
 				try {
-					$invoice = $objectService->find(
+					$invoice = $this->objectService->find(
 						id: $invoiceId,
 						register: $registerSlug,
 						schema: 'ARInvoice',

--- a/lib/Service/CogsPosterService.php
+++ b/lib/Service/CogsPosterService.php
@@ -366,10 +366,9 @@ class CogsPosterService {
 			->setSchema($schema)
 			->saveObject($data);
 
-		if (is_array($saved) === true) {
-			return $saved;
-		}
-
+		// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so an
+		// is_array() arm here is unreachable by type. The jsonSerialize() path
+		// below is the one that has always run.
 		if (is_object($saved) === true && method_exists($saved, 'jsonSerialize') === true) {
 			$out = $saved->jsonSerialize();
 			if (is_array($out) === true) {

--- a/lib/Service/Commitment/CommitmentMaterialisationService.php
+++ b/lib/Service/Commitment/CommitmentMaterialisationService.php
@@ -559,11 +559,11 @@ class CommitmentMaterialisationService {
 			$ruleNumber++;
 		}
 
-		if (is_array($saved) === true) {
-			return $saved;
-		}
-
-		return $draft;
+		// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+		// is_array() arm here was unreachable by type and persist() returned the
+		// unsaved DRAFT on every call — the Verplichting's stored id never
+		// reached the caller.
+		return (array)$saved->jsonSerialize();
 	}//end persist()
 
 	/**

--- a/lib/Service/CycleCountService.php
+++ b/lib/Service/CycleCountService.php
@@ -453,13 +453,11 @@ class CycleCountService {
 				$filters['locationId'] = $locationFilter;
 			}
 
-			$rows = ($this->objectService
+			// ADR-084: findAll() is declared `: array` — never null, always an array.
+			$rows = $this->objectService
 				->setRegister($this->register())
 				->setSchema('InventoryStock')
-				->findAll(['filters' => $filters]) ?? []);
-			if (is_array($rows) === false) {
-				return [];
-			}
+				->findAll(['filters' => $filters]);
 
 			// Category filter requires a Product lookup. Fall back to client-side
 			// filter (the volume of stock rows per administration is bounded by SKU
@@ -517,10 +515,23 @@ class CycleCountService {
 				)
 			);
 			foreach ($skus as $sku) {
-				$product = $this->objectService
+				// ADR-084: this passed a filter ARRAY to find(int|string $id), which
+				// looks up a single object by identifier — it never applied the
+				// filters, and the is_array() test on its ObjectEntityInterface
+				// result was false regardless, so every SKU was categorised ''.
+				// findAll() is the filtered lookup and returns array rows.
+				$products = $this->objectService
 					->setRegister($this->register())
 					->setSchema('Product')
-					->find(['filters' => ['administrationId' => $administrationId, 'sku' => $sku]]);
+					->findAll(
+						[
+							'filters' => [
+								'administrationId' => $administrationId,
+								'sku' => $sku,
+							],
+						]
+					);
+				$product = ($products[0] ?? null);
 				$cat = '';
 				if (is_array($product) === true && isset($product['category']) === true) {
 					$cat = (string)$product['category'];
@@ -560,7 +571,8 @@ class CycleCountService {
 	 */
 	private function findLinesForCount(string $administrationId, string $countId): array {
 		try {
-			$rows = ($this->objectService
+			// ADR-084: findAll() is declared `: array` — never null, always an array.
+			return $this->objectService
 				->setRegister($this->register())
 				->setSchema('InventoryCycleCountLine')
 				->findAll(
@@ -570,12 +582,7 @@ class CycleCountService {
 							'countId' => $countId,
 						],
 					]
-				) ?? []);
-			if (is_array($rows) === true) {
-				return $rows;
-			}
-
-			return [];
+				);
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'CycleCountService: findLinesForCount failed',

--- a/lib/Service/EInvoice/EInvoiceService.php
+++ b/lib/Service/EInvoice/EInvoiceService.php
@@ -104,8 +104,12 @@ final class EInvoiceService {
 		private readonly ObjectServiceInterface $objectService,
 		?PeppolTransmissionPortInterface $peppolPort = null,
 	) {
+		// ADR-084: the adapter takes the ObjectService contract now, not the DI
+		// container. This site still passed `container: $container` — a parameter
+		// this constructor does not declare — so every EInvoiceService built
+		// without an explicit $peppolPort fataled at REQUEST time.
 		$this->peppolPort = ($peppolPort ?? new LogPeppolTransmissionAdapter(
-			container: $container,
+			objectService: $objectService,
 			appConfig: $appConfig,
 			logger: $logger
 		));
@@ -363,11 +367,11 @@ final class EInvoiceService {
 				->setSchema($schema)
 				->saveObject($object);
 
-			if (is_array($result) === true) {
-				return $result;
-			}
-
-			return $object;
+			// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+			// is_array() arm here was unreachable by type and this helper returned
+			// the INPUT on every save — silently discarding the id/uuid the store
+			// had just generated, which callers then read back as empty.
+			return (array)$result->jsonSerialize();
 		} catch (Throwable $e) {
 			$this->logger->error(
 				'EInvoiceService: failed to persist object',

--- a/lib/Service/ExceptionResolutionService.php
+++ b/lib/Service/ExceptionResolutionService.php
@@ -934,11 +934,11 @@ class ExceptionResolutionService {
 				->setSchema($schema)
 				->saveObject($object);
 
-			if (is_array($result) === true) {
-				return $result;
-			}
-
-			return $object;
+			// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+			// is_array() arm here was unreachable by type and this helper returned
+			// the INPUT on every save — silently discarding the id/uuid the store
+			// had just generated, which callers then read back as empty.
+			return (array)$result->jsonSerialize();
 		} catch (\Throwable $exception) {
 			$this->logger->error(
 				'ExceptionResolutionService: failed to persist object',

--- a/lib/Service/FifoValuationService.php
+++ b/lib/Service/FifoValuationService.php
@@ -591,11 +591,9 @@ class FifoValuationService {
 			->setSchema('InventoryValuation')
 			->saveObject($data);
 
-		if (is_array($saved) === false) {
-			return $this->asArray(row: $saved);
-		}
-
-		return $saved;
+		// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+		// is_array() test was constant — asArray() is the only path that runs.
+		return $this->asArray(row: $saved);
 	}//end saveValuation()
 
 	/**

--- a/lib/Service/FixedAssetDisposalService.php
+++ b/lib/Service/FixedAssetDisposalService.php
@@ -548,10 +548,9 @@ class FixedAssetDisposalService {
 			->setSchema($schema)
 			->saveObject($data);
 
-		if (is_array($saved) === true) {
-			return $saved;
-		}
-
+		// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so an
+		// is_array() arm here is unreachable by type. The jsonSerialize() path
+		// below is the one that has always run.
 		if (is_object($saved) === true && method_exists($saved, 'jsonSerialize') === true) {
 			$out = $saved->jsonSerialize();
 			if (is_array($out) === true) {

--- a/lib/Service/GRIRClearingService.php
+++ b/lib/Service/GRIRClearingService.php
@@ -1351,10 +1351,9 @@ class GRIRClearingService {
 			->setSchema($schema)
 			->saveObject($data);
 
-		if (is_array($saved) === true) {
-			return $saved;
-		}
-
+		// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so an
+		// is_array() arm here is unreachable by type. The jsonSerialize() path
+		// below is the one that has always run.
 		if (is_object($saved) === true && method_exists($saved, 'jsonSerialize') === true) {
 			$out = $saved->jsonSerialize();
 			if (is_array($out) === true) {

--- a/lib/Service/GoodsReceiptNoteService.php
+++ b/lib/Service/GoodsReceiptNoteService.php
@@ -910,11 +910,11 @@ class GoodsReceiptNoteService {
 				->setSchema($schema)
 				->saveObject($object);
 
-			if (is_array($result) === true) {
-				return $result;
-			}
-
-			return $object;
+			// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+			// is_array() arm here was unreachable by type and this helper returned
+			// the INPUT on every save — silently discarding the id/uuid the store
+			// had just generated, which callers then read back as empty.
+			return (array)$result->jsonSerialize();
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'GoodsReceiptNoteService: failed to persist object',

--- a/lib/Service/IntercompanyLinkService.php
+++ b/lib/Service/IntercompanyLinkService.php
@@ -262,10 +262,9 @@ class IntercompanyLinkService {
 			->setSchema(self::SCHEMA_ENTRY)
 			->saveObject($data);
 
-		if (is_array($saved) === true) {
-			return $saved;
-		}
-
+		// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so an
+		// is_array() arm here is unreachable by type. The jsonSerialize() path
+		// below is the one that has always run.
 		if (is_object($saved) === true && method_exists($saved, 'jsonSerialize') === true) {
 			$out = $saved->jsonSerialize();
 			if (is_array($out) === true) {

--- a/lib/Service/InventoryGlAdjustmentPoster.php
+++ b/lib/Service/InventoryGlAdjustmentPoster.php
@@ -232,10 +232,9 @@ class InventoryGlAdjustmentPoster {
 			->setSchema($schema)
 			->saveObject($data);
 
-		if (is_array($saved) === true) {
-			return $saved;
-		}
-
+		// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so an
+		// is_array() arm here is unreachable by type. The jsonSerialize() path
+		// below is the one that has always run.
 		if (is_object($saved) === true && method_exists($saved, 'jsonSerialize') === true) {
 			$out = $saved->jsonSerialize();
 			if (is_array($out) === true) {

--- a/lib/Service/InvoiceGenerationService.php
+++ b/lib/Service/InvoiceGenerationService.php
@@ -759,11 +759,14 @@ class InvoiceGenerationService {
 	private function find(string $schema, string $id): ?array {
 		try {
 			$rs = $this->objectService->setRegister($this->register())->setSchema($schema)->find($id);
-			if (is_array($rs) === true) {
-				return $rs;
+			// ADR-084: find() is declared `: ?ObjectEntityInterface`, so the old
+			// is_array() arm was unreachable by type and this helper returned NULL
+			// for every existing record — every lookup read as "not found".
+			if ($rs === null) {
+				return null;
 			}
 
-			return null;
+			return (array)$rs->jsonSerialize();
 		} catch (\Throwable $e) {
 			return null;
 		}

--- a/lib/Service/LandedCostAllocationService.php
+++ b/lib/Service/LandedCostAllocationService.php
@@ -403,11 +403,9 @@ class LandedCostAllocationService {
 			->setSchema('InventoryValuation')
 			->saveObject($data);
 
-		if (is_array($saved) === false) {
-			return $this->asArray(row: $saved);
-		}
-
-		return $saved;
+		// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+		// is_array() test was constant — asArray() is the only path that runs.
+		return $this->asArray(row: $saved);
 	}//end saveValuation()
 
 	/**

--- a/lib/Service/MovingAverageValuationService.php
+++ b/lib/Service/MovingAverageValuationService.php
@@ -280,11 +280,9 @@ class MovingAverageValuationService {
 			->setSchema('InventoryValuation')
 			->saveObject($data);
 
-		if (is_array($saved) === false) {
-			return $this->asArray(row: $saved);
-		}
-
-		return $saved;
+		// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+		// is_array() test was constant — asArray() is the only path that runs.
+		return $this->asArray(row: $saved);
 	}//end saveValuation()
 
 	/**

--- a/lib/Service/MultiPoConsolidationService.php
+++ b/lib/Service/MultiPoConsolidationService.php
@@ -894,11 +894,11 @@ class MultiPoConsolidationService {
 				->setSchema($schema)
 				->saveObject($object);
 
-			if (is_array($result) === true) {
-				return $result;
-			}
-
-			return $object;
+			// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+			// is_array() arm here was unreachable by type and this helper returned
+			// the INPUT on every save — silently discarding the id/uuid the store
+			// had just generated, which callers then read back as empty.
+			return (array)$result->jsonSerialize();
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'MultiPoConsolidationService: failed to persist object',

--- a/lib/Service/NrvWriteDownService.php
+++ b/lib/Service/NrvWriteDownService.php
@@ -296,11 +296,9 @@ class NrvWriteDownService {
 			->setSchema('InventoryValuation')
 			->saveObject($data);
 
-		if (is_array($saved) === false) {
-			return $this->asArray(row: $saved);
-		}
-
-		return $saved;
+		// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+		// is_array() test was constant — asArray() is the only path that runs.
+		return $this->asArray(row: $saved);
 	}//end saveValuation()
 
 	/**

--- a/lib/Service/OssRecordResolver.php
+++ b/lib/Service/OssRecordResolver.php
@@ -149,10 +149,9 @@ class OssRecordResolver {
 			->setSchema(self::SCHEMA_PAYMENT)
 			->saveObject($data);
 
-		if (is_array($saved) === true) {
-			return $saved;
-		}
-
+		// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so an
+		// is_array() arm here is unreachable by type. The jsonSerialize() path
+		// below is the one that has always run.
 		if (is_object($saved) === true && method_exists($saved, 'jsonSerialize') === true) {
 			$out = $saved->jsonSerialize();
 			if (is_array($out) === true) {

--- a/lib/Service/Peppol/LogPeppolTransmissionAdapter.php
+++ b/lib/Service/Peppol/LogPeppolTransmissionAdapter.php
@@ -43,10 +43,10 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Service\Peppol;
 
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Service\PurchaseOrder\PeppolTransmissionAdapterInterface;
 use OCP\IAppConfig;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -71,14 +71,16 @@ final class LogPeppolTransmissionAdapter implements PeppolTransmissionAdapterInt
 	];
 
 	/**
-	 * DI container — used to lazily fetch OR's ObjectService for the party lookup.
-	 * The container indirection keeps this class testable without forcing a
-	 * hard dependency on OpenRegister when a schema is absent (e.g. greenfield
-	 * deployments).
+	 * OpenRegister's object service, injected per ADR-083/ADR-084.
 	 *
-	 * @var ContainerInterface
+	 * The party lookup is still wrapped in a try/catch so a missing schema
+	 * (e.g. a greenfield deployment without `Vendor`/`CustomerMaster`) degrades
+	 * to "no participant id" rather than failing the transmission — that
+	 * tolerance lives in {@see lookupInSchema()}, not in the wiring.
+	 *
+	 * @var ObjectServiceInterface
 	 */
-	private ContainerInterface $container;
+	private ObjectServiceInterface $objectService;
 
 	/**
 	 * App config (resolves the register slug).
@@ -97,19 +99,19 @@ final class LogPeppolTransmissionAdapter implements PeppolTransmissionAdapterInt
 	/**
 	 * Constructor.
 	 *
-	 * @param ContainerInterface $container DI container — OR's ObjectService
-	 *                                      is fetched lazily.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service,
+	 *                                             injected per ADR-083.
 	 * @param IAppConfig $appConfig App config for the register slug.
 	 * @param LoggerInterface|null $logger Optional logger (defaults to NullLogger).
 	 *
 	 * @return void
 	 */
 	public function __construct(
-		ContainerInterface $container,
+		ObjectServiceInterface $objectService,
 		IAppConfig $appConfig,
 		?LoggerInterface $logger = null,
 	) {
-		$this->container = $container;
+		$this->objectService = $objectService;
 		$this->appConfig = $appConfig;
 		$this->logger = ($logger ?? new NullLogger());
 
@@ -245,8 +247,7 @@ final class LogPeppolTransmissionAdapter implements PeppolTransmissionAdapterInt
 	private function lookupInSchema(string $administrationId, string $partyId, string $schema, string $idField): ?string {
 		try {
 			$register = $this->register();
-			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
-			$rows = $objectService
+			$rows = $this->objectService
 				->setRegister($register)
 				->setSchema($schema)
 				->findAll(

--- a/lib/Service/PurchaseOrderApprovalService.php
+++ b/lib/Service/PurchaseOrderApprovalService.php
@@ -397,11 +397,11 @@ class PurchaseOrderApprovalService {
 				->setSchema($schema)
 				->saveObject($object);
 
-			if (is_array($result) === true) {
-				return $result;
-			}
-
-			return $object;
+			// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+			// is_array() arm here was unreachable by type and this helper returned
+			// the INPUT on every save — silently discarding the id/uuid the store
+			// had just generated, which callers then read back as empty.
+			return (array)$result->jsonSerialize();
 		} catch (\Throwable $exception) {
 			$this->logger->error(
 				'PurchaseOrderApprovalService: failed to persist object',

--- a/lib/Service/PurchaseOrderService.php
+++ b/lib/Service/PurchaseOrderService.php
@@ -196,22 +196,32 @@ class PurchaseOrderService {
 		?FrameworkAgreementDrawdownGuard $frameworkAgreementDrawdownGuard = null,
 		private readonly ?ApprovalActivityEmitter $activityEmitter = null,
 	) {
+		// ADR-084: these three collaborators used to be handed the DI container so
+		// they could resolve OpenRegister's ObjectService lazily. They now take the
+		// contract directly, so the container argument was removed from all three —
+		// but this composition site kept passing `container: $container`, a
+		// parameter this constructor no longer declares. An undefined variable is
+		// null, so every PurchaseOrderService built without an explicit
+		// $peppolAdapter/$supplierQualificationGuard/$frameworkAgreementDrawdownGuard
+		// died here at REQUEST time (Error: Unknown named parameter $container /
+		// TypeError: $container must be of type ContainerInterface, null given),
+		// taking every /api/purchase-orders* route with it.
 		$this->peppolAdapter = ($peppolAdapter ?? new LogPeppolTransmissionAdapter(
-			container: $container,
+			objectService: $objectService,
 			appConfig: $appConfig,
 			logger: $logger
 		));
 		$this->purchaseOrderMailer = ($purchaseOrderMailer ?? new LogPurchaseOrderMailer(logger: $logger));
 		$this->peppolMapper = ($peppolMapper ?? new PeppolBisOrderMapper());
 		$this->supplierQualificationGuard = ($supplierQualificationGuard ?? new SupplierQualificationGuard(
-			container: $container,
 			appConfig: $appConfig,
-			logger: $logger
+			logger: $logger,
+			objectService: $objectService
 		));
 		$this->frameworkAgreementDrawdownGuard = ($frameworkAgreementDrawdownGuard ?? new FrameworkAgreementDrawdownGuard(
-			container: $container,
 			appConfig: $appConfig,
-			logger: $logger
+			logger: $logger,
+			objectService: $objectService
 		));
 	}//end __construct()
 
@@ -1101,11 +1111,11 @@ class PurchaseOrderService {
 				->setSchema($schema)
 				->saveObject($object);
 
-			if (is_array($result) === true) {
-				return $result;
-			}
-
-			return $object;
+			// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+			// is_array() arm here was unreachable by type and this helper returned
+			// the INPUT on every save — silently discarding the id/uuid the store
+			// had just generated, which callers then read back as empty.
+			return (array)$result->jsonSerialize();
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'PurchaseOrderService: failed to persist object',

--- a/lib/Service/RequisitionConversionService.php
+++ b/lib/Service/RequisitionConversionService.php
@@ -191,11 +191,11 @@ class RequisitionConversionService {
 				->setSchema($schema)
 				->saveObject($object);
 
-			if (is_array($result) === true) {
-				return $result;
-			}
-
-			return $object;
+			// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+			// is_array() arm here was unreachable by type and this helper returned
+			// the INPUT on every save — silently discarding the id/uuid the store
+			// had just generated, which callers then read back as empty.
+			return (array)$result->jsonSerialize();
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'RequisitionConversionService: failed to persist object',

--- a/lib/Service/RequisitionService.php
+++ b/lib/Service/RequisitionService.php
@@ -456,11 +456,11 @@ class RequisitionService {
 				->setSchema($schema)
 				->saveObject($object);
 
-			if (is_array($result) === true) {
-				return $result;
-			}
-
-			return $object;
+			// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+			// is_array() arm here was unreachable by type and this helper returned
+			// the INPUT on every save — silently discarding the id/uuid the store
+			// had just generated, which callers then read back as empty.
+			return (array)$result->jsonSerialize();
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'RequisitionService: failed to persist object',

--- a/lib/Service/ServiceReceiptService.php
+++ b/lib/Service/ServiceReceiptService.php
@@ -737,11 +737,11 @@ class ServiceReceiptService {
 				->setSchema($schema)
 				->saveObject($object);
 
-			if (is_array($result) === true) {
-				return $result;
-			}
-
-			return $object;
+			// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+			// is_array() arm here was unreachable by type and this helper returned
+			// the INPUT on every save — silently discarding the id/uuid the store
+			// had just generated, which callers then read back as empty.
+			return (array)$result->jsonSerialize();
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'ServiceReceiptService: failed to persist object',

--- a/lib/Service/StockLedgerService.php
+++ b/lib/Service/StockLedgerService.php
@@ -258,22 +258,15 @@ class StockLedgerService {
 			'lifecycleState' => 'posted',
 		];
 
-		$sourceSide = ($this->objectService
+		// ADR-084: findAll() is declared `: array` — never null, always an array.
+		$sourceSide = $this->objectService
 			->setRegister($this->register())
 			->setSchema('StockMove')
-			->findAll(['filters' => array_merge($base, ['sourceLocationId' => $locationId])]) ?? []);
-		$destinationSide = ($this->objectService
+			->findAll(['filters' => array_merge($base, ['sourceLocationId' => $locationId])]);
+		$destinationSide = $this->objectService
 			->setRegister($this->register())
 			->setSchema('StockMove')
-			->findAll(['filters' => array_merge($base, ['destinationLocationId' => $locationId])]) ?? []);
-
-		if (is_array($sourceSide) === false) {
-			$sourceSide = [];
-		}
-
-		if (is_array($destinationSide) === false) {
-			$destinationSide = [];
-		}
+			->findAll(['filters' => array_merge($base, ['destinationLocationId' => $locationId])]);
 
 		$byId = [];
 		foreach (array_merge($sourceSide, $destinationSide) as $move) {
@@ -306,7 +299,8 @@ class StockLedgerService {
 			return [];
 		}
 
-		$rows = ($this->objectService
+		// ADR-084: findAll() is declared `: array` — never null, always an array.
+		return $this->objectService
 			->setRegister($this->register())
 			->setSchema('StockMove')
 			->findAll(
@@ -318,13 +312,7 @@ class StockLedgerService {
 						'lifecycleState' => 'draft',
 					],
 				]
-			) ?? []);
-
-		if (is_array($rows) === true) {
-			return $rows;
-		}
-
-		return [];
+			);
 	}//end draftMovesForSource()
 
 	/**

--- a/lib/Service/SupplierInvoiceService.php
+++ b/lib/Service/SupplierInvoiceService.php
@@ -865,11 +865,11 @@ class SupplierInvoiceService {
 				->setSchema($schema)
 				->saveObject($object);
 
-			if (is_array($result) === true) {
-				return $result;
-			}
-
-			return $object;
+			// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+			// is_array() arm here was unreachable by type and this helper returned
+			// the INPUT on every save — silently discarding the id/uuid the store
+			// had just generated, which callers then read back as empty.
+			return (array)$result->jsonSerialize();
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'SupplierInvoiceService: failed to persist object',

--- a/lib/Service/SupplierQualificationService.php
+++ b/lib/Service/SupplierQualificationService.php
@@ -250,11 +250,11 @@ class SupplierQualificationService {
 				->setSchema($schema)
 				->saveObject($object);
 
-			if (is_array($result) === true) {
-				return $result;
-			}
-
-			return $object;
+			// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+			// is_array() arm here was unreachable by type and this helper returned
+			// the INPUT on every save — silently discarding the id/uuid the store
+			// had just generated, which callers then read back as empty.
+			return (array)$result->jsonSerialize();
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'SupplierQualificationService: failed to persist object',

--- a/lib/Service/ThreeWayMatchingEngine.php
+++ b/lib/Service/ThreeWayMatchingEngine.php
@@ -1114,11 +1114,11 @@ class ThreeWayMatchingEngine {
 				->setSchema($schema)
 				->saveObject($object);
 
-			if (is_array($result) === true) {
-				return $result;
-			}
-
-			return $object;
+			// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+			// is_array() arm here was unreachable by type and this helper returned
+			// the INPUT on every save — silently discarding the id/uuid the store
+			// had just generated, which callers then read back as empty.
+			return (array)$result->jsonSerialize();
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'ThreeWayMatchingEngine: failed to persist object',

--- a/lib/Service/TimeIntakeService.php
+++ b/lib/Service/TimeIntakeService.php
@@ -718,11 +718,14 @@ class TimeIntakeService {
 	private function find(string $schema, string $id): ?array {
 		try {
 			$rs = $this->objectService->setRegister($this->register())->setSchema($schema)->find($id);
-			if (is_array($rs) === true) {
-				return $rs;
+			// ADR-084: find() is declared `: ?ObjectEntityInterface`, so the old
+			// is_array() arm was unreachable by type and this helper returned NULL
+			// for every existing record — every lookup read as "not found".
+			if ($rs === null) {
+				return null;
 			}
 
-			return null;
+			return (array)$rs->jsonSerialize();
 		} catch (\Throwable $e) {
 			return null;
 		}

--- a/lib/Service/VendorPerformanceAggregation.php
+++ b/lib/Service/VendorPerformanceAggregation.php
@@ -1129,11 +1129,11 @@ class VendorPerformanceAggregation {
 				->setSchema($schema)
 				->saveObject($object);
 
-			if (is_array($result) === true) {
-				return $result;
-			}
-
-			return $object;
+			// ADR-084: saveObject() is declared `: ObjectEntityInterface`, so the
+			// is_array() arm here was unreachable by type and this helper returned
+			// the INPUT on every save — silently discarding the id/uuid the store
+			// had just generated, which callers then read back as empty.
+			return (array)$result->jsonSerialize();
 		} catch (Throwable $e) {
 			$this->logger->error(
 				'VendorPerformanceAggregation: failed to persist object',

--- a/lib/Service/WbsoAccountService.php
+++ b/lib/Service/WbsoAccountService.php
@@ -179,10 +179,13 @@ class WbsoAccountService {
 		);
 
 
-		return $this->objectService
+		// ADR-084: saveObject() returns an ObjectEntityInterface, not the array
+		// this method declares — returning it raised a TypeError on every call.
+		return (array)$this->objectService
 			->setRegister($this->register())
 			->setSchema('Account')
-			->saveObject($payload);
+			->saveObject($payload)
+			->jsonSerialize();
 
 	}//end createAccount()
 
@@ -223,10 +226,12 @@ class WbsoAccountService {
 		);
 
 
-		return $this->objectService
+		// ADR-084: see createAccount() — the contract returns an entity.
+		return (array)$this->objectService
 			->setRegister($this->register())
 			->setSchema('Account')
-			->saveObject($merged);
+			->saveObject($merged)
+			->jsonSerialize();
 
 	}//end updateAccount()
 

--- a/lib/Service/WbsoDocumentService.php
+++ b/lib/Service/WbsoDocumentService.php
@@ -160,10 +160,13 @@ class WbsoDocumentService {
 		$this->validateDocumentPayload(payload: $payload);
 
 
-		return $this->objectService
+		// ADR-084: saveObject() returns an ObjectEntityInterface, not the array
+		// this method declares — returning it raised a TypeError on every call.
+		return (array)$this->objectService
 			->setRegister($this->register())
 			->setSchema('Document')
-			->saveObject($payload);
+			->saveObject($payload)
+			->jsonSerialize();
 
 	}//end createDocument()
 
@@ -203,10 +206,12 @@ class WbsoDocumentService {
 		$document['filedBy'] = $approver;
 
 
-		return $this->objectService
+		// ADR-084: see createDocument() — the contract returns an entity.
+		return (array)$this->objectService
 			->setRegister($this->register())
 			->setSchema('Document')
-			->saveObject($document);
+			->saveObject($document)
+			->jsonSerialize();
 
 	}//end fileDocument()
 
@@ -252,10 +257,12 @@ class WbsoDocumentService {
 		$document['archivalReason'] = $reason;
 
 
-		return $this->objectService
+		// ADR-084: see createDocument() — the contract returns an entity.
+		return (array)$this->objectService
 			->setRegister($this->register())
 			->setSchema('Document')
-			->saveObject($document);
+			->saveObject($document)
+			->jsonSerialize();
 
 	}//end archiveDocument()
 

--- a/lib/Service/WbsoTransactionService.php
+++ b/lib/Service/WbsoTransactionService.php
@@ -163,10 +163,13 @@ class WbsoTransactionService {
 		$this->validateTransactionPayload(payload: $payload);
 
 
-		return $this->objectService
+		// ADR-084: saveObject() returns an ObjectEntityInterface, not the array
+		// this method declares — returning it raised a TypeError on every call.
+		return (array)$this->objectService
 			->setRegister($this->register())
 			->setSchema('Transaction')
-			->saveObject($payload);
+			->saveObject($payload)
+			->jsonSerialize();
 
 	}//end createTransaction()
 
@@ -197,10 +200,12 @@ class WbsoTransactionService {
 		$existing['postedAt'] = (new DateTimeImmutable())->format(DateTimeInterface::ATOM);
 
 
-		return $this->objectService
+		// ADR-084: see createTransaction() — the contract returns an entity.
+		return (array)$this->objectService
 			->setRegister($this->register())
 			->setSchema('Transaction')
-			->saveObject($existing);
+			->saveObject($existing)
+			->jsonSerialize();
 
 	}//end postTransaction()
 
@@ -250,10 +255,12 @@ class WbsoTransactionService {
 		];
 
 
-		return $this->objectService
+		// ADR-084: see createTransaction() — the contract returns an entity.
+		return (array)$this->objectService
 			->setRegister($this->register())
 			->setSchema('Transaction')
-			->saveObject($reversal);
+			->saveObject($reversal)
+			->jsonSerialize();
 
 	}//end reverseTransaction()
 

--- a/tests/Unit/Controller/SupplierInvoiceImportControllerTest.php
+++ b/tests/Unit/Controller/SupplierInvoiceImportControllerTest.php
@@ -22,10 +22,12 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Controller;
 
+use OCA\OpenRegister\Contract\ObjectEntityInterface;
 use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Controller\SupplierInvoiceImportController;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\SupplierInvoiceService;
+use OCA\Shillinq\Tests\Unit\Service\Support\ObjectEntityStub;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -33,7 +35,6 @@ use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
@@ -77,13 +78,6 @@ final class SupplierInvoiceImportControllerTest extends TestCase {
 	private IUserSession&MockObject $session;
 
 	/**
-	 * Mock ContainerInterface.
-	 *
-	 * @var ContainerInterface&MockObject
-	 */
-	private ContainerInterface&MockObject $container;
-
-	/**
 	 * Mock LoggerInterface.
 	 *
 	 * @var LoggerInterface&MockObject
@@ -123,7 +117,6 @@ final class SupplierInvoiceImportControllerTest extends TestCase {
 		$this->service = $this->createMock(SupplierInvoiceService::class);
 		$this->administrationContext = $this->createMock(AdministrationContextService::class);
 		$this->session = $this->createMock(IUserSession::class);
-		$this->container = $this->createMock(ContainerInterface::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 
 		// Authenticated session by default.
@@ -141,85 +134,46 @@ final class SupplierInvoiceImportControllerTest extends TestCase {
 		);
 		$this->administrationContext->method('canAccess')->willReturn(true);
 
-		// ObjectService stub used for the duplicate pre-check + CSV writes.
-		$this->container->method('get')->willReturn($this->makeObjectServiceStub());
-
 		$this->controller = new SupplierInvoiceImportController(
 			request: $this->request,
 			supplierInvoiceService: $this->service,
 			administrationContext: $this->administrationContext,
 			session: $this->session,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: $this->makeObjectServiceStub(),
 		);
 
 	}//end setUp()
 
 	/**
-	 * Build a fluent ObjectService stub (setRegister/setSchema/findAll/saveObject).
+	 * Build an ObjectService double over the real contract.
 	 *
-	 * @return object
+	 * @return ObjectServiceInterface
 	 */
-	private function makeObjectServiceStub(): object {
-		$test = $this;
-		return new class($test) {
-			/**
-			 * Back-reference to the test case.
-			 *
-			 * @var SupplierInvoiceImportControllerTest
-			 */
-			private $test;
-
-			/**
-			 * @param SupplierInvoiceImportControllerTest $test Test case.
-			 */
-			public function __construct($test) {
-				$this->test = $test;
+	private function makeObjectServiceStub(): ObjectServiceInterface {
+		// ADR-084: this file's own duck-typed stub reached the controller through a
+		// ContainerInterface mock, while `objectService:` got a bare createMock() —
+		// so the controller read an EMPTY double, recorded no filters, and its
+		// saveObject() helper returned its own input. createMock() of the real
+		// interface is regenerated from the contract, so a signature that moves
+		// upstream breaks this double instead of quietly answering the old shape.
+		$objectService = $this->createMock(ObjectServiceInterface::class);
+		$objectService->method('setRegister')->willReturnSelf();
+		$objectService->method('setSchema')->willReturnSelf();
+		$objectService->method('findAll')->willReturnCallback(
+			function (array $config = []): array {
+				$this->recordFilters((array)($config['filters'] ?? []));
+				return $this->stubRowsForTest();
 			}
-
-			/**
-			 * @param string $r Register slug.
-			 *
-			 * @return self
-			 */
-			public function setRegister(string $r): self {
-				return $this;
-			}
-
-			/**
-			 * @param string $s Schema slug.
-			 *
-			 * @return self
-			 */
-			public function setSchema(string $s): self {
-				return $this;
-			}
-
-			/**
-			 * Mirrors OpenRegister ObjectService::findAll(array $config) — the filter
-			 * map travels inside $config['filters'], never as a top-level `filters:`
-			 * argument. Recording the unwrapped map keeps the test asserting the exact
-			 * filters OpenRegister would receive.
-			 *
-			 * @param array<string,mixed> $config Find configuration (filters, limit, …).
-			 *
-			 * @return array<int,array<string,mixed>>
-			 */
-			public function findAll(array $config = []): array {
-				$this->test->recordFilters((array)($config['filters'] ?? []));
-				return $this->test->stubRowsForTest();
-			}
-
-			/**
-			 * @param array<string,mixed> $object Object to persist.
-			 *
-			 * @return array<string,mixed>
-			 */
-			public function saveObject(array $object): array {
+		);
+		$objectService->method('saveObject')->willReturnCallback(
+			static function (array $object): ObjectEntityInterface {
 				$object['id'] = 'created-id';
-				return $object;
+				return new ObjectEntityStub(payload: $object);
 			}
-		};
+		);
+
+		return $objectService;
 
 	}//end makeObjectServiceStub()
 

--- a/tests/Unit/Service/Peppol/LogPeppolTransmissionAdapterTest.php
+++ b/tests/Unit/Service/Peppol/LogPeppolTransmissionAdapterTest.php
@@ -22,12 +22,12 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service\Peppol;
 
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\Peppol\LogPeppolTransmissionAdapter;
 use OCA\Shillinq\Service\Peppol\PeppolTransmissionPortInterface;
 use OCA\Shillinq\Service\PurchaseOrder\PeppolTransmissionAdapterInterface;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;
 
 /**
@@ -176,56 +176,28 @@ final class LogPeppolTransmissionAdapterTest extends TestCase {
 	 * @return LogPeppolTransmissionAdapter
 	 */
 	private function buildAdapter(array $rows): LogPeppolTransmissionAdapter {
-		$stub = new class($rows) {
-			/**
-			 * @var array<string,array<int,array<string,mixed>>>
-			 */
-			private array $rows;
-
-			/**
-			 * @var string
-			 */
-			private string $schema = '';
-
-			/**
-			 * @param array<string,array<int,array<string,mixed>>> $rows Schema rows.
-			 */
-			public function __construct(array $rows) {
-				$this->rows = $rows;
+		// ADR-084: the adapter takes ObjectServiceInterface, not the container, so
+		// the double has to BE that interface rather than merely quack like it.
+		// createMock() gives the whole 25-method surface for free and, crucially,
+		// is regenerated from the real interface — a signature that moves upstream
+		// breaks this double instead of leaving it quietly answering the old shape.
+		$schema = '';
+		$objectService = $this->createMock(ObjectServiceInterface::class);
+		$objectService->method('setRegister')->willReturnSelf();
+		$objectService->method('setSchema')->willReturnCallback(
+			static function (string|int $requested) use (&$schema, $objectService): ObjectServiceInterface {
+				$schema = (string)$requested;
+				return $objectService;
 			}
-
-			/**
-			 * @param string $register Register slug (ignored).
-			 *
-			 * @return static
-			 */
-			public function setRegister(string $register): static {
-				unset($register);
-				return $this;
-			}
-
-			/**
-			 * @param string $schema Schema slug.
-			 *
-			 * @return static
-			 */
-			public function setSchema(string $schema): static {
-				$this->schema = $schema;
-				return $this;
-			}
-
-			/**
-			 * @param array<string,mixed> $params Query params.
-			 *
-			 * @return array<int,array<string,mixed>>
-			 */
-			public function findAll(array $params = []): array {
-				$rows = ($this->rows[$this->schema] ?? []);
-				$filters = ($params['filters'] ?? []);
+		);
+		$objectService->method('findAll')->willReturnCallback(
+			static function (array $config = []) use (&$schema, $rows): array {
+				$candidates = ($rows[$schema] ?? []);
+				$filters = ($config['filters'] ?? []);
 
 				return array_values(
 					array_filter(
-						$rows,
+						$candidates,
 						static function (array $row) use ($filters): bool {
 							foreach ($filters as $key => $value) {
 								if (($row[$key] ?? null) !== $value) {
@@ -238,19 +210,17 @@ final class LogPeppolTransmissionAdapterTest extends TestCase {
 					)
 				);
 			}
-		};
-
-		$container = $this->createMock(ContainerInterface::class);
-		$container->method('get')->willReturn($stub);
+		);
 
 		$appConfig = $this->createMock(IAppConfig::class);
 		$appConfig->method('getValueString')->willReturn('shillinq');
 
 		return new LogPeppolTransmissionAdapter(
-			container: $container,
+			objectService: $objectService,
 			appConfig: $appConfig,
 			logger: new NullLogger()
 		);
 
 	}//end buildAdapter()
+
 }//end class

--- a/tests/Unit/Service/PurchaseOrderGovernanceGuardTest.php
+++ b/tests/Unit/Service/PurchaseOrderGovernanceGuardTest.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\PurchaseOrderService;
 use OCA\Shillinq\Tests\Unit\Service\Support\InMemoryObjectServiceStub;
@@ -31,7 +30,6 @@ use OCP\IAppConfig;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -52,11 +50,12 @@ final class PurchaseOrderGovernanceGuardTest extends TestCase {
 	 * @return PurchaseOrderService
 	 */
 	private function buildService(array $data, string $qualificationPolicy, ?InMemoryObjectServiceStub &$stubOut = null): PurchaseOrderService {
+		// ADR-084: the stub used to reach the service (and its self-constructed
+		// governance guards) through a ContainerInterface mock, while
+		// `objectService:` got a bare createMock() — so the guards consulted an
+		// EMPTY double and neither REQ-PG-002 nor REQ-PG-004 could ever fire.
 		$stub = new InMemoryObjectServiceStub($data);
 		$stubOut = $stub;
-
-		$container = $this->createMock(ContainerInterface::class);
-		$container->method('get')->willReturn($stub);
 
 		$appConfig = $this->createMock(IAppConfig::class);
 		$appConfig->method('getValueString')->willReturnCallback(
@@ -94,7 +93,7 @@ final class PurchaseOrderGovernanceGuardTest extends TestCase {
 			administrationContext: $administrationContext,
 			notificationManager: $notificationManager,
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: $stub,
 		);
 	}//end buildService()
 

--- a/tests/Unit/Service/SupplierInvoiceServiceTest.php
+++ b/tests/Unit/Service/SupplierInvoiceServiceTest.php
@@ -39,13 +39,12 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\SupplierInvoiceService;
+use OCA\Shillinq\Tests\Unit\Service\Support\InMemoryObjectServiceStub;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -54,13 +53,6 @@ use Psr\Log\LoggerInterface;
  * phpcs:disable CustomSniffs.Functions.NamedParameters
  */
 final class SupplierInvoiceServiceTest extends TestCase {
-
-	/**
-	 * Mock ContainerInterface.
-	 *
-	 * @var ContainerInterface&MockObject
-	 */
-	private ContainerInterface&MockObject $container;
 
 	/**
 	 * Mock IAppConfig.
@@ -103,136 +95,13 @@ final class SupplierInvoiceServiceTest extends TestCase {
 		array &$saved,
 		array $accessibleAdministrations,
 	): SupplierInvoiceService {
-		$stub = new class($data, $saved) {
-
-			/**
-			 * Schema => rows.
-			 *
-			 * @var array<string,array<int,array<string,mixed>>>
-			 */
-			private array $data;
-
-			/**
-			 * Captured saves (mutable ref).
-			 *
-			 * @var array<int,array<string,mixed>>
-			 */
-			private array $saved;
-
-			/**
-			 * Active schema.
-			 *
-			 * @var string
-			 */
-			private string $schema = '';
-
-			/**
-			 * Auto-increment id counter for saved objects.
-			 *
-			 * @var integer
-			 */
-			private int $idCounter = 0;
-
-			/**
-			 * Constructor.
-			 *
-			 * @param array<string,array<int,array<string,mixed>>> $data Schema rows.
-			 * @param array<int,array<string,mixed>> $saved Capture ref.
-			 */
-			public function __construct(array $data, array &$saved) {
-				$this->data = $data;
-				$this->saved = &$saved;
-			}//end __construct()
-
-			/**
-			 * Fluent register setter.
-			 *
-			 * @param string $register Register slug.
-			 *
-			 * @return static
-			 */
-			public function setRegister(string $register): static {
-				return $this;
-			}//end setRegister()
-
-			/**
-			 * Fluent schema setter.
-			 *
-			 * @param string $schema Schema slug.
-			 *
-			 * @return static
-			 */
-			public function setSchema(string $schema): static {
-				$this->schema = $schema;
-				return $this;
-			}//end setSchema()
-
-			/**
-			 * Return rows for the active schema, applying equality filters.
-			 *
-			 * @param array<string,mixed> $params Query parameters.
-			 *
-			 * @return array<int,array<string,mixed>>
-			 */
-			public function findAll(array $params = []): array {
-				$rows = ($this->data[$this->schema] ?? []);
-				$filters = ($params['filters'] ?? []);
-				if ($filters === []) {
-					return $rows;
-				}
-
-				return array_values(
-					array_filter(
-						$rows,
-						static function (array $row) use ($filters): bool {
-							foreach ($filters as $key => $value) {
-								if (($row[$key] ?? null) !== $value) {
-									return false;
-								}
-							}
-
-							return true;
-						}
-					)
-				);
-			}//end findAll()
-
-			/**
-			 * Capture a saved object; stamp an id when absent.
-			 *
-			 * @param array<string,mixed> $object Object payload.
-			 *
-			 * @return array<string,mixed>
-			 */
-			public function saveObject(array $object): array {
-				if (isset($object['id']) === false || $object['id'] === '') {
-					$this->idCounter++;
-					$object['id'] = 'obj-' . $this->idCounter;
-				}
-
-				// Replace by id if it exists in the current schema.
-				$rows = ($this->data[$this->schema] ?? []);
-				$updated = false;
-				foreach ($rows as $i => $row) {
-					if (($row['id'] ?? null) === $object['id']) {
-						$this->data[$this->schema][$i] = $object;
-						$updated = true;
-						break;
-					}
-				}
-
-				if ($updated === false) {
-					$this->data[$this->schema][] = $object;
-				}
-
-				$this->saved[] = ['schema' => $this->schema, 'object' => $object];
-				return $object;
-			}//end saveObject()
-		};
-
-		$container = $this->createMock(ContainerInterface::class);
-		$container->method('get')->willReturn($stub);
-		$this->container = $container;
+		// ADR-084: this file's own duck-typed stub reached the service through a
+		// ContainerInterface mock, while `objectService:` got a bare createMock() —
+		// so SupplierInvoiceService read an EMPTY double and the saveObject() path
+		// returned its own input, which made three assertions here pass without the
+		// store ever being consulted. The shared stub IMPLEMENTS the contract, so
+		// PHP itself rejects it if a signature moves upstream.
+		$stub = new InMemoryObjectServiceStub(data: $data, saveSink: $saved);
 
 		$administrationContext = $this->createMock(AdministrationContextService::class);
 		$administrationContext->method('canAccess')->willReturnCallback(
@@ -245,7 +114,7 @@ final class SupplierInvoiceServiceTest extends TestCase {
 			appConfig: $this->appConfig,
 			administrationContext: $administrationContext,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: $stub,
 		);
 
 	}//end buildService()
@@ -351,8 +220,8 @@ XML;
 		$this->expectException(\RuntimeException::class);
 		$this->expectExceptionMessage('UBL Invoice XML is malformed');
 
-		// libxml emits a warning on parse failure; silence to keep the test
-		// output clean.
+		// The libxml parser emits a warning on parse failure; silence it to keep
+		// the test output clean.
 		$previous = libxml_use_internal_errors(true);
 		try {
 			$service->parseUblInvoice(ublXml: '<not-an-xml');

--- a/tests/Unit/Service/SupplierQualificationServiceTest.php
+++ b/tests/Unit/Service/SupplierQualificationServiceTest.php
@@ -22,13 +22,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\SupplierQualificationService;
 use OCA\Shillinq\Tests\Unit\Service\Support\InMemoryObjectServiceStub;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -45,9 +43,10 @@ final class SupplierQualificationServiceTest extends TestCase {
 	 * @return SupplierQualificationService
 	 */
 	private function buildService(array $data): SupplierQualificationService {
-		$container = $this->createMock(ContainerInterface::class);
-		$container->method('get')->willReturn(new InMemoryObjectServiceStub($data));
-
+		// ADR-084: the in-memory stub used to reach the service through a
+		// ContainerInterface mock, while `objectService:` got a bare
+		// createMock() — so the service consulted an EMPTY double and the seeded
+		// $data was never read. Inject the stub itself.
 		$appConfig = $this->createMock(IAppConfig::class);
 		$appConfig->method('getValueString')->willReturn('shillinq');
 
@@ -59,7 +58,7 @@ final class SupplierQualificationServiceTest extends TestCase {
 			appConfig: $appConfig,
 			administrationContext: $administrationContext,
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new InMemoryObjectServiceStub($data),
 		);
 	}//end buildService()
 

--- a/tests/Unit/Service/Support/InMemoryObjectServiceStub.php
+++ b/tests/Unit/Service/Support/InMemoryObjectServiceStub.php
@@ -5,7 +5,27 @@
  *
  * Honours equality filters on findAll and stamps / updates ids on saveObject,
  * mirroring the fluent OpenRegister ObjectService surface the services consume
- * (setRegister -> setSchema -> findAll / saveObject).
+ * (setRegister -> setSchema -> findAll / saveObject / find).
+ *
+ * ## Why it implements the contract rather than quacking like it
+ *
+ * Before ADR-084 this was a duck-typed class handed to production through an
+ * untyped `ContainerInterface`. Production now type-hints
+ * `OCA\OpenRegister\Contract\ObjectServiceInterface`, so a duck cannot be passed
+ * at all — and the usual workaround, `createMock(ObjectServiceInterface::class)`
+ * with nothing configured, is worse than a compile error: `setRegister()` hands
+ * back a fresh mock, `findAll()` answers `[]` and `find()` answers `null`, so
+ * every test reads "no such record" and every guard reads "nothing to object
+ * to". A whole suite can go green, or red for the wrong reason, without the
+ * store ever being consulted.
+ *
+ * Declaring `implements ObjectServiceInterface` makes PHP itself the check: if
+ * a signature moves upstream this file stops declaring and the suite says so,
+ * instead of continuing to answer the old shape.
+ *
+ * Methods this app does not exercise throw {@see \LogicException} by name. An
+ * unstubbed call must FAIL rather than return an empty value that a caller
+ * cannot distinguish from a real empty result.
  *
  * @category Test
  * @package  OCA\Shillinq\Tests\Unit\Service\Support
@@ -26,10 +46,18 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service\Support;
 
+use OCA\OpenRegister\Contract\ObjectEntityInterface;
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
+use OCP\IUser;
+use RuntimeException;
+
 /**
  * Minimal in-memory ObjectService test double.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods) Mirrors the 25-method contract.
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength) Mirrors the 25-method contract.
  */
-final class InMemoryObjectServiceStub {
+final class InMemoryObjectServiceStub implements ObjectServiceInterface {
 
 	/**
 	 * Schema => rows.
@@ -44,6 +72,13 @@ final class InMemoryObjectServiceStub {
 	 * @var array<int,array<string,mixed>>
 	 */
 	public array $saved = [];
+
+	/**
+	 * Active register.
+	 *
+	 * @var string
+	 */
+	private string $register = '';
 
 	/**
 	 * Active schema.
@@ -62,45 +97,70 @@ final class InMemoryObjectServiceStub {
 	/**
 	 * Constructor.
 	 *
-	 * @param array<string,array<int,array<string,mixed>>> $data Seed rows.
+	 * @param array<string,array<int,array<string,mixed>>> $data      Seed rows.
+	 * @param array<int,array<string,mixed>>|null          $saveSink  Optional caller-owned
+	 *                                                                array to bind {@see $saved}
+	 *                                                                to, for tests that assert on
+	 *                                                                a local `$saved` variable.
 	 */
-	public function __construct(array $data = []) {
+	public function __construct(array $data = [], ?array &$saveSink = null) {
 		$this->data = $data;
+		if ($saveSink !== null) {
+			$this->saved = &$saveSink;
+		}
+
 	}//end __construct()
 
 	/**
 	 * Fluent register setter.
 	 *
-	 * @param string $register Register slug.
+	 * @param string|int $register Register slug.
 	 *
-	 * @return self
+	 * @return static
 	 */
-	public function setRegister(string $register): self {
+	public function setRegister(string|int $register): static {
+		$this->register = (string)$register;
 		return $this;
+
 	}//end setRegister()
 
 	/**
 	 * Fluent schema setter.
 	 *
-	 * @param string $schema Schema slug.
+	 * @param string|int $schema Schema slug.
 	 *
-	 * @return self
+	 * @return static
 	 */
-	public function setSchema(string $schema): self {
-		$this->schema = $schema;
+	public function setSchema(string|int $schema): static {
+		$this->schema = (string)$schema;
 		return $this;
+
 	}//end setSchema()
+
+	/**
+	 * Drop the register/schema scope.
+	 *
+	 * @return void
+	 */
+	public function clearCurrents(): void {
+		$this->register = '';
+		$this->schema = '';
+
+	}//end clearCurrents()
 
 	/**
 	 * Return rows for the active schema, applying equality filters.
 	 *
-	 * @param array<string,mixed> $params Query params.
+	 * @param array $config        Filters, limit, offset, sort and search.
+	 * @param bool  $_rbac         Apply register RBAC (ignored by the stub).
+	 * @param bool  $_multitenancy Apply organisation scoping (ignored by the stub).
 	 *
 	 * @return array<int,array<string,mixed>>
 	 */
-	public function findAll(array $params = []): array {
+	public function findAll(array $config = [], bool $_rbac = true, bool $_multitenancy = true): array {
 		$rows = ($this->data[$this->schema] ?? []);
-		$filters = ($params['filters'] ?? []);
+		$filters = ($config['filters'] ?? []);
+
 		return array_values(
 			array_filter(
 				$rows,
@@ -115,34 +175,512 @@ final class InMemoryObjectServiceStub {
 				}
 			)
 		);
+
 	}//end findAll()
+
+	/**
+	 * Find one row on the active schema by id or uuid.
+	 *
+	 * @param int|string      $id            Object id, UUID or slug.
+	 * @param ?array          $_extend       Relations to expand (ignored).
+	 * @param bool            $files         Include file metadata (ignored).
+	 * @param string|int|null $register      Register override (ignored).
+	 * @param string|int|null $schema        Schema override, when given.
+	 * @param bool            $_rbac         Apply register RBAC (ignored).
+	 * @param bool            $_multitenancy Apply organisation scoping (ignored).
+	 * @param bool            $_render       Render the entity (ignored).
+	 * @param bool            $_audit        Write an audit entry (ignored).
+	 *
+	 * @return ?ObjectEntityInterface
+	 */
+	public function find(
+		int|string $id,
+		?array $_extend = [],
+		bool $files = false,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $_render = true,
+		bool $_audit = true
+	): ?ObjectEntityInterface {
+		$target = $this->schema;
+		if ($schema !== null) {
+			$target = (string)$schema;
+		}
+
+		foreach (($this->data[$target] ?? []) as $row) {
+			if ((string)($row['id'] ?? '') === (string)$id || (string)($row['uuid'] ?? '') === (string)$id) {
+				return new ObjectEntityStub(payload: $row, register: $this->register, schema: $target);
+			}
+		}
+
+		return null;
+
+	}//end find()
 
 	/**
 	 * Capture a saved object; stamp an id when absent, update in place otherwise.
 	 *
-	 * @param array<string,mixed> $object Object payload.
+	 * @param array           $object        Object payload.
+	 * @param ?array          $extend        Relations to expand (ignored).
+	 * @param string|int|null $register      Register override (ignored).
+	 * @param string|int|null $schema        Schema override, when given.
+	 * @param ?string         $uuid          Explicit UUID (ignored).
+	 * @param bool            $_rbac         Apply register RBAC (ignored).
+	 * @param bool            $_multitenancy Apply organisation scoping (ignored).
+	 * @param bool            $silent        Suppress events (ignored).
+	 * @param bool            $_validation   Validate against the schema (ignored).
+	 * @param ?array          $uploadedFiles Files uploaded alongside (ignored).
+	 * @param ?IUser          $currentUser   Explicit acting user (ignored).
+	 * @param bool            $failIfExists  Fail instead of updating (ignored).
 	 *
-	 * @return array<string,mixed>
+	 * @return ObjectEntityInterface
 	 */
-	public function saveObject(array $object): array {
+	public function saveObject(
+		array $object,
+		?array $extend = [],
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		?string $uuid = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $silent = false,
+		bool $_validation = true,
+		?array $uploadedFiles = null,
+		?IUser $currentUser = null,
+		bool $failIfExists = false
+	): ObjectEntityInterface {
+		$target = $this->schema;
+		if ($schema !== null) {
+			$target = (string)$schema;
+		}
+
+
 		if (isset($object['id']) === false || $object['id'] === '') {
 			$this->idCounter++;
 			$object['id'] = 'obj-' . $this->idCounter;
-			$this->data[$this->schema][] = $object;
-			$this->saved[] = ['schema' => $this->schema, 'object' => $object];
-			return $object;
+			$this->data[$target][] = $object;
+			$this->saved[] = ['schema' => $target, 'object' => $object];
+
+			return new ObjectEntityStub(payload: $object, register: $this->register, schema: $target);
 		}
 
-		foreach (($this->data[$this->schema] ?? []) as $index => $row) {
+		foreach (($this->data[$target] ?? []) as $index => $row) {
 			if (($row['id'] ?? null) === $object['id']) {
-				$this->data[$this->schema][$index] = $object;
-				$this->saved[] = ['schema' => $this->schema, 'object' => $object];
-				return $object;
+				$this->data[$target][$index] = $object;
+				$this->saved[] = ['schema' => $target, 'object' => $object];
+
+				return new ObjectEntityStub(payload: $object, register: $this->register, schema: $target);
 			}
 		}
 
-		$this->data[$this->schema][] = $object;
-		$this->saved[] = ['schema' => $this->schema, 'object' => $object];
-		return $object;
+		$this->data[$target][] = $object;
+		$this->saved[] = ['schema' => $target, 'object' => $object];
+
+		return new ObjectEntityStub(payload: $object, register: $this->register, schema: $target);
+
 	}//end saveObject()
+
+	/**
+	 * Count rows on the active schema.
+	 *
+	 * @param array $config Filters, limit, offset, sort and search.
+	 *
+	 * @return int
+	 */
+	public function count(array $config = []): int {
+		return count($this->findAll(config: $config));
+
+	}//end count()
+
+	/**
+	 * Refuse a call this stub does not model.
+	 *
+	 * @param string $method The contract method that was called.
+	 *
+	 * @return never
+	 *
+	 * @throws \LogicException Always.
+	 */
+	private function unsupported(string $method): never {
+		throw new \LogicException(
+			'InMemoryObjectServiceStub does not model ' . $method . '(). Returning an empty '
+			. 'value here would be indistinguishable from a real empty result, so the stub '
+			. 'refuses instead. Model the method if the code under test needs it.'
+		);
+
+	}//end unsupported()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param array   $query         The search query.
+	 * @param bool    $_rbac         Apply register RBAC.
+	 * @param bool    $_multitenancy Apply organisation scoping.
+	 * @param ?array  $ids           Restrict to these ids.
+	 * @param ?string $uses          Restrict to objects used by this one.
+	 * @param ?array  $views         Restrict to these views.
+	 *
+	 * @return array|int
+	 */
+	public function searchObjects(
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		?array $ids = null,
+		?string $uses = null,
+		?array $views = null
+	): array|int {
+		$this->unsupported(method: 'searchObjects');
+
+	}//end searchObjects()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param string          $uuid            The object UUID.
+	 * @param string|int|null $register        Register id, UUID or slug.
+	 * @param string|int|null $schema          Schema id, UUID or slug.
+	 * @param bool            $_rbac           Apply register RBAC.
+	 * @param bool            $_multitenancy   Apply organisation scoping.
+	 * @param bool            $_retentionSweep Run as part of a retention sweep.
+	 * @param ?IUser          $currentUser     Explicit acting user.
+	 * @param bool            $permanent       Delete permanently.
+	 *
+	 * @return bool
+	 */
+	public function deleteObject(
+		string $uuid,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $_retentionSweep = false,
+		?IUser $currentUser = null,
+		bool $permanent = false
+	): bool {
+		$this->unsupported(method: 'deleteObject');
+
+	}//end deleteObject()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param array   $query         The search query.
+	 * @param bool    $_rbac         Apply register RBAC.
+	 * @param bool    $_multitenancy Apply organisation scoping.
+	 * @param bool    $deleted       Include soft-deleted objects.
+	 * @param ?array  $ids           Restrict to these ids.
+	 * @param ?string $uses          Restrict to objects used by this one.
+	 * @param ?array  $views         Restrict to these views.
+	 *
+	 * @return array
+	 */
+	public function searchObjectsPaginated(
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $deleted = false,
+		?array $ids = null,
+		?string $uses = null,
+		?array $views = null
+	): array {
+		$this->unsupported(method: 'searchObjectsPaginated');
+
+	}//end searchObjectsPaginated()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param string $registerSlug  The register slug.
+	 * @param string $schemaSlug    The schema slug.
+	 * @param array  $filters       Equality filters.
+	 * @param bool   $_rbac         Apply register RBAC.
+	 * @param bool   $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array|int
+	 */
+	public function searchObjectsBySlug(
+		string $registerSlug,
+		string $schemaSlug,
+		array $filters = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): array|int {
+		return $this->setRegister(register: $registerSlug)
+			->setSchema(schema: $schemaSlug)
+			->findAll(config: ['filters' => $filters]);
+
+	}//end searchObjectsBySlug()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param array                 $requestParams Raw request parameters.
+	 * @param int|string|array|null $register      Register id, UUID or slug.
+	 * @param int|string|array|null $schema        Schema id, UUID or slug.
+	 * @param ?array                $ids           Restrict to these ids.
+	 *
+	 * @return array
+	 */
+	public function buildSearchQuery(
+		array $requestParams,
+		int|string|array|null $register = null,
+		int|string|array|null $schema = null,
+		?array $ids = null
+	): array {
+		$this->unsupported(method: 'buildSearchQuery');
+
+	}//end buildSearchQuery()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param array           $objects        The objects to store.
+	 * @param string|int|null $register       Register id, UUID or slug.
+	 * @param string|int|null $schema         Schema id, UUID or slug.
+	 * @param bool            $_rbac          Apply register RBAC.
+	 * @param bool            $_multitenancy  Apply organisation scoping.
+	 * @param bool            $validation     Validate against the schema.
+	 * @param bool            $events         Emit events for each object.
+	 * @param bool            $deduplicateIds Drop duplicate ids.
+	 * @param bool            $enrich         Enrich each object.
+	 * @param bool            $_audit         Write an audit-trail entry.
+	 *
+	 * @return array
+	 */
+	public function saveObjects(
+		array $objects,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $validation = false,
+		bool $events = false,
+		bool $deduplicateIds = true,
+		bool $enrich = true,
+		bool $_audit = true
+	): array {
+		$this->unsupported(method: 'saveObjects');
+
+	}//end saveObjects()
+
+	/**
+	 * Run an operation with system privileges — the stub simply runs it.
+	 *
+	 * @param callable $operation The operation to run.
+	 *
+	 * @return mixed
+	 */
+	public function runAsSystem(callable $operation) {
+		return $operation();
+
+	}//end runAsSystem()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param string|int $identifier The object id or UUID.
+	 * @param bool       $advisory   Take an advisory lock.
+	 *
+	 * @return bool
+	 */
+	public function unlockObject(string|int $identifier, bool $advisory = false): bool {
+		$this->unsupported(method: 'unlockObject');
+
+	}//end unlockObject()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param string  $identifier The object id or UUID.
+	 * @param ?string $process    A label for the holding process.
+	 * @param ?int    $duration   Lock duration in seconds.
+	 * @param bool    $advisory   Take an advisory lock.
+	 *
+	 * @return array
+	 */
+	public function lockObject(
+		string $identifier,
+		?string $process = null,
+		?int $duration = null,
+		bool $advisory = false
+	): array {
+		$this->unsupported(method: 'lockObject');
+
+	}//end lockObject()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param array $uuids         The object UUIDs.
+	 * @param bool  $_rbac         Apply register RBAC.
+	 * @param bool  $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array
+	 */
+	public function deleteObjects(array $uuids = [], bool $_rbac = true, bool $_multitenancy = true): array {
+		$this->unsupported(method: 'deleteObjects');
+
+	}//end deleteObjects()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param string $uuid          The object UUID.
+	 * @param array  $filters       Equality filters.
+	 * @param bool   $_rbac         Apply register RBAC.
+	 * @param bool   $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array
+	 */
+	public function getLogs(string $uuid, array $filters = [], bool $_rbac = true, bool $_multitenancy = true): array {
+		$this->unsupported(method: 'getLogs');
+
+	}//end getLogs()
+
+	/**
+	 * Apply a partial update to a stored object.
+	 *
+	 * @param string $objectId      The object UUID or id.
+	 * @param array  $data          The fields to change.
+	 * @param bool   $_rbac         Apply register RBAC (ignored).
+	 * @param bool   $_multitenancy Apply organisation scoping (ignored).
+	 *
+	 * @return ObjectEntityInterface
+	 */
+	public function updateObject(
+		string $objectId,
+		array $data,
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): ObjectEntityInterface {
+		$existing = $this->find(id: $objectId);
+		$merged = $data;
+		if ($existing !== null) {
+			$merged = array_merge($existing->getObject(), $data);
+		}
+
+		$merged['id'] = $objectId;
+
+		return $this->saveObject(object: $merged);
+
+	}//end updateObject()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param string $objectId      The object UUID.
+	 * @param array  $query         The search query.
+	 * @param bool   $_rbac         Apply register RBAC.
+	 * @param bool   $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array
+	 */
+	public function getObjectUses(
+		string $objectId,
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): array {
+		$this->unsupported(method: 'getObjectUses');
+
+	}//end getObjectUses()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param string $objectId      The object UUID.
+	 * @param array  $query         The search query.
+	 * @param bool   $_rbac         Apply register RBAC.
+	 * @param bool   $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array
+	 */
+	public function getObjectUsedBy(
+		string $objectId,
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): array {
+		$this->unsupported(method: 'getObjectUsedBy');
+
+	}//end getObjectUsedBy()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param string $search       The term to match relations against.
+	 * @param bool   $partialMatch Match relations partially.
+	 *
+	 * @return array
+	 */
+	public function findByRelations(string $search, bool $partialMatch = true): array {
+		$this->unsupported(method: 'findByRelations');
+
+	}//end findByRelations()
+
+	/**
+	 * Find without audit or read events.
+	 *
+	 * @param string          $id            Object id, UUID or slug.
+	 * @param ?array          $_extend       Relations to expand (ignored).
+	 * @param bool            $files         Include file metadata (ignored).
+	 * @param string|int|null $register      Register override (ignored).
+	 * @param string|int|null $schema        Schema override, when given.
+	 * @param bool            $_rbac         Apply register RBAC (ignored).
+	 * @param bool            $_multitenancy Apply organisation scoping (ignored).
+	 *
+	 * @return ObjectEntityInterface
+	 */
+	public function findSilent(
+		string $id,
+		?array $_extend = [],
+		bool $files = false,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): ObjectEntityInterface {
+		$found = $this->find(id: $id, schema: $schema);
+		if ($found === null) {
+			throw new RuntimeException('InMemoryObjectServiceStub: no object ' . $id);
+		}
+
+		return $found;
+
+	}//end findSilent()
+
+	/**
+	 * Count the objects a search query would return.
+	 *
+	 * @param array   $query         The search query.
+	 * @param bool    $_rbac         Apply register RBAC.
+	 * @param bool    $_multitenancy Apply organisation scoping.
+	 * @param ?array  $ids           Restrict to these ids.
+	 * @param ?string $uses          Restrict to objects used by this one.
+	 *
+	 * @return int
+	 */
+	public function countSearchObjects(
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		?array $ids = null,
+		?string $uses = null
+	): int {
+		$this->unsupported(method: 'countSearchObjects');
+
+	}//end countSearchObjects()
+
+	/**
+	 * No context object is ever held by the stub.
+	 *
+	 * @return ?ObjectEntityInterface
+	 */
+	public function getObject(): ?ObjectEntityInterface {
+		return null;
+
+	}//end getObject()
 }//end class

--- a/tests/Unit/Service/Support/ObjectEntityStub.php
+++ b/tests/Unit/Service/Support/ObjectEntityStub.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * Test double for OpenRegister's ObjectEntityInterface.
+ *
+ * ADR-084 moved the leaf apps off an untyped `ContainerInterface` hop and onto
+ * OpenRegister's published contract. One consequence is easy to miss and was
+ * missed here: `find()` and `saveObject()` are declared
+ * `: ?ObjectEntityInterface` / `: ObjectEntityInterface`, so a double that hands
+ * back a bare array no longer stands in for the real service — and a double that
+ * hands back an unconfigured mock serialises to nothing at all, which reads in a
+ * test as "the record was not found" rather than "the double was not wired".
+ *
+ * This class is the smallest honest entity: it carries a payload and returns it
+ * from `jsonSerialize()` and `getObject()`, which is exactly what the production
+ * conversions call.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Service\Support
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Service\Support;
+
+use OCA\OpenRegister\Contract\ObjectEntityInterface;
+
+/**
+ * An ObjectEntityInterface carrying a plain array payload.
+ */
+final class ObjectEntityStub implements ObjectEntityInterface {
+
+	/**
+	 * The stored object payload.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private array $payload;
+
+	/**
+	 * Owning register slug.
+	 *
+	 * @var string|null
+	 */
+	private ?string $register;
+
+	/**
+	 * Owning schema slug.
+	 *
+	 * @var string|null
+	 */
+	private ?string $schema;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array<string,mixed> $payload  The stored object payload.
+	 * @param string|null         $register Owning register slug.
+	 * @param string|null         $schema   Owning schema slug.
+	 */
+	public function __construct(array $payload, ?string $register = null, ?string $schema = null) {
+		$this->payload = $payload;
+		$this->register = $register;
+		$this->schema = $schema;
+
+	}//end __construct()
+
+	/**
+	 * The payload, as the production conversions read it.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function jsonSerialize(): array {
+		return $this->payload;
+
+	}//end jsonSerialize()
+
+	/**
+	 * The payload.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function getObject(): array {
+		return $this->payload;
+
+	}//end getObject()
+
+	/**
+	 * The object UUID, taken from the payload when present.
+	 *
+	 * @return string|null
+	 */
+	public function getUuid(): ?string {
+		$uuid = ($this->payload['uuid'] ?? $this->payload['id'] ?? null);
+		if ($uuid === null) {
+			return null;
+		}
+
+		return (string)$uuid;
+
+	}//end getUuid()
+
+	/**
+	 * The owning register slug.
+	 *
+	 * @return string|null
+	 */
+	public function getRegister(): ?string {
+		return $this->register;
+
+	}//end getRegister()
+
+	/**
+	 * The owning schema slug.
+	 *
+	 * @return string|null
+	 */
+	public function getSchema(): ?string {
+		return $this->schema;
+
+	}//end getSchema()
+
+	/**
+	 * The owning organisation, taken from the payload when present.
+	 *
+	 * @return string|null
+	 */
+	public function getOrganisation(): ?string {
+		$organisation = ($this->payload['organisation'] ?? null);
+		if ($organisation === null) {
+			return null;
+		}
+
+		return (string)$organisation;
+
+	}//end getOrganisation()
+
+	/**
+	 * The owner, taken from the payload when present.
+	 *
+	 * @return string|null
+	 */
+	public function getOwner(): ?string {
+		$owner = ($this->payload['owner'] ?? null);
+		if ($owner === null) {
+			return null;
+		}
+
+		return (string)$owner;
+
+	}//end getOwner()
+}//end class


### PR DESCRIPTION
fix(adr-084): repair the call sites the contract migration left behind

ADR-084 (#556) moved this app off an untyped ContainerInterface hop onto
OpenRegister's published `ObjectServiceInterface`. Five composition sites and
34 result conversions were not carried over, and the tooling has been reporting
them all along on a leg that has been red for other reasons since.

TWO LIVE 500s ON `development`

`PurchaseOrderService::__construct()` and `EInvoiceService::__construct()` both
pass `container: $container` — a parameter neither constructor declares. An
undefined variable is null, so:

  * `LogPeppolTransmissionAdapter` (the one class the migration missed, still
    typed `ContainerInterface`) → TypeError, null given;
  * `SupplierQualificationGuard` / `FrameworkAgreementDrawdownGuard` (migrated,
    no `$container` any more) → Error: Unknown named parameter $container.

Both fire at REQUEST time, so every `/api/purchase-orders*` route and the AR
e-invoice send path answer 500 before any controller code runs. This is R2's
composition-root defect one layer down: a service's own constructor, which
`lib/AppInfo/Application.php`-scoped checkers cannot see.

THREE SILENT NO-OPS

  * `BudgetOverrunGuard::canPost()` used a local `$objectService` that does not
    exist → Error → its own fail-closed catch → the budget check DENIED every
    posting.
  * `StockReservationGuard::casUpdate()` called `updateObject(id:, object:,
    register:, schema:)` against a contract declaring `(objectId, data, …)` →
    Unknown named parameter → caught → every compare-and-set reported a
    collision instead of writing.
  * `FoldDunningWriteoffIntoArInvoice` used a local `$objectService` inside a
    try → every ARInvoice read as missing, so the repair folded nothing.

34 RESULT CONVERSIONS THAT COULD NOT MATCH

`find()` returns `?ObjectEntityInterface` and `saveObject()` returns
`ObjectEntityInterface`, so every `is_array($result)` arm is unreachable BY
TYPE. Fifteen private `saveObject()` helpers therefore returned their own INPUT
— discarding the id/uuid the store had just generated; two private `find()`
helpers returned NULL for every existing record; `ExpenseReimbursementGuard`
and `StockReservationGuard` fell through to `(array)$entity`, which yields
property names rather than the stored payload; `CycleCountService` passed a
filter ARRAY to `find(int|string $id)`. Eight Wbso* methods returned the entity
from a method declared `: array`.

All converted through `jsonSerialize()`, which is the conversion this codebase
already used on the paths that worked.

TEST DOUBLES PINNED TO THE MOVED SIGNATURE

The repo-wide shape is: a duck-typed stub wired into a `ContainerInterface`
mock production no longer consults, plus a BARE `createMock(
ObjectServiceInterface::class)` as the real argument — so the service reads an
empty double. `InMemoryObjectServiceStub` now `implements
ObjectServiceInterface` (PHP itself rejects it if a signature moves upstream)
and returns a new `ObjectEntityStub`; five test files are wired to the double
the code under test actually uses. Unmodelled contract methods THROW rather
than return an empty value a caller cannot distinguish from a real empty
result.

Two procurement-governance gates — REQ-PG-002 (unqualified supplier blocked)
and REQ-PG-004 (call-off over the framework ceiling) — were being asserted
against a double that was never consulted.

MEASURED, same command both sides, `git archive origin/development lib` as the
base tree, php 8.3.33 + this repo's own vendor:

  composer phpmd   (lib/, 680 files)  10 findings, rc 2  ->  0 findings, rc 0
  composer phpstan (lib/, 680 files)  66 errors          ->  2 errors
  composer phpcs   (lib/, 680 files)  0                  ->  0
  phpunit -c phpunit.xml (4138 tests) 162E/342F = 504    ->  141E/341F = 482

Truly-new failing tests versus the base run: NONE (failing-test-name sets
diffed, not counts). 22 tests fixed. Three tests moved from passing to failing
mid-way and are now green: they had been asserting that an input array contains
what an input array contains, because the save path returned its own argument.

The 2 residual phpstan errors are NOT ADR-084: `PayrollService::$logger` and
`PayrollJaaropgaveService::$logger` became unread when #851 removed the
orphaned methods that logged. Left for their author rather than deleting an
injected dependency on a guess.

STILL OWED, and deliberately not attempted here: ~480 unit tests across ~130
test files carry the same double defect. The recipe is in this diff twice — a
contract-implementing shared stub, and a `createMock(ObjectServiceInterface)`
with `willReturnSelf()`/`willReturnCallback()` where per-test behaviour is
needed. It is a burn-down, not a decision.
