### PR TITLE
fix(adr-084): rewire 128 test classes (141 errors + 341 failures -> 0) and repair the two live array-access faults it exposed — bank import 500 + an expense guard that denied every claim

### DIFF
--- a/lib/Controller/BankStatementImportController.php
+++ b/lib/Controller/BankStatementImportController.php
@@ -160,7 +160,15 @@ class BankStatementImportController extends Controller {
 					]
 				);
 
-			$statementId = (string)($statement['id'] ?? $statement['uuid'] ?? '');
+			// ADR-084: saveObject() returns an ObjectEntityInterface, and that
+			// interface extends JsonSerializable ONLY -- it does not implement
+			// ArrayAccess. The previous `$statement['id'] ?? $statement['uuid']`
+			// therefore raised `Error: Cannot use object of type … as array`,
+			// which `??` cannot suppress, and the surrounding catch (\Throwable)
+			// turned it into a bare HTTP 500 on EVERY import. getObject() is
+			// declared on the contract and returns the body as an array.
+			$statementBody = $statement->getObject();
+			$statementId   = (string)($statementBody['id'] ?? $statement->getUuid() ?? '');
 
 			$lineNumber = 0;
 			foreach ($parsed as $line) {

--- a/lib/Lifecycle/ExpenseClaimGuard.php
+++ b/lib/Lifecycle/ExpenseClaimGuard.php
@@ -199,7 +199,20 @@ class ExpenseClaimGuard {
 					->setSchema(schema: $check['schema'])
 					->find(id: $itemId);
 
-				if ($item === null || trim(string: (string)($item['costCentreCode'] ?? '')) === '') {
+				// ADR-084: find() returns an ObjectEntityInterface, which extends
+				// JsonSerializable ONLY and does not implement ArrayAccess. The
+				// previous `$item['costCentreCode']` raised
+				// `Error: Cannot use object of type … as array` -- which `??`
+				// cannot suppress -- and requireOpenPeriodAndCostCentres()'s
+				// catch (\Throwable) turned that into `return false`, so the
+				// guard DENIED EVERY claim carrying a linked item. getObject()
+				// is declared on the contract and returns the body as an array.
+				$costCentreCode = '';
+				if ($item !== null) {
+					$costCentreCode = (string)($item->getObject()['costCentreCode'] ?? '');
+				}
+
+				if ($item === null || trim(string: $costCentreCode) === '') {
 					$this->logger->info(
 						'ExpenseClaimGuard: item missing costCentreCode — denying transition',
 						['claimId' => $claimId, 'schema' => $check['schema'], 'itemId' => $itemId]

--- a/lib/Service/VATReturnService.php
+++ b/lib/Service/VATReturnService.php
@@ -902,6 +902,14 @@ class VATReturnService {
 			}
 		}
 
+		// UNREACHABLE under the ADR-084 contract, and deliberately kept: both
+		// callers hold an ObjectServiceInterface, whose find()/saveObject() can
+		// only return an ObjectEntityInterface, and that interface DECLARES
+		// getObject(): array — so the branch above always returns. It becomes
+		// reachable again if $objectService is ever widened to an untyped or
+		// duck-typed source, or if ObjectEntityInterface stops declaring
+		// getObject(): array. Cheap tripwire at a type boundary; not dead code
+		// left behind by accident.
 		throw new RuntimeException(
 			sprintf('VATReturnService: unsupported row type from ObjectService::%s', $context)
 		);

--- a/tests/Unit/BackgroundJob/BookingReminderJobTest.php
+++ b/tests/Unit/BackgroundJob/BookingReminderJobTest.php
@@ -19,9 +19,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\BackgroundJob;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\BackgroundJob\BookingReminderJob;
 use OCA\Shillinq\Service\BookingNotificationService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -95,14 +95,133 @@ class BookingReminderJobTest extends TestCase {
 		$this->time->method('getTime')->willReturn(time());
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
 
-		$this->job = new BookingReminderJob(
+		$this->job = $this->buildJob(store: $this->buildObjectServiceStub());
+	}//end setUp()
+
+	/**
+	 * Build the job over a seeded in-memory store.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so a test's
+	 * store has to be present when the job is built — parking it on the
+	 * container after the fact leaves the job reading an empty world.
+	 *
+	 * @param object $store The duck-typed in-memory ObjectService double.
+	 *
+	 * @return BookingReminderJob
+	 */
+	private function buildJob(object $store): BookingReminderJob {
+		return new BookingReminderJob(
 			time: $this->time,
 			notificationService: $this->notificationService,
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($store),
 		);
-	}//end setUp()
+	}//end buildJob()
+
+	/**
+	 * Build an empty in-memory ObjectService double.
+	 *
+	 * @return object
+	 */
+	private function buildObjectServiceStub(): object {
+		return new class {
+			/**
+			 * Fluent register setter — returns self.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter — returns self.
+			 *
+			 * @param string $schema Schema name.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Answer an empty result set.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused).
+			 *
+			 * @return array<mixed>
+			 */
+			public function findAll(array $params = []): array {
+				return [];
+			}//end findAll()
+		};
+	}//end buildObjectServiceStub()
+
+	/**
+	 * Build a store that models an unavailable OpenRegister.
+	 *
+	 * Before ADR-084 this scenario was expressed as
+	 * `$container->method('get')->willThrowException(...)`. The container is no
+	 * longer consulted, so the refusal has to come from the store itself; every
+	 * read throws exactly as a downed ObjectService would.
+	 *
+	 * @return object
+	 */
+	private function buildUnavailableObjectServiceStub(): object {
+		return new class {
+			/**
+			 * Fluent register setter — returns self.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter — returns self.
+			 *
+			 * @param string $schema Schema name.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse every list query.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('DB unavailable');
+			}//end findAll()
+
+			/**
+			 * Refuse every single-object lookup.
+			 *
+			 * @param string|int $id Object ID.
+			 *
+			 * @return object|null
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function find(string|int $id): ?object {
+				throw new \RuntimeException('DB unavailable');
+			}//end find()
+		};
+	}//end buildUnavailableObjectServiceStub()
 
 	/**
 	 * BookingReminderJob can be instantiated with correct interval.
@@ -123,9 +242,7 @@ class BookingReminderJobTest extends TestCase {
 	 * @spec openspec/changes/bookings-notification-triggers/tasks.md#task-7
 	 */
 	public function testJobHandlesObjectServiceErrorGracefully(): void {
-		$this->container
-			->method('get')
-			->willThrowException(new \RuntimeException('DB unavailable'));
+		$this->job = $this->buildJob(store: $this->buildUnavailableObjectServiceStub());
 
 		// Logger::error should be called for each window that fails.
 		$this->logger

--- a/tests/Unit/Consolidation/ConsolidationGuardTest.php
+++ b/tests/Unit/Consolidation/ConsolidationGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Consolidation;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Consolidation\ConsolidationGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -91,13 +91,31 @@ class ConsolidationGuardTest extends TestCase {
 
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
 
-		$this->guard = new ConsolidationGuard(
-			appConfig: $this->appConfig,
-			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+		$this->guard = $this->buildGuard(
+			store: $this->buildObjectServiceStub(findReturn: null, findAllReturn: [])
 		);
 
 	}//end setUp()
+
+	/**
+	 * Build the guard over a seeded in-memory store.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so a test's
+	 * store has to be present when the guard is built — parking it on the
+	 * container after the fact leaves the guard reading an empty world.
+	 *
+	 * @param object $store The duck-typed in-memory ObjectService double.
+	 *
+	 * @return ConsolidationGuard
+	 */
+	private function buildGuard(object $store): ConsolidationGuard {
+		return new ConsolidationGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end buildGuard()
 
 	/**
 	 * RequireFiscalPeriodClosed denies when fiscalYearId is missing.
@@ -123,7 +141,7 @@ class ConsolidationGuardTest extends TestCase {
 	 */
 	public function testRequireFiscalPeriodClosedPermitsWhenFiscalYearAbsent(): void {
 		$objectService = $this->buildObjectServiceStub(findReturn: null, findAllReturn: []);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$result = $this->guard->requireFiscalPeriodClosed(
 			[
@@ -144,7 +162,7 @@ class ConsolidationGuardTest extends TestCase {
 	public function testRequireFiscalPeriodClosedPermitsWhenClosed(): void {
 		$fiscalYear = ['id' => 'fy-2026', 'isClosed' => true];
 		$objectService = $this->buildObjectServiceStub(findReturn: $fiscalYear, findAllReturn: []);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$result = $this->guard->requireFiscalPeriodClosed(
 			[
@@ -165,7 +183,7 @@ class ConsolidationGuardTest extends TestCase {
 	public function testRequireFiscalPeriodClosedDenieswhenOpen(): void {
 		$fiscalYear = ['id' => 'fy-2026', 'isClosed' => false];
 		$objectService = $this->buildObjectServiceStub(findReturn: $fiscalYear, findAllReturn: []);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$result = $this->guard->requireFiscalPeriodClosed(
 			[
@@ -184,7 +202,7 @@ class ConsolidationGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testRequireFiscalPeriodClosedIsFailClosedOnException(): void {
-		$this->container->method('get')->willThrowException(new \RuntimeException('DB error'));
+		$this->guard = $this->buildGuard(store: $this->buildUnavailableObjectServiceStub());
 
 		$result = $this->guard->requireFiscalPeriodClosed(
 			[
@@ -216,7 +234,7 @@ class ConsolidationGuardTest extends TestCase {
 	 */
 	public function testRequireAllMembersFinalisedPermitsWhenGroupAbsent(): void {
 		$objectService = $this->buildObjectServiceStub(findReturn: null, findAllReturn: []);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$result = $this->guard->requireAllMembersFinalised(
 			[
@@ -242,7 +260,7 @@ class ConsolidationGuardTest extends TestCase {
 		// Both administrations have a final BalanceSheet.
 		$balanceSheet = [['id' => 'bs-001', 'status' => 'final']];
 		$objectService = $this->buildObjectServiceStub(findReturn: $group, findAllReturn: $balanceSheet);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$result = $this->guard->requireAllMembersFinalised(
 			[
@@ -267,7 +285,7 @@ class ConsolidationGuardTest extends TestCase {
 		];
 		// No final BalanceSheet for adm-1.
 		$objectService = $this->buildObjectServiceStub(findReturn: $group, findAllReturn: []);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$result = $this->guard->requireAllMembersFinalised(
 			[
@@ -422,4 +440,67 @@ class ConsolidationGuardTest extends TestCase {
 			}//end findAll()
 		};
 	}//end buildObjectServiceStub()
+
+	/**
+	 * Build a store that models an unavailable OpenRegister.
+	 *
+	 * Before ADR-084 this scenario was expressed as
+	 * `$container->method('get')->willThrowException(...)`. The container is no
+	 * longer consulted, so the refusal has to come from the store itself; every
+	 * read throws exactly as a downed ObjectService would, which is what the
+	 * guard's fail-closed arm is there to catch.
+	 *
+	 * @return object
+	 */
+	private function buildUnavailableObjectServiceStub(): object {
+		return new class {
+			/**
+			 * Fluent register setter — returns self.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter — returns self.
+			 *
+			 * @param string $schema Schema name.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse every single-object lookup.
+			 *
+			 * @param string|int $id Object ID.
+			 *
+			 * @return object|null
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function find(string|int $id): ?object {
+				throw new \RuntimeException('DB error');
+			}//end find()
+
+			/**
+			 * Refuse every list query.
+			 *
+			 * @param array<string,mixed> $params Filter params.
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('DB error');
+			}//end findAll()
+		};
+	}//end buildUnavailableObjectServiceStub()
 }//end class

--- a/tests/Unit/Controller/BankStatementImportControllerTest.php
+++ b/tests/Unit/Controller/BankStatementImportControllerTest.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Controller;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Controller\BankStatementImportController;
 use OCA\Shillinq\Lifecycle\StatementParser;
 use OCA\Shillinq\Service\AdministrationContextService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -195,7 +195,7 @@ class BankStatementImportControllerTest extends TestCase {
 			administrationContext: $this->adminContext,
 			session: $this->session,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objectService),
 		);
 	}//end controller()
 

--- a/tests/Unit/Controller/BookingNotificationControllerTest.php
+++ b/tests/Unit/Controller/BookingNotificationControllerTest.php
@@ -19,11 +19,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Controller;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Controller\BookingNotificationController;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\BookingNotificationService;
 use OCA\Shillinq\Service\SettingsService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IGroupManager;
 use OCP\IRequest;
@@ -125,16 +125,73 @@ class BookingNotificationControllerTest extends TestCase {
 
 		$this->settingsService->method('getRegisterSlug')->willReturn('shillinq');
 
-		$this->controller = new BookingNotificationController(
+		$this->controller = $this->buildController(store: $this->buildEmptyObjectServiceStub());
+	}//end setUp()
+
+	/**
+	 * Build the controller over a seeded in-memory store.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so a test's
+	 * store has to be present when the controller is built — parking it on the
+	 * container after the fact leaves the controller reading an empty world.
+	 *
+	 * @param object $store The duck-typed in-memory ObjectService double.
+	 *
+	 * @return BookingNotificationController
+	 */
+	private function buildController(object $store): BookingNotificationController {
+		return new BookingNotificationController(
 			request: $this->request,
 			settingsService: $this->settingsService,
 			groupManager: $this->groupManager,
 			userSession: $this->userSession,
 			logger: $this->logger,
 			administrationContext: $this->administrationContext,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($store),
 		);
-	}//end setUp()
+	}//end buildController()
+
+	/**
+	 * Build an empty in-memory ObjectService double.
+	 *
+	 * @return object
+	 */
+	private function buildEmptyObjectServiceStub(): object {
+		return new class {
+			/**
+			 * Fluent register setter — returns self.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter — returns self.
+			 *
+			 * @param string $schema Schema name.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Answer an empty result set.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused).
+			 *
+			 * @return array<mixed>
+			 */
+			public function findAll(array $params = []): array {
+				return [];
+			}//end findAll()
+		};
+	}//end buildEmptyObjectServiceStub()
 
 	/**
 	 * GetBookingTriggers throws OCSForbiddenException when user is unauthenticated.
@@ -178,7 +235,7 @@ class BookingNotificationControllerTest extends TestCase {
 		};
 		// phpcs:enable
 		// phpcs:disable CustomSn.Functions.NamedParameters
-		$this->container->method('get')->willReturn($objectService);
+		$this->controller = $this->buildController(store: $objectService);
 		// phpcs:enable CustomSn.Functions.NamedParameters
 
 		$response = $this->controller->getBookingTriggers(id: 'booking-123');
@@ -230,7 +287,7 @@ class BookingNotificationControllerTest extends TestCase {
 		};
 		// phpcs:enable
 		// phpcs:disable CustomSn.Functions.NamedParameters
-		$this->container->method('get')->willReturn($objectService);
+		$this->controller = $this->buildController(store: $objectService);
 		$this->administrationContext->method('canAccess')->willReturn(true);
 		// phpcs:enable CustomSn.Functions.NamedParameters
 
@@ -267,7 +324,7 @@ class BookingNotificationControllerTest extends TestCase {
 		};
 		// phpcs:enable
 		// phpcs:disable CustomSn.Functions.NamedParameters
-		$this->container->method('get')->willReturn($objectService);
+		$this->controller = $this->buildController(store: $objectService);
 		$this->administrationContext->method('canAccess')->willReturn(false);
 		// phpcs:enable CustomSn.Functions.NamedParameters
 
@@ -303,7 +360,7 @@ class BookingNotificationControllerTest extends TestCase {
 		};
 		// phpcs:enable
 		// phpcs:disable CustomSn.Functions.NamedParameters
-		$this->container->method('get')->willReturn($objectService);
+		$this->controller = $this->buildController(store: $objectService);
 		// An empty administrationId must still reach canAccess(), which
 		// returns false for it — assert the guard consults the seam rather
 		// than short-circuiting past it (the #474 defect).
@@ -360,7 +417,7 @@ class BookingNotificationControllerTest extends TestCase {
 		};
 		// phpcs:enable
 		// phpcs:disable CustomSn.Functions.NamedParameters
-		$this->container->method('get')->willReturn($objectService);
+		$this->controller = $this->buildController(store: $objectService);
 		// phpcs:enable CustomSn.Functions.NamedParameters
 
 		$response = $this->controller->getNotificationMonitor();
@@ -391,13 +448,13 @@ class BookingNotificationControllerTest extends TestCase {
 				return [['id' => 'trig-1', 'active' => true], ['id' => 'trig-2', 'active' => true]];
 			}
 
-			public function saveObject(array $object, string $register, string $schema): array {
+			public function saveObject(array $object, string $register = '', string $schema = ''): array {
 				return $object;
 			}
 		};
 		// phpcs:enable
 		// phpcs:disable CustomSn.Functions.NamedParameters
-		$this->container->method('get')->willReturn($objectService);
+		$this->controller = $this->buildController(store: $objectService);
 		// phpcs:enable CustomSn.Functions.NamedParameters
 
 		$this->logger->expects(static::once())->method('warning');

--- a/tests/Unit/Controller/GRIRReconciliationControllerTest.php
+++ b/tests/Unit/Controller/GRIRReconciliationControllerTest.php
@@ -30,11 +30,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Controller;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Controller\GRIRReconciliationController;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\GRIRClearingService;
 use OCA\Shillinq\Tests\Unit\Service\InMemoryObjectService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\AppFramework\Http;
 use OCP\IAppConfig;
 use OCP\IRequest;
@@ -120,7 +120,7 @@ class GRIRReconciliationControllerTest extends TestCase {
 			appConfig: $appConfig,
 			administrationContext: $administrationContext,
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objects),
 		);
 
 		$request = $this->createMock(IRequest::class);

--- a/tests/Unit/Controller/LeaseReassessmentControllerTest.php
+++ b/tests/Unit/Controller/LeaseReassessmentControllerTest.php
@@ -22,11 +22,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Controller;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Controller\LeaseReassessmentController;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\LeaseAmortizationCalculator;
 use OCA\Shillinq\Service\LeaseReassessmentService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\AppFramework\Http;
 use OCP\IAppConfig;
 use OCP\IRequest;
@@ -169,15 +169,26 @@ final class LeaseReassessmentControllerTest extends TestCase {
 			/**
 			 * Capture saveObject calls; echo the row back.
 			 *
+			 * Register and schema are optional because the real contract declares
+			 * them optional: a caller that has already narrowed the scope through
+			 * setRegister()/setSchema() passes the payload alone. When the schema
+			 * is omitted the row is filed under the last one selected, so
+			 * findAll() still finds it.
+			 *
 			 * @param array<string,mixed> $object The row.
 			 * @param string $register Register slug.
 			 * @param string $schema Schema slug.
 			 *
 			 * @return array<string,mixed>
 			 */
-			public function saveObject(array $object, string $register, string $schema): array {
-				$this->saved[$schema] = ($this->saved[$schema] ?? []);
-				$this->saved[$schema][] = $object;
+			public function saveObject(array $object, string $register = '', string $schema = ''): array {
+				$key = $schema;
+				if ($key === '') {
+					$key = $this->lastSchema;
+				}
+
+				$this->saved[$key] = ($this->saved[$key] ?? []);
+				$this->saved[$key][] = $object;
 				return $object;
 			}//end saveObject()
 		};
@@ -192,7 +203,7 @@ final class LeaseReassessmentControllerTest extends TestCase {
 			appConfig: $appConfig,
 			calculator: new LeaseAmortizationCalculator(),
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Controller/PaymentRunControllerTest.php
+++ b/tests/Unit/Controller/PaymentRunControllerTest.php
@@ -22,11 +22,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Controller;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Controller\PaymentRunController;
 use OCA\Shillinq\PaymentRun\PaymentRunExportService;
 use OCA\Shillinq\PaymentRun\PaymentRunReconciliationService;
 use OCA\Shillinq\Service\AdministrationContextService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\AppFramework\Http;
 use OCP\IRequest;
 use OCP\IUser;
@@ -91,8 +91,9 @@ class PaymentRunControllerTest extends TestCase {
 		PaymentRunExportService $export,
 		PaymentRunReconciliationService $reconcile,
 	): PaymentRunController {
+		$objects   = $this->objectServiceReturning($run);
 		$container = $this->createMock(ContainerInterface::class);
-		$container->method('get')->willReturn($this->objectServiceReturning($run));
+		$container->method('get')->willReturn($objects);
 
 		$adminContext = $this->createMock(AdministrationContextService::class);
 		$adminContext->method('canAccess')->willReturn($canAccess);
@@ -109,7 +110,7 @@ class PaymentRunControllerTest extends TestCase {
 			$adminContext,
 			$session,
 			$this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($objects),
 		);
 	}//end controller()
 

--- a/tests/Unit/Guard/AccountBalanceGuardTest.php
+++ b/tests/Unit/Guard/AccountBalanceGuardTest.php
@@ -21,6 +21,7 @@ namespace OCA\Shillinq\Tests\Unit\Guard;
 
 use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Guard\AccountBalanceGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -82,13 +83,31 @@ class AccountBalanceGuardTest extends TestCase {
 		// Default: return the canonical register slug.
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
 
-		$this->guard = new AccountBalanceGuard(
-			appConfig: $this->appConfig,
-			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+		$this->guard = $this->buildGuard(
+			store: $this->buildObjectServiceStub(lines: [], closingAccounts: [])
 		);
 
 	}//end setUp()
+
+	/**
+	 * Build the guard over a seeded in-memory store.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so a test's
+	 * store has to be present when the guard is built — parking it on the
+	 * container after the fact leaves the guard reading an empty world.
+	 *
+	 * @param object $store The duck-typed in-memory ObjectService double.
+	 *
+	 * @return AccountBalanceGuard
+	 */
+	private function buildGuard(object $store): AccountBalanceGuard {
+		return new AccountBalanceGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end buildGuard()
 
 	/**
 	 * requireZeroBalance returns true when the GLLine register is unavailable (T1).
@@ -96,9 +115,14 @@ class AccountBalanceGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testRequireZeroBalancePermitsArchiveInT1State(): void {
-		// Simulate T1: container throws when trying to get ObjectService.
-		$this->container->method('get')
-			->willThrowException(new \RuntimeException('ObjectService not found'));
+		// ADR-084 deleted the container probe this test used to simulate: with the
+		// contract injected non-nullably the guard can no longer distinguish "the
+		// GLLine schema is absent" from "the account has no GLLine rows". An empty
+		// store is what the guard actually observes in a T1 state, and it is still
+		// the case that an account carrying no postings has a zero balance.
+		$this->guard = $this->buildGuard(
+			store: $this->buildObjectServiceStub(lines: [], closingAccounts: [])
+		);
 
 		$result = $this->guard->requireZeroBalance(['accountNumber' => '0001', 'administrationId' => 'adm-1']);
 
@@ -122,7 +146,7 @@ class AccountBalanceGuardTest extends TestCase {
 
 		// The ObjectService stub: setRegister/setSchema returns itself, findAll returns $lines.
 		$objectService = $this->buildObjectServiceStub(lines: $lines, closingAccounts: []);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$result = $this->guard->requireZeroBalance(['accountNumber' => '0001', 'administrationId' => 'adm-1']);
 
@@ -141,7 +165,7 @@ class AccountBalanceGuardTest extends TestCase {
 		];
 
 		$objectService = $this->buildObjectServiceStub(lines: $lines, closingAccounts: []);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$result = $this->guard->requireZeroBalance(['accountNumber' => '0001', 'administrationId' => 'adm-1']);
 
@@ -152,21 +176,24 @@ class AccountBalanceGuardTest extends TestCase {
 	/**
 	 * requireZeroBalance is fail-closed: returns false (denies archive) on exception.
 	 *
-	 * The first container->get() call is the T1 probe in isGLLineRegisterAvailable(),
-	 * which must succeed so the guard proceeds to compute the balance. The second call
-	 * is the actual computation path, where findAll() throws to trigger fail-closed.
+	 * The store throws, so the outer try/catch must return false.
+	 *
+	 * The previous version also asserted `container->get()` was called exactly
+	 * twice — a T1 probe plus the computation. ADR-084 deleted both the probe
+	 * and the container, and the guard now receives its ObjectService through
+	 * the constructor, so nothing resolves a container at all. That expectation
+	 * could never fire again: it was not coverage, it was a guaranteed failure
+	 * describing an architecture that no longer exists. Removed rather than
+	 * relaxed; the assertion that matters — fail-closed on exception — is
+	 * untouched and is what the store's throwing findAll() now exercises.
 	 *
 	 * @return void
 	 */
 	public function testRequireZeroBalanceIsFailClosedOnException(): void {
-		// Probe call: succeeds (empty lines) so isGLLineRegisterAvailable() returns true.
-		$probeStub = $this->buildObjectServiceStub(lines: [], closingAccounts: []);
 		// Computation call: throws so the outer try-catch returns false (fail-closed).
 		$throwStub = $this->buildObjectServiceStubThatThrows();
 
-		$this->container->expects($this->exactly(2))
-			->method('get')
-			->willReturnOnConsecutiveCalls($probeStub, $throwStub);
+		$this->guard = $this->buildGuard(store: $throwStub);
 
 		$result = $this->guard->requireZeroBalance(['accountNumber' => '0001', 'administrationId' => 'adm-1']);
 
@@ -180,8 +207,20 @@ class AccountBalanceGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testRequireSingleClosingAccountPermitsNonClosingAccount(): void {
-		// Container should not be touched for non-closing accounts.
-		$this->container->expects($this->never())->method('get');
+		// The data layer must not be touched for non-closing accounts. Asserted
+		// against the ObjectService the guard actually holds — the old
+		// `container->expects($this->never())->method('get')` was vacuously true
+		// after ADR-084, because nothing consults a container any more, so it
+		// would have stayed green even if the guard queried on every call.
+		$objectService = $this->createMock(ObjectServiceInterface::class);
+		$objectService->expects($this->never())->method('findAll');
+		$objectService->expects($this->never())->method('find');
+
+		$this->guard = new AccountBalanceGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: $objectService,
+		);
 
 		$result = $this->guard->requireSingleClosingAccount(['isClosingAccount' => false]);
 
@@ -196,7 +235,7 @@ class AccountBalanceGuardTest extends TestCase {
 	 */
 	public function testRequireSingleClosingAccountPermitsFirstClosingAccount(): void {
 		$objectService = $this->buildObjectServiceStub(lines: [], closingAccounts: []);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$result = $this->guard->requireSingleClosingAccount([
 			'isClosingAccount' => true,
@@ -218,7 +257,7 @@ class AccountBalanceGuardTest extends TestCase {
 			['id' => 'other-uuid', 'accountNumber' => 'CLOSE-OLD', 'administrationId' => 'adm-1', 'isClosingAccount' => true],
 		];
 		$objectService = $this->buildObjectServiceStub(lines: [], closingAccounts: $existingClosing);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$result = $this->guard->requireSingleClosingAccount([
 			'isClosingAccount' => true,

--- a/tests/Unit/Guard/BankReconciliationGuardTest.php
+++ b/tests/Unit/Guard/BankReconciliationGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Guard;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Guard\BankReconciliationGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -84,13 +84,29 @@ class BankReconciliationGuardTest extends TestCase {
 
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
 
-		$this->guard = new BankReconciliationGuard(
-			appConfig: $this->appConfig,
-			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
-		);
+		$this->guard = $this->buildGuard(store: $this->buildObjectServiceStub());
 
 	}//end setUp()
+
+	/**
+	 * Build the guard over a seeded in-memory store.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so a test's
+	 * store has to be present when the guard is built — parking it on the
+	 * container after the fact leaves the guard reading an empty world.
+	 *
+	 * @param object $store The duck-typed in-memory ObjectService double.
+	 *
+	 * @return BankReconciliationGuard
+	 */
+	private function buildGuard(object $store): BankReconciliationGuard {
+		return new BankReconciliationGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end buildGuard()
 
 	/**
 	 * A brand-new reconciliation (no id) with a valid period is permitted to save.
@@ -137,7 +153,7 @@ class BankReconciliationGuardTest extends TestCase {
 		$stub = $this->buildObjectServiceStub(
 			stored: ['id' => 'rec-1', 'status' => 'reconciled'],
 		);
-		$this->container->method('get')->willReturn($stub);
+		$this->guard = $this->buildGuard(store: $stub);
 
 		$result = $this->guard->requireUnlockedAndValidDates(
 			[
@@ -162,7 +178,7 @@ class BankReconciliationGuardTest extends TestCase {
 		$stub = $this->buildObjectServiceStub(
 			stored: ['id' => 'rec-1', 'status' => 'reconciled'],
 		);
-		$this->container->method('get')->willReturn($stub);
+		$this->guard = $this->buildGuard(store: $stub);
 
 		$result = $this->guard->requireUnlockedAndValidDates(
 			[
@@ -184,7 +200,7 @@ class BankReconciliationGuardTest extends TestCase {
 		$stub = $this->buildObjectServiceStub(
 			stored: ['id' => 'rec-1', 'status' => 'reconciled'],
 		);
-		$this->container->method('get')->willReturn($stub);
+		$this->guard = $this->buildGuard(store: $stub);
 
 		$result = $this->guard->requireParentUnlocked(
 			[
@@ -206,7 +222,7 @@ class BankReconciliationGuardTest extends TestCase {
 		$stub = $this->buildObjectServiceStub(
 			stored: ['id' => 'rec-1', 'status' => 'in-progress'],
 		);
-		$this->container->method('get')->willReturn($stub);
+		$this->guard = $this->buildGuard(store: $stub);
 
 		$result = $this->guard->requireParentUnlocked(
 			[
@@ -232,7 +248,7 @@ class BankReconciliationGuardTest extends TestCase {
 				['matchType' => 'pending-review', 'bankTransactionAmount' => 50.00],
 			],
 		);
-		$this->container->method('get')->willReturn($stub);
+		$this->guard = $this->buildGuard(store: $stub);
 
 		$result = $this->guard->requireResolvedMatches(
 			[
@@ -262,7 +278,7 @@ class BankReconciliationGuardTest extends TestCase {
 				['matchType' => 'rejected', 'bankTransactionAmount' => 99.00, 'journalEntryId' => null],
 			],
 		);
-		$this->container->method('get')->willReturn($stub);
+		$this->guard = $this->buildGuard(store: $stub);
 
 		$result = $this->guard->requireResolvedMatches(
 			[
@@ -306,7 +322,7 @@ class BankReconciliationGuardTest extends TestCase {
 	 */
 	public function testApproveFailClosedOnLookupError(): void {
 		$stub = $this->buildObjectServiceStubThatThrows();
-		$this->container->method('get')->willReturn($stub);
+		$this->guard = $this->buildGuard(store: $stub);
 
 		$result = $this->guard->requireResolvedMatches(
 			[

--- a/tests/Unit/Guard/CreditLimitGuardTest.php
+++ b/tests/Unit/Guard/CreditLimitGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Guard;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Guard\CreditLimitGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -89,13 +89,31 @@ class CreditLimitGuardTest extends TestCase {
 
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
 
-		$this->guard = new CreditLimitGuard(
-			appConfig: $this->appConfig,
-			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+		$this->guard = $this->buildGuard(
+			store: $this->buildObjectServiceStub(customers: [], invoices: [])
 		);
 
 	}//end setUp()
+
+	/**
+	 * Build the guard over a seeded in-memory store.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so a test's
+	 * store has to be present when the guard is built — parking it on the
+	 * container after the fact leaves the guard reading an empty world.
+	 *
+	 * @param object $store The duck-typed in-memory ObjectService double.
+	 *
+	 * @return CreditLimitGuard
+	 */
+	private function buildGuard(object $store): CreditLimitGuard {
+		return new CreditLimitGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end buildGuard()
 
 	/**
 	 * No credit limit configured → unlimited credit; issue permitted.
@@ -105,7 +123,7 @@ class CreditLimitGuardTest extends TestCase {
 	public function testPermitsWhenNoCreditLimitSet(): void {
 		$customer = [['customerNumber' => 'CUST-1', 'administrationId' => 'adm-1', 'creditLimitCents' => null]];
 		$objectService = $this->buildObjectServiceStub(customers: $customer, invoices: []);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$result = $this->guard->requireWithinCreditLimit(
 			[
@@ -132,7 +150,7 @@ class CreditLimitGuardTest extends TestCase {
 			['invoiceNumber' => 'INV-9', 'status' => 'draft', 'totalCents' => 40000],
 		];
 		$objectService = $this->buildObjectServiceStub(customers: $customer, invoices: $invoices);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		// Outstanding excluding INV-9 = 30000; + this invoice 40000 = 70000 <= 100000.
 		$result = $this->guard->requireWithinCreditLimit(
@@ -159,7 +177,7 @@ class CreditLimitGuardTest extends TestCase {
 			['invoiceNumber' => 'INV-1', 'status' => 'issued', 'totalCents' => 80000],
 		];
 		$objectService = $this->buildObjectServiceStub(customers: $customer, invoices: $invoices);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		// 80000 outstanding + 30000 this invoice = 110000 > 100000.
 		$result = $this->guard->requireWithinCreditLimit(
@@ -186,7 +204,7 @@ class CreditLimitGuardTest extends TestCase {
 			['invoiceNumber' => 'INV-1', 'status' => 'overdue', 'totalCents' => 60000],
 		];
 		$objectService = $this->buildObjectServiceStub(customers: $customer, invoices: $invoices);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		// 60000 + 40000 = 100000 == limit → permitted.
 		$result = $this->guard->requireWithinCreditLimit(
@@ -215,7 +233,7 @@ class CreditLimitGuardTest extends TestCase {
 			['invoiceNumber' => 'INV-3', 'status' => 'issued', 'totalCents' => 10000],
 		];
 		$objectService = $this->buildObjectServiceStub(customers: $customer, invoices: $invoices);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		// Outstanding = 10000 (only INV-3); + 30000 this invoice = 40000 <= 50000.
 		$result = $this->guard->requireWithinCreditLimit(
@@ -238,7 +256,7 @@ class CreditLimitGuardTest extends TestCase {
 	 */
 	public function testDeniesWhenCustomerNotFound(): void {
 		$objectService = $this->buildObjectServiceStub(customers: [], invoices: []);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$result = $this->guard->requireWithinCreditLimit(
 			[
@@ -279,8 +297,7 @@ class CreditLimitGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testIsFailClosedOnException(): void {
-		$this->container->method('get')
-			->willThrowException(new \RuntimeException('DB error'));
+		$this->guard = $this->buildGuard(store: $this->buildObjectServiceStubThatThrows());
 
 		$result = $this->guard->requireWithinCreditLimit(
 			[
@@ -378,4 +395,66 @@ class CreditLimitGuardTest extends TestCase {
 			}//end findAll()
 		};
 	}//end buildObjectServiceStub()
+
+	/**
+	 * Build a store whose every read throws.
+	 *
+	 * Before ADR-084 this scenario was expressed as
+	 * `$container->method('get')->willThrowException(...)`. The container is no
+	 * longer consulted, so the refusal has to come from the store itself, which
+	 * is what the guard's fail-closed arm is there to catch.
+	 *
+	 * @return object
+	 */
+	private function buildObjectServiceStubThatThrows(): object {
+		return new class {
+			/**
+			 * Fluent register setter — returns self.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter — returns self.
+			 *
+			 * @param string $schema Schema name.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse every list query.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('DB error');
+			}//end findAll()
+
+			/**
+			 * Refuse every single-object lookup.
+			 *
+			 * @param string|int $id Object ID.
+			 *
+			 * @return object|null
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function find(string|int $id): ?object {
+				throw new \RuntimeException('DB error');
+			}//end find()
+		};
+	}//end buildObjectServiceStubThatThrows()
 }//end class

--- a/tests/Unit/Guard/IntercompanyEliminationGuardTest.php
+++ b/tests/Unit/Guard/IntercompanyEliminationGuardTest.php
@@ -26,11 +26,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Guard;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Guard\IntercompanyEliminationGuard;
 use OCA\Shillinq\Service\IntercompanyJournalService;
 use OCA\Shillinq\Service\IntercompanyLinkService;
 use OCA\Shillinq\Tests\Unit\Service\InMemoryObjectService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -80,7 +80,7 @@ class IntercompanyEliminationGuardTest extends TestCase {
 			appConfig: $appConfig,
 			journalService: $journalService,
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objects),
 		);
 
 		$this->guard = new IntercompanyEliminationGuard(

--- a/tests/Unit/Guard/OssPaymentGuardTest.php
+++ b/tests/Unit/Guard/OssPaymentGuardTest.php
@@ -29,11 +29,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Guard;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Guard\OssPaymentGuard;
 use OCA\Shillinq\Service\OssPaymentReconciliation;
 use OCA\Shillinq\Service\OssRecordResolver;
 use OCA\Shillinq\Tests\Unit\Service\InMemoryObjectService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -82,7 +82,7 @@ class OssPaymentGuardTest extends TestCase {
 			resolver: new OssRecordResolver(
 				appConfig: $appConfig,
 				logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objects),
 		),
 			reconciliation: new OssPaymentReconciliation(),
 		);

--- a/tests/Unit/Guard/RateScheduleOverlapGuardTest.php
+++ b/tests/Unit/Guard/RateScheduleOverlapGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Guard;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Guard\RateScheduleOverlapGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -93,7 +93,7 @@ final class RateScheduleOverlapGuardTest extends TestCase {
 		return new RateScheduleOverlapGuard(
 			appConfig: $appConfig,
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildGuard()

--- a/tests/Unit/Lifecycle/AnnualReportGuardTest.php
+++ b/tests/Unit/Lifecycle/AnnualReportGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\AnnualReportGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -83,13 +83,29 @@ class AnnualReportGuardTest extends TestCase {
 
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
 
-		$this->guard = new AnnualReportGuard(
-			appConfig: $this->appConfig,
-			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
-		);
+		$this->guard = $this->buildGuard(store: $this->buildObjectServiceStub(records: []));
 
 	}//end setUp()
+
+	/**
+	 * Build the guard over a seeded in-memory store.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so a test's
+	 * store has to be present when the guard is built — parking it on the
+	 * container after the fact leaves the guard reading an empty world.
+	 *
+	 * @param object $store The duck-typed in-memory ObjectService double.
+	 *
+	 * @return AnnualReportGuard
+	 */
+	private function buildGuard(object $store): AnnualReportGuard {
+		return new AnnualReportGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end buildGuard()
 
 	/**
 	 * A jaarrekening whose linked balans balances (activa = passiva) may opmaken (REQ-T9-002).
@@ -97,8 +113,8 @@ class AnnualReportGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCanOpmakenWhenBalansBalances(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(records: [['reportId' => 'r-1', 'totalAssets' => 845000, 'totalLiabilities' => 845000]])
+		$this->guard = $this->buildGuard(
+			store: $this->buildObjectServiceStub(records: [['reportId' => 'r-1', 'totalAssets' => 845000, 'totalLiabilities' => 845000]])
 		);
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -112,8 +128,8 @@ class AnnualReportGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCannotOpmakenWhenBalansUnbalanced(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(records: [['reportId' => 'r-2', 'totalAssets' => 845000, 'totalLiabilities' => 800000]])
+		$this->guard = $this->buildGuard(
+			store: $this->buildObjectServiceStub(records: [['reportId' => 'r-2', 'totalAssets' => 845000, 'totalLiabilities' => 800000]])
 		);
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -137,7 +153,7 @@ class AnnualReportGuardTest extends TestCase {
 			],
 		];
 
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub(records: [$balanceSheet]));
+		$this->guard = $this->buildGuard(store: $this->buildObjectServiceStub(records: [$balanceSheet]));
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
 		self::assertTrue($this->guard->canOpmaken(annualReportId: 'r-3', object: ['id' => 'r-3']));
@@ -150,7 +166,7 @@ class AnnualReportGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCannotOpmakenWithoutBalanceSheet(): void {
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub(records: []));
+		$this->guard = $this->buildGuard(store: $this->buildObjectServiceStub(records: []));
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
 		self::assertFalse($this->guard->canOpmaken(annualReportId: 'r-4', object: ['id' => 'r-4']));
@@ -163,8 +179,8 @@ class AnnualReportGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testZeroTotalBalansCannotOpmaken(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(records: [['reportId' => 'r-5', 'totalAssets' => 0, 'totalLiabilities' => 0]])
+		$this->guard = $this->buildGuard(
+			store: $this->buildObjectServiceStub(records: [['reportId' => 'r-5', 'totalAssets' => 0, 'totalLiabilities' => 0]])
 		);
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -178,8 +194,7 @@ class AnnualReportGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testOpmaakExceptionFailsClosed(): void {
-		$this->container->method('get')
-			->willThrowException(new \RuntimeException('ObjectService unavailable'));
+		$this->guard = $this->buildGuard(store: $this->buildUnavailableObjectServiceStub());
 
 		$this->logger->expects($this->once())->method('error');
 
@@ -320,4 +335,67 @@ class AnnualReportGuardTest extends TestCase {
 			}//end findAll()
 		};
 	}//end buildObjectServiceStub()
+
+	/**
+	 * Build a store that models an unavailable OpenRegister.
+	 *
+	 * Before ADR-084 this scenario was expressed as
+	 * `$container->method('get')->willThrowException(...)`. The container is no
+	 * longer consulted, so the refusal has to come from the store itself; every
+	 * read throws exactly as a downed ObjectService would, which is what the
+	 * guard's fail-closed arm is there to catch.
+	 *
+	 * @return object
+	 */
+	private function buildUnavailableObjectServiceStub(): object {
+		return new class {
+			/**
+			 * Fluent register setter — returns self.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter — returns self.
+			 *
+			 * @param string $schema Schema name.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse every list query.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end findAll()
+
+			/**
+			 * Refuse every single-object lookup.
+			 *
+			 * @param string|int $id Object ID.
+			 *
+			 * @return object|null
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function find(string|int $id): ?object {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end find()
+		};
+	}//end buildUnavailableObjectServiceStub()
 }//end class

--- a/tests/Unit/Lifecycle/BcfClaimGuardTest.php
+++ b/tests/Unit/Lifecycle/BcfClaimGuardTest.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\BcfClaimGuard;
 use OCA\Shillinq\Service\BcfClaimService;
 use OCA\Shillinq\Service\BcfCompensationCalculator;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -86,13 +86,14 @@ class BcfClaimGuardTest extends TestCase {
 	 * @return BcfClaimGuard
 	 */
 	private function guardWith(array $recordsBySchema): BcfClaimGuard {
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub($recordsBySchema));
+		$store = $this->buildObjectServiceStub($recordsBySchema);
+		$this->container->method('get')->willReturn($store);
 
 		$calculator = new BcfCompensationCalculator();
 		$service = new BcfClaimService(
 			appConfig: $this->appConfig,
 			calculator: $calculator,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($store),
 		);
 
 		return new BcfClaimGuard(
@@ -100,7 +101,7 @@ class BcfClaimGuardTest extends TestCase {
 			claimService: $service,
 			calculator: $calculator,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($store),
 		);
 
 	}//end guardWith()
@@ -236,6 +237,7 @@ class BcfClaimGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testSubmitExceptionFailsClosed(): void {
+		$store = $this->buildUnavailableObjectServiceStub();
 		$this->container->method('get')->willThrowException(new \RuntimeException('ObjectService unavailable'));
 		$this->logger->expects($this->once())->method('error');
 
@@ -243,14 +245,14 @@ class BcfClaimGuardTest extends TestCase {
 		$service = new BcfClaimService(
 			appConfig: $this->appConfig,
 			calculator: $calculator,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($store),
 		);
 		$guard = new BcfClaimGuard(
 			appConfig: $this->appConfig,
 			claimService: $service,
 			calculator: $calculator,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($store),
 		);
 
 		self::assertFalse(
@@ -330,6 +332,82 @@ class BcfClaimGuardTest extends TestCase {
 		};
 
 	}//end buildObjectServiceStub()
+
+	/**
+	 * Build a store that models an unavailable OpenRegister.
+	 *
+	 * Before ADR-084 this scenario was expressed as
+	 * `$container->method('get')->willThrowException(...)`. The container is no
+	 * longer consulted, so the refusal has to come from the store itself; every
+	 * read throws exactly as a downed ObjectService would.
+	 *
+	 * @return object
+	 */
+	private function buildUnavailableObjectServiceStub(): object {
+		return new class {
+			/**
+			 * Fluent register setter.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter.
+			 *
+			 * @param string $schema Schema slug.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse every list query.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end findAll()
+
+			/**
+			 * Refuse every single-object lookup.
+			 *
+			 * @param string|int $id Object id.
+			 *
+			 * @return ?object
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function find(string|int $id): ?object {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end find()
+
+			/**
+			 * Refuse every write.
+			 *
+			 * @param array<string,mixed> $object Object payload.
+			 *
+			 * @return array<string,mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function saveObject(array $object): array {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end saveObject()
+		};
+
+	}//end buildUnavailableObjectServiceStub()
 
 	// phpcs:enable CustomSniffs.Functions.NamedParameters
 }//end class

--- a/tests/Unit/Lifecycle/BudgetOverrunGuardTest.php
+++ b/tests/Unit/Lifecycle/BudgetOverrunGuardTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\BudgetOverrunGuard;
 use OCA\Shillinq\Service\BegrotingswijzigingStacker;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -79,14 +79,32 @@ final class BudgetOverrunGuardTest extends TestCase {
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
 
-		$this->guard = new BudgetOverrunGuard(
-			appConfig: $this->appConfig,
-			stacker: new BegrotingswijzigingStacker(),
-			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+		$this->guard = $this->buildGuard(
+			store: $this->objectServiceStub(taskFields: [], wijzigingen: [], glLines: [])
 		);
 
 	}//end setUp()
+
+	/**
+	 * Build the guard over a seeded in-memory store.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so a test's
+	 * store has to be present when the guard is built — parking it on the
+	 * container after the fact leaves the guard reading an empty world.
+	 *
+	 * @param object $store The duck-typed in-memory ObjectService double.
+	 *
+	 * @return BudgetOverrunGuard
+	 */
+	private function buildGuard(object $store): BudgetOverrunGuard {
+		return new BudgetOverrunGuard(
+			appConfig: $this->appConfig,
+			stacker: new BegrotingswijzigingStacker(),
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end buildGuard()
 
 	/**
 	 * REQ-010: a posting within the authorized lasten stays within budget.
@@ -124,8 +142,8 @@ final class BudgetOverrunGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCanPostWithinStackedBudgetSucceeds(): void {
-		$this->container->method('get')->willReturn(
-			$this->objectServiceStub(
+		$this->guard = $this->buildGuard(
+			store: $this->objectServiceStub(
 				taskFields: [['taskFieldCode' => '1.2', 'revenue' => 0.0, 'expenses' => 500.0]],
 				wijzigingen: [['status' => 'determined', 'movements' => [['taskFieldCode' => '1.2', 'lasten_delta' => 100.0]]]],
 				glLines: [['taskFieldCode' => '1.2', 'side' => 'debit', 'amount' => 400.0]]
@@ -143,8 +161,8 @@ final class BudgetOverrunGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCanPostOverBudgetFails(): void {
-		$this->container->method('get')->willReturn(
-			$this->objectServiceStub(
+		$this->guard = $this->buildGuard(
+			store: $this->objectServiceStub(
 				taskFields: [['taskFieldCode' => '1.2', 'revenue' => 0.0, 'expenses' => 500.0]],
 				wijzigingen: [],
 				glLines: [['taskFieldCode' => '1.2', 'side' => 'debit', 'amount' => 450.0]]
@@ -172,7 +190,7 @@ final class BudgetOverrunGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCanPostFailsClosedOnException(): void {
-		$this->container->method('get')->willThrowException(new \RuntimeException('OR down'));
+		$this->guard = $this->buildGuard(store: $this->buildUnavailableObjectServiceStub());
 		self::assertFalse($this->guard->canPost(budgetId: 'pb-1', taskFieldCode: '1.2', attempted: 1.0));
 
 	}//end testCanPostFailsClosedOnException()
@@ -276,6 +294,69 @@ final class BudgetOverrunGuardTest extends TestCase {
 			}//end findAll()
 		};
 	}//end objectServiceStub()
+
+	/**
+	 * Build a store that models an unavailable OpenRegister.
+	 *
+	 * Before ADR-084 this scenario was expressed as
+	 * `$container->method('get')->willThrowException(...)`. The container is no
+	 * longer consulted, so the refusal has to come from the store itself; every
+	 * read throws exactly as a downed ObjectService would, which is what the
+	 * guard's fail-closed arm is there to catch.
+	 *
+	 * @return object
+	 */
+	private function buildUnavailableObjectServiceStub(): object {
+		return new class {
+			/**
+			 * Fluent register setter — returns self.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter — returns self.
+			 *
+			 * @param string $schema Schema name.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse every list query.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('OR down');
+			}//end findAll()
+
+			/**
+			 * Refuse every single-object lookup.
+			 *
+			 * @param string|int $id Object ID.
+			 *
+			 * @return object|null
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function find(string|int $id): ?object {
+				throw new \RuntimeException('OR down');
+			}//end find()
+		};
+	}//end buildUnavailableObjectServiceStub()
 
 	// phpcs:enable CustomSniffs.Functions.NamedParameters
 }//end class

--- a/tests/Unit/Lifecycle/ComplianceValidatorTest.php
+++ b/tests/Unit/Lifecycle/ComplianceValidatorTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Lifecycle\ComplianceValidator;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -92,13 +92,31 @@ class ComplianceValidatorTest extends TestCase {
 			->with(Application::APP_ID, 'register', 'shillinq')
 			->willReturn('shillinq');
 
-		$this->validator = new ComplianceValidator(
-			appConfig: $this->appConfig,
-			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+		$this->validator = $this->buildValidator(
+			store: $this->buildObjectServiceMock(bankingRuleRules: [])
 		);
 
 	}//end setUp()
+
+	/**
+	 * Build the validator over a seeded in-memory store.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so a test's
+	 * store has to be present when the validator is built — parking it on the
+	 * container after the fact leaves the validator reading an empty world.
+	 *
+	 * @param object $store The duck-typed in-memory ObjectService double.
+	 *
+	 * @return ComplianceValidator
+	 */
+	private function buildValidator(object $store): ComplianceValidator {
+		return new ComplianceValidator(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end buildValidator()
 
 	/**
 	 * Build a minimal valid TreasuryAccount fixture.
@@ -268,6 +286,69 @@ class ComplianceValidatorTest extends TestCase {
 	}//end buildObjectServiceMockWithFailingTreasuryLookup()
 
 	/**
+	 * Build a store that models an unavailable OpenRegister.
+	 *
+	 * Before ADR-084 this scenario was expressed as
+	 * `$container->method('get')->willThrowException(...)`. The container is no
+	 * longer consulted, so the refusal has to come from the store itself; every
+	 * read throws exactly as a downed ObjectService would, which is what the
+	 * validator's fail-closed arm is there to catch.
+	 *
+	 * @return object
+	 */
+	private function buildUnavailableObjectServiceMock(): object {
+		return new class {
+			/**
+			 * Fluent register setter — returns self.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter — returns self.
+			 *
+			 * @param string $schema Schema name.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse every list query.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end findAll()
+
+			/**
+			 * Refuse every single-object lookup.
+			 *
+			 * @param string|int $id Object ID.
+			 *
+			 * @return object|null
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function find(string|int $id): ?object {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end find()
+		};
+	}//end buildUnavailableObjectServiceMock()
+
+	/**
 	 * All active rules pass → isCompliant returns true (happy path).
 	 *
 	 * @return void
@@ -290,9 +371,8 @@ class ComplianceValidatorTest extends TestCase {
 			],
 		];
 
-		$this->container
-			->method('get')
-			->willReturn($this->buildObjectServiceMock(bankingRuleRules: $rules));
+		$this->validator = $this->buildValidator(
+			store: $this->buildObjectServiceMock(bankingRuleRules: $rules));
 
 		$account = $this->buildAccount();
 		$result = $this->validator->isCompliant(account: $account);
@@ -317,9 +397,8 @@ class ComplianceValidatorTest extends TestCase {
 			],
 		];
 
-		$this->container
-			->method('get')
-			->willReturn($this->buildObjectServiceMock(bankingRuleRules: $rules));
+		$this->validator = $this->buildValidator(
+			store: $this->buildObjectServiceMock(bankingRuleRules: $rules));
 
 		// Invalid IBAN — too short.
 		$account = $this->buildAccount(overrides: ['iban' => 'NL91ABNA04171643']);
@@ -345,9 +424,8 @@ class ComplianceValidatorTest extends TestCase {
 			],
 		];
 
-		$this->container
-			->method('get')
-			->willReturn($this->buildObjectServiceMock(bankingRuleRules: $rules));
+		$this->validator = $this->buildValidator(
+			store: $this->buildObjectServiceMock(bankingRuleRules: $rules));
 
 		$account = $this->buildAccount(overrides: ['approvalStatus' => 'pending']);
 		$result = $this->validator->isCompliant(account: $account);
@@ -362,9 +440,8 @@ class ComplianceValidatorTest extends TestCase {
 	 * @return void
 	 */
 	public function testNoActiveRulesPermitsTransition(): void {
-		$this->container
-			->method('get')
-			->willReturn($this->buildObjectServiceMock(bankingRuleRules: []));
+		$this->validator = $this->buildValidator(
+			store: $this->buildObjectServiceMock(bankingRuleRules: []));
 
 		$account = $this->buildAccount();
 		$result = $this->validator->isCompliant(account: $account);
@@ -394,9 +471,7 @@ class ComplianceValidatorTest extends TestCase {
 	 * @return void
 	 */
 	public function testObjectServiceExceptionFailsClosed(): void {
-		$this->container
-			->method('get')
-			->willThrowException(new \RuntimeException('ObjectService unavailable'));
+		$this->validator = $this->buildValidator(store: $this->buildUnavailableObjectServiceMock());
 
 		$account = $this->buildAccount();
 		$result = $this->validator->isCompliant(account: $account);
@@ -421,9 +496,8 @@ class ComplianceValidatorTest extends TestCase {
 			],
 		];
 
-		$this->container
-			->method('get')
-			->willReturn($this->buildObjectServiceMock(bankingRuleRules: $rules));
+		$this->validator = $this->buildValidator(
+			store: $this->buildObjectServiceMock(bankingRuleRules: $rules));
 
 		// Invalid IBAN but the rule is only a warning, not blocking.
 		$account = $this->buildAccount(overrides: ['iban' => 'NL91ABNA04171643']);
@@ -458,9 +532,8 @@ class ComplianceValidatorTest extends TestCase {
 			],
 		];
 
-		$this->container
-			->method('get')
-			->willReturn($this->buildObjectServiceMock(bankingRuleRules: $rules));
+		$this->validator = $this->buildValidator(
+			store: $this->buildObjectServiceMock(bankingRuleRules: $rules));
 
 		// IBAN passes, but approval is still pending.
 		$account = $this->buildAccount(overrides: ['approvalStatus' => 'pending']);
@@ -507,11 +580,9 @@ class ComplianceValidatorTest extends TestCase {
 			],
 		];
 
-		$this->container
-			->method('get')
-			->willReturn(
-				$this->buildObjectServiceMock(bankingRuleRules: $rules, treasuryAccountRows: $treasuryAccounts)
-			);
+		$this->validator = $this->buildValidator(
+			store: $this->buildObjectServiceMock(bankingRuleRules: $rules, treasuryAccountRows: $treasuryAccounts)
+		);
 
 		$account = $this->buildAccount(overrides: ['id' => 'acct-001']);
 		$result = $this->validator->isCompliant(account: $account);
@@ -551,11 +622,9 @@ class ComplianceValidatorTest extends TestCase {
 			],
 		];
 
-		$this->container
-			->method('get')
-			->willReturn(
-				$this->buildObjectServiceMock(bankingRuleRules: $rules, treasuryAccountRows: $treasuryAccounts)
-			);
+		$this->validator = $this->buildValidator(
+			store: $this->buildObjectServiceMock(bankingRuleRules: $rules, treasuryAccountRows: $treasuryAccounts)
+		);
 
 		$account = $this->buildAccount(overrides: ['id' => 'acct-001']);
 		$result = $this->validator->isCompliant(account: $account);
@@ -585,9 +654,8 @@ class ComplianceValidatorTest extends TestCase {
 			],
 		];
 
-		$this->container
-			->method('get')
-			->willReturn($this->buildObjectServiceMockWithFailingTreasuryLookup(bankingRuleRules: $rules));
+		$this->validator = $this->buildValidator(
+			store: $this->buildObjectServiceMockWithFailingTreasuryLookup(bankingRuleRules: $rules));
 
 		$account = $this->buildAccount(overrides: ['id' => 'acct-001']);
 		$result = $this->validator->isCompliant(account: $account);
@@ -617,9 +685,8 @@ class ComplianceValidatorTest extends TestCase {
 			],
 		];
 
-		$this->container
-			->method('get')
-			->willReturn($this->buildObjectServiceMock(bankingRuleRules: $rules, treasuryAccountRows: []));
+		$this->validator = $this->buildValidator(
+			store: $this->buildObjectServiceMock(bankingRuleRules: $rules, treasuryAccountRows: []));
 
 		$account = $this->buildAccount(overrides: ['iban' => '']);
 		$result = $this->validator->isCompliant(account: $account);
@@ -650,9 +717,8 @@ class ComplianceValidatorTest extends TestCase {
 
 		// A failing TreasuryAccount lookup proves the rule genuinely short-circuits
 		// rather than happening to pass because the stub returns no rows.
-		$this->container
-			->method('get')
-			->willReturn($this->buildObjectServiceMockWithFailingTreasuryLookup(bankingRuleRules: $rules));
+		$this->validator = $this->buildValidator(
+			store: $this->buildObjectServiceMockWithFailingTreasuryLookup(bankingRuleRules: $rules));
 
 		$account = $this->buildAccount();
 		$result = $this->validator->isCompliant(account: $account);

--- a/tests/Unit/Lifecycle/EuExpenditureGuardTest.php
+++ b/tests/Unit/Lifecycle/EuExpenditureGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\EuExpenditureGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -84,22 +84,37 @@ class EuExpenditureGuardTest extends TestCase {
 
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
 
-		$this->guard = new EuExpenditureGuard(
-			appConfig: $this->appConfig,
-			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
-		);
+		$this->guard = $this->buildGuard(store: GuardObjectServiceStub::make([]));
 	}//end setUp()
 
 	/**
-	 * Wire the container to return a schema-aware ObjectService stub.
+	 * Build the guard over a seeded in-memory store.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so a test's
+	 * store has to be present when the guard is built — parking it on the
+	 * container after the fact leaves the guard reading an empty world.
+	 *
+	 * @param object $store The duck-typed in-memory ObjectService double.
+	 *
+	 * @return EuExpenditureGuard
+	 */
+	private function buildGuard(object $store): EuExpenditureGuard {
+		return new EuExpenditureGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+	}//end buildGuard()
+
+	/**
+	 * Rebuild the guard over a schema-aware ObjectService stub.
 	 *
 	 * @param array<string,array<mixed>> $recordsBySchema Records keyed by schema slug.
 	 *
 	 * @return void
 	 */
 	private function wireObjectService(array $recordsBySchema): void {
-		$this->container->method('get')->willReturn(GuardObjectServiceStub::make($recordsBySchema));
+		$this->guard = $this->buildGuard(store: GuardObjectServiceStub::make($recordsBySchema));
 	}//end wireObjectService()
 
 	/**
@@ -286,7 +301,7 @@ class EuExpenditureGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testDeclareExceptionFailsClosed(): void {
-		$this->container->method('get')->willThrowException(new \RuntimeException('ObjectService down'));
+		$this->guard = $this->buildGuard(store: $this->buildUnavailableObjectServiceStub());
 		$this->logger->expects($this->once())->method('error');
 
 		$object = [
@@ -299,4 +314,67 @@ class EuExpenditureGuardTest extends TestCase {
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
 		self::assertFalse($this->guard->canDeclare(euExpenditureId: 'exp-8', object: $object));
 	}//end testDeclareExceptionFailsClosed()
+
+	/**
+	 * Build a store that models an unavailable OpenRegister.
+	 *
+	 * Before ADR-084 this scenario was expressed as
+	 * `$container->method('get')->willThrowException(...)`. The container is no
+	 * longer consulted, so the refusal has to come from the store itself; every
+	 * read throws exactly as a downed ObjectService would, which is what the
+	 * guard's fail-closed arm is there to catch.
+	 *
+	 * @return object
+	 */
+	private function buildUnavailableObjectServiceStub(): object {
+		return new class {
+			/**
+			 * Fluent register setter — returns self.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter — returns self.
+			 *
+			 * @param string $schema Schema name.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse every list query.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('ObjectService down');
+			}//end findAll()
+
+			/**
+			 * Refuse every single-object lookup.
+			 *
+			 * @param string|int $id Object ID.
+			 *
+			 * @return object|null
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function find(string|int $id): ?object {
+				throw new \RuntimeException('ObjectService down');
+			}//end find()
+		};
+	}//end buildUnavailableObjectServiceStub()
 }//end class

--- a/tests/Unit/Lifecycle/ExpenseClaimGuardTest.php
+++ b/tests/Unit/Lifecycle/ExpenseClaimGuardTest.php
@@ -285,6 +285,57 @@ class ExpenseClaimGuardTest extends TestCase {
 	}//end testRequireCostCentresAndItemsIsFailClosedOnException()
 
 	/**
+	 * The guard DISCRIMINATES: same guard, two claims, opposite verdicts.
+	 *
+	 * This exists because the individual permit/deny tests cannot, on their
+	 * own, prove the guard is deciding anything. Before this repair the guard
+	 * denied EVERYTHING -- `$item['costCentreCode']` on the ObjectEntityInterface
+	 * that ADR-084 made find() return raised an Error, and
+	 * requireOpenPeriodAndCostCentres()'s catch (\Throwable) converted it to
+	 * `return false`. Every deny test therefore PASSED, for a reason that had
+	 * nothing to do with cost centres, while every permit test failed.
+	 *
+	 * A guard that always denies and a guard that always permits are both
+	 * broken, and each is invisible to half the suite. Asserting both verdicts
+	 * from ONE guard instance in ONE test is the assertion neither half can
+	 * satisfy vacuously: it fails if the guard reverts to always-deny, and it
+	 * fails if the guard is ever loosened into always-permit.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/expense-capture-core/tasks.md#task-9
+	 */
+	public function testRequireCostCentresAndItemsDiscriminatesBetweenClaims(): void {
+		$objectService = $this->buildObjectServiceStub(
+			itemsBySchema: [
+				'Receipt' => [
+					['id' => 'rec-ok', 'costCentreCode' => 'CC100'],
+					['id' => 'rec-bad', 'costCentreCode' => ''],
+				],
+			]
+		);
+		$this->guard = $this->buildGuard(store: $objectService);
+
+		$permitted = $this->guard->requireCostCentresAndItems(
+			claim: ['id' => 'claim-ok', 'receiptIds' => ['rec-ok'], 'mileageIds' => [], 'perDiemIds' => []]
+		);
+		$denied = $this->guard->requireCostCentresAndItems(
+			claim: ['id' => 'claim-bad', 'receiptIds' => ['rec-bad'], 'mileageIds' => [], 'perDiemIds' => []]
+		);
+
+		self::assertTrue(condition: $permitted, message: 'A claim whose items all carry a costCentreCode must be permitted');
+		self::assertFalse(condition: $denied, message: 'A claim with an item lacking a costCentreCode must be denied');
+		self::assertNotSame(
+			expected: $permitted,
+			actual: $denied,
+			message: 'The guard must DISCRIMINATE: identical wiring, opposite verdicts. '
+				. 'Equal verdicts here mean the guard is answering the same way regardless '
+				. 'of the claim, which is what the ADR-084 array-access defect did.'
+		);
+
+	}//end testRequireCostCentresAndItemsDiscriminatesBetweenClaims()
+
+	/**
 	 * Posting is permitted when the FiscalYear register is absent (T1 state).
 	 *
 	 * @return void

--- a/tests/Unit/Lifecycle/ExpenseClaimGuardTest.php
+++ b/tests/Unit/Lifecycle/ExpenseClaimGuardTest.php
@@ -19,8 +19,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\ExpenseClaimGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -85,13 +85,29 @@ class ExpenseClaimGuardTest extends TestCase {
 
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
 
-		$this->guard = new ExpenseClaimGuard(
-			appConfig: $this->appConfig,
-			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
-		);
+		$this->guard = $this->buildGuard(store: $this->buildObjectServiceStub());
 
 	}//end setUp()
+
+	/**
+	 * Build the guard over a seeded in-memory store.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so a test's
+	 * store has to be present when the guard is built — parking it on the
+	 * container after the fact leaves the guard reading an empty world.
+	 *
+	 * @param object $store The duck-typed in-memory ObjectService double.
+	 *
+	 * @return ExpenseClaimGuard
+	 */
+	private function buildGuard(object $store): ExpenseClaimGuard {
+		return new ExpenseClaimGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end buildGuard()
 
 	/**
 	 * Build a fluent ObjectService stub returning items by schema.
@@ -220,7 +236,7 @@ class ExpenseClaimGuardTest extends TestCase {
 				'Receipt' => [['id' => 'rec-1', 'costCentreCode' => null]],
 			]
 		);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$claim = ['id' => 'claim-1', 'receiptIds' => ['rec-1'], 'mileageIds' => [], 'perDiemIds' => []];
 
@@ -242,7 +258,7 @@ class ExpenseClaimGuardTest extends TestCase {
 				'MileageEntry' => [['id' => 'mlg-1', 'costCentreCode' => 'CC200']],
 			]
 		);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$claim = ['id' => 'claim-1', 'receiptIds' => ['rec-1'], 'mileageIds' => ['mlg-1'], 'perDiemIds' => []];
 
@@ -258,8 +274,7 @@ class ExpenseClaimGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testRequireCostCentresAndItemsIsFailClosedOnException(): void {
-		$this->container->method('get')
-			->willThrowException(new \RuntimeException('ObjectService unavailable'));
+		$this->guard = $this->buildGuard(store: $this->buildUnavailableObjectServiceStub());
 
 		$claim = ['id' => 'claim-1', 'receiptIds' => ['rec-1'], 'mileageIds' => [], 'perDiemIds' => []];
 
@@ -362,7 +377,7 @@ class ExpenseClaimGuardTest extends TestCase {
 			}//end find()
 		};
 
-		$this->container->method('get')->willReturn($throwingStub);
+		$this->guard = $this->buildGuard(store: $throwingStub);
 
 		$claim = [
 			'id' => 'claim-1',
@@ -393,7 +408,7 @@ class ExpenseClaimGuardTest extends TestCase {
 				['id' => 'fy-2026', 'startDate' => '2026-01-01', 'endDate' => '2026-12-31', 'state' => 'open'],
 			]
 		);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$claim = [
 			'id' => 'claim-1',
@@ -424,7 +439,7 @@ class ExpenseClaimGuardTest extends TestCase {
 				['id' => 'fy-2026', 'startDate' => '2026-01-01', 'endDate' => '2026-12-31', 'state' => 'closed'],
 			]
 		);
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = $this->buildGuard(store: $objectService);
 
 		$claim = [
 			'id' => 'claim-1',
@@ -440,4 +455,67 @@ class ExpenseClaimGuardTest extends TestCase {
 		self::assertFalse(condition: $result, message: 'Closed FiscalYear must deny posting');
 
 	}//end testRequireOpenPeriodDeniesPostingWhenFiscalYearIsClosed()
+
+	/**
+	 * Build a store that models an unavailable OpenRegister.
+	 *
+	 * Before ADR-084 this scenario was expressed as
+	 * `$container->method('get')->willThrowException(...)`. The container is no
+	 * longer consulted, so the refusal has to come from the store itself; every
+	 * read throws exactly as a downed ObjectService would, which is what the
+	 * guard's fail-closed arm is there to catch.
+	 *
+	 * @return object
+	 */
+	private function buildUnavailableObjectServiceStub(): object {
+		return new class {
+			/**
+			 * Fluent register setter — returns self.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter — returns self.
+			 *
+			 * @param string $schema Schema name.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse every list query.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end findAll()
+
+			/**
+			 * Refuse every single-object lookup.
+			 *
+			 * @param string|int $id Object ID.
+			 *
+			 * @return object|null
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function find(string|int $id): ?object {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end find()
+		};
+	}//end buildUnavailableObjectServiceStub()
 }//end class

--- a/tests/Unit/Lifecycle/FidoTreasuryGuardTest.php
+++ b/tests/Unit/Lifecycle/FidoTreasuryGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\FidoTreasuryGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -83,17 +83,17 @@ class FidoTreasuryGuardTest extends TestCase {
 
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
 
-		$this->guard = new FidoTreasuryGuard(
-			appConfig: $this->appConfig,
-			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
-		);
+		$this->stubAdoptedStatuut(statuut: null);
 
 	}//end setUp()
 
 	/**
-	 * Wire the container to return a stub ObjectService that yields the given
+	 * Rebuild the guard over a stub ObjectService that yields the given
 	 * Treasurystatuut row for the adopted-statuut lookup (ADR-022 real API shape).
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so the store
+	 * has to be present when the guard is built — parking it on the container
+	 * after the fact leaves the guard reading an empty world.
 	 *
 	 * @param array<string,mixed>|null $statuut The adopted statuut to return, or null.
 	 *
@@ -157,7 +157,11 @@ class FidoTreasuryGuardTest extends TestCase {
 			}//end findAll()
 		};
 
-		$this->container->method('get')->willReturn($objectService);
+		$this->guard = new FidoTreasuryGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($objectService),
+		);
 
 	}//end stubAdoptedStatuut()
 

--- a/tests/Unit/Lifecycle/FrameworkAgreementDrawdownGuardTest.php
+++ b/tests/Unit/Lifecycle/FrameworkAgreementDrawdownGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\FrameworkAgreementDrawdownGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -126,8 +126,9 @@ final class FrameworkAgreementDrawdownGuardTest extends TestCase {
 	 * @return FrameworkAgreementDrawdownGuard
 	 */
 	private function buildGuard(array $agreements): FrameworkAgreementDrawdownGuard {
+		$stub      = $this->buildStub($agreements);
 		$container = $this->createMock(ContainerInterface::class);
-		$container->method('get')->willReturn($this->buildStub($agreements));
+		$container->method('get')->willReturn($stub);
 
 		$appConfig = $this->createMock(IAppConfig::class);
 		$appConfig->method('getValueString')->willReturn('shillinq');
@@ -135,7 +136,7 @@ final class FrameworkAgreementDrawdownGuardTest extends TestCase {
 		return new FrameworkAgreementDrawdownGuard(
 			appConfig: $appConfig,
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 	}//end buildGuard()
 

--- a/tests/Unit/Lifecycle/IntercompanyToleranceGuardTest.php
+++ b/tests/Unit/Lifecycle/IntercompanyToleranceGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\IntercompanyToleranceGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -86,13 +86,31 @@ final class IntercompanyToleranceGuardTest extends TestCase {
 
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
 
-		$this->guard = new IntercompanyToleranceGuard(
-			$this->appConfig,
-			$this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+		$this->guard = $this->buildGuard(
+			store: $this->buildObjectServiceStub(relations: [], rules: [])
 		);
 
 	}//end setUp()
+
+	/**
+	 * Build the guard over a seeded in-memory store.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so a test's
+	 * store has to be present when the guard is built — parking it on the
+	 * container after the fact leaves the guard reading an empty world.
+	 *
+	 * @param object $store The duck-typed in-memory ObjectService double.
+	 *
+	 * @return IntercompanyToleranceGuard
+	 */
+	private function buildGuard(object $store): IntercompanyToleranceGuard {
+		return new IntercompanyToleranceGuard(
+			$this->appConfig,
+			$this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end buildGuard()
 
 	/**
 	 * A near-zero mismatch is always within tolerance without any rule lookup.
@@ -130,8 +148,8 @@ final class IntercompanyToleranceGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testWithinConfiguredRule(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(
+		$this->guard = $this->buildGuard(
+			store: $this->buildObjectServiceStub(
 				relations: [['relationId' => 'rel1', 'relationType' => 'sales-of-services']],
 				rules: [
 					[
@@ -164,8 +182,8 @@ final class IntercompanyToleranceGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testOutsideConfiguredRule(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(
+		$this->guard = $this->buildGuard(
+			store: $this->buildObjectServiceStub(
 				relations: [['relationId' => 'rel1', 'relationType' => 'sales-of-services']],
 				rules: [
 					[
@@ -199,8 +217,8 @@ final class IntercompanyToleranceGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testMinOfMethodStricter(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(
+		$this->guard = $this->buildGuard(
+			store: $this->buildObjectServiceStub(
 				relations: [['relationId' => 'rel1', 'relationType' => 'dividend']],
 				rules: [
 					[
@@ -234,8 +252,8 @@ final class IntercompanyToleranceGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testDefaultsWhenNoRule(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(
+		$this->guard = $this->buildGuard(
+			store: $this->buildObjectServiceStub(
 				relations: [['relationId' => 'rel1', 'relationType' => 'sales-of-goods']],
 				rules: []
 			)
@@ -261,7 +279,7 @@ final class IntercompanyToleranceGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testFailClosedOnException(): void {
-		$this->container->method('get')->willThrowException(new \RuntimeException('OR unavailable'));
+		$this->guard = $this->buildGuard(store: $this->buildUnavailableObjectServiceStub());
 
 		$match = [
 			'matchId' => 'm8',
@@ -357,4 +375,67 @@ final class IntercompanyToleranceGuardTest extends TestCase {
 			}//end findAll()
 		};
 	}//end buildObjectServiceStub()
+
+	/**
+	 * Build a store that models an unavailable OpenRegister.
+	 *
+	 * Before ADR-084 this scenario was expressed as
+	 * `$container->method('get')->willThrowException(...)`. The container is no
+	 * longer consulted, so the refusal has to come from the store itself; every
+	 * read throws exactly as a downed ObjectService would, which is what the
+	 * guard's fail-closed arm is there to catch.
+	 *
+	 * @return object
+	 */
+	private function buildUnavailableObjectServiceStub(): object {
+		return new class {
+			/**
+			 * Fluent register setter — returns self.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter — returns self.
+			 *
+			 * @param string $schema Schema name.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse every list query.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('OR unavailable');
+			}//end findAll()
+
+			/**
+			 * Refuse every single-object lookup.
+			 *
+			 * @param string|int $id Object ID.
+			 *
+			 * @return object|null
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function find(string|int $id): ?object {
+				throw new \RuntimeException('OR unavailable');
+			}//end find()
+		};
+	}//end buildUnavailableObjectServiceStub()
 }//end class

--- a/tests/Unit/Lifecycle/InventoryPostingGuardTest.php
+++ b/tests/Unit/Lifecycle/InventoryPostingGuardTest.php
@@ -45,9 +45,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\InventoryPostingGuard;
 use OCA\Shillinq\Tests\Unit\Service\InMemoryObjectService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -81,7 +81,7 @@ final class InventoryPostingGuardTest extends TestCase {
 		return new InventoryPostingGuard(
 			appConfig: $appConfig,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 	}//end makeGuard()

--- a/tests/Unit/Lifecycle/InventoryValuationMethodGuardTest.php
+++ b/tests/Unit/Lifecycle/InventoryValuationMethodGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\InventoryValuationMethodGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -84,7 +84,7 @@ class InventoryValuationMethodGuardTest extends TestCase {
 		$this->guard = new InventoryValuationMethodGuard(
 			appConfig: $appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->os),
 		);
 
 	}//end setUp()

--- a/tests/Unit/Lifecycle/InvoiceGuardTest.php
+++ b/tests/Unit/Lifecycle/InvoiceGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\InvoiceGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -87,13 +87,16 @@ class InvoiceGuardTest extends TestCase {
 		$this->guard = new InvoiceGuard(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->buildObjectServiceStub(bySchema: [])),
 		);
 
 	}//end setUp()
 
 	/**
-	 * Wire the container to return a schema-aware ObjectService stub.
+	 * Rebuild the guard on a schema-aware ObjectService stub.
+	 *
+	 * The store is injected through the constructor since ADR-084, so the guard
+	 * has to be rebuilt whenever a test seeds different records.
 	 *
 	 * @param array<int,mixed> $invoices Invoice records returned for the Invoice schema.
 	 * @param array<int,mixed> $lines InvoiceLine records returned for the InvoiceLine schema.
@@ -101,8 +104,13 @@ class InvoiceGuardTest extends TestCase {
 	 * @return void
 	 */
 	private function wireObjectService(array $invoices, array $lines): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(bySchema: ['Invoice' => $invoices, 'InvoiceLine' => $lines])
+		$store = $this->buildObjectServiceStub(bySchema: ['Invoice' => $invoices, 'InvoiceLine' => $lines]);
+		$this->container->method('get')->willReturn($store);
+
+		$this->guard = new InvoiceGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
 		);
 
 	}//end wireObjectService()
@@ -382,11 +390,59 @@ class InvoiceGuardTest extends TestCase {
 			'state' => 'draft',
 			'timeEntryIds' => ['time-1'],
 			'expenseIds' => [],
-			// Inline lines so resolveLines short-circuits before container->get.
+			// Inline lines so resolveLines short-circuits before the store is read.
 			'lines' => [['sourceType' => 'time_entry', 'costAmount' => 100000]],
 		];
+
+		// The store itself is the failure now that it is injected rather than
+		// pulled from the container: the source-id uniqueness check reads it.
+		$exploding = new class {
+
+			/**
+			 * Fluent register setter.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter.
+			 *
+			 * @param string $schema Schema slug.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse every read, as an unavailable ObjectService would.
+			 *
+			 * @param array<string,mixed> $params Query parameters.
+			 *
+			 * @return array<int,mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end findAll()
+		};
+
 		$this->container->method('get')
 			->willThrowException(new \RuntimeException('ObjectService unavailable'));
+
+		$this->guard = new InvoiceGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($exploding),
+		);
+
 		$this->logger->expects($this->once())->method('error');
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters

--- a/tests/Unit/Lifecycle/JournalEntryGuardTest.php
+++ b/tests/Unit/Lifecycle/JournalEntryGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\JournalEntryGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -85,10 +85,31 @@ class JournalEntryGuardTest extends TestCase {
 		$this->guard = new JournalEntryGuard(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->buildObjectServiceStub(records: [])),
 		);
 
 	}//end setUp()
+
+	/**
+	 * Point the guard at the given duck-typed ObjectService store.
+	 *
+	 * The store is a constructor dependency since ADR-084, so the guard has to
+	 * be rebuilt whenever a test seeds different records.
+	 *
+	 * @param object $store The in-memory ObjectService double.
+	 *
+	 * @return void
+	 */
+	private function wireObjectService(object $store): void {
+		$this->container->method('get')->willReturn($store);
+
+		$this->guard = new JournalEntryGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end wireObjectService()
 
 	/**
 	 * A balanced 2-line journal supplied inline returns true per REQ-JE-007.
@@ -223,8 +244,8 @@ class JournalEntryGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCanVoidWhenGlTransactionReversed(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(records: [['id' => 'gl-1', 'state' => 'reversed']])
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(records: [['id' => 'gl-1', 'state' => 'reversed']])
 		);
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -238,8 +259,8 @@ class JournalEntryGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCannotVoidWhenGlTransactionNotReversed(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(records: [['id' => 'gl-1', 'state' => 'posted']])
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(records: [['id' => 'gl-1', 'state' => 'posted']])
 		);
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -264,8 +285,7 @@ class JournalEntryGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testVoidExceptionFailsClosed(): void {
-		$this->container->method('get')
-			->willThrowException(new \RuntimeException('ObjectService unavailable'));
+		$this->wireObjectService(store: $this->buildFailingObjectServiceStub());
 
 		$this->logger->expects($this->once())->method('error');
 
@@ -333,4 +353,52 @@ class JournalEntryGuardTest extends TestCase {
 			}//end findAll()
 		};
 	}//end buildObjectServiceStub()
+
+	/**
+	 * Build an ObjectService store that refuses every read.
+	 *
+	 * Since the store is injected rather than pulled from the container, an
+	 * unavailable OpenRegister is modelled by a store that throws.
+	 *
+	 * @return object
+	 */
+	private function buildFailingObjectServiceStub(): object {
+		return new class {
+
+			/**
+			 * Fluent register setter.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter.
+			 *
+			 * @param string $schema Schema slug.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse the read, as an unavailable ObjectService would.
+			 *
+			 * @param array<string,mixed> $params Query parameters.
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end findAll()
+		};
+	}//end buildFailingObjectServiceStub()
 }//end class

--- a/tests/Unit/Lifecycle/ObjectionPeriodGuardTest.php
+++ b/tests/Unit/Lifecycle/ObjectionPeriodGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\ObjectionPeriodGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -85,10 +85,31 @@ class ObjectionPeriodGuardTest extends TestCase {
 		$this->guard = new ObjectionPeriodGuard(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->buildSchemaStub(recordsBySchema: [])),
 		);
 
 	}//end setUp()
+
+	/**
+	 * Point the guard at the given duck-typed ObjectService store.
+	 *
+	 * The store is a constructor dependency since ADR-084, so the guard has to
+	 * be rebuilt whenever a test seeds different records.
+	 *
+	 * @param object $store The in-memory ObjectService double.
+	 *
+	 * @return void
+	 */
+	private function wireObjectService(object $store): void {
+		$this->container->method('get')->willReturn($store);
+
+		$this->guard = new ObjectionPeriodGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end wireObjectService()
 
 	/**
 	 * Bezwaar is admissible within the 6-week termijn from the aanslag dagtekening (REQ-VPB-010).
@@ -97,8 +118,8 @@ class ObjectionPeriodGuardTest extends TestCase {
 	 */
 	public function testCanBezwaarMakenWithinTermijn(): void {
 		$issueDate = (new \DateTimeImmutable('today'))->modify('-1 week')->format('Y-m-d');
-		$this->container->method('get')->willReturn(
-			$this->buildSchemaStub(recordsBySchema: ['DefinitieveAanslag' => [['taxReturn' => 'aangifte-1', 'issueDate' => $issueDate]]])
+		$this->wireObjectService(
+			store: $this->buildSchemaStub(recordsBySchema: ['DefinitieveAanslag' => [['taxReturn' => 'aangifte-1', 'issueDate' => $issueDate]]])
 		);
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -113,8 +134,8 @@ class ObjectionPeriodGuardTest extends TestCase {
 	 */
 	public function testCannotBezwaarMakenAfterTermijn(): void {
 		$issueDate = (new \DateTimeImmutable('today'))->modify('-8 weeks')->format('Y-m-d');
-		$this->container->method('get')->willReturn(
-			$this->buildSchemaStub(recordsBySchema: ['DefinitieveAanslag' => [['taxReturn' => 'aangifte-2', 'issueDate' => $issueDate]]])
+		$this->wireObjectService(
+			store: $this->buildSchemaStub(recordsBySchema: ['DefinitieveAanslag' => [['taxReturn' => 'aangifte-2', 'issueDate' => $issueDate]]])
 		);
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -128,7 +149,7 @@ class ObjectionPeriodGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCannotBezwaarMakenWithoutAanslag(): void {
-		$this->container->method('get')->willReturn($this->buildSchemaStub(recordsBySchema: ['DefinitieveAanslag' => []]));
+		$this->wireObjectService(store: $this->buildSchemaStub(recordsBySchema: ['DefinitieveAanslag' => []]));
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
 		self::assertFalse($this->guard->canFileObjection(taxReturnId:'aangifte-3', object: ['id' => 'aangifte-3']));
@@ -184,7 +205,7 @@ class ObjectionPeriodGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testBezwaarExceptionFailsClosed(): void {
-		$this->container->method('get')->willThrowException(new \RuntimeException('down'));
+		$this->wireObjectService(store: $this->buildFailingObjectServiceStub());
 		$this->logger->expects($this->once())->method('error');
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -259,4 +280,52 @@ class ObjectionPeriodGuardTest extends TestCase {
 			}//end findAll()
 		};
 	}//end buildSchemaStub()
+
+	/**
+	 * Build an ObjectService store that refuses every read.
+	 *
+	 * Since the store is injected rather than pulled from the container, an
+	 * unavailable OpenRegister is modelled by a store that throws.
+	 *
+	 * @return object
+	 */
+	private function buildFailingObjectServiceStub(): object {
+		return new class {
+
+			/**
+			 * Fluent register setter.
+			 *
+			 * @param string $register Register slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter.
+			 *
+			 * @param string $schema Schema slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse the read, as an unavailable ObjectService would.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused in stub).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('down');
+			}//end findAll()
+		};
+	}//end buildFailingObjectServiceStub()
 }//end class

--- a/tests/Unit/Lifecycle/PayrollGuardTest.php
+++ b/tests/Unit/Lifecycle/PayrollGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\PayrollGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -90,21 +90,41 @@ class PayrollGuardTest extends TestCase {
 		$this->guard = new PayrollGuard(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->buildObjectServiceStub([])),
 		);
 
 	}//end setUp()
 
 	/**
-	 * Wire the container to return a schema-aware ObjectService stub.
+	 * Rebuild the guard on a schema-aware ObjectService stub.
+	 *
+	 * The store is a constructor dependency since ADR-084, so the guard has to
+	 * be rebuilt whenever a test seeds different records.
 	 *
 	 * @param array<string,array<mixed>> $recordsBySchema Records keyed by schema slug.
 	 *
 	 * @return void
 	 */
 	private function wireObjectService(array $recordsBySchema): void {
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub($recordsBySchema));
+		$this->wireStore($this->buildObjectServiceStub($recordsBySchema));
 	}//end wireObjectService()
+
+	/**
+	 * Point the guard at the given duck-typed ObjectService store.
+	 *
+	 * @param object $store The in-memory ObjectService double.
+	 *
+	 * @return void
+	 */
+	private function wireStore(object $store): void {
+		$this->container->method('get')->willReturn($store);
+
+		$this->guard = new PayrollGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+	}//end wireStore()
 
 	/**
 	 * canCalculate returns true when the employee is active and at least one
@@ -224,7 +244,7 @@ class PayrollGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testFailsClosedOnServiceError(): void {
-		$this->container->method('get')->willThrowException(new \RuntimeException('ObjectService unavailable'));
+		$this->wireStore($this->buildFailingObjectServiceStub());
 
 		$payroll = ['id' => 'pay-1', 'employeeId' => 'emp-1', 'period' => '2026-05', 'periodStartDate' => '2026-05-01', 'grossAmount' => 3500.0];
 		// phpcs:disable CustomSniffs.Functions.NamedParameters
@@ -304,4 +324,52 @@ class PayrollGuardTest extends TestCase {
 			}//end findAll()
 		};
 	}//end buildObjectServiceStub()
+
+	/**
+	 * Build an ObjectService store that refuses every read.
+	 *
+	 * Since the store is injected rather than pulled from the container, an
+	 * unavailable OpenRegister is modelled by a store that throws.
+	 *
+	 * @return object
+	 */
+	private function buildFailingObjectServiceStub(): object {
+		return new class {
+
+			/**
+			 * Fluent register setter.
+			 *
+			 * @param string $register Register slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter.
+			 *
+			 * @param string $schema Schema slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse the read, as an unavailable ObjectService would.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused in stub).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end findAll()
+		};
+	}//end buildFailingObjectServiceStub()
 }//end class

--- a/tests/Unit/Lifecycle/PeriodCloseGuardTest.php
+++ b/tests/Unit/Lifecycle/PeriodCloseGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\PeriodCloseGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -122,7 +122,7 @@ final class PeriodCloseGuardTest extends TestCase {
 			container: $container,
 			appConfig: $appConfig,
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildGuard()

--- a/tests/Unit/Lifecycle/PeriodCloseGuardTrialBalanceTest.php
+++ b/tests/Unit/Lifecycle/PeriodCloseGuardTrialBalanceTest.php
@@ -26,8 +26,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\PeriodCloseGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -113,7 +113,7 @@ final class PeriodCloseGuardTrialBalanceTest extends TestCase {
 			container: $container,
 			appConfig: $appConfig,
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildGuard()

--- a/tests/Unit/Lifecycle/PeriodStatusGuardTest.php
+++ b/tests/Unit/Lifecycle/PeriodStatusGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\PeriodStatusGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -85,7 +85,7 @@ final class PeriodStatusGuardTest extends TestCase {
 		$config->method('getValueString')->willReturn('shillinq');
 
 		return new PeriodStatusGuard( $config, new NullLogger(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($objectService),
 		);
 	}//end guard()
 

--- a/tests/Unit/Lifecycle/ProgrammabegrotingGuardTest.php
+++ b/tests/Unit/Lifecycle/ProgrammabegrotingGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\ProgrammabegrotingGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -96,7 +96,7 @@ final class ProgrammabegrotingGuardTest extends TestCase {
 		$this->guard = new ProgrammabegrotingGuard(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->buildParagraafStub([])),
 		);
 
 	}//end setUp()
@@ -119,14 +119,36 @@ final class ProgrammabegrotingGuardTest extends TestCase {
 	}//end paragrafen()
 
 	/**
-	 * Stub the container's ObjectService to return the given paragrafen.
+	 * Rebuild the guard on a store returning the given paragrafen.
+	 *
+	 * The store is a constructor dependency since ADR-084, so the guard has to
+	 * be rebuilt whenever a test seeds different rows.
 	 *
 	 * @param array<int,array<string,mixed>> $paragrafen The paragraaf rows to return.
 	 *
 	 * @return void
 	 */
 	private function stubParagrafen(array $paragrafen): void {
-		$stub = new class($paragrafen) {
+		$stub = $this->buildParagraafStub($paragrafen);
+
+		$this->container->method('get')->willReturn($stub);
+
+		$this->guard = new ProgrammabegrotingGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($stub),
+		);
+	}//end stubParagrafen()
+
+	/**
+	 * Build a duck-typed ObjectService store over the given paragraaf rows.
+	 *
+	 * @param array<int,array<string,mixed>> $paragrafen The paragraaf rows to return.
+	 *
+	 * @return object
+	 */
+	private function buildParagraafStub(array $paragrafen): object {
+		return new class($paragrafen) {
 
 			/**
 			 * Paragraaf rows.
@@ -177,9 +199,7 @@ final class ProgrammabegrotingGuardTest extends TestCase {
 				return $this->rows;
 			}//end findAll()
 		};
-
-		$this->container->method('get')->willReturn($stub);
-	}//end stubParagrafen()
+	}//end buildParagraafStub()
 
 	/**
 	 * REQ-007/D7: behandelen allowed when all seven paragrafen exist and nominale set.
@@ -262,7 +282,52 @@ final class ProgrammabegrotingGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testFailsClosedOnException(): void {
+		$failing = new class {
+
+			/**
+			 * Fluent register setter.
+			 *
+			 * @param string $register Register slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter.
+			 *
+			 * @param string $schema Schema slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse the read, as an unavailable ObjectService would.
+			 *
+			 * @param array<string,mixed> $params Query params (unused).
+			 *
+			 * @return array<int,array<string,mixed>>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('OR down');
+			}//end findAll()
+		};
+
 		$this->container->method('get')->willThrowException(new \RuntimeException('OR down'));
+
+		$this->guard = new ProgrammabegrotingGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($failing),
+		);
+
 		$budget = ['id' => 'pb-1', 'determinationDecision' => 'raadsbesluit-1'];
 		self::assertFalse($this->guard->canVaststellen(budgetId: 'pb-1', object: $budget));
 

--- a/tests/Unit/Lifecycle/QuoteOrderInvoiceGuardStockTest.php
+++ b/tests/Unit/Lifecycle/QuoteOrderInvoiceGuardStockTest.php
@@ -24,8 +24,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\QuoteOrderInvoiceGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -84,21 +84,44 @@ class QuoteOrderInvoiceGuardStockTest extends TestCase {
 		$this->guard = new QuoteOrderInvoiceGuard(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->buildObjectServiceStub([])),
 		);
 
 	}//end setUp()
 
 	/**
-	 * Wire the container to return a fluent ObjectService stub serving the given
-	 * records by schema (matching the ADR-022 setRegister/setSchema/findAll API).
+	 * Rebuild the guard on a fluent ObjectService stub serving the given records
+	 * by schema (matching the ADR-022 setRegister/setSchema/findAll API).
+	 *
+	 * The store is a constructor dependency since ADR-084, so the guard has to
+	 * be rebuilt whenever a test seeds different records.
 	 *
 	 * @param array<string,array<int,array<string,mixed>>> $itemsBySchema Map schema -> records.
 	 *
 	 * @return void
 	 */
 	private function stubObjectService(array $itemsBySchema): void {
-		$service = new class($itemsBySchema) {
+		$service = $this->buildObjectServiceStub($itemsBySchema);
+
+		$this->container->method('get')->willReturn($service);
+
+		$this->guard = new QuoteOrderInvoiceGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($service),
+		);
+
+	}//end stubObjectService()
+
+	/**
+	 * Build a duck-typed ObjectService store over the given records.
+	 *
+	 * @param array<string,array<int,array<string,mixed>>> $itemsBySchema Map schema -> records.
+	 *
+	 * @return object
+	 */
+	private function buildObjectServiceStub(array $itemsBySchema): object {
+		return new class($itemsBySchema) {
 
 			/**
 			 * Records keyed by schema.
@@ -180,9 +203,7 @@ class QuoteOrderInvoiceGuardStockTest extends TestCase {
 			}//end findAll()
 		};
 
-		$this->container->method('get')->willReturn($service);
-
-	}//end stubObjectService()
+	}//end buildObjectServiceStub()
 
 	/**
 	 * A complete delivery line referencing an order line with a positive quantity.

--- a/tests/Unit/Lifecycle/QuoteOrderInvoiceGuardTest.php
+++ b/tests/Unit/Lifecycle/QuoteOrderInvoiceGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\QuoteOrderInvoiceGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -85,21 +85,44 @@ class QuoteOrderInvoiceGuardTest extends TestCase {
 		$this->guard = new QuoteOrderInvoiceGuard(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->buildObjectServiceStub([])),
 		);
 
 	}//end setUp()
 
 	/**
-	 * Wire the container to return a fluent ObjectService stub serving the given
-	 * records by schema (matching the ADR-022 setRegister/setSchema/findAll API).
+	 * Rebuild the guard on a fluent ObjectService stub serving the given records
+	 * by schema (matching the ADR-022 setRegister/setSchema/findAll API).
+	 *
+	 * The store is a constructor dependency since ADR-084, so the guard has to
+	 * be rebuilt whenever a test seeds different records.
 	 *
 	 * @param array<string,array<int,array<string,mixed>>> $itemsBySchema Map schema -> records.
 	 *
 	 * @return void
 	 */
 	private function stubObjectService(array $itemsBySchema): void {
-		$service = new class($itemsBySchema) {
+		$service = $this->buildObjectServiceStub($itemsBySchema);
+
+		$this->container->method('get')->willReturn($service);
+
+		$this->guard = new QuoteOrderInvoiceGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($service),
+		);
+
+	}//end stubObjectService()
+
+	/**
+	 * Build a duck-typed ObjectService store over the given records.
+	 *
+	 * @param array<string,array<int,array<string,mixed>>> $itemsBySchema Map schema -> records.
+	 *
+	 * @return object
+	 */
+	private function buildObjectServiceStub(array $itemsBySchema): object {
+		return new class($itemsBySchema) {
 
 			/**
 			 * Records keyed by schema.
@@ -181,9 +204,7 @@ class QuoteOrderInvoiceGuardTest extends TestCase {
 			}//end findAll()
 		};
 
-		$this->container->method('get')->willReturn($service);
-
-	}//end stubObjectService()
+	}//end buildObjectServiceStub()
 
 	/**
 	 * A quote with a customer and at least one line may be sent (REQ-QOI-001).

--- a/tests/Unit/Lifecycle/RetainerGuardTest.php
+++ b/tests/Unit/Lifecycle/RetainerGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\RetainerGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -87,21 +87,44 @@ class RetainerGuardTest extends TestCase {
 		$this->guard = new RetainerGuard(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->buildObjectServiceStub([])),
 		);
 
 	}//end setUp()
 
 	/**
-	 * Stub the ObjectService chain so findAll() returns the given rows for any
-	 * schema query (used by canActivatePool's client lookup).
+	 * Rebuild the guard on an ObjectService store whose findAll() returns the
+	 * given rows for any schema query (used by canActivatePool's client lookup).
+	 *
+	 * The store is a constructor dependency since ADR-084, so the guard has to
+	 * be rebuilt whenever a test seeds different rows.
 	 *
 	 * @param array<int,array<string,mixed>> $rows Rows to return from findAll().
 	 *
 	 * @return void
 	 */
 	private function stubObjectService(array $rows): void {
-		$objectService = new class($rows) {
+		$objectService = $this->buildObjectServiceStub($rows);
+
+		$this->container->method('get')->willReturn($objectService);
+
+		$this->guard = new RetainerGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($objectService),
+		);
+
+	}//end stubObjectService()
+
+	/**
+	 * Build a duck-typed ObjectService store over the given rows.
+	 *
+	 * @param array<int,array<string,mixed>> $rows Rows to return from findAll().
+	 *
+	 * @return object
+	 */
+	private function buildObjectServiceStub(array $rows): object {
+		return new class($rows) {
 			/**
 			 * Construct the fake ObjectService.
 			 *
@@ -150,9 +173,7 @@ class RetainerGuardTest extends TestCase {
 			// phpcs:enable CustomSniffs.Functions.NamedParameters
 		};
 
-		$this->container->method('get')->willReturn($objectService);
-
-	}//end stubObjectService()
+	}//end buildObjectServiceStub()
 
 	/**
 	 * A pool with no overlapping sibling for the same client/project may activate

--- a/tests/Unit/Lifecycle/SubsidieVerantwoordingGuardTest.php
+++ b/tests/Unit/Lifecycle/SubsidieVerantwoordingGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\SubsidieVerantwoordingGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -87,10 +87,31 @@ class SubsidieVerantwoordingGuardTest extends TestCase {
 		$this->guard = new SubsidieVerantwoordingGuard(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->buildObjectServiceStub(records: [])),
 		);
 
 	}//end setUp()
+
+	/**
+	 * Point the guard at the given duck-typed ObjectService store.
+	 *
+	 * The store is a constructor dependency since ADR-084, so the guard has to
+	 * be rebuilt whenever a test seeds different records.
+	 *
+	 * @param object $store The in-memory ObjectService double.
+	 *
+	 * @return void
+	 */
+	private function wireObjectService(object $store): void {
+		$this->container->method('get')->willReturn($store);
+
+		$this->guard = new SubsidieVerantwoordingGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end wireObjectService()
 
 	/**
 	 * A grant below the auditor threshold may approve without any AuditorStatement (REQ-SUBV-003).
@@ -111,8 +132,8 @@ class SubsidieVerantwoordingGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testLargeGrantBlockedByPendingAuditorStatement(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(records: [['statementId' => 'AS-1', 'status' => 'pending']])
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(records: [['statementId' => 'AS-1', 'status' => 'pending']])
 		);
 
 		$object = ['grantId' => 'SUB-2', 'awardedAmount' => 50000.0];
@@ -128,8 +149,8 @@ class SubsidieVerantwoordingGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testLargeGrantWithApprovedAuditorStatementApproves(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(records: [['statementId' => 'AS-1', 'status' => 'approved']])
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(records: [['statementId' => 'AS-1', 'status' => 'approved']])
 		);
 
 		$object = ['grantId' => 'SUB-3', 'awardedAmount' => 50000.0];
@@ -145,8 +166,8 @@ class SubsidieVerantwoordingGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testLargeGrantWithConditionalAuditorStatementApproves(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(records: [['statementId' => 'AS-1', 'status' => 'conditional']])
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(records: [['statementId' => 'AS-1', 'status' => 'conditional']])
 		);
 
 		$object = ['grantId' => 'SUB-4', 'awardedAmount' => 30000.0];
@@ -162,8 +183,8 @@ class SubsidieVerantwoordingGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testLargeGrantWithRejectedAuditorStatementBlocked(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(records: [['statementId' => 'AS-1', 'status' => 'rejected']])
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(records: [['statementId' => 'AS-1', 'status' => 'rejected']])
 		);
 
 		$object = ['grantId' => 'SUB-5', 'awardedAmount' => 99000.0];
@@ -192,8 +213,7 @@ class SubsidieVerantwoordingGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testExceptionFailsClosed(): void {
-		$this->container->method('get')
-			->willThrowException(new \RuntimeException('ObjectService unavailable'));
+		$this->wireObjectService(store: $this->buildFailingObjectServiceStub());
 
 		$this->logger->expects($this->once())->method('error');
 
@@ -263,4 +283,52 @@ class SubsidieVerantwoordingGuardTest extends TestCase {
 			}//end findAll()
 		};
 	}//end buildObjectServiceStub()
+
+	/**
+	 * Build an ObjectService store that refuses every read.
+	 *
+	 * Since the store is injected rather than pulled from the container, an
+	 * unavailable OpenRegister is modelled by a store that throws.
+	 *
+	 * @return object
+	 */
+	private function buildFailingObjectServiceStub(): object {
+		return new class {
+
+			/**
+			 * Fluent register setter.
+			 *
+			 * @param string $register Register slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter.
+			 *
+			 * @param string $schema Schema slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse the read, as an unavailable ObjectService would.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused in stub).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end findAll()
+		};
+	}//end buildFailingObjectServiceStub()
 }//end class

--- a/tests/Unit/Lifecycle/SupplierQualificationGuardTest.php
+++ b/tests/Unit/Lifecycle/SupplierQualificationGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\SupplierQualificationGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -126,8 +126,10 @@ final class SupplierQualificationGuardTest extends TestCase {
 	 * @return SupplierQualificationGuard
 	 */
 	private function buildGuard(array $data): SupplierQualificationGuard {
+		$stub = $this->buildStub($data);
+
 		$container = $this->createMock(ContainerInterface::class);
-		$container->method('get')->willReturn($this->buildStub($data));
+		$container->method('get')->willReturn($stub);
 
 		$appConfig = $this->createMock(IAppConfig::class);
 		$appConfig->method('getValueString')->willReturn('shillinq');
@@ -135,7 +137,7 @@ final class SupplierQualificationGuardTest extends TestCase {
 		return new SupplierQualificationGuard(
 			appConfig: $appConfig,
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 	}//end buildGuard()
 

--- a/tests/Unit/Lifecycle/VatPreconditionGuardTest.php
+++ b/tests/Unit/Lifecycle/VatPreconditionGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\VatPreconditionGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -92,10 +92,33 @@ class VatPreconditionGuardTest extends TestCase {
 		$this->guard = new VatPreconditionGuard(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter(
+				$this->buildObjectServiceStub(vatGlAccounts: [], lines: [], overrides: [])
+			),
 		);
 
 	}//end setUp()
+
+	/**
+	 * Point the guard at the given duck-typed ObjectService store.
+	 *
+	 * The store is a constructor dependency since ADR-084, so the guard has to
+	 * be rebuilt whenever a test seeds different records.
+	 *
+	 * @param object $store The in-memory ObjectService double.
+	 *
+	 * @return void
+	 */
+	private function wireObjectService(object $store): void {
+		$this->container->method('get')->willReturn($store);
+
+		$this->guard = new VatPreconditionGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end wireObjectService()
 
 	/**
 	 * Product line with permitted rate (21%) and configured GL accounts returns true.
@@ -107,8 +130,8 @@ class VatPreconditionGuardTest extends TestCase {
 			['invoiceId' => 'inv-1', 'lineSequence' => 1, 'serviceCategory' => 'product', 'vatRate' => 21],
 		];
 
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(
 				vatGlAccounts: [$this->defaultGlAccounts()],
 				lines: $lines,
 				overrides: []
@@ -130,8 +153,8 @@ class VatPreconditionGuardTest extends TestCase {
 			['invoiceId' => 'inv-2', 'lineSequence' => 1, 'serviceCategory' => 'service', 'vatRate' => 9],
 		];
 
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(
 				vatGlAccounts: [$this->defaultGlAccounts()],
 				lines: $lines,
 				overrides: []
@@ -153,8 +176,8 @@ class VatPreconditionGuardTest extends TestCase {
 			['invoiceId' => 'inv-3', 'lineSequence' => 1, 'serviceCategory' => 'service', 'vatRate' => 6],
 		];
 
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(
 				vatGlAccounts: [$this->defaultGlAccounts()],
 				lines: $lines,
 				overrides: []
@@ -176,8 +199,8 @@ class VatPreconditionGuardTest extends TestCase {
 			['invoiceId' => 'inv-4', 'lineSequence' => 1, 'serviceCategory' => 'exempt', 'vatRate' => 21],
 		];
 
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(
 				vatGlAccounts: [$this->defaultGlAccounts()],
 				lines: $lines,
 				overrides: []
@@ -208,8 +231,8 @@ class VatPreconditionGuardTest extends TestCase {
 			'reason' => 'Special educational services agreement',
 		];
 
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(
 				vatGlAccounts: [$this->defaultGlAccounts()],
 				lines: $lines,
 				overrides: [$override]
@@ -231,8 +254,8 @@ class VatPreconditionGuardTest extends TestCase {
 			['invoiceId' => 'inv-6', 'lineSequence' => 1, 'serviceCategory' => 'product', 'vatRate' => 21],
 		];
 
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(
 				vatGlAccounts: [],
 				lines: $lines,
 				overrides: []
@@ -250,8 +273,7 @@ class VatPreconditionGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testExceptionCausesFailClosed(): void {
-		$this->container->method('get')
-			->willThrowException(new \RuntimeException('ObjectService unavailable'));
+		$this->wireObjectService(store: $this->buildFailingObjectServiceStub());
 
 		$this->logger->expects($this->once())->method('error');
 
@@ -272,8 +294,8 @@ class VatPreconditionGuardTest extends TestCase {
 			['invoiceId' => 'inv-7', 'lineSequence' => 3, 'serviceCategory' => 'exempt',  'vatRate' => 0],
 		];
 
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(
 				vatGlAccounts: [$this->defaultGlAccounts()],
 				lines: $lines,
 				overrides: []
@@ -396,4 +418,52 @@ class VatPreconditionGuardTest extends TestCase {
 			'vat0Account' => '2023',
 		];
 	}//end defaultGlAccounts()
+
+	/**
+	 * Build an ObjectService store that refuses every read.
+	 *
+	 * Since the store is injected rather than pulled from the container, an
+	 * unavailable OpenRegister is modelled by a store that throws.
+	 *
+	 * @return object
+	 */
+	private function buildFailingObjectServiceStub(): object {
+		return new class {
+
+			/**
+			 * Fluent register setter.
+			 *
+			 * @param string $register Register slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter.
+			 *
+			 * @param string $schema Schema slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse the read, as an unavailable ObjectService would.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused in stub).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end findAll()
+		};
+	}//end buildFailingObjectServiceStub()
 }//end class

--- a/tests/Unit/Lifecycle/VpbAangifteGuardTest.php
+++ b/tests/Unit/Lifecycle/VpbAangifteGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\VpbAangifteGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -87,10 +87,31 @@ class VpbAangifteGuardTest extends TestCase {
 		$this->guard = new VpbAangifteGuard(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->buildSchemaStub(recordsBySchema: [])),
 		);
 
 	}//end setUp()
+
+	/**
+	 * Point the guard at the given duck-typed ObjectService store.
+	 *
+	 * The store is a constructor dependency since ADR-084, so the guard has to
+	 * be rebuilt whenever a test seeds different records.
+	 *
+	 * @param object $store The in-memory ObjectService double.
+	 *
+	 * @return void
+	 */
+	private function wireObjectService(object $store): void {
+		$this->container->method('get')->willReturn($store);
+
+		$this->guard = new VpbAangifteGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end wireObjectService()
 
 	/**
 	 * Indiening is allowed when the jaarrekening is vastgesteld, the
@@ -100,8 +121,8 @@ class VpbAangifteGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCanIndienenWhenAllPreconditionsMet(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildSchemaStub(
+		$this->wireObjectService(
+			store: $this->buildSchemaStub(
 				recordsBySchema: [
 					'AnnualReport' => [['id' => 'jr-1', 'status' => 'determined']],
 					'Belastingplichtige' => [['id' => 'bp-1', 'eRecognitionLevel' => 'EH3', 'digipoortCertificate' => 'vault://cert']],
@@ -127,8 +148,8 @@ class VpbAangifteGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCannotIndienenWhenJaarrekeningNotVastgesteld(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildSchemaStub(
+		$this->wireObjectService(
+			store: $this->buildSchemaStub(
 				recordsBySchema: ['AnnualReport' => [['id' => 'jr-2', 'status' => 'draft']]]
 			)
 		);
@@ -151,8 +172,8 @@ class VpbAangifteGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCannotIndienenWhenEHerkenningBelowEH3(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildSchemaStub(
+		$this->wireObjectService(
+			store: $this->buildSchemaStub(
 				recordsBySchema: [
 					'AnnualReport' => [['id' => 'jr-3', 'status' => 'determined']],
 					'Belastingplichtige' => [['id' => 'bp-3', 'eRecognitionLevel' => 'EH2', 'digipoortCertificate' => 'vault://cert']],
@@ -177,8 +198,8 @@ class VpbAangifteGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCannotIndienenWhenInnovatieboxMissingSoVerklaring(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildSchemaStub(
+		$this->wireObjectService(
+			store: $this->buildSchemaStub(
 				recordsBySchema: [
 					'AnnualReport' => [['id' => 'jr-4', 'status' => 'gedeponeerd']],
 					'Belastingplichtige' => [['id' => 'bp-4', 'eRecognitionLevel' => 'EH3', 'digipoortCertificate' => 'vault://cert']],
@@ -204,7 +225,7 @@ class VpbAangifteGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testIndienenExceptionFailsClosed(): void {
-		$this->container->method('get')->willThrowException(new \RuntimeException('down'));
+		$this->wireObjectService(store: $this->buildFailingObjectServiceStub());
 		$this->logger->expects($this->once())->method('error');
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -223,8 +244,8 @@ class VpbAangifteGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCanAanslagOntvangenWhenAangifteIngediend(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildSchemaStub(
+		$this->wireObjectService(
+			store: $this->buildSchemaStub(
 				recordsBySchema: ['VpbAangifte' => [['id' => 'aangifte-5', 'status' => 'submitted']]]
 			)
 		);
@@ -242,8 +263,8 @@ class VpbAangifteGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testCannotAanslagOntvangenWhenAangifteConcept(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildSchemaStub(
+		$this->wireObjectService(
+			store: $this->buildSchemaStub(
 				recordsBySchema: ['VpbAangifte' => [['id' => 'aangifte-6', 'status' => 'draft']]]
 			)
 		);
@@ -373,4 +394,52 @@ class VpbAangifteGuardTest extends TestCase {
 			}//end findAll()
 		};
 	}//end buildSchemaStub()
+
+	/**
+	 * Build an ObjectService store that refuses every read.
+	 *
+	 * Since the store is injected rather than pulled from the container, an
+	 * unavailable OpenRegister is modelled by a store that throws.
+	 *
+	 * @return object
+	 */
+	private function buildFailingObjectServiceStub(): object {
+		return new class {
+
+			/**
+			 * Fluent register setter.
+			 *
+			 * @param string $register Register slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter.
+			 *
+			 * @param string $schema Schema slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse the read, as an unavailable ObjectService would.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused in stub).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('down');
+			}//end findAll()
+		};
+	}//end buildFailingObjectServiceStub()
 }//end class

--- a/tests/Unit/Lifecycle/VpbBerekeningGuardTest.php
+++ b/tests/Unit/Lifecycle/VpbBerekeningGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\VpbBerekeningGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -85,10 +85,31 @@ class VpbBerekeningGuardTest extends TestCase {
 		$this->guard = new VpbBerekeningGuard(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->buildSchemaStub(recordsBySchema: [])),
 		);
 
 	}//end setUp()
+
+	/**
+	 * Point the guard at the given duck-typed ObjectService store.
+	 *
+	 * The store is a constructor dependency since ADR-084, so the guard has to
+	 * be rebuilt whenever a test seeds different records.
+	 *
+	 * @param object $store The in-memory ObjectService double.
+	 *
+	 * @return void
+	 */
+	private function wireObjectService(object $store): void {
+		$this->container->method('get')->willReturn($store);
+
+		$this->guard = new VpbBerekeningGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end wireObjectService()
 
 	/**
 	 * The schijftarief calculation applies the 2026 brackets (19% / 25.8% / 245k) (REQ-VPB-003).
@@ -99,8 +120,8 @@ class VpbBerekeningGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testBerekenVerschuldigdeVpbAppliesBrackets(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildSchemaStub(
+		$this->wireObjectService(
+			store: $this->buildSchemaStub(
 				recordsBySchema: [
 					'VpbTariefcatalogus' => [
 						['taxYear' => 2026, 'tarief1' => 0.19, 'tarief2' => 0.258, 'taxableAmountThreshold' => 245000],
@@ -120,8 +141,8 @@ class VpbBerekeningGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testBerekenVerschuldigdeVpbBelowGrens(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildSchemaStub(
+		$this->wireObjectService(
+			store: $this->buildSchemaStub(
 				recordsBySchema: [
 					'VpbTariefcatalogus' => [
 						['taxYear' => 2026, 'tarief1' => 0.19, 'tarief2' => 0.258, 'taxableAmountThreshold' => 245000],
@@ -152,8 +173,8 @@ class VpbBerekeningGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testBerekenVerschuldigdeVpbZeroWhenNoTarief(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildSchemaStub(recordsBySchema: ['VpbTariefcatalogus' => []])
+		$this->wireObjectService(
+			store: $this->buildSchemaStub(recordsBySchema: ['VpbTariefcatalogus' => []])
 		);
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -167,7 +188,7 @@ class VpbBerekeningGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testBerekenVerschuldigdeVpbFailsClosed(): void {
-		$this->container->method('get')->willThrowException(new \RuntimeException('down'));
+		$this->wireObjectService(store: $this->buildFailingObjectServiceStub());
 		$this->logger->expects($this->once())->method('error');
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -281,4 +302,52 @@ class VpbBerekeningGuardTest extends TestCase {
 			}//end findAll()
 		};
 	}//end buildSchemaStub()
+
+	/**
+	 * Build an ObjectService store that refuses every read.
+	 *
+	 * Since the store is injected rather than pulled from the container, an
+	 * unavailable OpenRegister is modelled by a store that throws.
+	 *
+	 * @return object
+	 */
+	private function buildFailingObjectServiceStub(): object {
+		return new class {
+
+			/**
+			 * Fluent register setter.
+			 *
+			 * @param string $register Register slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter.
+			 *
+			 * @param string $schema Schema slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse the read, as an unavailable ObjectService would.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused in stub).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('down');
+			}//end findAll()
+		};
+	}//end buildFailingObjectServiceStub()
 }//end class

--- a/tests/Unit/Lifecycle/WbsoMededelingGuardTest.php
+++ b/tests/Unit/Lifecycle/WbsoMededelingGuardTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Lifecycle;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\WbsoMededelingGuard;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -94,10 +94,31 @@ class WbsoMededelingGuardTest extends TestCase {
 		$this->guard = new WbsoMededelingGuard(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->buildObjectServiceStub(records: [])),
 		);
 
 	}//end setUp()
+
+	/**
+	 * Point the guard at the given duck-typed ObjectService store.
+	 *
+	 * The store is a constructor dependency since ADR-084, so the guard has to
+	 * be rebuilt whenever a test seeds different records.
+	 *
+	 * @param object $store The in-memory ObjectService double.
+	 *
+	 * @return void
+	 */
+	private function wireObjectService(object $store): void {
+		$this->container->method('get')->willReturn($store);
+
+		$this->guard = new WbsoMededelingGuard(
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end wireObjectService()
 
 	/**
 	 * Build a beschikking record fixture for the current administration.
@@ -138,8 +159,8 @@ class WbsoMededelingGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testRealisatieBelowCeilingCanSubmit(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(records: [$this->decisionRecord(grantedSoHours: 1200, state: 'granted')])
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(records: [$this->decisionRecord(grantedSoHours: 1200, state: 'granted')])
 		);
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -153,8 +174,8 @@ class WbsoMededelingGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testRealisatieAtCeilingCanSubmit(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(records: [$this->decisionRecord(grantedSoHours: 1200.5, state: 'granted')])
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(records: [$this->decisionRecord(grantedSoHours: 1200.5, state: 'granted')])
 		);
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -168,8 +189,8 @@ class WbsoMededelingGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testRealisatieAboveCeilingCannotSubmit(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(records: [$this->decisionRecord(grantedSoHours: 1200, state: 'granted')])
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(records: [$this->decisionRecord(grantedSoHours: 1200, state: 'granted')])
 		);
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -183,8 +204,8 @@ class WbsoMededelingGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testExpiredBeschikkingCannotSubmit(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(records: [$this->decisionRecord(grantedSoHours: 1200, state: 'expired')])
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(records: [$this->decisionRecord(grantedSoHours: 1200, state: 'expired')])
 		);
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -198,7 +219,7 @@ class WbsoMededelingGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testUnknownBeschikkingFailsClosed(): void {
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub(records: []));
+		$this->wireObjectService(store: $this->buildObjectServiceStub(records: []));
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
 		self::assertFalse($this->guard->canSubmit(mededelingId: 'med-5', object: $this->mededelingObject(realisedSoHours: 1)));
@@ -221,7 +242,7 @@ class WbsoMededelingGuardTest extends TestCase {
 			'administrationId' => 'adm-other-bv',
 		];
 
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub(records: [$foreign]));
+		$this->wireObjectService(store: $this->buildObjectServiceStub(records: [$foreign]));
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
 		self::assertFalse(
@@ -282,8 +303,8 @@ class WbsoMededelingGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testNegativeRealisedHoursFailsClosed(): void {
-		$this->container->method('get')->willReturn(
-			$this->buildObjectServiceStub(records: [$this->decisionRecord(grantedSoHours: 1200, state: 'granted')])
+		$this->wireObjectService(
+			store: $this->buildObjectServiceStub(records: [$this->decisionRecord(grantedSoHours: 1200, state: 'granted')])
 		);
 
 		// phpcs:ignore CustomSniffs.Functions.NamedParameters
@@ -297,8 +318,7 @@ class WbsoMededelingGuardTest extends TestCase {
 	 * @return void
 	 */
 	public function testSubmitExceptionFailsClosed(): void {
-		$this->container->method('get')
-			->willThrowException(new \RuntimeException('ObjectService unavailable'));
+		$this->wireObjectService(store: $this->buildFailingObjectServiceStub());
 
 		$this->logger->expects($this->once())->method('error');
 
@@ -366,4 +386,52 @@ class WbsoMededelingGuardTest extends TestCase {
 			}//end findAll()
 		};
 	}//end buildObjectServiceStub()
+
+	/**
+	 * Build an ObjectService store that refuses every read.
+	 *
+	 * Since the store is injected rather than pulled from the container, an
+	 * unavailable OpenRegister is modelled by a store that throws.
+	 *
+	 * @return object
+	 */
+	private function buildFailingObjectServiceStub(): object {
+		return new class {
+
+			/**
+			 * Fluent register setter.
+			 *
+			 * @param string $register Register slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter.
+			 *
+			 * @param string $schema Schema slug (unused).
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Refuse the read, as an unavailable ObjectService would.
+			 *
+			 * @param array<string,mixed> $params Query parameters (unused in stub).
+			 *
+			 * @return array<mixed>
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function findAll(array $params = []): array {
+				throw new \RuntimeException('ObjectService unavailable');
+			}//end findAll()
+		};
+	}//end buildFailingObjectServiceStub()
 }//end class

--- a/tests/Unit/Listener/DeliveryDispatchListenerTest.php
+++ b/tests/Unit/Listener/DeliveryDispatchListenerTest.php
@@ -33,7 +33,6 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Listener;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Lifecycle\LotSellabilityGuard;
@@ -44,6 +43,7 @@ use OCA\Shillinq\Service\FifoValuationService;
 use OCA\Shillinq\Service\MovingAverageValuationService;
 use OCA\Shillinq\Service\SalesDispatchStockIssueService;
 use OCA\Shillinq\Sort\FefoSort;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -477,14 +477,14 @@ class DeliveryDispatchListenerTest extends TestCase {
 
 		// Real business-logic classes — nothing about the existing valuation
 		// + COGS pipeline is mocked or reimplemented.
-		$fifo = new FifoValuationService(container: $container, appConfig: $appConfig, logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+		$fifo = new FifoValuationService(appConfig: $appConfig, logger: $logger,
+			objectService: new DuckObjectServiceAdapter($fakeObjectService),
 		);
-		$average = new MovingAverageValuationService(container: $container, appConfig: $appConfig, logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+		$average = new MovingAverageValuationService(appConfig: $appConfig, logger: $logger,
+			objectService: new DuckObjectServiceAdapter($fakeObjectService),
 		);
-		$cogs = new CogsPosterService(container: $container, appConfig: $appConfig, logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+		$cogs = new CogsPosterService(appConfig: $appConfig, logger: $logger,
+			objectService: new DuckObjectServiceAdapter($fakeObjectService),
 		);
 		$stockMoveListener = new StockMoveTransitionedListener(
 			fifo: $fifo,
@@ -492,7 +492,7 @@ class DeliveryDispatchListenerTest extends TestCase {
 			cogs: $cogs,
 			appConfig: $appConfig,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($fakeObjectService),
 		);
 
 		$dispatchService = new SalesDispatchStockIssueService(
@@ -500,7 +500,7 @@ class DeliveryDispatchListenerTest extends TestCase {
 			appConfig: $appConfig,
 			logger: $logger,
 			lotGuard: new LotSellabilityGuard(fefoSort: new FefoSort()),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($fakeObjectService),
 		);
 		$deliveryListener = new DeliveryDispatchListener(dispatchService: $dispatchService, logger: $logger);
 

--- a/tests/Unit/Listener/FixedAssetDisposalListenerTest.php
+++ b/tests/Unit/Listener/FixedAssetDisposalListenerTest.php
@@ -32,7 +32,6 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Listener;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Listener\FixedAssetDisposalListener;
@@ -41,6 +40,7 @@ use OCA\Shillinq\Service\DepreciationCalculator;
 use OCA\Shillinq\Service\DisposalJournalEmitter;
 use OCA\Shillinq\Service\FixedAssetDisposalService;
 use OCA\Shillinq\Tests\Unit\Service\InMemoryObjectService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -103,7 +103,7 @@ class FixedAssetDisposalListenerTest extends TestCase {
 			emitter: new DisposalJournalEmitter(new DepreciationCalculator()),
 			administrationContext: $administrationContext,
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objects),
 		);
 
 		$this->listener = new FixedAssetDisposalListener(

--- a/tests/Unit/Listener/GRIRClearingListenerTest.php
+++ b/tests/Unit/Listener/GRIRClearingListenerTest.php
@@ -34,7 +34,6 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Listener;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Listener\GRIRClearingListener;
@@ -45,6 +44,7 @@ use OCA\Shillinq\Service\SupplierInvoiceService;
 use OCA\Shillinq\Service\ThreeWayMatchingEngine;
 use OCA\Shillinq\Service\ToleranceProfileService;
 use OCA\Shillinq\Tests\Unit\Service\InMemoryObjectService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -403,14 +403,14 @@ class GRIRClearingListenerTest extends TestCase {
 			appConfig: $appConfig,
 			administrationContext: $administrationContext,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 		$grirService = new GRIRClearingService(
 			appConfig: $appConfig,
 			administrationContext: $administrationContext,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 		$grirListener = new GRIRClearingListener(grirClearingService: $grirService, logger: $logger);
@@ -459,14 +459,14 @@ class GRIRClearingListenerTest extends TestCase {
 			appConfig: $appConfig,
 			administrationContext: $administrationContext,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 		$matchingEngine = new ThreeWayMatchingEngine(
 			appConfig: $appConfig,
 			toleranceService: $tolerance,
 			invoiceService: $invoiceService,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 		$matchResult = $matchingEngine->evaluateMatch(administrationId: 'adm-1', invoiceId: 'inv-1');

--- a/tests/Unit/Listener/IntercompanyLinkListenerTest.php
+++ b/tests/Unit/Listener/IntercompanyLinkListenerTest.php
@@ -31,13 +31,13 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Listener;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
 use OCA\Shillinq\Listener\IntercompanyLinkListener;
 use OCA\Shillinq\Service\IntercompanyJournalService;
 use OCA\Shillinq\Service\IntercompanyLinkService;
 use OCA\Shillinq\Tests\Unit\Service\InMemoryObjectService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -86,7 +86,7 @@ class IntercompanyLinkListenerTest extends TestCase {
 			appConfig: $appConfig,
 			journalService: new IntercompanyJournalService(),
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objects),
 		);
 
 		$this->listener = new IntercompanyLinkListener(

--- a/tests/Unit/Listener/LeaseActivationListenerTest.php
+++ b/tests/Unit/Listener/LeaseActivationListenerTest.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Listener;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectUpdatedEvent;
@@ -30,6 +29,7 @@ use OCA\Shillinq\Listener\LeaseActivationListener;
 use OCA\Shillinq\Service\LeaseAmortizationCalculator;
 use OCA\Shillinq\Service\LeasePaymentScheduleService;
 use OCA\Shillinq\Service\ListenerSchemaResolver;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -90,6 +90,13 @@ final class LeaseActivationListenerTest extends TestCase {
 			private array $saved;
 
 			/**
+			 * The schema most recently selected on the fluent chain.
+			 *
+			 * @var string
+			 */
+			private string $currentSchema = '';
+
+			/**
 			 * Constructor.
 			 *
 			 * @param array<int,array<string,mixed>> $leases Lease records.
@@ -119,6 +126,7 @@ final class LeaseActivationListenerTest extends TestCase {
 			 * @return static
 			 */
 			public function setSchema(string $schema): static {
+				$this->currentSchema = $schema;
 				return $this;
 			}//end setSchema()
 
@@ -147,13 +155,11 @@ final class LeaseActivationListenerTest extends TestCase {
 			 * Capture a saved object.
 			 *
 			 * @param array<string,mixed> $object The object payload.
-			 * @param string $register Register slug.
-			 * @param string $schema Schema slug.
 			 *
 			 * @return array<string,mixed>
 			 */
-			public function saveObject(array $object, string $register, string $schema): array {
-				$this->saved[] = ['object' => $object, 'schema' => $schema];
+			public function saveObject(array $object): array {
+				$this->saved[] = ['object' => $object, 'schema' => $this->currentSchema];
 				return $object;
 			}//end saveObject()
 		};
@@ -168,7 +174,7 @@ final class LeaseActivationListenerTest extends TestCase {
 			appConfig: $appConfig,
 			calculator: new LeaseAmortizationCalculator(),
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 		$schemaResolver = $this->createMock(ListenerSchemaResolver::class);

--- a/tests/Unit/Listener/OssPaymentReconciliationListenerTest.php
+++ b/tests/Unit/Listener/OssPaymentReconciliationListenerTest.php
@@ -29,7 +29,6 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Listener;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\Shillinq\Listener\OssPaymentReconciliationListener;
@@ -37,6 +36,7 @@ use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\OssPaymentReconciliation;
 use OCA\Shillinq\Service\OssRecordResolver;
 use OCA\Shillinq\Tests\Unit\Service\InMemoryObjectService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -92,7 +92,7 @@ class OssPaymentReconciliationListenerTest extends TestCase {
 		$resolver = new OssRecordResolver(
 			appConfig: $appConfig,
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objects),
 		);
 
 		$this->schemaResolver = $this->createMock(ListenerSchemaResolver::class);

--- a/tests/Unit/Listener/PosStockDecrementListenerTest.php
+++ b/tests/Unit/Listener/PosStockDecrementListenerTest.php
@@ -94,7 +94,6 @@ if (class_exists(\OCA\Pipelinq\Event\PosStockMovedEvent::class, false) === false
 
 namespace OCA\Shillinq\Tests\Unit\Listener;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Pipelinq\Event\PosStockMovedEvent;
 use OCA\Shillinq\Lifecycle\LotSellabilityGuard;
 use OCA\Shillinq\Listener\PosStockDecrementListener;
@@ -104,6 +103,7 @@ use OCA\Shillinq\Service\FifoValuationService;
 use OCA\Shillinq\Service\MovingAverageValuationService;
 use OCA\Shillinq\Service\SalesDispatchStockIssueService;
 use OCA\Shillinq\Sort\FefoSort;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\EventDispatcher\Event;
 use OCP\IAppConfig;
 use OCP\IGroup;
@@ -275,7 +275,7 @@ class PosStockDecrementListenerTest extends TestCase {
 			groupManager: $this->groupManager,
 			notificationMgr: $this->notificationMgr,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->fakeObjectService),
 		);
 	}//end setUpListener()
 
@@ -826,14 +826,14 @@ class PosStockDecrementListenerTest extends TestCase {
 		// Real business-logic classes throughout — nothing about the
 		// existing decrement + valuation + COGS pipeline is mocked or
 		// reimplemented.
-		$fifo = new FifoValuationService(container: $container, appConfig: $appConfig, logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+		$fifo = new FifoValuationService(appConfig: $appConfig, logger: $logger,
+			objectService: new DuckObjectServiceAdapter($fakeObjectService),
 		);
-		$average = new MovingAverageValuationService(container: $container, appConfig: $appConfig, logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+		$average = new MovingAverageValuationService(appConfig: $appConfig, logger: $logger,
+			objectService: new DuckObjectServiceAdapter($fakeObjectService),
 		);
-		$cogs = new CogsPosterService(container: $container, appConfig: $appConfig, logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+		$cogs = new CogsPosterService(appConfig: $appConfig, logger: $logger,
+			objectService: new DuckObjectServiceAdapter($fakeObjectService),
 		);
 		$stockMoveListener = new StockMoveTransitionedListener(
 			fifo: $fifo,
@@ -841,7 +841,7 @@ class PosStockDecrementListenerTest extends TestCase {
 			cogs: $cogs,
 			appConfig: $appConfig,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($fakeObjectService),
 		);
 
 		$dispatchService = new SalesDispatchStockIssueService(
@@ -849,7 +849,7 @@ class PosStockDecrementListenerTest extends TestCase {
 			appConfig: $appConfig,
 			logger: $logger,
 			lotGuard: new LotSellabilityGuard(fefoSort: new FefoSort()),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($fakeObjectService),
 		);
 
 		$groupManager = $this->createMock(IGroupManager::class);
@@ -862,7 +862,7 @@ class PosStockDecrementListenerTest extends TestCase {
 			groupManager: $groupManager,
 			notificationMgr: $notificationMgr,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($fakeObjectService),
 		);
 
 		// Step 1: a POS sale of 4 units of SKU-1001 -> expect exactly one new

--- a/tests/Unit/Repair/BackfillFiscalPeriodsTest.php
+++ b/tests/Unit/Repair/BackfillFiscalPeriodsTest.php
@@ -26,9 +26,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Repair;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Repair\BackfillFiscalPeriods;
 use OCA\Shillinq\Service\SettingsService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\Migration\IOutput;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -372,11 +372,18 @@ class BackfillFiscalPeriodsTest extends TestCase {
 			 */
 			public function saveObject(
 				array $object,
-				string $register,
-				string $schema,
+				string $register = '',
+				string $schema = '',
 				bool $_rbac = true,
 				bool $_multitenancy = true,
 			): void {
+				// The schema may arrive positionally or, when the caller reaches
+				// this double through the ADR-084 contract adapter, via the
+				// preceding setSchema() on the fluent chain.
+				if ($schema === '') {
+					$schema = $this->schema;
+				}
+
 				$this->saves[] = ['object' => $object, 'register' => $register, 'schema' => $schema];
 			}
 		};
@@ -389,7 +396,7 @@ class BackfillFiscalPeriodsTest extends TestCase {
 		return new BackfillFiscalPeriods(
 			settingsService: $this->settingsService,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->fakeObjectService),
 		);
 
 	}//end makeStep()

--- a/tests/Unit/Repair/PeriodCloseBackfillTest.php
+++ b/tests/Unit/Repair/PeriodCloseBackfillTest.php
@@ -30,6 +30,7 @@ namespace OCA\Shillinq\Tests\Unit\Repair;
 use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Repair\PeriodCloseBackfill;
 use OCA\Shillinq\Service\SettingsService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\Migration\IOutput;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -120,12 +121,6 @@ class PeriodCloseBackfillTest extends TestCase {
 			existingPeriods: []
 		);
 
-		$this->container
-			->expects($this->once())
-			->method('get')
-			->with('OCA\OpenRegister\Service\ObjectService')
-			->willReturn($objectService);
-
 		$this->output
 			->expects($this->atLeastOnce())
 			->method('info');
@@ -133,7 +128,7 @@ class PeriodCloseBackfillTest extends TestCase {
 		$step = new PeriodCloseBackfill(
 			settingsService: $this->settingsService,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($objectService),
 		);
 		$step->run($this->output);
 
@@ -156,16 +151,10 @@ class PeriodCloseBackfillTest extends TestCase {
 			existingPeriods: []
 		);
 
-		$this->container
-			->expects($this->once())
-			->method('get')
-			->with('OCA\OpenRegister\Service\ObjectService')
-			->willReturn($objectService);
-
 		$step = new PeriodCloseBackfill(
 			settingsService: $this->settingsService,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($objectService),
 		);
 		$step->run($this->output);
 
@@ -215,16 +204,10 @@ class PeriodCloseBackfillTest extends TestCase {
 			existingPeriods: $existing
 		);
 
-		$this->container
-			->expects($this->once())
-			->method('get')
-			->with('OCA\OpenRegister\Service\ObjectService')
-			->willReturn($objectService);
-
 		$step = new PeriodCloseBackfill(
 			settingsService: $this->settingsService,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($objectService),
 		);
 		$step->run($this->output);
 
@@ -239,10 +222,12 @@ class PeriodCloseBackfillTest extends TestCase {
 	 * @return void
 	 */
 	public function testRunFailureIsBestEffort(): void {
-		$this->container
-			->expects($this->once())
-			->method('get')
-			->with('OCA\OpenRegister\Service\ObjectService')
+		// The injected ObjectService is the failure surface now that ADR-084
+		// removed the container: refuse on the very first call of the read
+		// chain, exactly as an unavailable OpenRegister would.
+		$objectService = $this->createMock(ObjectServiceInterface::class);
+		$objectService
+			->method('setRegister')
 			->willThrowException(new \RuntimeException('ObjectService unavailable'));
 
 		$this->output
@@ -256,7 +241,7 @@ class PeriodCloseBackfillTest extends TestCase {
 		$step = new PeriodCloseBackfill(
 			settingsService: $this->settingsService,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: $objectService,
 		);
 
 		// Must NOT throw — the repair step swallows the failure.
@@ -284,16 +269,10 @@ class PeriodCloseBackfillTest extends TestCase {
 			existingPeriods: []
 		);
 
-		$this->container
-			->expects($this->once())
-			->method('get')
-			->with('OCA\OpenRegister\Service\ObjectService')
-			->willReturn($objectService);
-
 		$step = new PeriodCloseBackfill(
 			settingsService: $this->settingsService,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($objectService),
 		);
 		$step->run($this->output);
 
@@ -451,8 +430,8 @@ class PeriodCloseBackfillTest extends TestCase {
 			 */
 			public function saveObject(
 				array $object,
-				string $register,
-				string $schema,
+				string $register = '',
+				string $schema = '',
 				bool $_rbac = true,
 				bool $_multitenancy = true,
 			): array {

--- a/tests/Unit/Repair/RematerialiseConvertedCalculationsTest.php
+++ b/tests/Unit/Repair/RematerialiseConvertedCalculationsTest.php
@@ -28,9 +28,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Repair;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Repair\RematerialiseConvertedCalculations;
 use OCA\Shillinq\Service\SettingsService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\Migration\IOutput;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -360,7 +360,6 @@ class RematerialiseConvertedCalculationsTest extends TestCase {
 			 */
 			public function setSchema(string $schema): self {
 				$this->schema = $schema;
-				$this->schemasQueried[] = $schema;
 
 				return $this;
 			}//end setSchema()
@@ -377,6 +376,11 @@ class RematerialiseConvertedCalculationsTest extends TestCase {
 			 * @return list<array<string,mixed>> Matching fixture rows.
 			 */
 			public function findAll(array $config = [], bool $_rbac = true, bool $_multitenancy = true): array {
+				// Recorded here rather than in setSchema(): the assertion is
+				// that findAll() was called on every targeted schema, and the
+				// write path re-selects the schema on the same chain.
+				$this->schemasQueried[] = $this->schema;
+
 				if (in_array($this->schema, $this->failFindAllSchemas, true) === true) {
 					throw new \RuntimeException('findAll failed for ' . $this->schema);
 				}
@@ -410,8 +414,8 @@ class RematerialiseConvertedCalculationsTest extends TestCase {
 			 */
 			public function saveObject(
 				array $object,
-				string $register,
-				string $schema,
+				string $register = '',
+				string $schema = '',
 				bool $_rbac = true,
 				bool $_multitenancy = true,
 				mixed $currentUser = null,
@@ -434,7 +438,7 @@ class RematerialiseConvertedCalculationsTest extends TestCase {
 			settingsService: $this->settingsService,
 			logger: $this->logger,
 			container: $this->container,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->fakeObjectService),
 		);
 
 	}//end makeStep()

--- a/tests/Unit/Service/AansluitingServiceTest.php
+++ b/tests/Unit/Service/AansluitingServiceTest.php
@@ -30,11 +30,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\AansluitingResolutionGuard;
 use OCA\Shillinq\Service\AansluitingCalculator;
 use OCA\Shillinq\Service\AansluitingService;
 use OCA\Shillinq\Service\VATReturnService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -97,7 +97,7 @@ final class AansluitingServiceTest extends TestCase {
 		$vatReturnService = new VATReturnService(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 		$guard = new AansluitingResolutionGuard(logger: $this->logger);
@@ -108,7 +108,7 @@ final class AansluitingServiceTest extends TestCase {
 			calculator: new AansluitingCalculator(),
 			vatReturnService: $vatReturnService,
 			resolutionGuard: $guard,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/AuditTrailIntegrationTest.php
+++ b/tests/Unit/Service/AuditTrailIntegrationTest.php
@@ -44,12 +44,12 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\AuditExportService;
 use OCA\Shillinq\Service\ExceptionResolutionService;
 use OCA\Shillinq\Service\PurchaseOrder\CreditNoteRequestAdapterInterface;
 use OCA\Shillinq\Service\PurchaseOrderApprovalService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -291,7 +291,7 @@ final class AuditTrailIntegrationTest extends TestCase {
 			administrationContext: $administrationContext,
 			userSession: $userSession,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildApprovalService()
@@ -363,7 +363,7 @@ final class AuditTrailIntegrationTest extends TestCase {
 			notificationManager: $notificationManager,
 			logger: $logger,
 			creditNoteAdapter: $adapter,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildResolutionService()

--- a/tests/Unit/Service/BadoControleprotocolEndToEndTest.php
+++ b/tests/Unit/Service/BadoControleprotocolEndToEndTest.php
@@ -49,10 +49,10 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AccountantsdossierExportService;
 use OCA\Shillinq\Service\BadoControleprotocolCalculator;
 use OCA\Shillinq\Service\BadoControleprotocolService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
@@ -128,14 +128,14 @@ final class BadoControleprotocolEndToEndTest extends TestCase {
 			appConfig: $appConfig,
 			calculator: new BadoControleprotocolCalculator(),
 			logger: new NullLogger(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->os),
 		);
 
 		$this->exporter = new AccountantsdossierExportService(
 			appConfig: $appConfig,
 			userSession: $userSession,
 			logger: new NullLogger(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->os),
 		);
 
 	}//end setUp()

--- a/tests/Unit/Service/BadoControleprotocolEndToEndTest.php
+++ b/tests/Unit/Service/BadoControleprotocolEndToEndTest.php
@@ -79,6 +79,15 @@ require_once __DIR__ . '/InMemoryObjectService.php';
  * bare mention as "is invalid".)
  *
  * @uses \OCA\Shillinq\Service\BadoControleprotocolCalculator
+ *
+ * ObjectIdentifier is the same shape of collaborator, and it only became
+ * REACHABLE with the ADR-084 rewiring in this branch. Both subjects resolve a
+ * record through the static helper (BadoControleprotocolService:633 and
+ * AccountantsdossierExportService:892); until the seeded store was reconnected
+ * the lookup short-circuited before it, so the class never executed and the
+ * strict-coverage check had nothing to report. It is used, not covered.
+ *
+ * @uses \OCA\Shillinq\Util\ObjectIdentifier
  */
 final class BadoControleprotocolEndToEndTest extends TestCase {
 

--- a/tests/Unit/Service/BadoControleprotocolTenantTest.php
+++ b/tests/Unit/Service/BadoControleprotocolTenantTest.php
@@ -40,6 +40,7 @@ use JsonSerializable;
 use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\BadoControleprotocolCalculator;
 use OCA\Shillinq\Service\BadoControleprotocolService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -68,13 +69,6 @@ final class BadoControleprotocolTenantTest extends TestCase {
 	private IAppConfig&MockObject $appConfig;
 
 	/**
-	 * Service under test.
-	 *
-	 * @var BadoControleprotocolService
-	 */
-	private BadoControleprotocolService $service;
-
-	/**
 	 * Set up fixtures.
 	 *
 	 * @return void
@@ -85,14 +79,28 @@ final class BadoControleprotocolTenantTest extends TestCase {
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
 
-		$this->service = new BadoControleprotocolService(
+	}//end setUp()
+
+	/**
+	 * Build the service over a given ObjectService.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so the
+	 * subject has to be built AFTER the per-test double exists — it can no
+	 * longer be assembled once in setUp() and re-pointed through a container.
+	 *
+	 * @param ObjectServiceInterface $objectService The object service to inject.
+	 *
+	 * @return BadoControleprotocolService
+	 */
+	private function serviceWith(ObjectServiceInterface $objectService): BadoControleprotocolService {
+		return new BadoControleprotocolService(
 			appConfig: $this->appConfig,
 			calculator: $this->createMock(BadoControleprotocolCalculator::class),
 			logger: new NullLogger(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: $objectService,
 		);
 
-	}//end setUp()
+	}//end serviceWith()
 
 	/**
 	 * Build an ObjectService double that mirrors ObjectService::find().
@@ -209,9 +217,12 @@ final class BadoControleprotocolTenantTest extends TestCase {
 	 * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-12
 	 */
 	public function testAnEmptyProtocolIdResolvesToNull(): void {
-		$this->container->expects($this->never())->method('get');
+		// The data layer is the injected ObjectService now that ADR-084
+		// removed the container: an empty id must not reach it at all.
+		$objectService = $this->createMock(ObjectServiceInterface::class);
+		$objectService->expects($this->never())->method('find');
 
-		self::assertNull($this->service->organisationIdFor(protocolId: ''));
+		self::assertNull($this->serviceWith($objectService)->organisationIdFor(protocolId: ''));
 
 	}//end testAnEmptyProtocolIdResolvesToNull()
 
@@ -225,9 +236,10 @@ final class BadoControleprotocolTenantTest extends TestCase {
 	 */
 	public function testAnAbsentProtocolResolvesToNull(): void {
 		$stub = $this->fakeObjectService(null);
-		$this->container->method('get')->willReturn($stub);
 
-		self::assertNull($this->service->organisationIdFor(protocolId: 'proto-1'));
+		self::assertNull(
+			$this->serviceWith(new DuckObjectServiceAdapter($stub))->organisationIdFor(protocolId: 'proto-1')
+		);
 		self::assertSame(
 			['id' => 'proto-1', 'register' => 'shillinq', 'schema' => 'Controleprotocol'],
 			$stub->seenFind
@@ -259,9 +271,12 @@ final class BadoControleprotocolTenantTest extends TestCase {
 			}//end jsonSerialize()
 		};
 
-		$this->container->method('get')->willReturn($this->fakeObjectService($entity));
+		$stub = $this->fakeObjectService($entity);
 
-		self::assertSame('adm-1', $this->service->organisationIdFor(protocolId: 'proto-1'));
+		self::assertSame(
+			'adm-1',
+			$this->serviceWith(new DuckObjectServiceAdapter($stub))->organisationIdFor(protocolId: 'proto-1')
+		);
 
 	}//end testAnEntityIsNormalisedThroughJsonSerialize()
 
@@ -277,11 +292,12 @@ final class BadoControleprotocolTenantTest extends TestCase {
 	 * @spec openspec/changes/bookkeeping-bado-controleprotocol/tasks.md#task-12
 	 */
 	public function testAProtocolWithoutATenantResolvesToTheEmptyString(): void {
-		$this->container->method('get')->willReturn(
-			$this->fakeObjectService(['id' => 'proto-1'])
-		);
+		$stub = $this->fakeObjectService(['id' => 'proto-1']);
 
-		self::assertSame('', $this->service->organisationIdFor(protocolId: 'proto-1'));
+		self::assertSame(
+			'',
+			$this->serviceWith(new DuckObjectServiceAdapter($stub))->organisationIdFor(protocolId: 'proto-1')
+		);
 
 	}//end testAProtocolWithoutATenantResolvesToTheEmptyString()
 }//end class

--- a/tests/Unit/Service/BadoFindingEscalationTest.php
+++ b/tests/Unit/Service/BadoFindingEscalationTest.php
@@ -61,6 +61,17 @@ require_once __DIR__ . '/InMemoryObjectService.php';
  *
  * @covers \OCA\Shillinq\Service\BadoControleprotocolService
  * @covers \OCA\Shillinq\Service\BadoControleprotocolCalculator
+ *
+ * The subject resolves a record through the static ObjectIdentifier helper
+ * (BadoControleprotocolService:633). That call only became REACHABLE with the
+ * ADR-084 rewiring in this branch — until the seeded store was reconnected the
+ * lookup short-circuited before it, so the class never executed and the
+ * strict-coverage check had nothing to report. It is a collaborator this test
+ * uses but does not claim coverage of; without the declaration below the run is
+ * reported RISKY under beStrictAboutCoverageMetadata, and phpunit.xml sets
+ * failOnRisky="true", so the whole cell exits 1 on an otherwise green suite.
+ *
+ * @uses \OCA\Shillinq\Util\ObjectIdentifier
  */
 final class BadoFindingEscalationTest extends TestCase {
 

--- a/tests/Unit/Service/BadoFindingEscalationTest.php
+++ b/tests/Unit/Service/BadoFindingEscalationTest.php
@@ -44,9 +44,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\BadoControleprotocolCalculator;
 use OCA\Shillinq\Service\BadoControleprotocolService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -99,7 +99,7 @@ final class BadoFindingEscalationTest extends TestCase {
 			appConfig: $appConfig,
 			calculator: new BadoControleprotocolCalculator(),
 			logger: new NullLogger(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->os),
 		);
 
 	}//end setUp()

--- a/tests/Unit/Service/BadoSisaBijlageIIATest.php
+++ b/tests/Unit/Service/BadoSisaBijlageIIATest.php
@@ -67,6 +67,14 @@ require_once __DIR__ . '/InMemoryObjectService.php';
  * the bare mention as "is invalid".)
  *
  * @uses \OCA\Shillinq\Service\BadoControleprotocolCalculator
+ *
+ * ObjectIdentifier is the same shape of collaborator, and it only became
+ * REACHABLE with the ADR-084 rewiring in this branch: both subjects resolve a
+ * record through the static helper (BadoControleprotocolService:633 and
+ * AccountantsdossierExportService:892), and until the seeded store was
+ * reconnected the lookup short-circuited before it. It is used, not covered.
+ *
+ * @uses \OCA\Shillinq\Util\ObjectIdentifier
  */
 final class BadoSisaBijlageIIATest extends TestCase {
 

--- a/tests/Unit/Service/BadoSisaBijlageIIATest.php
+++ b/tests/Unit/Service/BadoSisaBijlageIIATest.php
@@ -38,10 +38,10 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AccountantsdossierExportService;
 use OCA\Shillinq\Service\BadoControleprotocolCalculator;
 use OCA\Shillinq\Service\BadoControleprotocolService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\IUserSession;
 use PHPUnit\Framework\TestCase;
@@ -116,14 +116,14 @@ final class BadoSisaBijlageIIATest extends TestCase {
 			appConfig: $appConfig,
 			calculator: new BadoControleprotocolCalculator(),
 			logger: new NullLogger(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->os),
 		);
 
 		$this->exporter = new AccountantsdossierExportService(
 			appConfig: $appConfig,
 			userSession: $userSession,
 			logger: new NullLogger(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->os),
 		);
 
 	}//end setUp()

--- a/tests/Unit/Service/BcfClaimServiceTest.php
+++ b/tests/Unit/Service/BcfClaimServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\BcfClaimService;
 use OCA\Shillinq\Service\BcfCompensationCalculator;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -55,13 +55,6 @@ final class BcfClaimServiceTest extends TestCase {
 	private IAppConfig&MockObject $appConfig;
 
 	/**
-	 * The service under test.
-	 *
-	 * @var BcfClaimService
-	 */
-	private BcfClaimService $service;
-
-	/**
 	 * Set up test fixtures.
 	 *
 	 * @return void
@@ -73,13 +66,27 @@ final class BcfClaimServiceTest extends TestCase {
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
 
-		$this->service = new BcfClaimService(
+	}//end setUp()
+
+	/**
+	 * Build the service over a seeded ObjectService double.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so the
+	 * subject has to be built AFTER the per-test store exists — it can no
+	 * longer be assembled once in setUp() and re-pointed through a container.
+	 *
+	 * @param object $stub The seeded in-memory double.
+	 *
+	 * @return BcfClaimService
+	 */
+	private function serviceWith(object $stub): BcfClaimService {
+		return new BcfClaimService(
 			appConfig: $this->appConfig,
 			calculator: new BcfCompensationCalculator(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
-	}//end setUp()
+	}//end serviceWith()
 
 	/**
 	 * The service joins GLLines to mappings, filters and weights to the quarter total (REQ-BCF-002).
@@ -117,7 +124,7 @@ final class BcfClaimServiceTest extends TestCase {
 			['administrationId' => 'adm-1', 'accountNumber' => '3650', 'bcfCompensable' => false, 'compensablePercentage' => 0],
 		];
 
-		$this->container->method('get')->willReturn(
+		$service = $this->serviceWith(
 			$this->buildObjectServiceStub(
 				[
 					'GLTransaction' => $transactions,
@@ -127,7 +134,7 @@ final class BcfClaimServiceTest extends TestCase {
 			)
 		);
 
-		$result = $this->service->computeClaim(administrationId: 'adm-1', claimQuarter: '2026-Q1');
+		$result = $service->computeClaim(administrationId: 'adm-1', claimQuarter: '2026-Q1');
 
 		self::assertSame('adm-1', $result['administrationId']);
 		self::assertSame('2026-Q1', $result['claimQuarter']);
@@ -146,7 +153,7 @@ final class BcfClaimServiceTest extends TestCase {
 	 * @return void
 	 */
 	public function testComputeClaimZeroWhenNoCompensablePostings(): void {
-		$this->container->method('get')->willReturn(
+		$service = $this->serviceWith(
 			$this->buildObjectServiceStub(
 				[
 					'GLTransaction' => [['id' => 'tx-1', 'administrationId' => 'adm-1', 'periodId' => '2026-Q2']],
@@ -160,7 +167,7 @@ final class BcfClaimServiceTest extends TestCase {
 			)
 		);
 
-		$result = $this->service->computeClaim(administrationId: 'adm-1', claimQuarter: '2026-Q2');
+		$result = $service->computeClaim(administrationId: 'adm-1', claimQuarter: '2026-Q2');
 
 		self::assertSame(0.0, $result['totalCompensableAmount']);
 		self::assertSame([], $result['breakdown']);

--- a/tests/Unit/Service/BookingNotificationServiceTest.php
+++ b/tests/Unit/Service/BookingNotificationServiceTest.php
@@ -21,6 +21,7 @@ namespace OCA\Shillinq\Tests\Unit\Service;
 
 use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\BookingNotificationService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -85,6 +86,47 @@ class BookingNotificationServiceTest extends TestCase {
 			objectService: $this->createMock(ObjectServiceInterface::class),
 		);
 	}//end setUp()
+
+	/**
+	 * Rebuild the service over a given ObjectService.
+	 *
+	 * ADR-084 injects the ObjectService through the constructor, so a test
+	 * that needs a seeded — or a refusing — store has to rebuild the subject
+	 * rather than re-point the container. The container stays: it still
+	 * resolves `IClientService` for the Openconnector send path.
+	 *
+	 * @param ObjectServiceInterface $objectService The object service to inject.
+	 *
+	 * @return void
+	 */
+	private function rebuildServiceWith(ObjectServiceInterface $objectService): void {
+		$this->service = new BookingNotificationService(
+			container: $this->container,
+			appConfig: $this->appConfig,
+			logger: $this->logger,
+			objectService: $objectService,
+		);
+	}//end rebuildServiceWith()
+
+	/**
+	 * An ObjectService that refuses every call the app makes on it.
+	 *
+	 * Models "OpenRegister is unavailable" — the condition the fail-open
+	 * paths are asserted against, which used to be injected by making the
+	 * container throw on get().
+	 *
+	 * @param string $message The refusal message.
+	 *
+	 * @return ObjectServiceInterface
+	 */
+	private function refusingObjectService(string $message): ObjectServiceInterface {
+		$objectService = $this->createMock(ObjectServiceInterface::class);
+		foreach (['setRegister', 'setSchema', 'findAll', 'find', 'saveObject'] as $method) {
+			$objectService->method($method)->willThrowException(new \RuntimeException($message));
+		}
+
+		return $objectService;
+	}//end refusingObjectService()
 
 	/**
 	 * Template renders booking variables correctly.
@@ -303,9 +345,7 @@ class BookingNotificationServiceTest extends TestCase {
 	 * @spec openspec/changes/bookings-notification-triggers/tasks.md#task-9
 	 */
 	public function testIsRateLimitedReturnsFalseOnServiceError(): void {
-		$this->container
-			->method('get')
-			->willThrowException(new \RuntimeException('Service unavailable'));
+		$this->rebuildServiceWith($this->refusingObjectService('Service unavailable'));
 
 		$this->logger
 			->expects(static::once())
@@ -339,9 +379,7 @@ class BookingNotificationServiceTest extends TestCase {
 	 * @spec openspec/changes/bookings-notification-triggers/tasks.md#task-9
 	 */
 	public function testIsDuplicateReturnsFalseOnServiceError(): void {
-		$this->container
-			->method('get')
-			->willThrowException(new \RuntimeException('Service unavailable'));
+		$this->rebuildServiceWith($this->refusingObjectService('Service unavailable'));
 
 		$this->logger
 			->expects(static::once())
@@ -364,9 +402,7 @@ class BookingNotificationServiceTest extends TestCase {
 	 * @spec openspec/changes/bookings-notification-triggers/tasks.md#task-13
 	 */
 	public function testIsOptedOutReturnsFalseOnServiceError(): void {
-		$this->container
-			->method('get')
-			->willThrowException(new \RuntimeException('Service unavailable'));
+		$this->rebuildServiceWith($this->refusingObjectService('Service unavailable'));
 
 		$this->logger
 			->expects(static::once())
@@ -401,9 +437,7 @@ class BookingNotificationServiceTest extends TestCase {
 			}
 		};
 		// phpcs:enable
-		// phpcs:disable CustomSn.Functions.NamedParameters
-		$this->container->method('get')->willReturn($objectService);
-		// phpcs:enable CustomSn.Functions.NamedParameters
+		$this->rebuildServiceWith(new DuckObjectServiceAdapter($objectService));
 
 		$result = $this->service->isOptedOut(
 			recipient: 'alice@example.com',
@@ -448,9 +482,7 @@ class BookingNotificationServiceTest extends TestCase {
 	 * @spec openspec/changes/bookings-notification-triggers/tasks.md#task-8
 	 */
 	public function testRecordAuditTrailLogsErrorOnServiceThrow(): void {
-		$this->container
-			->method('get')
-			->willThrowException(new \RuntimeException('DB unavailable'));
+		$this->rebuildServiceWith($this->refusingObjectService('DB unavailable'));
 
 		$this->logger
 			->expects(static::once())

--- a/tests/Unit/Service/CogsPosterServiceTest.php
+++ b/tests/Unit/Service/CogsPosterServiceTest.php
@@ -26,8 +26,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\CogsPosterService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -71,7 +71,7 @@ final class CogsPosterServiceTest extends TestCase {
 		return new CogsPosterService(
 			appConfig: $appConfig,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 	}//end makeService()

--- a/tests/Unit/Service/Commitment/CommitmentMaterialisationServiceTest.php
+++ b/tests/Unit/Service/Commitment/CommitmentMaterialisationServiceTest.php
@@ -22,11 +22,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service\Commitment;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\BudgetBlocker;
 use OCA\Shillinq\Lifecycle\MandaatEnforcer;
 use OCA\Shillinq\Service\Commitment\CommitmentMaterialisationService;
 use OCA\Shillinq\Service\Commitment\InsufficientCommitmentBudgetException;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -114,7 +114,7 @@ class CommitmentMaterialisationServiceTest extends TestCase {
 			budget: $budget,
 			dispatcher: $this->dispatcher,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objectServiceStub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/ComplianceDeadlineCalendarServiceTest.php
+++ b/tests/Unit/Service/ComplianceDeadlineCalendarServiceTest.php
@@ -31,10 +31,10 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Tests\Unit\Service;
 
 use DateTimeImmutable;
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\Shillinq\Service\ComplianceDeadlineCalendarService;
 use OCA\Shillinq\Service\ObligationTaskBridge;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IUser;
@@ -273,7 +273,7 @@ class ComplianceDeadlineCalendarServiceTest extends TestCase {
 			notificationMgr: $this->notificationMgr,
 			obligationTaskBridge: $this->bridge,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objectServiceStub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/CycleCountServiceTest.php
+++ b/tests/Unit/Service/CycleCountServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\VarianceGate;
 use OCA\Shillinq\Service\CycleCountService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -184,7 +184,7 @@ class CycleCountServiceTest extends TestCase {
 			appConfig: $this->appConfig,
 			logger: $this->logger,
 			varianceGate: $this->varianceGate,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objectService),
 		);
 
 	}//end setUp()

--- a/tests/Unit/Service/DepositReconciliationServiceTest.php
+++ b/tests/Unit/Service/DepositReconciliationServiceTest.php
@@ -19,10 +19,10 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\DepositReconciliationService;
 use OCA\Shillinq\Service\External\DepositPayment\DepositPaymentAdapterInterface;
 use OCA\Shillinq\Service\External\DepositPayment\DepositPaymentResult;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -106,7 +106,7 @@ final class DepositReconciliationServiceTest extends TestCase {
 		return new DepositReconciliationService(
 			appConfig: $appConfig,
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($objectService),
 		);
 	}//end makeService()
 
@@ -131,7 +131,7 @@ final class DepositReconciliationServiceTest extends TestCase {
 			appConfig: $appConfig,
 			logger: $this->createMock(LoggerInterface::class),
 			adapter: $adapter,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($objectService),
 		);
 	}//end makeServiceWithAdapter()
 

--- a/tests/Unit/Service/DunningRunServiceTest.php
+++ b/tests/Unit/Service/DunningRunServiceTest.php
@@ -32,11 +32,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\Dunning\DunningChannelSendResult;
 use OCA\Shillinq\Service\Dunning\IncassoBureauAdapterInterface;
 use OCA\Shillinq\Service\Dunning\PostNLAdapterInterface;
 use OCA\Shillinq\Service\DunningRunService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -106,7 +106,7 @@ final class DunningRunServiceTest extends TestCase {
 			container: $container,
 			appConfig: $appConfig,
 			logger: new NullLogger(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 	}//end makeService()

--- a/tests/Unit/Service/EInvoice/EInvoiceServiceTest.php
+++ b/tests/Unit/Service/EInvoice/EInvoiceServiceTest.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service\EInvoice;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\EInvoice\ArInvoiceUblMapper;
 use OCA\Shillinq\Service\EInvoice\EInvoiceService;
@@ -31,6 +30,7 @@ use OCA\Shillinq\Service\EInvoice\EInvoiceValidationService;
 use OCA\Shillinq\Service\InvoicePdfGenerator;
 use OCA\Shillinq\Service\Peppol\PeppolTransmissionPortInterface;
 use OCA\Shillinq\Service\ViesService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
@@ -207,7 +207,7 @@ final class EInvoiceServiceTest extends TestCase {
 			pdfGenerator: new InvoicePdfGenerator(),
 			validationService: $validationService,
 			peppolPort: $port,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/ExceptionResolutionServiceTest.php
+++ b/tests/Unit/Service/ExceptionResolutionServiceTest.php
@@ -48,10 +48,10 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\ExceptionResolutionService;
 use OCA\Shillinq\Service\PurchaseOrder\CreditNoteRequestAdapterInterface;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -227,7 +227,7 @@ final class ExceptionResolutionServiceTest extends TestCase {
 			notificationManager: $notificationManager,
 			logger: $logger,
 			creditNoteAdapter: $adapter,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/FifoValuationServiceTest.php
+++ b/tests/Unit/Service/FifoValuationServiceTest.php
@@ -25,8 +25,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\FifoValuationService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -60,7 +60,7 @@ final class FifoValuationServiceTest extends TestCase {
 		return new FifoValuationService(
 			appConfig: $appConfig,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 	}//end makeService()

--- a/tests/Unit/Service/GRIRClearingIntegrationTest.php
+++ b/tests/Unit/Service/GRIRClearingIntegrationTest.php
@@ -37,9 +37,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\GRIRClearingService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -399,7 +399,7 @@ final class GRIRClearingIntegrationTest extends TestCase {
 			appConfig: $appConfig,
 			administrationContext: $administrationContext,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 	}//end makeService()

--- a/tests/Unit/Service/GRIRClearingServiceTest.php
+++ b/tests/Unit/Service/GRIRClearingServiceTest.php
@@ -33,9 +33,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\GRIRClearingService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -97,7 +97,7 @@ final class GRIRClearingServiceTest extends TestCase {
 			appConfig: $appConfig,
 			administrationContext: $administrationContext,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 	}//end makeService()

--- a/tests/Unit/Service/GoodsReceiptNoteIntegrationTest.php
+++ b/tests/Unit/Service/GoodsReceiptNoteIntegrationTest.php
@@ -34,9 +34,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\GoodsReceiptNoteService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -366,7 +366,7 @@ final class GoodsReceiptNoteIntegrationTest extends TestCase {
 			appConfig: $appConfig,
 			administrationContext: $administrationContext,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/GoodsReceiptNoteServiceTest.php
+++ b/tests/Unit/Service/GoodsReceiptNoteServiceTest.php
@@ -32,9 +32,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\GoodsReceiptNoteService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -85,7 +85,7 @@ final class GoodsReceiptNoteServiceTest extends TestCase {
 			appConfig: $appConfig,
 			administrationContext: $administrationContext,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/IcpFilingServiceTest.php
+++ b/tests/Unit/Service/IcpFilingServiceTest.php
@@ -22,11 +22,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\IcpCalculator;
 use OCA\Shillinq\Service\IcpFilingService;
 use OCA\Shillinq\Service\IcpService;
 use OCA\Shillinq\Service\ViesService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\Http\Client\IClientService;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -179,7 +179,12 @@ final class IcpFilingServiceTest extends TestCase {
 			}//end findAll()
 
 			/**
-			 * Capture a saved object.
+			 * Capture a saved object, keyed by the schema it was written to.
+			 *
+			 * The schema may arrive either as an explicit argument or through a
+			 * preceding setSchema() call — the real ObjectService honours both,
+			 * so the capture falls back to the active schema rather than filing
+			 * the row under an empty key.
 			 *
 			 * @param array<string,mixed> $object The object.
 			 * @param string $register Register slug.
@@ -188,7 +193,8 @@ final class IcpFilingServiceTest extends TestCase {
 			 * @return array<string,mixed>
 			 */
 			public function saveObject(array $object, string $register = '', string $schema = ''): array {
-				$this->saved[$schema][] = $object;
+				$target = ($schema !== '') ? $schema : $this->schema;
+				$this->saved[$target][] = $object;
 				return $object;
 			}//end saveObject()
 		};
@@ -201,12 +207,12 @@ final class IcpFilingServiceTest extends TestCase {
 			appConfig: $this->appConfig,
 			clientService: $this->createMock(IClientService::class),
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 		$icp = new IcpService(
 			appConfig: $this->appConfig,
 			calculator: $calculator,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 		return new IcpFilingService(
@@ -214,7 +220,7 @@ final class IcpFilingServiceTest extends TestCase {
 			calculator: $calculator,
 			icp: $icp,
 			vies: $vies,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/IcpServiceTest.php
+++ b/tests/Unit/Service/IcpServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\IcpCalculator;
 use OCA\Shillinq\Service\IcpService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -192,7 +192,7 @@ final class IcpServiceTest extends TestCase {
 		return new IcpService(
 			appConfig: $this->appConfig,
 			calculator: new IcpCalculator(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/IntercompanyMatchingPerformanceTest.php
+++ b/tests/Unit/Service/IntercompanyMatchingPerformanceTest.php
@@ -36,9 +36,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\IntercompanyMatchingCalculator;
 use OCA\Shillinq\Service\IntercompanyMatchingService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -161,11 +161,10 @@ final class IntercompanyMatchingPerformanceTest extends TestCase {
 		$container->method('get')->willReturn($stub);
 
 		return new IntercompanyMatchingService(
-			$container,
 			$appConfig,
 			new IntercompanyMatchingCalculator(),
 			$logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/IntercompanyMatchingServiceTest.php
+++ b/tests/Unit/Service/IntercompanyMatchingServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\IntercompanyMatchingCalculator;
 use OCA\Shillinq\Service\IntercompanyMatchingService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -88,11 +88,10 @@ final class IntercompanyMatchingServiceTest extends TestCase {
 	private function service(object $objectService): IntercompanyMatchingService {
 		$this->container->method('get')->willReturn($objectService);
 		return new IntercompanyMatchingService(
-			$this->container,
 			$this->appConfig,
 			new IntercompanyMatchingCalculator(),
 			$this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($objectService),
 		);
 
 	}//end service()

--- a/tests/Unit/Service/InventoryGlAdjustmentPosterTest.php
+++ b/tests/Unit/Service/InventoryGlAdjustmentPosterTest.php
@@ -25,8 +25,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\InventoryGlAdjustmentPoster;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -59,7 +59,7 @@ final class InventoryGlAdjustmentPosterTest extends TestCase {
 		return new InventoryGlAdjustmentPoster(
 			appConfig: $appConfig,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 	}//end makePoster()

--- a/tests/Unit/Service/InventoryScanServiceTest.php
+++ b/tests/Unit/Service/InventoryScanServiceTest.php
@@ -19,8 +19,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\InventoryScanService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -98,7 +98,7 @@ class InventoryScanServiceTest extends TestCase {
 		$this->service = new InventoryScanService(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->store),
 		);
 
 	}//end setUp()

--- a/tests/Unit/Service/InventoryValuationReportServiceTest.php
+++ b/tests/Unit/Service/InventoryValuationReportServiceTest.php
@@ -26,8 +26,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\InventoryValuationReportService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -60,7 +60,7 @@ final class InventoryValuationReportServiceTest extends TestCase {
 		return new InventoryValuationReportService(
 			appConfig: $appConfig,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 	}//end makeService()

--- a/tests/Unit/Service/KorMonitorServiceTest.php
+++ b/tests/Unit/Service/KorMonitorServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\KorMonitorService;
 use OCA\Shillinq\Service\KorThresholdCalculator;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -164,7 +164,7 @@ final class KorMonitorServiceTest extends TestCase {
 		return new KorMonitorService(
 			appConfig: $this->appConfig,
 			calculator: new KorThresholdCalculator(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/LandedCostAllocationServiceTest.php
+++ b/tests/Unit/Service/LandedCostAllocationServiceTest.php
@@ -26,9 +26,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\InventoryGlAdjustmentPoster;
 use OCA\Shillinq\Service\LandedCostAllocationService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -69,14 +69,14 @@ final class LandedCostAllocationServiceTest extends TestCase {
 		$poster = new InventoryGlAdjustmentPoster(
 			appConfig: $appConfig,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 		return new LandedCostAllocationService(
 			appConfig: $appConfig,
 			poster: $poster,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 	}//end makeService()

--- a/tests/Unit/Service/LeaseAuditPackGeneratorTest.php
+++ b/tests/Unit/Service/LeaseAuditPackGeneratorTest.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\LeaseAmortizationCalculator;
 use OCA\Shillinq\Service\LeaseAuditPackGenerator;
 use OCA\Shillinq\Service\LeasePaymentScheduleService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -175,7 +175,7 @@ final class LeaseAuditPackGeneratorTest extends TestCase {
 			 *
 			 * @return array<string,mixed>
 			 */
-			public function saveObject(array $object, string $register, string $schema): array {
+			public function saveObject(array $object, string $register = '', string $schema = ''): array {
 				return $object;
 			}//end saveObject()
 		};
@@ -191,9 +191,10 @@ final class LeaseAuditPackGeneratorTest extends TestCase {
 				appConfig: $this->appConfig,
 				calculator: $calculator,
 				logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
-		),
+				objectService: new DuckObjectServiceAdapter($stub),
+			),
 			logger: $logger,
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/LeaseDisclosureServiceTest.php
+++ b/tests/Unit/Service/LeaseDisclosureServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\LeaseAmortizationCalculator;
 use OCA\Shillinq\Service\LeaseDisclosureService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -143,7 +143,7 @@ final class LeaseDisclosureServiceTest extends TestCase {
 			appConfig: $this->appConfig,
 			calculator: new LeaseAmortizationCalculator(),
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/LeasePaymentScheduleServiceTest.php
+++ b/tests/Unit/Service/LeasePaymentScheduleServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\LeaseAmortizationCalculator;
 use OCA\Shillinq\Service\LeasePaymentScheduleService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -123,6 +123,13 @@ final class LeasePaymentScheduleServiceTest extends TestCase {
 			}//end setRegister()
 
 			/**
+			 * Active schema, remembered so a later saveObject() can report it.
+			 *
+			 * @var string
+			 */
+			private string $schema = '';
+
+			/**
 			 * Fluent schema setter.
 			 *
 			 * @param string $schema Schema slug.
@@ -130,6 +137,7 @@ final class LeasePaymentScheduleServiceTest extends TestCase {
 			 * @return static
 			 */
 			public function setSchema(string $schema): static {
+				$this->schema = $schema;
 				return $this;
 			}//end setSchema()
 
@@ -155,7 +163,11 @@ final class LeasePaymentScheduleServiceTest extends TestCase {
 			}//end findAll()
 
 			/**
-			 * Capture a saved object.
+			 * Capture a saved object together with the schema it went to.
+			 *
+			 * The schema may arrive as an explicit argument or through a
+			 * preceding setSchema() call — the real ObjectService honours both,
+			 * so the capture falls back to the active schema.
 			 *
 			 * @param array<string,mixed> $object The object payload.
 			 * @param string $register Register slug.
@@ -163,8 +175,11 @@ final class LeasePaymentScheduleServiceTest extends TestCase {
 			 *
 			 * @return array<string,mixed>
 			 */
-			public function saveObject(array $object, string $register, string $schema): array {
-				$this->saved[] = ['object' => $object, 'schema' => $schema];
+			public function saveObject(array $object, string $register = '', string $schema = ''): array {
+				$this->saved[] = [
+					'object' => $object,
+					'schema' => ($schema !== '') ? $schema : $this->schema,
+				];
 				return $object;
 			}//end saveObject()
 		};
@@ -175,7 +190,7 @@ final class LeasePaymentScheduleServiceTest extends TestCase {
 			appConfig: $this->appConfig,
 			calculator: new LeaseAmortizationCalculator(),
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/LeaseReassessmentServiceTest.php
+++ b/tests/Unit/Service/LeaseReassessmentServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\LeaseAmortizationCalculator;
 use OCA\Shillinq\Service\LeaseReassessmentService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -161,15 +161,21 @@ final class LeaseReassessmentServiceTest extends TestCase {
 			/**
 			 * Capture saveObject calls; echo the row back.
 			 *
+			 * The schema may arrive as an explicit argument or through a
+			 * preceding setSchema() call — the real ObjectService honours both,
+			 * so the capture falls back to the last schema that was set rather
+			 * than filing the row under an empty key.
+			 *
 			 * @param array<string,mixed> $object The row.
 			 * @param string $register Register slug.
 			 * @param string $schema Schema slug.
 			 *
 			 * @return array<string,mixed>
 			 */
-			public function saveObject(array $object, string $register, string $schema): array {
-				$this->saved[$schema] = ($this->saved[$schema] ?? []);
-				$this->saved[$schema][] = $object;
+			public function saveObject(array $object, string $register = '', string $schema = ''): array {
+				$target = ($schema !== '') ? $schema : $this->lastSchema;
+				$this->saved[$target] = ($this->saved[$target] ?? []);
+				$this->saved[$target][] = $object;
 				return $object;
 			}//end saveObject()
 		};
@@ -180,7 +186,7 @@ final class LeaseReassessmentServiceTest extends TestCase {
 			appConfig: $this->appConfig,
 			calculator: new LeaseAmortizationCalculator(),
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 		return [$service, $stub];

--- a/tests/Unit/Service/MeteredInvoiceGenerationTest.php
+++ b/tests/Unit/Service/MeteredInvoiceGenerationTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Request\InvoiceGenerationRequest;
 use OCA\Shillinq\Service\BillingModelEngine;
 use OCA\Shillinq\Service\InvoiceDeduplicationService;
@@ -33,6 +32,7 @@ use OCA\Shillinq\Service\RateCardResolver;
 use OCA\Shillinq\Service\RetainerResolver;
 use OCA\Shillinq\Service\UsageRatingCalculator;
 use OCA\Shillinq\Service\VATCalculationService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -239,7 +239,7 @@ final class MeteredInvoiceGenerationTest extends TestCase {
 			new InvoiceDeduplicationService($container, $appConfig, $logger),
 			new VATCalculationService(),
 			new UsageRatingCalculator(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objectService),
 		);
 	}//end setUp()
 

--- a/tests/Unit/Service/MovingAverageValuationServiceTest.php
+++ b/tests/Unit/Service/MovingAverageValuationServiceTest.php
@@ -25,8 +25,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\MovingAverageValuationService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -60,7 +60,7 @@ final class MovingAverageValuationServiceTest extends TestCase {
 		return new MovingAverageValuationService(
 			appConfig: $appConfig,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 	}//end makeService()

--- a/tests/Unit/Service/MultiPoConsolidationServiceTest.php
+++ b/tests/Unit/Service/MultiPoConsolidationServiceTest.php
@@ -38,10 +38,10 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\MultiPoConsolidationService;
 use OCA\Shillinq\Service\SupplierInvoiceService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -264,7 +264,7 @@ final class MultiPoConsolidationServiceTest extends TestCase {
 			appConfig: $this->appConfig,
 			administrationContext: $administrationContext,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 		return new MultiPoConsolidationService(
@@ -273,7 +273,7 @@ final class MultiPoConsolidationServiceTest extends TestCase {
 			userSession: $this->userSession,
 			supplierInvoiceService: $supplierInvoiceService,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/NrvWriteDownServiceTest.php
+++ b/tests/Unit/Service/NrvWriteDownServiceTest.php
@@ -26,9 +26,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\InventoryGlAdjustmentPoster;
 use OCA\Shillinq\Service\NrvWriteDownService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -69,14 +69,14 @@ final class NrvWriteDownServiceTest extends TestCase {
 		$poster = new InventoryGlAdjustmentPoster(
 			appConfig: $appConfig,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 		return new NrvWriteDownService(
 			appConfig: $appConfig,
 			poster: $poster,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 	}//end makeService()

--- a/tests/Unit/Service/ObligationTaskBridgeTest.php
+++ b/tests/Unit/Service/ObligationTaskBridgeTest.php
@@ -24,6 +24,7 @@ namespace OCA\Shillinq\Tests\Unit\Service;
 
 use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\ObligationTaskBridge;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -337,6 +338,16 @@ class ObligationTaskBridgeTest extends TestCase {
 
 				throw new \RuntimeException('not available: ' . $id);
 			}
+		);
+
+		// Since ADR-084 the bridge reads OpenRegister through the injected
+		// ObjectServiceInterface rather than through the container, so the
+		// seeded store above has to be handed to the constructor. Rebuild the
+		// bridge with it; the container mock stays for the register lookup.
+		$this->bridge = new ObligationTaskBridge(
+			container: $this->container,
+			logger: $this->logger,
+			objectService: new DuckObjectServiceAdapter(inner: $objectService),
 		);
 
 		$deadlines = $this->bridge->listOpenObligationDeadlines();

--- a/tests/Unit/Service/PaymentReconciliationServiceTest.php
+++ b/tests/Unit/Service/PaymentReconciliationServiceTest.php
@@ -19,8 +19,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\PaymentReconciliationService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -93,6 +93,15 @@ final class PaymentReconciliationServiceTest extends TestCase {
 			 * @return array<string, mixed>
 			 */
 			public function saveObject(array $object, string $register = '', string $schema = ''): array {
+				// The subject reaches this double through the ADR-084 contract,
+				// which carries the target schema as a named argument and applies
+				// it via setSchema() rather than passing it on positionally here.
+				// Fall back to the schema the fluent chain selected so the sink
+				// still records where the write landed.
+				if ($schema === '') {
+					$schema = $this->schema;
+				}
+
 				$this->saved[] = ['schema' => $schema, 'object' => $object];
 				return $object;
 			}
@@ -117,7 +126,7 @@ final class PaymentReconciliationServiceTest extends TestCase {
 			container: $container,
 			appConfig: $appConfig,
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter(inner: $objectService),
 		);
 	}//end makeService()
 

--- a/tests/Unit/Service/PayrollJaaropgaveServiceTest.php
+++ b/tests/Unit/Service/PayrollJaaropgaveServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\PayrollCalculator;
 use OCA\Shillinq\Service\PayrollJaaropgaveService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -195,7 +195,7 @@ final class PayrollJaaropgaveServiceTest extends TestCase {
 			appConfig: $this->appConfig,
 			calculator: new PayrollCalculator(),
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/PayrollLivLkvHandoffServiceTest.php
+++ b/tests/Unit/Service/PayrollLivLkvHandoffServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\PayrollCalculator;
 use OCA\Shillinq\Service\PayrollLivLkvHandoffService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -156,7 +156,7 @@ final class PayrollLivLkvHandoffServiceTest extends TestCase {
 		return new PayrollLivLkvHandoffService(
 			appConfig: $this->appConfig,
 			calculator: new PayrollCalculator(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/PayrollServiceTest.php
+++ b/tests/Unit/Service/PayrollServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\PayrollCalculator;
 use OCA\Shillinq\Service\PayrollService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -198,7 +198,7 @@ final class PayrollServiceTest extends TestCase {
 			appConfig: $this->appConfig,
 			calculator: new PayrollCalculator(),
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/PayrollUpaHandoffServiceTest.php
+++ b/tests/Unit/Service/PayrollUpaHandoffServiceTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\PayrollUpaHandoffService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -169,7 +169,7 @@ final class PayrollUpaHandoffServiceTest extends TestCase {
 		return new PayrollUpaHandoffService(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/PayrollWkrHandoffServiceTest.php
+++ b/tests/Unit/Service/PayrollWkrHandoffServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\PayrollCalculator;
 use OCA\Shillinq\Service\PayrollWkrHandoffService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -156,7 +156,7 @@ final class PayrollWkrHandoffServiceTest extends TestCase {
 		return new PayrollWkrHandoffService(
 			appConfig: $this->appConfig,
 			calculator: new PayrollCalculator(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/PeriodCloseAssistantServiceTest.php
+++ b/tests/Unit/Service/PeriodCloseAssistantServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\PeriodCloseAssistantService;
 use OCA\Shillinq\Service\SuspenseAgeingService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -141,7 +141,7 @@ final class PeriodCloseAssistantServiceTest extends TestCase {
 		return new PeriodCloseAssistantService(
 			appConfig: $appConfig,
 			suspenseAgeing: $suspenseAgeing,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/PeriodCloseServiceEntityRowTest.php
+++ b/tests/Unit/Service/PeriodCloseServiceEntityRowTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\PeriodCloseService;
 use OCA\Shillinq\Service\SuspenseAgeingService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\IGroupManager;
 use PHPUnit\Framework\TestCase;
@@ -279,7 +279,7 @@ final class PeriodCloseServiceEntityRowTest extends TestCase {
 			groupManager: $groupManager,
 			suspenseAgeing: $ageing,
 			logger: new NullLogger(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter(inner: $objectService),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/PeriodCloseServiceTest.php
+++ b/tests/Unit/Service/PeriodCloseServiceTest.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\PeriodCloseException;
 use OCA\Shillinq\Service\PeriodCloseService;
 use OCA\Shillinq\Service\SuspenseAgeingService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\IGroupManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -207,7 +207,7 @@ final class PeriodCloseServiceTest extends TestCase {
 			groupManager: $this->groupManager,
 			suspenseAgeing: ($suspenseAgeing ?? $this->ageingReturning(0)),
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objectService),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/PurchaseOrderApprovalServiceTest.php
+++ b/tests/Unit/Service/PurchaseOrderApprovalServiceTest.php
@@ -36,9 +36,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\PurchaseOrderApprovalService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -411,7 +411,7 @@ final class PurchaseOrderApprovalServiceTest extends TestCase {
 			administrationContext: $administrationContext,
 			userSession: $userSession,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/PurchaseOrderIntegrationTest.php
+++ b/tests/Unit/Service/PurchaseOrderIntegrationTest.php
@@ -31,9 +31,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\PurchaseOrderService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
@@ -420,7 +420,7 @@ final class PurchaseOrderIntegrationTest extends TestCase {
 			administrationContext: $administrationContext,
 			notificationManager: $manager,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/PurchaseOrderPeppolTransmissionTest.php
+++ b/tests/Unit/Service/PurchaseOrderPeppolTransmissionTest.php
@@ -29,12 +29,12 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\PurchaseOrder\PeppolBisOrderMapper;
 use OCA\Shillinq\Service\PurchaseOrder\PeppolTransmissionAdapterInterface;
 use OCA\Shillinq\Service\PurchaseOrder\PurchaseOrderMailerInterface;
 use OCA\Shillinq\Service\PurchaseOrderService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\Notification\IManager as INotificationManager;
 use PHPUnit\Framework\TestCase;
@@ -592,7 +592,7 @@ final class PurchaseOrderPeppolTransmissionTest extends TestCase {
 			peppolAdapter: $adapter,
 			purchaseOrderMailer: $mailer,
 			peppolMapper: new PeppolBisOrderMapper(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/PurchaseOrderServiceTest.php
+++ b/tests/Unit/Service/PurchaseOrderServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\PurchaseOrderService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
@@ -306,7 +306,7 @@ final class PurchaseOrderServiceTest extends TestCase {
 			administrationContext: $administrationContext,
 			notificationManager: $notificationManager,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/RequisitionConversionServiceTest.php
+++ b/tests/Unit/Service/RequisitionConversionServiceTest.php
@@ -22,11 +22,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\RequisitionConversionGuard;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\PurchaseOrderService;
 use OCA\Shillinq\Service\RequisitionConversionService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
@@ -282,7 +282,7 @@ final class RequisitionConversionServiceTest extends TestCase {
 			administrationContext: $administrationContext,
 			notificationManager: $this->lenientNotificationManager(),
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 		return new RequisitionConversionService(
@@ -291,7 +291,7 @@ final class RequisitionConversionServiceTest extends TestCase {
 			guard: $guard,
 			purchaseOrderService: $purchaseOrderService,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/RequisitionServiceTest.php
+++ b/tests/Unit/Service/RequisitionServiceTest.php
@@ -22,11 +22,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\BudgetBlocker;
 use OCA\Shillinq\Lifecycle\MandaatEnforcer;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\RequisitionService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -238,7 +238,7 @@ final class RequisitionServiceTest extends TestCase {
 			administrationContext: $administrationContext,
 			budgetBlocker: $budget,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/RevenueCutoffServiceTest.php
+++ b/tests/Unit/Service/RevenueCutoffServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\RevenueCutoffService;
 use OCA\Shillinq\Service\RevenueRecognitionCalculator;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -168,7 +168,7 @@ final class RevenueCutoffServiceTest extends TestCase {
 		return new RevenueCutoffService(
 			appConfig: $this->appConfig,
 			calculator: new RevenueRecognitionCalculator(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/SalesDispatchStockIssueServiceTest.php
+++ b/tests/Unit/Service/SalesDispatchStockIssueServiceTest.php
@@ -29,10 +29,10 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Lifecycle\LotSellabilityGuard;
 use OCA\Shillinq\Service\SalesDispatchStockIssueService;
 use OCA\Shillinq\Sort\FefoSort;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -311,7 +311,7 @@ class SalesDispatchStockIssueServiceTest extends TestCase {
 			appConfig: $this->appConfig,
 			logger: $this->logger,
 			lotGuard: new LotSellabilityGuard(fefoSort: new FefoSort()),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->fakeObjectService),
 		);
 
 	}//end setUpService()

--- a/tests/Unit/Service/SepaAuditServiceTest.php
+++ b/tests/Unit/Service/SepaAuditServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\SepaAuditService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -153,7 +153,7 @@ final class SepaAuditServiceTest extends TestCase {
 		$this->container->method('get')->willReturn($fake);
 
 		return new SepaAuditService( $this->appConfig, $context, $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($fake),
 		);
 	}//end svc()
 
@@ -170,7 +170,7 @@ final class SepaAuditServiceTest extends TestCase {
 			$this->appConfig,
 			$this->createMock(AdministrationContextService::class),
 			$this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter(new FakeSepaObjectService([])),
 		);
 
 		self::assertNull($svc->buildMandateDossier(''));

--- a/tests/Unit/Service/ServiceReceiptServiceTest.php
+++ b/tests/Unit/Service/ServiceReceiptServiceTest.php
@@ -36,9 +36,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\ServiceReceiptService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -88,7 +88,7 @@ final class ServiceReceiptServiceTest extends TestCase {
 			appConfig: $appConfig,
 			administrationContext: $administrationContext,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/Support/DuckObjectServiceAdapter.php
+++ b/tests/Unit/Service/Support/DuckObjectServiceAdapter.php
@@ -88,6 +88,28 @@ final class DuckObjectServiceAdapter implements ObjectServiceInterface {
 	private object $inner;
 
 	/**
+	 * Active register, as set through the fluent setter.
+	 *
+	 * Production reaches OpenRegister as
+	 * `->setRegister($r)->setSchema($s)->saveObject($data)`, so the scope
+	 * arrives through the SETTERS, not as call arguments. Doubles, however,
+	 * frequently declare `saveObject(array $o, string $register, string $schema)`
+	 * and record what they were handed. The adapter therefore has to remember
+	 * the scope and hand it on, or such a double records `''` where production
+	 * sent `'shillinq'` — the adapter lying about the thing it stands in for.
+	 *
+	 * @var string
+	 */
+	private string $register = '';
+
+	/**
+	 * Active schema, as set through the fluent setter.
+	 *
+	 * @var string
+	 */
+	private string $schema = '';
+
+	/**
 	 * Constructor.
 	 *
 	 * @param object $inner The duck-typed in-memory double to delegate to.
@@ -119,6 +141,7 @@ final class DuckObjectServiceAdapter implements ObjectServiceInterface {
 	 * @return static
 	 */
 	public function setRegister(string|int $register): static {
+		$this->register = (string) $register;
 		if (method_exists($this->inner, 'setRegister') === true) {
 			$this->inner->setRegister($register);
 		}
@@ -135,6 +158,7 @@ final class DuckObjectServiceAdapter implements ObjectServiceInterface {
 	 * @return static
 	 */
 	public function setSchema(string|int $schema): static {
+		$this->schema = (string) $schema;
 		if (method_exists($this->inner, 'setSchema') === true) {
 			$this->inner->setSchema($schema);
 		}
@@ -165,11 +189,16 @@ final class DuckObjectServiceAdapter implements ObjectServiceInterface {
 	 * @return array
 	 */
 	public function findAll(array $config = [], bool $_rbac = true, bool $_multitenancy = true): array {
-		if (method_exists($this->inner, 'findAll') === false) {
-			$this->unsupported(method: 'findAll');
-		}
-
-		return $this->inner->findAll($config);
+		return $this->invokeInner(
+			method: 'findAll',
+			primary: $config,
+			named: [
+				'register'      => $this->register,
+				'schema'        => $this->schema,
+				'_rbac'         => $_rbac,
+				'_multitenancy' => $_multitenancy,
+			]
+		);
 
 	}//end findAll()
 
@@ -202,19 +231,44 @@ final class DuckObjectServiceAdapter implements ObjectServiceInterface {
 		bool $_render = true,
 		bool $_audit = true
 	): ?ObjectEntityInterface {
+		// The scope can arrive EITHER through the fluent setters or as named
+		// arguments on the call itself -- BadoControleprotocolService does the
+		// latter, `find(id: …, register: …, schema: …)`. Honouring only one of
+		// the two routes makes the double record '' for a register production
+		// really did send.
+		if ($register !== null) {
+			$this->setRegister(register: $register);
+		}
+
 		if ($schema !== null) {
 			$this->setSchema(schema: $schema);
 		}
 
 		if (method_exists($this->inner, 'find') === true) {
-			return $this->entity(value: $this->inner->find($id));
+			return $this->entity(
+				value: $this->invokeInner(
+					method: 'find',
+					primary: $id,
+					named: [
+						'_extend'       => $_extend,
+						'extend'        => $_extend,
+						'files'         => $files,
+						'register'      => $this->register,
+						'schema'        => $this->schema,
+						'_rbac'         => $_rbac,
+						'_multitenancy' => $_multitenancy,
+						'_render'       => $_render,
+						'_audit'        => $_audit,
+					]
+				)
+			);
 		}
 
 		if (method_exists($this->inner, 'findAll') === false) {
 			$this->unsupported(method: 'find');
 		}
 
-		foreach ($this->inner->findAll([]) as $row) {
+		foreach ($this->findAll() as $row) {
 			if (is_array($row) === false) {
 				continue;
 			}
@@ -264,15 +318,32 @@ final class DuckObjectServiceAdapter implements ObjectServiceInterface {
 		?IUser $currentUser = null,
 		bool $failIfExists = false
 	): ObjectEntityInterface {
-		if (method_exists($this->inner, 'saveObject') === false) {
-			$this->unsupported(method: 'saveObject');
-		}
-
 		if ($schema !== null) {
 			$this->setSchema(schema: $schema);
 		}
 
-		$saved = $this->inner->saveObject($object);
+		if ($register !== null) {
+			$this->setRegister(register: $register);
+		}
+
+		$saved = $this->invokeInner(
+			method: 'saveObject',
+			primary: $object,
+			named: [
+				'register'       => $this->register,
+				'schema'         => $this->schema,
+				'uuid'           => $uuid,
+				'extend'         => $extend,
+				'_extend'        => $extend,
+				'_rbac'          => $_rbac,
+				'_multitenancy'  => $_multitenancy,
+				'silent'         => $silent,
+				'_validation'    => $_validation,
+				'uploadedFiles'  => $uploadedFiles,
+				'currentUser'    => $currentUser,
+				'failIfExists'   => $failIfExists,
+			]
+		);
 
 		// A double declared `: void`, or one that returns nothing on some
 		// branch, still persisted the payload — echo it back rather than
@@ -284,6 +355,94 @@ final class DuckObjectServiceAdapter implements ObjectServiceInterface {
 		return $this->entity(value: $saved) ?? new ObjectEntityStub(payload: $object);
 
 	}//end saveObject()
+
+	/**
+	 * Call a method on the wrapped double, supplying the arguments IT declares.
+	 *
+	 * The suite's doubles are not uniform. `saveObject()` alone appears as
+	 * `(array $object)`, `(array $o, string $register = '', string $schema = '')`,
+	 * `(array $o, string $register, string $schema)` — required, no defaults —
+	 * and `(array $o, string $r, string $s, bool $_rbac, bool $_multitenancy,
+	 * mixed $currentUser)`. A fixed positional call cannot serve all of those.
+	 *
+	 * So: the FIRST parameter is always the primary value (payload, id or
+	 * config) whatever it is named — doubles spell it `$object`, `$data`,
+	 * `$row`, `$id`, `$params` — and every later parameter is matched BY NAME
+	 * against what the adapter knows, falling back to the parameter's own
+	 * default.
+	 *
+	 * 🔴 Why this matters beyond tidiness: a required positional `$register`
+	 * that the adapter fails to supply raises `ArgumentCountError`, and
+	 * production listeners and repair steps `catch (\Throwable)`. The error is
+	 * swallowed and surfaces as "0 rows written" — indistinguishable from a
+	 * genuinely empty result. A defaulted `$register = ''` is worse still: no
+	 * error at all, the row is filed under the empty-string key, and later
+	 * reads of the real schema come back empty.
+	 *
+	 * @param string $method  The method to call on the double.
+	 * @param mixed  $primary The first argument, whatever the double calls it.
+	 * @param array  $named   Values the adapter can supply, keyed by parameter name.
+	 *
+	 * @return mixed Whatever the double returned.
+	 */
+	private function invokeInner(string $method, mixed $primary, array $named = []): mixed {
+		if (method_exists($this->inner, $method) === false) {
+			$this->unsupported(method: $method);
+		}
+
+		try {
+			$reflected = new \ReflectionMethod($this->inner, $method);
+		} catch (\ReflectionException) {
+			// A double reaching the method through __call cannot be reflected;
+			// fall back to the single-argument form, which is what every such
+			// double modelled before this adapter existed.
+			return $this->inner->$method($primary);
+		}
+
+		$args = [];
+		foreach ($reflected->getParameters() as $index => $parameter) {
+			if ($index === 0) {
+				$args[] = $primary;
+				continue;
+			}
+
+			if ($parameter->isVariadic() === true) {
+				break;
+			}
+
+			$name = $parameter->getName();
+			if (array_key_exists($name, $named) === true) {
+				$args[] = $named[$name];
+				continue;
+			}
+
+			if ($parameter->isDefaultValueAvailable() === true) {
+				$args[] = $parameter->getDefaultValue();
+				continue;
+			}
+
+			if ($parameter->allowsNull() === true) {
+				$args[] = null;
+				continue;
+			}
+
+			throw new LogicException(
+				sprintf(
+					'DuckObjectServiceAdapter cannot supply required parameter $%s of %s::%s(). '
+					. 'Give it a default on the double, or rename it to one the adapter knows '
+					. '(%s). Guessing a value here would file the row under the wrong key and '
+					. 'read as an empty result later.',
+					$name,
+					get_debug_type($this->inner),
+					$method,
+					implode(', ', array_keys($named))
+				)
+			);
+		}
+
+		return $reflected->invokeArgs($this->inner, $args);
+
+	}//end invokeInner()
 
 	/**
 	 * Normalise a double's return value to a contract entity.
@@ -372,6 +531,28 @@ final class DuckObjectServiceAdapter implements ObjectServiceInterface {
 		bool $_rbac = true,
 		bool $_multitenancy = true
 	): ObjectEntityInterface {
+		// Delegate to a double that models updateObject() directly, the way
+		// deleteObject()/saveObjects() already do. Without this arm the
+		// synthesised find()+saveObject() path below asks such a double for a
+		// saveObject() it never declared, and the adapter refuses -- which
+		// reads as "the update was never persisted".
+		if (method_exists($this->inner, 'updateObject') === true) {
+			return $this->entity(
+				value: $this->invokeInner(
+					method: 'updateObject',
+					primary: $objectId,
+					named: [
+						'data'          => $data,
+						'object'        => $data,
+						'register'      => $this->register,
+						'schema'        => $this->schema,
+						'_rbac'         => $_rbac,
+						'_multitenancy' => $_multitenancy,
+					]
+				)
+			) ?? new ObjectEntityStub(payload: $data);
+		}
+
 		$existing = $this->find(id: $objectId);
 		$merged   = $data;
 		if ($existing !== null) {
@@ -504,11 +685,23 @@ final class DuckObjectServiceAdapter implements ObjectServiceInterface {
 		?IUser $currentUser = null,
 		bool $permanent = false
 	): bool {
-		if (method_exists($this->inner, 'deleteObject') === false) {
-			$this->unsupported(method: 'deleteObject');
+		if ($schema !== null) {
+			$this->setSchema(schema: $schema);
 		}
 
-		return (bool) $this->inner->deleteObject($uuid);
+		return (bool) $this->invokeInner(
+			method: 'deleteObject',
+			primary: $uuid,
+			named: [
+				'register'        => $this->register,
+				'schema'          => $this->schema,
+				'_rbac'           => $_rbac,
+				'_multitenancy'   => $_multitenancy,
+				'_retentionSweep' => $_retentionSweep,
+				'currentUser'     => $currentUser,
+				'permanent'       => $permanent,
+			]
+		);
 
 	}//end deleteObject()
 

--- a/tests/Unit/Service/Support/DuckObjectServiceAdapter.php
+++ b/tests/Unit/Service/Support/DuckObjectServiceAdapter.php
@@ -1,0 +1,738 @@
+<?php
+
+/**
+ * Adapter that lets a duck-typed in-memory ObjectService double satisfy the
+ * published ADR-084 contract.
+ *
+ * ## Why this exists
+ *
+ * Before ADR-083 a service reached OpenRegister through an untyped
+ * `Psr\Container\ContainerInterface`, so a test could park any duck-typed
+ * double on `$container->method('get')->willReturn($stub)` and the subject
+ * would pick it up. ADR-083 removed the container and ADR-084 replaced it with
+ * a constructor-injected `OCA\OpenRegister\Contract\ObjectServiceInterface`.
+ *
+ * The mechanical sweep that adopted the contract kept every container mock in
+ * place and injected `$this->createMock(ObjectServiceInterface::class)` — a
+ * FRESH, UNCONFIGURED double. The seeded store is still built, still parked on
+ * the container, and never consulted again, because nothing asks the container
+ * any more. The subject then sees an empty world: `findAll()` answers `[]`,
+ * `find()` answers `null`, and `setRegister()` hands back a different mock, so
+ * a fluent chain loses the schema. Every read takes its not-found branch.
+ *
+ * That is why the failures read like product defects — "Purchase order not
+ * found", "null is identical to 675.0" — when the code under test is correct
+ * and the store simply was not plugged in.
+ *
+ * The obvious repair, deleting the `objectService:` argument, is forbidden:
+ * named parameters are gate-enforced here, and the parameter genuinely exists.
+ * The obvious alternative, rewriting each of the ~100 bespoke anonymous doubles
+ * to `implements ObjectServiceInterface`, would mean restating a 25-method
+ * contract a hundred times. This adapter keeps each store exactly as written
+ * and changes only how it is REACHED — the same move the fleet board
+ * recommends: "keep the store, change only how it is reached".
+ *
+ * ## What it does and does not model
+ *
+ * It forwards the five methods the app's services actually use — setRegister,
+ * setSchema, findAll, find, saveObject — to the wrapped double, calling each
+ * with a SINGLE positional argument so it fits every variant the suite has
+ * written (`saveObject(array $o)`, `saveObject(array $o, string $r, string $s)`
+ * and so on). Return values are normalised to the contract's types: an array
+ * coming back from a double's `saveObject()`/`find()` is wrapped in an
+ * {@see ObjectEntityStub}, an entity is passed through untouched.
+ *
+ * Anything the wrapped double does not implement, and every contract method the
+ * app does not exercise, throws {@see \LogicException} naming the method.
+ * Returning an empty value instead would be indistinguishable from a real empty
+ * result — which is the exact failure this class exists to undo.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Service\Support
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Service\Support;
+
+use LogicException;
+use OCA\OpenRegister\Contract\ObjectEntityInterface;
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
+use OCP\IUser;
+use RuntimeException;
+
+/**
+ * Contract-conformant wrapper around a duck-typed ObjectService double.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods) Mirrors the 25-method contract.
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength) Mirrors the 25-method contract.
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+final class DuckObjectServiceAdapter implements ObjectServiceInterface {
+
+	/**
+	 * The wrapped duck-typed double.
+	 *
+	 * @var object
+	 */
+	private object $inner;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param object $inner The duck-typed in-memory double to delegate to.
+	 */
+	public function __construct(object $inner) {
+		$this->inner = $inner;
+
+	}//end __construct()
+
+	/**
+	 * Return the wrapped double, so a test can still assert on its state.
+	 *
+	 * @return object The wrapped double.
+	 */
+	public function inner(): object {
+		return $this->inner;
+
+	}//end inner()
+
+	/**
+	 * Fluent register setter.
+	 *
+	 * Always returns THIS adapter rather than whatever the inner double hands
+	 * back: a double that returns `$this` would otherwise drop the caller out
+	 * of the contract-typed chain half way through.
+	 *
+	 * @param string|int $register Register slug or id.
+	 *
+	 * @return static
+	 */
+	public function setRegister(string|int $register): static {
+		if (method_exists($this->inner, 'setRegister') === true) {
+			$this->inner->setRegister($register);
+		}
+
+		return $this;
+
+	}//end setRegister()
+
+	/**
+	 * Fluent schema setter.
+	 *
+	 * @param string|int $schema Schema slug or id.
+	 *
+	 * @return static
+	 */
+	public function setSchema(string|int $schema): static {
+		if (method_exists($this->inner, 'setSchema') === true) {
+			$this->inner->setSchema($schema);
+		}
+
+		return $this;
+
+	}//end setSchema()
+
+	/**
+	 * Drop the register/schema scope.
+	 *
+	 * @return void
+	 */
+	public function clearCurrents(): void {
+		if (method_exists($this->inner, 'clearCurrents') === true) {
+			$this->inner->clearCurrents();
+		}
+
+	}//end clearCurrents()
+
+	/**
+	 * Delegate a list query to the wrapped double.
+	 *
+	 * @param array $config        Filters, limit, offset, sort and search.
+	 * @param bool  $_rbac         Apply register RBAC (the double ignores it).
+	 * @param bool  $_multitenancy Apply organisation scoping (the double ignores it).
+	 *
+	 * @return array
+	 */
+	public function findAll(array $config = [], bool $_rbac = true, bool $_multitenancy = true): array {
+		if (method_exists($this->inner, 'findAll') === false) {
+			$this->unsupported(method: 'findAll');
+		}
+
+		return $this->inner->findAll($config);
+
+	}//end findAll()
+
+	/**
+	 * Delegate a single-object lookup to the wrapped double.
+	 *
+	 * Falls back to scanning `findAll()` for a matching `id`/`uuid` when the
+	 * double models no `find()` of its own, which most of them do not.
+	 *
+	 * @param int|string      $id            Object id, UUID or slug.
+	 * @param ?array          $_extend       Relations to expand (ignored).
+	 * @param bool            $files         Include file metadata (ignored).
+	 * @param string|int|null $register      Register override (ignored).
+	 * @param string|int|null $schema        Schema override, applied when given.
+	 * @param bool            $_rbac         Apply register RBAC (ignored).
+	 * @param bool            $_multitenancy Apply organisation scoping (ignored).
+	 * @param bool            $_render       Render the entity (ignored).
+	 * @param bool            $_audit        Write an audit entry (ignored).
+	 *
+	 * @return ?ObjectEntityInterface
+	 */
+	public function find(
+		int|string $id,
+		?array $_extend = [],
+		bool $files = false,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $_render = true,
+		bool $_audit = true
+	): ?ObjectEntityInterface {
+		if ($schema !== null) {
+			$this->setSchema(schema: $schema);
+		}
+
+		if (method_exists($this->inner, 'find') === true) {
+			return $this->entity(value: $this->inner->find($id));
+		}
+
+		if (method_exists($this->inner, 'findAll') === false) {
+			$this->unsupported(method: 'find');
+		}
+
+		foreach ($this->inner->findAll([]) as $row) {
+			if (is_array($row) === false) {
+				continue;
+			}
+
+			if ((string) ($row['id'] ?? '') === (string) $id || (string) ($row['uuid'] ?? '') === (string) $id) {
+				return new ObjectEntityStub(payload: $row);
+			}
+		}
+
+		return null;
+
+	}//end find()
+
+	/**
+	 * Delegate a write to the wrapped double and normalise the result.
+	 *
+	 * The payload is passed as the ONLY positional argument, because the
+	 * suite's doubles declare `saveObject()` with anywhere between one and
+	 * three parameters and every one of them takes the payload first.
+	 *
+	 * @param array           $object        Object payload.
+	 * @param ?array          $extend        Relations to expand (ignored).
+	 * @param string|int|null $register      Register override (ignored).
+	 * @param string|int|null $schema        Schema override, applied when given.
+	 * @param ?string         $uuid          Explicit UUID (ignored).
+	 * @param bool            $_rbac         Apply register RBAC (ignored).
+	 * @param bool            $_multitenancy Apply organisation scoping (ignored).
+	 * @param bool            $silent        Suppress events (ignored).
+	 * @param bool            $_validation   Validate against the schema (ignored).
+	 * @param ?array          $uploadedFiles Files uploaded alongside (ignored).
+	 * @param ?IUser          $currentUser   Explicit acting user (ignored).
+	 * @param bool            $failIfExists  Fail instead of updating (ignored).
+	 *
+	 * @return ObjectEntityInterface
+	 */
+	public function saveObject(
+		array $object,
+		?array $extend = [],
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		?string $uuid = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $silent = false,
+		bool $_validation = true,
+		?array $uploadedFiles = null,
+		?IUser $currentUser = null,
+		bool $failIfExists = false
+	): ObjectEntityInterface {
+		if (method_exists($this->inner, 'saveObject') === false) {
+			$this->unsupported(method: 'saveObject');
+		}
+
+		if ($schema !== null) {
+			$this->setSchema(schema: $schema);
+		}
+
+		$saved = $this->inner->saveObject($object);
+
+		// A double declared `: void`, or one that returns nothing on some
+		// branch, still persisted the payload — echo it back rather than
+		// handing the caller a null it cannot distinguish from a refusal.
+		if ($saved === null) {
+			return new ObjectEntityStub(payload: $object);
+		}
+
+		return $this->entity(value: $saved) ?? new ObjectEntityStub(payload: $object);
+
+	}//end saveObject()
+
+	/**
+	 * Normalise a double's return value to a contract entity.
+	 *
+	 * @param mixed $value Whatever the double returned.
+	 *
+	 * @return ?ObjectEntityInterface
+	 */
+	private function entity(mixed $value): ?ObjectEntityInterface {
+		if ($value === null) {
+			return null;
+		}
+
+		if ($value instanceof ObjectEntityInterface) {
+			return $value;
+		}
+
+		if (is_array($value) === true) {
+			return new ObjectEntityStub(payload: $value);
+		}
+
+		if (is_object($value) === true && method_exists($value, 'jsonSerialize') === true) {
+			$payload = $value->jsonSerialize();
+			if (is_array($payload) === true) {
+				return new ObjectEntityStub(payload: $payload);
+			}
+		}
+
+		throw new LogicException(
+			'DuckObjectServiceAdapter cannot turn a ' . get_debug_type($value) . ' into an '
+			. 'ObjectEntityInterface. The wrapped double returned a shape the contract has no '
+			. 'place for; model it explicitly rather than letting it read as an empty result.'
+		);
+
+	}//end entity()
+
+	/**
+	 * Count rows the given query would return.
+	 *
+	 * @param array $config Filters, limit, offset, sort and search.
+	 *
+	 * @return int
+	 */
+	public function count(array $config = []): int {
+		return count($this->findAll(config: $config));
+
+	}//end count()
+
+	/**
+	 * Scoped list query, expressed through the modelled methods.
+	 *
+	 * @param string $registerSlug  The register slug.
+	 * @param string $schemaSlug    The schema slug.
+	 * @param array  $filters       Equality filters.
+	 * @param bool   $_rbac         Apply register RBAC (ignored).
+	 * @param bool   $_multitenancy Apply organisation scoping (ignored).
+	 *
+	 * @return array|int
+	 */
+	public function searchObjectsBySlug(
+		string $registerSlug,
+		string $schemaSlug,
+		array $filters = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): array|int {
+		return $this->setRegister(register: $registerSlug)
+			->setSchema(schema: $schemaSlug)
+			->findAll(config: ['filters' => $filters]);
+
+	}//end searchObjectsBySlug()
+
+	/**
+	 * Apply a partial update through the modelled methods.
+	 *
+	 * @param string $objectId      The object UUID or id.
+	 * @param array  $data          The fields to change.
+	 * @param bool   $_rbac         Apply register RBAC (ignored).
+	 * @param bool   $_multitenancy Apply organisation scoping (ignored).
+	 *
+	 * @return ObjectEntityInterface
+	 */
+	public function updateObject(
+		string $objectId,
+		array $data,
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): ObjectEntityInterface {
+		$existing = $this->find(id: $objectId);
+		$merged   = $data;
+		if ($existing !== null) {
+			$merged = array_merge($existing->getObject(), $data);
+		}
+
+		$merged['id'] = $objectId;
+
+		return $this->saveObject(object: $merged);
+
+	}//end updateObject()
+
+	/**
+	 * Find without audit or read events.
+	 *
+	 * @param string          $id            Object id, UUID or slug.
+	 * @param ?array          $_extend       Relations to expand (ignored).
+	 * @param bool            $files         Include file metadata (ignored).
+	 * @param string|int|null $register      Register override (ignored).
+	 * @param string|int|null $schema        Schema override, applied when given.
+	 * @param bool            $_rbac         Apply register RBAC (ignored).
+	 * @param bool            $_multitenancy Apply organisation scoping (ignored).
+	 *
+	 * @return ObjectEntityInterface
+	 */
+	public function findSilent(
+		string $id,
+		?array $_extend = [],
+		bool $files = false,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): ObjectEntityInterface {
+		$found = $this->find(id: $id, schema: $schema);
+		if ($found === null) {
+			throw new RuntimeException('DuckObjectServiceAdapter: no object ' . $id);
+		}
+
+		return $found;
+
+	}//end findSilent()
+
+	/**
+	 * Run an operation with system privileges — the adapter simply runs it.
+	 *
+	 * @param callable $operation The operation to run.
+	 *
+	 * @return mixed
+	 */
+	public function runAsSystem(callable $operation) {
+		return $operation();
+
+	}//end runAsSystem()
+
+	/**
+	 * No context object is ever held by the adapter.
+	 *
+	 * @return ?ObjectEntityInterface
+	 */
+	public function getObject(): ?ObjectEntityInterface {
+		return null;
+
+	}//end getObject()
+
+	/**
+	 * Refuse a call this adapter does not model.
+	 *
+	 * @param string $method The contract method that was called.
+	 *
+	 * @return never
+	 *
+	 * @throws LogicException Always.
+	 */
+	private function unsupported(string $method): never {
+		throw new LogicException(
+			'DuckObjectServiceAdapter does not model ' . $method . '(), and the wrapped double '
+			. 'does not either. Returning an empty value here would be indistinguishable from a '
+			. 'real empty result, so the adapter refuses instead. Model the method on the double '
+			. 'if the code under test needs it.'
+		);
+
+	}//end unsupported()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param array   $query         The search query.
+	 * @param bool    $_rbac         Apply register RBAC.
+	 * @param bool    $_multitenancy Apply organisation scoping.
+	 * @param ?array  $ids           Restrict to these ids.
+	 * @param ?string $uses          Restrict to objects used by this one.
+	 * @param ?array  $views         Restrict to these views.
+	 *
+	 * @return array|int
+	 */
+	public function searchObjects(
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		?array $ids = null,
+		?string $uses = null,
+		?array $views = null
+	): array|int {
+		$this->unsupported(method: 'searchObjects');
+
+	}//end searchObjects()
+
+	/**
+	 * Delegate a delete when the double models one, refuse otherwise.
+	 *
+	 * @param string          $uuid            The object UUID.
+	 * @param string|int|null $register        Register id, UUID or slug.
+	 * @param string|int|null $schema          Schema id, UUID or slug.
+	 * @param bool            $_rbac           Apply register RBAC.
+	 * @param bool            $_multitenancy   Apply organisation scoping.
+	 * @param bool            $_retentionSweep Run as part of a retention sweep.
+	 * @param ?IUser          $currentUser     Explicit acting user.
+	 * @param bool            $permanent       Delete permanently.
+	 *
+	 * @return bool
+	 */
+	public function deleteObject(
+		string $uuid,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $_retentionSweep = false,
+		?IUser $currentUser = null,
+		bool $permanent = false
+	): bool {
+		if (method_exists($this->inner, 'deleteObject') === false) {
+			$this->unsupported(method: 'deleteObject');
+		}
+
+		return (bool) $this->inner->deleteObject($uuid);
+
+	}//end deleteObject()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param array   $query         The search query.
+	 * @param bool    $_rbac         Apply register RBAC.
+	 * @param bool    $_multitenancy Apply organisation scoping.
+	 * @param bool    $deleted       Include soft-deleted objects.
+	 * @param ?array  $ids           Restrict to these ids.
+	 * @param ?string $uses          Restrict to objects used by this one.
+	 * @param ?array  $views         Restrict to these views.
+	 *
+	 * @return array
+	 */
+	public function searchObjectsPaginated(
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $deleted = false,
+		?array $ids = null,
+		?string $uses = null,
+		?array $views = null
+	): array {
+		$this->unsupported(method: 'searchObjectsPaginated');
+
+	}//end searchObjectsPaginated()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param array                 $requestParams Raw request parameters.
+	 * @param int|string|array|null $register      Register id, UUID or slug.
+	 * @param int|string|array|null $schema        Schema id, UUID or slug.
+	 * @param ?array                $ids           Restrict to these ids.
+	 *
+	 * @return array
+	 */
+	public function buildSearchQuery(
+		array $requestParams,
+		int|string|array|null $register = null,
+		int|string|array|null $schema = null,
+		?array $ids = null
+	): array {
+		$this->unsupported(method: 'buildSearchQuery');
+
+	}//end buildSearchQuery()
+
+	/**
+	 * Delegate a bulk write when the double models one, refuse otherwise.
+	 *
+	 * @param array           $objects        The objects to store.
+	 * @param string|int|null $register       Register id, UUID or slug.
+	 * @param string|int|null $schema         Schema id, UUID or slug.
+	 * @param bool            $_rbac          Apply register RBAC.
+	 * @param bool            $_multitenancy  Apply organisation scoping.
+	 * @param bool            $validation     Validate against the schema.
+	 * @param bool            $events         Emit events for each object.
+	 * @param bool            $deduplicateIds Drop duplicate ids.
+	 * @param bool            $enrich         Enrich each object.
+	 * @param bool            $_audit         Write an audit-trail entry.
+	 *
+	 * @return array
+	 */
+	public function saveObjects(
+		array $objects,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $validation = false,
+		bool $events = false,
+		bool $deduplicateIds = true,
+		bool $enrich = true,
+		bool $_audit = true
+	): array {
+		if (method_exists($this->inner, 'saveObjects') === true) {
+			return $this->inner->saveObjects($objects);
+		}
+
+		$out = [];
+		foreach ($objects as $object) {
+			$out[] = $this->saveObject(object: $object, schema: $schema);
+		}
+
+		return $out;
+
+	}//end saveObjects()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param string|int $identifier The object id or UUID.
+	 * @param bool       $advisory   Take an advisory lock.
+	 *
+	 * @return bool
+	 */
+	public function unlockObject(string|int $identifier, bool $advisory = false): bool {
+		$this->unsupported(method: 'unlockObject');
+
+	}//end unlockObject()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param string  $identifier The object id or UUID.
+	 * @param ?string $process    A label for the holding process.
+	 * @param ?int    $duration   Lock duration in seconds.
+	 * @param bool    $advisory   Take an advisory lock.
+	 *
+	 * @return array
+	 */
+	public function lockObject(
+		string $identifier,
+		?string $process = null,
+		?int $duration = null,
+		bool $advisory = false
+	): array {
+		$this->unsupported(method: 'lockObject');
+
+	}//end lockObject()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param array $uuids         The object UUIDs.
+	 * @param bool  $_rbac         Apply register RBAC.
+	 * @param bool  $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array
+	 */
+	public function deleteObjects(array $uuids = [], bool $_rbac = true, bool $_multitenancy = true): array {
+		$this->unsupported(method: 'deleteObjects');
+
+	}//end deleteObjects()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param string $uuid          The object UUID.
+	 * @param array  $filters       Equality filters.
+	 * @param bool   $_rbac         Apply register RBAC.
+	 * @param bool   $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array
+	 */
+	public function getLogs(string $uuid, array $filters = [], bool $_rbac = true, bool $_multitenancy = true): array {
+		$this->unsupported(method: 'getLogs');
+
+	}//end getLogs()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param string $objectId      The object UUID.
+	 * @param array  $query         The search query.
+	 * @param bool   $_rbac         Apply register RBAC.
+	 * @param bool   $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array
+	 */
+	public function getObjectUses(
+		string $objectId,
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): array {
+		$this->unsupported(method: 'getObjectUses');
+
+	}//end getObjectUses()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param string $objectId      The object UUID.
+	 * @param array  $query         The search query.
+	 * @param bool   $_rbac         Apply register RBAC.
+	 * @param bool   $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array
+	 */
+	public function getObjectUsedBy(
+		string $objectId,
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): array {
+		$this->unsupported(method: 'getObjectUsedBy');
+
+	}//end getObjectUsedBy()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param string $search       The term to match relations against.
+	 * @param bool   $partialMatch Match relations partially.
+	 *
+	 * @return array
+	 */
+	public function findByRelations(string $search, bool $partialMatch = true): array {
+		$this->unsupported(method: 'findByRelations');
+
+	}//end findByRelations()
+
+	/**
+	 * Not modelled.
+	 *
+	 * @param array   $query         The search query.
+	 * @param bool    $_rbac         Apply register RBAC.
+	 * @param bool    $_multitenancy Apply organisation scoping.
+	 * @param ?array  $ids           Restrict to these ids.
+	 * @param ?string $uses          Restrict to objects used by this one.
+	 *
+	 * @return int
+	 */
+	public function countSearchObjects(
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		?array $ids = null,
+		?string $uses = null
+	): int {
+		$this->unsupported(method: 'countSearchObjects');
+
+	}//end countSearchObjects()
+}//end class

--- a/tests/Unit/Service/TaxNotificationServiceTest.php
+++ b/tests/Unit/Service/TaxNotificationServiceTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\TaxNotificationService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
@@ -87,14 +87,30 @@ final class TaxNotificationServiceTest extends TestCase {
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
 
-		$this->service = new TaxNotificationService(
+		$this->service = $this->buildService($this->buildObjectServiceStub([]));
+
+	}//end setUp()
+
+	/**
+	 * Build the subject around a seeded in-memory ObjectService store.
+	 *
+	 * The store used to reach the subject through the container; ADR-084 injects
+	 * it as a contract-typed constructor argument instead, so each test rebuilds
+	 * the subject with its own store.
+	 *
+	 * @param object $store The seeded in-memory ObjectService double.
+	 *
+	 * @return TaxNotificationService
+	 */
+	private function buildService(object $store): TaxNotificationService {
+		return new TaxNotificationService(
 			appConfig: $this->appConfig,
 			notificationMgr: $this->notificationMgr,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($store),
 		);
 
-	}//end setUp()
+	}//end buildService()
 
 	/**
 	 * The reminder window matches exactly 7 and 1 day(s) before the deadline (REQ-VPB-013).
@@ -138,7 +154,7 @@ final class TaxNotificationServiceTest extends TestCase {
 			],
 		];
 
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub($deadlines));
+		$this->service = $this->buildService($this->buildObjectServiceStub($deadlines));
 
 		$notification = $this->createMock(INotification::class);
 		$notification->method('setApp')->willReturnSelf();
@@ -170,7 +186,7 @@ final class TaxNotificationServiceTest extends TestCase {
 			],
 		];
 
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub($deadlines));
+		$this->service = $this->buildService($this->buildObjectServiceStub($deadlines));
 		$this->notificationMgr->expects($this->never())->method('notify');
 
 		$count = $this->service->dispatchDueReminders(new \DateTimeImmutable('2025-04-13'));

--- a/tests/Unit/Service/TaxPaymentReconciliationServiceTest.php
+++ b/tests/Unit/Service/TaxPaymentReconciliationServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\TaxPaymentReconciliationService;
 use OCA\Shillinq\Service\TaxReportCalculator;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -68,13 +68,29 @@ final class TaxPaymentReconciliationServiceTest extends TestCase {
 		$this->container = $this->createMock(ContainerInterface::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
-		$this->service = new TaxPaymentReconciliationService(
-			appConfig: $this->appConfig,
-			calculator: new TaxReportCalculator(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
-		);
+		$this->service = $this->buildService($this->buildObjectServiceStub([]));
 
 	}//end setUp()
+
+	/**
+	 * Build the subject around a seeded in-memory ObjectService store.
+	 *
+	 * The store used to reach the subject through the container; ADR-084 injects
+	 * it as a contract-typed constructor argument instead, so each test rebuilds
+	 * the subject with its own store.
+	 *
+	 * @param object $store The seeded in-memory ObjectService double.
+	 *
+	 * @return TaxPaymentReconciliationService
+	 */
+	private function buildService(object $store): TaxPaymentReconciliationService {
+		return new TaxPaymentReconciliationService(
+			appConfig: $this->appConfig,
+			calculator: new TaxReportCalculator(),
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end buildService()
 
 	/**
 	 * A payment that matches a GL posting reports matched with zero variance (REQ-VPB-008).
@@ -97,7 +113,7 @@ final class TaxPaymentReconciliationServiceTest extends TestCase {
 			],
 		];
 
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub($records));
+		$this->service = $this->buildService($this->buildObjectServiceStub($records));
 
 		$result = $this->service->reconcile(administrationId: 'adm-1', paymentId: 'pay-1');
 
@@ -128,7 +144,7 @@ final class TaxPaymentReconciliationServiceTest extends TestCase {
 			],
 		];
 
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub($records));
+		$this->service = $this->buildService($this->buildObjectServiceStub($records));
 
 		$result = $this->service->reconcile(administrationId: 'adm-1', paymentId: 'pay-1');
 
@@ -145,7 +161,7 @@ final class TaxPaymentReconciliationServiceTest extends TestCase {
 	 */
 	public function testUnknownPaymentReturnsUnmatched(): void {
 		$records = ['TaxPaymentTracking' => [], 'GLLine' => []];
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub($records));
+		$this->service = $this->buildService($this->buildObjectServiceStub($records));
 
 		$result = $this->service->reconcile(administrationId: 'adm-1', paymentId: 'missing');
 

--- a/tests/Unit/Service/TaxReportServiceTest.php
+++ b/tests/Unit/Service/TaxReportServiceTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\TaxReportCalculator;
 use OCA\Shillinq\Service\TaxReportService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -71,13 +71,29 @@ final class TaxReportServiceTest extends TestCase {
 		$this->container = $this->createMock(ContainerInterface::class);
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->appConfig->method('getValueString')->willReturn('shillinq');
-		$this->service = new TaxReportService(
-			appConfig: $this->appConfig,
-			calculator: new TaxReportCalculator(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
-		);
+		$this->service = $this->buildService($this->buildObjectServiceStub([]));
 
 	}//end setUp()
+
+	/**
+	 * Build the subject around a seeded in-memory ObjectService store.
+	 *
+	 * The store used to reach the subject through the container; ADR-084 injects
+	 * it as a contract-typed constructor argument instead, so each test rebuilds
+	 * the subject with its own store.
+	 *
+	 * @param object $store The seeded in-memory ObjectService double.
+	 *
+	 * @return TaxReportService
+	 */
+	private function buildService(object $store): TaxReportService {
+		return new TaxReportService(
+			appConfig: $this->appConfig,
+			calculator: new TaxReportCalculator(),
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end buildService()
 
 	/**
 	 * Quarter computation joins GLLine to Account and aggregates by tax treatment (REQ-VPB-003, REQ-VPB-009).
@@ -99,7 +115,7 @@ final class TaxReportServiceTest extends TestCase {
 			],
 		];
 
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub($records));
+		$this->service = $this->buildService($this->buildObjectServiceStub($records));
 
 		$result = $this->service->computeQuarter(administrationId: 'adm-1', fiscalYear: 2025, quarter: 1);
 
@@ -132,7 +148,7 @@ final class TaxReportServiceTest extends TestCase {
 			],
 		];
 
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub($records));
+		$this->service = $this->buildService($this->buildObjectServiceStub($records));
 
 		$result = $this->service->computeQuarter(administrationId: 'adm-1', fiscalYear: 2025, quarter: 1);
 
@@ -154,7 +170,7 @@ final class TaxReportServiceTest extends TestCase {
 			],
 		];
 
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub($records));
+		$this->service = $this->buildService($this->buildObjectServiceStub($records));
 
 		$result = $this->service->computeQuarter(administrationId: 'adm-1', fiscalYear: 2025, quarter: 2);
 
@@ -177,7 +193,7 @@ final class TaxReportServiceTest extends TestCase {
 			],
 		];
 
-		$this->container->method('get')->willReturn($this->buildObjectServiceStub($records, ignorePeriod: true));
+		$this->service = $this->buildService($this->buildObjectServiceStub($records, ignorePeriod: true));
 
 		$result = $this->service->computeAnnual(administrationId: 'adm-1', fiscalYear: 2025);
 

--- a/tests/Unit/Service/ThreeWayMatchingEngineTest.php
+++ b/tests/Unit/Service/ThreeWayMatchingEngineTest.php
@@ -48,11 +48,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\SupplierInvoiceService;
 use OCA\Shillinq\Service\ThreeWayMatchingEngine;
 use OCA\Shillinq\Service\ToleranceProfileService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -223,7 +223,7 @@ final class ThreeWayMatchingEngineTest extends TestCase {
 			appConfig:             $appConfig,
 			administrationContext: $administrationContext,
 			logger:                $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 		return new ThreeWayMatchingEngine(
@@ -231,7 +231,7 @@ final class ThreeWayMatchingEngineTest extends TestCase {
 			toleranceService: $tolerance,
 			invoiceService:   $invoiceService,
 			logger:           $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildEngine()

--- a/tests/Unit/Service/TimeIntakeServiceTest.php
+++ b/tests/Unit/Service/TimeIntakeServiceTest.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Tests\Unit\Service;
 
 use InvalidArgumentException;
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\InvoiceGenerationService;
 use OCA\Shillinq\Service\TimeIntakeService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -198,7 +198,7 @@ final class TimeIntakeServiceTest extends TestCase {
 			$this->appConfig,
 			$this->logger,
 			$this->invoiceGenerationService,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->fake),
 		);
 
 	}//end svc()

--- a/tests/Unit/Service/Treasury/FxRevaluationServiceTest.php
+++ b/tests/Unit/Service/Treasury/FxRevaluationServiceTest.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service\Treasury;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\Treasury\FxRevaluationService;
 use OCA\Shillinq\Service\Treasury\TreasuryRateService;
 use OCA\Shillinq\Service\Treasury\TreasuryRateSnapshot;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -159,14 +159,24 @@ final class FxRevaluationServiceTest extends TestCase {
 			/**
 			 * Record the saved object under its schema.
 			 *
+			 * The register/schema arguments are optional so the fake also answers
+			 * the single-argument call the contract adapter makes; the schema
+			 * then falls back to the one `setSchema()` last selected, which the
+			 * adapter applies from the caller's named `schema:` argument.
+			 *
 			 * @param array<string,mixed> $object Object payload.
 			 * @param string $register Register slug.
 			 * @param string $schema Schema slug.
 			 *
 			 * @return array<string,mixed>
 			 */
-			public function saveObject(array $object, string $register, string $schema): array {
-				$this->saved[$schema][] = $object;
+			public function saveObject(array $object, string $register = '', string $schema = ''): array {
+				$target = $schema;
+				if ($target === '') {
+					$target = $this->schema;
+				}
+
+				$this->saved[$target][] = $object;
 				return $object;
 			}//end saveObject()
 		};
@@ -187,11 +197,10 @@ final class FxRevaluationServiceTest extends TestCase {
 		$this->treasuryRateService = $this->createMock(TreasuryRateService::class);
 
 		$this->service = new FxRevaluationService(
-			$container,
 			$appConfig,
 			$this->treasuryRateService,
 			new NullLogger(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objectService),
 		);
 	}//end setUp()
 

--- a/tests/Unit/Service/TrialBalancePerformanceTest.php
+++ b/tests/Unit/Service/TrialBalancePerformanceTest.php
@@ -28,9 +28,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\TrialBalanceCalculator;
 use OCA\Shillinq\Service\TrialBalanceService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -83,7 +83,7 @@ final class TrialBalancePerformanceTest extends TestCase {
 		$service = new TrialBalanceService(
 			appConfig: $appConfig,
 			calculator: new TrialBalanceCalculator(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 		$startedAt = microtime(true);

--- a/tests/Unit/Service/TrialBalanceServiceTest.php
+++ b/tests/Unit/Service/TrialBalanceServiceTest.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\TrialBalanceCalculator;
 use OCA\Shillinq\Service\TrialBalanceService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -169,7 +169,7 @@ final class TrialBalanceServiceTest extends TestCase {
 		return new TrialBalanceService(
 			appConfig: $this->appConfig,
 			calculator: new TrialBalanceCalculator(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/TrialBalanceTenancyIsolationTest.php
+++ b/tests/Unit/Service/TrialBalanceTenancyIsolationTest.php
@@ -29,11 +29,11 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Controller\TrialBalanceController;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\TrialBalanceCalculator;
 use OCA\Shillinq\Service\TrialBalanceService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\AppFramework\Http;
 use OCP\IAppConfig;
 use OCP\IRequest;
@@ -123,7 +123,7 @@ final class TrialBalanceTenancyIsolationTest extends TestCase {
 		$service = new TrialBalanceService(
 			appConfig: $this->appConfig,
 			calculator: new TrialBalanceCalculator(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objectService),
 		);
 
 		// Compute for adm-A; adm-B GLLines must never appear in the totals.
@@ -197,7 +197,7 @@ final class TrialBalanceTenancyIsolationTest extends TestCase {
 		$service = new TrialBalanceService(
 			appConfig: $this->appConfig,
 			calculator: new TrialBalanceCalculator(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->objectService),
 		);
 
 		// user-A asks for adm-A → 200 + adm-A totals.

--- a/tests/Unit/Service/VATReturnServiceEntityReturnTest.php
+++ b/tests/Unit/Service/VATReturnServiceEntityReturnTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\VATReturnService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -65,7 +65,7 @@ final class VATReturnServiceEntityReturnTest extends TestCase {
 		$service = new VATReturnService(
 			appConfig: $this->createMock(IAppConfig::class),
 			logger: new NullLogger(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($objectService),
 		);
 
 		$created = $service->createReturn(
@@ -101,7 +101,7 @@ final class VATReturnServiceEntityReturnTest extends TestCase {
 		$service = new VATReturnService(
 			appConfig: $this->createMock(IAppConfig::class),
 			logger: new NullLogger(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($objectService),
 		);
 
 		$created = $service->createReturn(
@@ -124,33 +124,33 @@ final class VATReturnServiceEntityReturnTest extends TestCase {
 		);
 	}//end testFindReturnResolvesAnEntityAndNullsOnlyWhenAbsent()
 
-	/**
-	 * A row the fake cannot serialise still fails loudly rather than silently.
+	/*
+	 * REMOVED: testUnconvertibleRowRaisesRatherThanReturningEmpty().
 	 *
-	 * Positive control: proves the guard above is asserting something. If
-	 * normaliseRow() ever "helpfully" returned [] for an unusable row, a
-	 * created return would come back empty instead of raising — and the
-	 * assertions above would have to be read very carefully to notice.
+	 * It asserted that normaliseRow() raises, rather than returning [], for a
+	 * row it cannot convert. ADR-084 moved that guarantee from RUNTIME to the
+	 * TYPE SYSTEM: ObjectServiceInterface::find() / ::saveObject() can only
+	 * hand back an ObjectEntityInterface, and that interface DECLARES
+	 * getObject(): array. So a conforming implementation normalises by
+	 * construction and the branch this test covered is unreachable — its
+	 * fixture (an entity exposing neither jsonSerialize() nor getObject())
+	 * can no longer be passed to the service at all.
 	 *
-	 * @return void
+	 * It is deleted rather than retargeted because the only ways to make it
+	 * pass would be to change the expected exception class or to rewrite the
+	 * fixture, either of which leaves a test asserting something other than
+	 * what its name claims.
+	 *
+	 * Measured, and the reason this is not a loss of coverage: it was GREEN on
+	 * `development` for the WRONG REASON. The unconfigured ObjectService mock
+	 * made the service throw `RuntimeException: VATReturn save did not return
+	 * an identifier` before normaliseRow() was ever reached, and a bare
+	 * expectException(RuntimeException::class) accepts any RuntimeException.
+	 * The guard under test never ran. Deleting it removes a false signal.
+	 *
+	 * See lib/Service/VATReturnService.php::normaliseRow(), where the
+	 * corresponding throw is kept as a deliberate type-boundary tripwire.
 	 */
-	public function testUnconvertibleRowRaisesRatherThanReturningEmpty(): void {
-		$objectService = $this->entityReturningObjectService(serialisable: false);
-		$service = new VATReturnService(
-			appConfig: $this->createMock(IAppConfig::class),
-			logger: new NullLogger(),
-			objectService: $this->createMock(ObjectServiceInterface::class),
-		);
-
-		$this->expectException(\RuntimeException::class);
-		$service->createReturn(
-			administrationId: 'adm-smb-1',
-			period: 'quarter',
-			periodYear: 2024,
-			periodNumber: 1,
-			regime: 'standard'
-		);
-	}//end testUnconvertibleRowRaisesRatherThanReturningEmpty()
 
 	/**
 	 * Build a PSR-11 container that yields the given fake ObjectService.
@@ -181,14 +181,16 @@ final class VATReturnServiceEntityReturnTest extends TestCase {
 	 * returns an entity object or null — exactly as declared on
 	 * OCA\OpenRegister\Service\ObjectService.
 	 *
-	 * @param bool $serialisable When false, the entity exposes neither
-	 *                           jsonSerialize() nor getObject(), standing in for
-	 *                           a row this app cannot normalise.
+	 * The `serialisable: false` variant was dropped together with
+	 * testUnconvertibleRowRaisesRatherThanReturningEmpty() — under ADR-084 an
+	 * entity that exposes neither jsonSerialize() nor getObject() cannot
+	 * satisfy ObjectEntityInterface, so it is not a shape the service can
+	 * receive and the branch had no remaining caller.
 	 *
 	 * @return object The fake ObjectService.
 	 */
-	private function entityReturningObjectService(bool $serialisable = true): object {
-		return new class($serialisable) {
+	private function entityReturningObjectService(): object {
+		return new class {
 			/**
 			 * Rows keyed by schema slug.
 			 *
@@ -209,22 +211,6 @@ final class VATReturnServiceEntityReturnTest extends TestCase {
 			 * @var integer
 			 */
 			private int $counter = 0;
-
-			/**
-			 * Whether returned entities can be converted back to an array.
-			 *
-			 * @var boolean
-			 */
-			private bool $serialisable;
-
-			/**
-			 * Constructor.
-			 *
-			 * @param bool $serialisable Whether entities expose jsonSerialize().
-			 */
-			public function __construct(bool $serialisable) {
-				$this->serialisable = $serialisable;
-			}//end __construct()
 
 			/**
 			 * Fluent register setter (no-op).
@@ -325,12 +311,6 @@ final class VATReturnServiceEntityReturnTest extends TestCase {
 			 * @return object
 			 */
 			private function wrap(array $row): object {
-				if ($this->serialisable === false) {
-					// Neither jsonSerialize() nor getObject() — unusable.
-					return new class {
-					};
-				}
-
 				return new class($row) implements \JsonSerializable {
 					/**
 					 * The wrapped row.

--- a/tests/Unit/Service/VATReturnServiceTest.php
+++ b/tests/Unit/Service/VATReturnServiceTest.php
@@ -27,8 +27,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\VATReturnService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -90,7 +90,7 @@ final class VATReturnServiceTest extends TestCase {
 		return new VATReturnService(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/VatSuppletieDetectionServiceTest.php
+++ b/tests/Unit/Service/VatSuppletieDetectionServiceTest.php
@@ -29,9 +29,9 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\VATReturnService;
 use OCA\Shillinq\Service\VatSuppletieDetectionService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -95,14 +95,14 @@ final class VatSuppletieDetectionServiceTest extends TestCase {
 		$vatReturnService = new VATReturnService(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 		$detectionService = new VatSuppletieDetectionService(
 			appConfig: $this->appConfig,
 			logger: $this->logger,
 			vatReturnService: $vatReturnService,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 		return [$vatReturnService, $detectionService];

--- a/tests/Unit/Service/VendorPerformanceAggregationIntegrationTest.php
+++ b/tests/Unit/Service/VendorPerformanceAggregationIntegrationTest.php
@@ -40,8 +40,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\VendorPerformanceAggregation;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -78,7 +78,7 @@ final class VendorPerformanceAggregationIntegrationTest extends TestCase {
 		return new VendorPerformanceAggregation(
 			appConfig: $appConfig,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 	}//end makeService()

--- a/tests/Unit/Service/VendorPerformanceAggregationTest.php
+++ b/tests/Unit/Service/VendorPerformanceAggregationTest.php
@@ -39,8 +39,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\VendorPerformanceAggregation;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -77,7 +77,7 @@ final class VendorPerformanceAggregationTest extends TestCase {
 		return new VendorPerformanceAggregation(
 			appConfig: $appConfig,
 			logger: $logger,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($os),
 		);
 
 	}//end makeService()

--- a/tests/Unit/Service/ViesServiceTest.php
+++ b/tests/Unit/Service/ViesServiceTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\ViesService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\Http\Client\IClientService;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -186,7 +186,14 @@ final class ViesServiceTest extends TestCase {
 			 * @return array<string,mixed>
 			 */
 			public function saveObject(array $object, string $register = '', string $schema = ''): array {
-				$this->saved[$schema][] = $object;
+				$target = $schema;
+				if ($target === '') {
+					// The contract adapter passes the payload alone and applies
+					// the caller's `schema:` through setSchema() first.
+					$target = $this->schema;
+				}
+
+				$this->saved[$target][] = $object;
 				return $object;
 			}//end saveObject()
 		};
@@ -198,7 +205,7 @@ final class ViesServiceTest extends TestCase {
 			appConfig: $this->appConfig,
 			clientService: $this->clientService,
 			logger: $this->createMock(LoggerInterface::class),
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/WbsoAccountServiceTest.php
+++ b/tests/Unit/Service/WbsoAccountServiceTest.php
@@ -27,8 +27,8 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Tests\Unit\Service;
 
 use InvalidArgumentException;
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\WbsoAccountService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -163,8 +163,8 @@ final class WbsoAccountServiceTest extends TestCase {
 
 		$this->container->method('get')->willReturn($stub);
 
-		return new WbsoAccountService(container: $this->container, appConfig: $this->appConfig,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+		return new WbsoAccountService(appConfig: $this->appConfig,
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 	}//end buildService()
 

--- a/tests/Unit/Service/WbsoAdministratieServiceTest.php
+++ b/tests/Unit/Service/WbsoAdministratieServiceTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\WbsoAdministratieService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -162,7 +162,7 @@ final class WbsoAdministratieServiceTest extends TestCase {
 
 		return new WbsoAdministratieService(
 			appConfig: $this->appConfig,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/WbsoDocumentServiceTest.php
+++ b/tests/Unit/Service/WbsoDocumentServiceTest.php
@@ -26,8 +26,8 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Tests\Unit\Service;
 
 use InvalidArgumentException;
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\WbsoDocumentService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -176,7 +176,7 @@ final class WbsoDocumentServiceTest extends TestCase {
 		return new WbsoDocumentService(
 			appConfig: $this->appConfig,
 			userSession: $this->session,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()

--- a/tests/Unit/Service/WbsoTransactionServiceTest.php
+++ b/tests/Unit/Service/WbsoTransactionServiceTest.php
@@ -26,8 +26,8 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Tests\Unit\Service;
 
 use InvalidArgumentException;
-use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\WbsoTransactionService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\IAppConfig;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -191,7 +191,7 @@ final class WbsoTransactionServiceTest extends TestCase {
 		return new WbsoTransactionService(
 			appConfig: $this->appConfig,
 			userSession: $this->userSession,
-			objectService: $this->createMock(ObjectServiceInterface::class),
+			objectService: new DuckObjectServiceAdapter($stub),
 		);
 
 	}//end buildService()


### PR DESCRIPTION
> **Stacked on #880** (`fix/shillinq-phpunit-adr084`). Merge that first; until it lands this PR's diff shows #880's commits too. **Its own contribution is 2 files.**

## What changes, stated plainly

`ExpenseClaimGuard` has **denied every expense claim carrying any linked receipt, mileage entry or per-diem** since ADR-084, and logged each refusal as an ordinary policy denial.

After this PR, those claims are **evaluated**: a claim whose items all carry a `costCentreCode` is permitted; one with an item lacking it is still denied.

**This is not a relaxation of a financial control.** It restores the control's ability to discriminate at all. A guard that refuses everything is not enforcing a policy — it is broken in a way that looks like enforcement. But it *is* an observable behaviour change on a financial path, which is why it is not buried in #880's 130-file test-wiring sweep.

## The defect

`lib/Lifecycle/ExpenseClaimGuard.php:202`

```php
if ($item === null || trim(string: (string)($item['costCentreCode'] ?? '')) === '') {
```

`$item` comes from `ObjectService::find()`. ADR-084 made that an `ObjectEntityInterface`, which **extends `JsonSerializable` only and does not implement `ArrayAccess`** — so the read raises `Error: Cannot use object of type … as array`.

**`??` does not suppress it.** Null coalescing guards an undefined *index*; it does not make an illegal array access on an object legal.

The `Error` propagates to `requireOpenPeriodAndCostCentres()`:

```php
} catch (\Throwable $e) {
    $this->logger->error('… failed — denying post (fail-closed)', …);
    return false;
}
```

So a crash became a refusal. This is the campaign's recurring shape: **an exception converted into a plausible-looking policy outcome**, with nothing in the logs a reader would recognise as a bug.

Repaired with `getObject()`, which is declared on the contract and returns the body as an array.

## Why the existing tests could not catch it

The suite already had both permit and deny cases. That was not enough, and the reason is the point of this PR:

- every **deny** test **passed** — for a reason that had nothing to do with cost centres;
- every **permit** test **failed**.

A guard that always denies and a guard that always permits are both broken, and **each is invisible to half the suite**.

Added `testRequireCostCentresAndItemsDiscriminatesBetweenClaims()`: one guard instance, two claims, opposite verdicts asserted together. It fails if the guard reverts to always-deny **and** if it is ever loosened into always-permit — neither half of the existing suite can satisfy it vacuously.

**Positive control run, not assumed:**

| guard | result |
|---|---|
| repaired (this PR) | `OK (8 tests, 11 assertions)` |
| `development`'s `ExpenseClaimGuard.php` restored | **fails** — `A claim whose items all carry a costCentreCode must be permitted` |

A tripwire nobody has watched fail is not a tripwire.

## Result

With this and #880's bank-import repair, **shillinq's PHPUnit is fully green**: `OK (4138 tests, 43888 assertions)`, measured against a bootstrap that reproduces CI's class resolution exactly and self-asserts before running.

Baseline on `development` was **141 errors + 341 failures**.

## Scope

Two files: `lib/Lifecycle/ExpenseClaimGuard.php` (the repair plus a comment naming the mechanism) and its test. Same `getObject()` shape as #880's `BankStatementImportController` fix — worth grepping other apps for array access on a `find()`/`saveObject()` result, since all four analysers scope to `lib/` and none of them can see this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
