### PR TITLE
chore(deps): add composer cooldown to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,29 @@ updates:
         - "*"
       exclude:
         - "@conduction/*"
+
+  # Composer had NO entry at all, so PHP dependencies were updated with no
+  # cooldown whatsoever — the window in which a compromised release is still
+  # published is exactly the window an instant update walks into. `npm` above
+  # has had one for a while; composer was simply never added, which is not a
+  # decision anyone made.
+  #
+  # Two days rather than one: that is the floor gate-93 enforces, and the npm
+  # entry's single day predates it.
+  #
+  # Our own packages are excluded from the wait on purpose. A cooldown protects
+  # against a compromised upstream release; `conduction/*` comes from this
+  # fleet's own CI, and delaying it would only slow the loop between a fix
+  # being released here and arriving here.
+  - package-ecosystem: "composer"
+    directory: "/"
+    target-branch: "development"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 2
+      include:
+        - "*"
+      exclude:
+        - "conduction/*"


### PR DESCRIPTION
## Summary

Adds a `composer` package-ecosystem entry to `.github/dependabot.yml` with
Dependabot's native `cooldown` key — this app had one for `npm` already but
none for `composer`, so composer dependencies got no release-age cooldown
at all.

```yaml
cooldown:
  default-days: 2
  exclude:
    - "conduction/*"
```

`target-branch: "development"` set to match this file's existing `npm`
entry convention.

Composer has no native install-time equivalent to npm's `min-release-age`
yet (`composer/composer#12847`, unreleased). Two third-party plugins were
evaluated and rejected — one breaks `composer install` on this app's own
PHP 8.3 CI matrix leg, the other is a ~3-month-old single-maintainer
package. This is the interim control: Dependabot-level only, delays
automated dependency PRs, does not block a manual `composer update`.

Part of the fleet-wide rollout in `ConductionNL/hydra`
`openspec/changes/composer-dependency-cooldown`, policed by new gate 93
(`composer-cooldown-config`, `ConductionNL/.github#488`). References
ADR-093 (proposed — `ConductionNL/hydra#591`).

🤖 Authored by Claude Code at Ruben's request.