### PR TITLE
test(e2e): poll the URL after an SPA click instead of awaiting a load that never happens

### DIFF
--- a/tests/e2e/waterschappen-bbv-variant.spec.ts
+++ b/tests/e2e/waterschappen-bbv-variant.spec.ts
@@ -114,8 +114,15 @@ test.describe('BBV dashboard — widget shell renders', () => {
 			await openButton.click()
 			// Drill-in lands on the BudgetBBVMappings list filtered by
 			// programmeCode (slice 06 wiring).
-			await page.waitForLoadState('domcontentloaded')
-			expect(page.url()).toMatch(/budget-mappings|bbv-dashboard/)
+			//
+			// POLLED, NOT waitForLoadState — see the note on the Add-CTA test
+			// below. This is a vue-router push inside an already-loaded
+			// document, so `waitForLoadState('domcontentloaded')` resolves in
+			// the same tick and the URL gets read before the router has
+			// pushed. The assertion itself is unchanged.
+			await expect
+				.poll(() => page.url(), { timeout: 15_000 })
+				.toMatch(/budget-mappings|bbv-dashboard/)
 		}
 	})
 })
@@ -182,8 +189,35 @@ test.describe('BBV mapping index — search + add + row click', () => {
 		const addCta = page.getByTestId('cn-cta-primary').first()
 		await expect(addCta).toBeVisible({ timeout: 15_000 })
 		await addCta.click()
-		await page.waitForLoadState('domcontentloaded')
-		expect(page.url()).toMatch(/budget-mappings\/new|budget-mappings\/[^/]+$/)
+
+		// ⚠️ THIS WAS A RACE, AND IT FIRED.
+		//
+		// The click triggers a vue-router `push` inside the document that is
+		// ALREADY loaded — no navigation, no new document. So
+		// `page.waitForLoadState('domcontentloaded')` had nothing to wait for:
+		// the current document reached that state long ago, the promise
+		// resolves immediately, and `page.url()` was read in effectively the
+		// same tick as the click handler. Whether the router had pushed by
+		// then was down to scheduling.
+		//
+		// Measured, not guessed. On PR #882 this test read
+		//   ✓ passed (12.5s)  at head 614acbea
+		//   ✗ failed          at head f2c6883e, "Received: …/budget-mappings"
+		// and the diff between those two heads is `lib/Lifecycle/
+		// ExpenseClaimGuard.php` plus thirteen PHPUnit files — zero `src/`,
+		// zero manifest, zero register fragments. Nothing in it can reach this
+		// button. A verdict that moves over a diff that cannot touch the
+		// subject is non-determinism, not a regression.
+		//
+		// `expect.poll` retries the SAME assertion instead of asserting once
+		// against an unsettled URL. Nothing is relaxed: the pattern is
+		// byte-identical, so a CTA that genuinely fails to navigate still
+		// fails here, just after 15s instead of instantly. `waitForURL` would
+		// also work but reports only a timeout; poll reports the URL it last
+		// saw, which is the half of the old failure message worth keeping.
+		await expect
+			.poll(() => page.url(), { timeout: 15_000 })
+			.toMatch(/budget-mappings\/new|budget-mappings\/[^/]+$/)
 	})
 })
 


### PR DESCRIPTION
## What this is

An **instrument repair**, not a fix. The two `expect(page.url())` assertions in
`tests/e2e/waterschappen-bbv-variant.spec.ts` that follow a **click** now poll
instead of reading the URL once, immediately after a `waitForLoadState` that had
nothing to wait for.

⚠️ **Read "What this does NOT do" before merging.** An earlier version of this
description claimed it fixed a flake on #882. A rerun refuted that. The
description below is the corrected one.

## The defect in the instrument

```ts
await addCta.click()
await page.waitForLoadState('domcontentloaded')
expect(page.url()).toMatch(/budget-mappings\/new|budget-mappings\/[^/]+$/)
```

The click is a vue-router `push` inside the document that is **already loaded** —
no navigation, no new document. `waitForLoadState('domcontentloaded')` therefore
resolves in the same tick, and `page.url()` is read before the router has
necessarily pushed. That is a real defect in how the assertion is taken,
independent of whether any particular run trips over it.

## What this does NOT do

It does **not** fix `waterschappen-bbv-variant.spec.ts:170` on PR #882, and
there is **no red-to-green measurement** behind this change.

What I actually measured:

| tree | runs | this test |
|---|---|---|
| `development` @ `5914bf34` | 1 | ✓ |
| #882 @ `614acbea` | 1 | ✓ |
| #882 @ `f2c6883e` | **2** | ✗ ✗ (byte-identical message) |

I first read the `614acbea` → `f2c6883e` flip as a flake, on the grounds that
`git diff --stat` between those heads is `ExpenseClaimGuard.php` plus thirteen
PHPUnit files — zero `src/`, zero manifest, zero register fragments, so nothing
in it can reach that button. I then re-ran the E2E job at the identical sha and
**it failed the same test again with the same message**. So it reproduces, it is
not a flake, and "the diff cannot touch the subject" turned out to bound only
*direct* modification — not interactions, shared seed state or execution order,
which is exactly what a 273-test suite against one seeded instance is full of.

That failure is **still unexplained and still open**, and it is #882's to
bisect against #881, not this PR's.

## Why it is still worth merging

- The mechanism argument stands on its own: `waitForLoadState` after an SPA
  router push is not a wait.
- It **cannot mask** the failure above. With polling in place, a CTA that
  genuinely never navigates still fails — after 15 s instead of instantly. If
  #882's failure is real, this change leaves it visible.
- The regexes are **byte-identical** and the locators are untouched. Nothing is
  relaxed, nothing is retargeted.

## Scope checked rather than assumed

Of the **24** `expect(page.url())` sites under `tests/e2e/`, exactly **two**
follow a `click()` — the Add-CTA test and the programme-table drill-in at `:117`,
which has the identical shape and has not fired. Every other site follows a
`goto()` (or a keyboard press on the firstrun wizard), where a document really
does load and `waitForLoadState` is the right instrument. Those are left alone.

## Verification

- `prettier --check` clean on the changed file.
- `tsc --noEmit` clean on the changed file.
- `playwright test --list` still enumerates all **15** tests in the file (a bad
  import would list fine and exit 0 — hence the `tsc` run as well).
- No `lib/`, `src/`, manifest, register fragment or composer file is touched, so
  no static-analysis or gate surface moves.

## CI — measured

**33 success / 4 skipped / 4 failure.** The 4 are `Integration Tests (Newman)`,
`E2E Tests (Playwright)`, `Hydra Gates` and `Quality Report` — **exactly the set
`development` itself fails**, so this is parity-clean under the fleet merge
policy, not a green PR.

- **E2E: 272 tests → 258 passed / 6 skipped / 8 failed.** The 8 are the same 8
  as the base, and **all 8 are product gaps**: #865 ×1 (`CashflowPdfRenderer` has
  zero callers), #866/#862 ×5 (the manifest declares `config.dashboard.*` and
  `config.filters[]`; nc-vue 2.3.0's `CnDashboardPage` takes `widgets`/`layout`
  and `CnIndexPage`'s filter prop is `quickFilters`), #860 ×2
  (`/inventory/products` is declared by no manifest and there is no `Product`
  schema). **E2E cannot honestly go green here without building those features.**
- **Newman:** the same single pre-existing assertion (`REQ-008`), fixed
  separately in #882.
- **Hydra Gates:** the same 6 gates as the base — this PR touches no gated
  surface. Also #882's.
