### PR TITLE
feat(cashflow): build the REQ-CF-016 PDF export end to end (#865)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -410,6 +410,15 @@ return \OCA\OpenRegister\AppHost\Routes::standard(
         // to the caller's accessible administrations (IDOR-safe).
             ['name' => 'sepaAudit#exportMandate', 'url' => '/api/sepa/mandates/{mandateId}/audit-export', 'verb' => 'GET'],
 
+        // 13-week cashflow PDF export (zzp-cashflow-13wk, REQ-CF-016 / #865).
+        // POST because the Cashflow Dashboard's declarative `headerActions[]`
+        // api-call action issues a POST through @nextcloud/axios, which carries
+        // the request token — so the endpoint keeps CSRF protection rather than
+        // opting out of it. It takes NO parameters: the horizon is resolved
+        // server-side from the caller's AdministrationMembership set, so no
+        // caller-supplied object identifier crosses the boundary.
+            ['name' => 'cashflowExport#exportPdf', 'url' => '/api/cashflow/export-pdf', 'verb' => 'POST'],
+
         // BCF compensation calculator (bookkeeping-bcf-claim). Pure compute
         // surface returning a what-if compensation result.
             ['name' => 'bcfClaim#compensation', 'url' => '/api/bcf/compensation', 'verb' => 'GET'],

--- a/lib/Controller/CashflowExportController.php
+++ b/lib/Controller/CashflowExportController.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Cashflow Export Controller
+ *
+ * The route half of REQ-CF-016 (#865): downloads the 13-week cashflow forecast
+ * as a PDF for a bank or accountant meeting. Before this existed,
+ * `CashflowPdfRenderer` had zero callers and `appinfo/routes.php` registered no
+ * cashflow export route at all, so the capability was written and unreachable.
+ *
+ * ## Authorisation posture
+ *
+ * `#[NoAdminRequired]` — this is an operator capability, not an admin one. It
+ * takes NO request parameters: the horizon is resolved server-side from the
+ * caller's own AdministrationMembership set (REQ-MA-001) by
+ * {@see \OCA\Shillinq\Service\CashflowExportService}. There is therefore no
+ * caller-supplied object identifier to guard, which is why no per-object check
+ * appears in this method body — the absence is the design, not an omission.
+ *
+ * No `#[NoCSRFRequired]`: the call is a POST issued by the SPA through
+ * `@nextcloud/axios`, which carries the request token.
+ *
+ * @category Controller
+ * @package  OCA\Shillinq\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Controller;
+
+use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\CashflowExportService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\DataDownloadResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * PDF export endpoint for the 13-week cashflow forecast (REQ-CF-016).
+ *
+ * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
+ */
+class CashflowExportController extends Controller {
+	/**
+	 * Construct the controller.
+	 *
+	 * @param IRequest $request The request.
+	 * @param CashflowExportService $exportService Assembles the export document.
+	 * @param IUserSession $userSession Session for the auth body-guard.
+	 * @param LoggerInterface $logger Logger.
+	 */
+	public function __construct(
+		IRequest $request,
+		private readonly CashflowExportService $exportService,
+		private readonly IUserSession $userSession,
+		private readonly LoggerInterface $logger,
+	) {
+		parent::__construct(appName: Application::APP_ID, request: $request);
+	}//end __construct()
+
+	/**
+	 * Download the current 13-week cashflow forecast as a PDF (REQ-CF-016).
+	 *
+	 * Answers 404 rather than an empty 200 when the caller's administration has
+	 * no horizon: a blank forecast handed to a bank is a worse artefact than a
+	 * refusal, and the dashboard surfaces the refusal as a toast.
+	 *
+	 * @return DataDownloadResponse|JSONResponse The PDF download, or a JSON error envelope.
+	 *
+	 * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
+	 */
+	#[NoAdminRequired]
+	public function exportPdf(): DataDownloadResponse|JSONResponse {
+		if ($this->userSession->getUser() === null) {
+			return new JSONResponse(['error' => 'Authentication required'], Http::STATUS_UNAUTHORIZED);
+		}
+
+		try {
+			$export = $this->exportService->buildHorizonExport();
+		} catch (Throwable $e) {
+			$this->logger->error(
+				'CashflowExportController: cashflow PDF export failed',
+				['exception' => $e->getMessage()]
+			);
+			return new JSONResponse(['error' => 'export_failed'], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+
+		if ($export === null) {
+			return new JSONResponse(['error' => 'no_cashflow_horizon'], Http::STATUS_NOT_FOUND);
+		}
+
+		return new DataDownloadResponse(
+			$export['payload'],
+			$export['filename'],
+			$export['mimeType']
+		);
+	}//end exportPdf()
+}//end class

--- a/lib/Service/CashflowExportService.php
+++ b/lib/Service/CashflowExportService.php
@@ -1,0 +1,337 @@
+<?php
+
+/**
+ * Cashflow Export Service
+ *
+ * Gathers a CashflowForecastHorizon and everything REQ-CF-016 says the export
+ * must contain out of OpenRegister, and hands it to
+ * {@see CashflowPdfRenderer::renderPdf()}. This is the caller the renderer
+ * never had (#865): the renderer existed with ZERO call sites, no route and no
+ * button, so a statutory-reporting capability was written and unreachable.
+ *
+ * ## Scoping, and why the horizon is not addressable
+ *
+ * `buildHorizonExport()` takes NO identifier. It resolves the most recently
+ * rolled horizon belonging to an administration the authenticated caller holds
+ * a valid AdministrationMembership for (REQ-MA-001), through
+ * {@see AdministrationContextService::accessibleAdministrationIds()}.
+ *
+ * That is a deliberate design choice rather than an omission: an endpoint that
+ * accepted a caller-supplied `horizonId` would need its own per-object
+ * authorisation guard, and the dashboard the button lives on
+ * (`/cashflow/dashboard`) carries no object context to supply one from. With
+ * no identifier crossing the boundary there is no IDOR surface to guard. When
+ * a per-horizon export is wanted later it belongs on the horizon DETAIL page,
+ * where the guard has an object to check against.
+ *
+ * ## `filters` addresses JSON properties, and that is the correct use here
+ *
+ * Every lookup below filters on a declared schema property
+ * (`administrationId`, `horizonId`) — never on `id`. `findAll(['filters' =>
+ * ['id' => …]])` matches NOTHING for every value, silently, because the
+ * entity's `id` is its own column and not a property the filter can see; see
+ * {@see \OCA\Shillinq\Util\ObjectIdentifier::findOne()} for the shape to use
+ * when a lookup really is by identifier.
+ *
+ * @category Service
+ * @package  OCA\Shillinq\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Service;
+
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
+use OCA\Shillinq\AppInfo\Application;
+use OCP\IAppConfig;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Assembles the REQ-CF-016 cashflow PDF export for the caller's current horizon.
+ *
+ * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
+ */
+class CashflowExportService {
+	/**
+	 * CashflowForecastHorizon schema slug.
+	 *
+	 * @var string
+	 */
+	public const SCHEMA_HORIZON = 'CashflowForecastHorizon';
+
+	/**
+	 * CashflowWeek schema slug.
+	 *
+	 * @var string
+	 */
+	public const SCHEMA_WEEK = 'CashflowWeek';
+
+	/**
+	 * CashflowARProjection schema slug.
+	 *
+	 * @var string
+	 */
+	public const SCHEMA_AR_PROJECTION = 'CashflowARProjection';
+
+	/**
+	 * CashflowRecurring schema slug.
+	 *
+	 * @var string
+	 */
+	public const SCHEMA_RECURRING = 'CashflowRecurring';
+
+	/**
+	 * How many customers REQ-CF-016 §3 asks for ("top 5 by AR balance").
+	 *
+	 * @var integer
+	 */
+	private const TOP_CUSTOMERS = 5;
+
+	/**
+	 * Construct the export service.
+	 *
+	 * @param IAppConfig $appConfig App config (OpenRegister register slug).
+	 * @param LoggerInterface $logger Logger — never receives a record body.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
+	 * @param AdministrationContextService $administrationContext Membership guard (REQ-MA-001).
+	 * @param CashflowPdfRenderer $renderer The document renderer.
+	 */
+	public function __construct(
+		private readonly IAppConfig $appConfig,
+		private readonly LoggerInterface $logger,
+		private readonly ObjectServiceInterface $objectService,
+		private readonly AdministrationContextService $administrationContext,
+		private readonly CashflowPdfRenderer $renderer,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Build the PDF export for the caller's current cashflow horizon (REQ-CF-016).
+	 *
+	 * @return array{filename:string,mimeType:string,payload:string}|null The
+	 *         download envelope, or null when the caller has no accessible
+	 *         administration or that administration has no horizon yet. Null is
+	 *         NOT an empty document on purpose: a blank export of an
+	 *         administration that has never been forecast reads, to a bank, as
+	 *         a business with no cashflow.
+	 *
+	 * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
+	 */
+	public function buildHorizonExport(): ?array {
+		$administrationIds = $this->administrationContext->accessibleAdministrationIds();
+		if ($administrationIds === []) {
+			return null;
+		}
+
+		$horizon = $this->currentHorizon(administrationIds: $administrationIds);
+		if ($horizon === null) {
+			return null;
+		}
+
+		$horizonId = (string)($horizon['horizonId'] ?? '');
+		$administrationId = (string)($horizon['administrationId'] ?? '');
+
+		return $this->renderer->renderPdf(
+			horizon: $horizon,
+			weeks: $this->weeksFor(horizonId: $horizonId),
+			scenario: null,
+			topCustomers: $this->topCustomersFor(horizonId: $horizonId),
+			recurringBreakdown: $this->recurringFor(administrationId: $administrationId)
+		);
+
+	}//end buildHorizonExport()
+
+	/**
+	 * Resolve the most recently rolled horizon across the caller's administrations.
+	 *
+	 * @param array<int,string> $administrationIds Administrations the caller may read.
+	 *
+	 * @return array<string,mixed>|null The horizon, or null when there is none.
+	 */
+	private function currentHorizon(array $administrationIds): ?array {
+		$candidates = [];
+		foreach ($administrationIds as $administrationId) {
+			foreach ($this->query(schema: self::SCHEMA_HORIZON, filters: ['administrationId' => $administrationId]) as $row) {
+				$candidates[] = $row;
+			}
+		}
+
+		if ($candidates === []) {
+			return null;
+		}
+
+		usort(
+			$candidates,
+			static function (array $left, array $right): int {
+				return strcmp((string)($right['rolledOn'] ?? ''), (string)($left['rolledOn'] ?? ''));
+			}
+		);
+
+		return $candidates[0];
+	}//end currentHorizon()
+
+	/**
+	 * Load a horizon's weeks, ordered by weeknummer (REQ-CF-016 §1).
+	 *
+	 * The sort is done here rather than being asked of OpenRegister because a
+	 * horizon is thirteen rows: the ordering is a property of the report, and
+	 * a caller that silently depended on storage order would render the table
+	 * out of sequence the first time a week was recomputed.
+	 *
+	 * @param string $horizonId The horizon's business identifier.
+	 *
+	 * @return list<array<string,mixed>> The weeks in weeknummer order.
+	 */
+	private function weeksFor(string $horizonId): array {
+		if ($horizonId === '') {
+			return [];
+		}
+
+		$weeks = $this->query(schema: self::SCHEMA_WEEK, filters: ['horizonId' => $horizonId]);
+		usort(
+			$weeks,
+			static function (array $left, array $right): int {
+				return ((int)($left['weekNumber'] ?? 0) <=> (int)($right['weekNumber'] ?? 0));
+			}
+		);
+
+		return $weeks;
+	}//end weeksFor()
+
+	/**
+	 * Build the top-5-by-AR-balance customer section (REQ-CF-016 §3).
+	 *
+	 * ⚠️ The key mapping below is not cosmetic. `CashflowARProjection` declares
+	 * `payment_history_average_deviation`, while the renderer — written against
+	 * the design document, and never called until now — reads
+	 * `gemiddeldeAfwijking`. Adapting here is the narrow fix: renaming the
+	 * renderer's read key changes a published input contract that its own tests
+	 * pin, and renaming the schema property is a data migration.
+	 *
+	 * @param string $horizonId The horizon's business identifier.
+	 *
+	 * @return list<array<string,mixed>> Up to five rows in the renderer's input shape.
+	 */
+	private function topCustomersFor(string $horizonId): array {
+		if ($horizonId === '') {
+			return [];
+		}
+
+		$projections = $this->query(schema: self::SCHEMA_AR_PROJECTION, filters: ['horizonId' => $horizonId]);
+
+		$byCustomer = [];
+		foreach ($projections as $projection) {
+			$customerId = (string)($projection['customerId'] ?? '');
+			if ($customerId === '') {
+				continue;
+			}
+
+			if (isset($byCustomer[$customerId]) === false) {
+				$byCustomer[$customerId] = [
+					'customerId' => $customerId,
+					'outstandingAmount' => 0.0,
+					'gemiddeldeAfwijking' => (string)($projection['payment_history_average_deviation'] ?? '?'),
+					'reliabilityScore' => (float)($projection['reliabilityScore'] ?? 0),
+				];
+			}
+
+			$byCustomer[$customerId]['outstandingAmount'] += (float)($projection['outstandingAmount'] ?? 0);
+		}
+
+		$rows = array_values($byCustomer);
+		usort(
+			$rows,
+			static function (array $left, array $right): int {
+				return ($right['outstandingAmount'] <=> $left['outstandingAmount']);
+			}
+		);
+
+		return array_slice($rows, 0, self::TOP_CUSTOMERS);
+	}//end topCustomersFor()
+
+	/**
+	 * Load the administration's recurring cost registry (REQ-CF-016 §3).
+	 *
+	 * @param string $administrationId The horizon's administration.
+	 *
+	 * @return list<array<string,mixed>> The recurring rows.
+	 */
+	private function recurringFor(string $administrationId): array {
+		if ($administrationId === '') {
+			return [];
+		}
+
+		return $this->query(schema: self::SCHEMA_RECURRING, filters: ['administrationId' => $administrationId]);
+	}//end recurringFor()
+
+	/**
+	 * Run one property-filtered query against the shillinq register.
+	 *
+	 * A failure is logged and answered as an empty result set rather than
+	 * propagated: a missing recurring registry must not stop the horizon
+	 * summary from reaching the bank.
+	 *
+	 * @param string $schema The schema slug.
+	 * @param array<string,mixed> $filters Property filters (never `id`).
+	 *
+	 * @return list<array<string,mixed>> The matching records as plain arrays.
+	 */
+	private function query(string $schema, array $filters): array {
+		try {
+			$rows = $this->objectService
+				->setRegister($this->register())
+				->setSchema($schema)
+				->findAll(['filters' => $filters]);
+		} catch (Throwable $e) {
+			$this->logger->error(
+				'CashflowExportService: failed to query OpenRegister',
+				['schema' => $schema, 'exception' => $e->getMessage()]
+			);
+			return [];
+		}
+
+		$result = [];
+		foreach ($rows as $row) {
+			if (is_array($row) === true) {
+				$result[] = $row;
+				continue;
+			}
+
+			if (is_object($row) === true && method_exists($row, 'getObject') === true) {
+				$payload = $row->getObject();
+				if (is_array($payload) === true) {
+					$result[] = $payload;
+				}
+			}
+		}
+
+		return $result;
+	}//end query()
+
+	/**
+	 * Resolve the OpenRegister register slug from app config.
+	 *
+	 * @return string The register slug, defaulting to `shillinq`.
+	 */
+	private function register(): string {
+		$register = $this->appConfig->getValueString(Application::APP_ID, 'register', 'shillinq');
+		if ($register === '') {
+			return 'shillinq';
+		}
+
+		return $register;
+	}//end register()
+}//end class

--- a/lib/Service/CashflowPdfRenderer.php
+++ b/lib/Service/CashflowPdfRenderer.php
@@ -131,6 +131,23 @@ class CashflowPdfRenderer {
 	private const CHART_HALF_HEIGHT = 300;
 
 	/**
+	 * Construct the renderer.
+	 *
+	 * `$pdf` defaults to a fresh {@see PdfDocument} so the existing
+	 * `new CashflowPdfRenderer()` call shape — used by the container and by
+	 * this class's own tests — keeps working unchanged. It is a collaborator
+	 * rather than a static utility because phpmd's CleanCode ruleset reports
+	 * static access, and `lib/` currently carries zero phpmd findings.
+	 *
+	 * @param PdfDocument $pdf The PDF object serialiser.
+	 */
+	public function __construct(
+		private readonly PdfDocument $pdf = new PdfDocument(),
+	) {
+
+	}//end __construct()
+
+	/**
 	 * Render a cashflow horizon to a textual PDF-compatible summary.
 	 *
 	 * Returns a string payload suitable for downstream PDF wrapping (e.g.
@@ -352,7 +369,7 @@ class CashflowPdfRenderer {
 		$ops[] = sprintf('%d %d Td', self::MARGIN_X, (self::PAGE_HEIGHT - self::MARGIN_Y));
 
 		foreach ($lines as $line) {
-			$ops[] = '(' . PdfDocument::escapeString(rtrim($line)) . ') Tj';
+			$ops[] = '(' . $this->pdf->escapeString(rtrim($line)) . ') Tj';
 			$ops[] = 'T*';
 		}
 
@@ -404,7 +421,7 @@ class CashflowPdfRenderer {
 			'BT',
 			'/F1 9 Tf',
 			sprintf('%d %d Td', self::MARGIN_X, (self::PAGE_HEIGHT - self::MARGIN_Y - 18)),
-			'(' . PdfDocument::escapeString(
+			'(' . $this->pdf->escapeString(
 				'Horizon ' . (string)($horizon['horizonStart'] ?? '?') . ' .. ' . (string)($horizon['horizonEnd'] ?? '?')
 				. '   blue = above buffer, amber = pre-alert, red = below buffer'
 			) . ') Tj',
@@ -420,21 +437,24 @@ class CashflowPdfRenderer {
 		foreach ($weeks as $index => $week) {
 			$balance = (float)($week['closingBalance'] ?? 0);
 			$height = (($balance / $scale) * self::CHART_HALF_HEIGHT);
-			$x = (self::MARGIN_X + ($index * $slot) + (($slot - $barWidth) / 2));
+			$barX = (self::MARGIN_X + ($index * $slot) + (($slot - $barWidth) / 2));
 
-			$y = $zeroY;
+			// A negative balance hangs DOWN from the zero line: the rectangle's
+			// origin is its bottom-left corner, so the bar's foot moves down by
+			// its own (negative) height and the height itself is drawn positive.
+			$barY = $zeroY;
 			if ($height < 0) {
-				$y = ($zeroY + $height);
+				$barY = ($zeroY + $height);
 			}
 
 			$ops[] = $this->bufferColour(status: (string)($week['bufferStatus'] ?? ''));
-			$ops[] = sprintf('%.2f %.2f %.2f %.2f re', $x, $y, $barWidth, abs($height));
+			$ops[] = sprintf('%.2f %.2f %.2f %.2f re', $barX, $barY, $barWidth, abs($height));
 			$ops[] = 'f';
 
 			$ops[] = 'BT';
 			$ops[] = '/F1 7 Tf';
-			$ops[] = sprintf('%.2f %.2f Td', $x, ($zeroY - self::CHART_HALF_HEIGHT - 14));
-			$ops[] = '(' . PdfDocument::escapeString('w' . (string)($week['weekNumber'] ?? '?')) . ') Tj';
+			$ops[] = sprintf('%.2f %.2f Td', $barX, ($zeroY - self::CHART_HALF_HEIGHT - 14));
+			$ops[] = '(' . $this->pdf->escapeString('w' . (string)($week['weekNumber'] ?? '?')) . ') Tj';
 			$ops[] = 'ET';
 		}
 
@@ -495,6 +515,6 @@ class CashflowPdfRenderer {
 		$objects[1] = '<< /Type /Catalog /Pages 2 0 R >>';
 		$objects[2] = '<< /Type /Pages /Kids [' . implode(' ', $kids) . '] /Count ' . count($kids) . ' >>';
 
-		return PdfDocument::assemble(objects: $objects);
+		return $this->pdf->assemble(objects: $objects);
 	}//end document()
 }//end class

--- a/lib/Service/CashflowPdfRenderer.php
+++ b/lib/Service/CashflowPdfRenderer.php
@@ -15,6 +15,23 @@
  * "Export PDF" UI button always has something to download even when OR's
  * renderer is offline.
  *
+ * ## Two outputs, and why both exist (#865)
+ *
+ * {@see render()} returns the plain-text report and is unchanged. It is the
+ * layout, and it is what every existing caller-facing test asserts on.
+ *
+ * {@see renderPdf()} is what the "Export PDF" affordance downloads: the same
+ * report, materialised as a real `%PDF-1.7` binary through
+ * {@see \OCA\Shillinq\Util\PdfDocument}, plus the REQ-CF-016 §2 closing-balance
+ * bar chart drawn as vector rectangles. Advertising `application/pdf` over
+ * `render()`'s bytes would have produced a file that fails to open in every
+ * viewer while every route/status assertion stayed green, which is exactly the
+ * shape #865 was filed about.
+ *
+ * ⚠️ The PDF is NOT PDF/A: no ICC OutputIntent is emitted and the standard-14
+ * Courier/Helvetica faces are referenced, not embedded. Nothing here asserts a
+ * conformance level.
+ *
  * @category Service
  * @package  OCA\Shillinq\Service
  *
@@ -34,6 +51,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Service;
 
+use OCA\Shillinq\Util\PdfDocument;
+
 /**
  * Pure data-to-PDF mapper for cashflow-horizon export.
  *
@@ -46,6 +65,71 @@ namespace OCA\Shillinq\Service;
  *     verification of each branch.
  */
 class CashflowPdfRenderer {
+	/**
+	 * A4 page width in PDF user-space units (points).
+	 *
+	 * @var integer
+	 */
+	private const PAGE_WIDTH = 595;
+
+	/**
+	 * A4 page height in PDF user-space units (points).
+	 *
+	 * @var integer
+	 */
+	private const PAGE_HEIGHT = 842;
+
+	/**
+	 * Left/right margin in points.
+	 *
+	 * @var integer
+	 */
+	private const MARGIN_X = 40;
+
+	/**
+	 * Top margin in points.
+	 *
+	 * @var integer
+	 */
+	private const MARGIN_Y = 48;
+
+	/**
+	 * Courier body size in points. Chosen so the widest row the text report
+	 * produces (the 6-column week table) fits the A4 text column.
+	 *
+	 * @var integer
+	 */
+	private const FONT_SIZE = 8;
+
+	/**
+	 * Baseline-to-baseline distance in points.
+	 *
+	 * @var integer
+	 */
+	private const LEADING = 10;
+
+	/**
+	 * Report lines per text page — `(PAGE_HEIGHT - 2*MARGIN_Y) / LEADING`,
+	 * rounded down.
+	 *
+	 * @var integer
+	 */
+	private const LINES_PER_PAGE = 74;
+
+	/**
+	 * Y coordinate of the bar chart's zero line.
+	 *
+	 * @var integer
+	 */
+	private const CHART_ZERO_Y = 420;
+
+	/**
+	 * Maximum bar length in points, in either direction from the zero line.
+	 *
+	 * @var integer
+	 */
+	private const CHART_HALF_HEIGHT = 300;
+
 	/**
 	 * Render a cashflow horizon to a textual PDF-compatible summary.
 	 *
@@ -178,4 +262,239 @@ class CashflowPdfRenderer {
 		];
 
 	}//end render()
+
+	/**
+	 * Render the same report as a real PDF binary (REQ-CF-016).
+	 *
+	 * This is the method the "Export PDF" affordance downloads. Layout:
+	 *
+	 *  - page 1 carries the REQ-CF-016 §2 closing-balance bar chart, drawn as
+	 *    vector rectangles coloured by each week's `bufferStatus`, and is
+	 *    omitted entirely when there are no weeks (a chart of nothing is a
+	 *    misleading empty axis, not an honest blank);
+	 *  - the remaining pages carry {@see render()}'s text report in Courier,
+	 *    whose fixed advance is what keeps the week table's columns aligned.
+	 *
+	 * The content streams are uncompressed on purpose: it costs a few KB on a
+	 * one-horizon document and it means the report text is greppable in the
+	 * artefact, so a test can assert the forecast actually reached the page
+	 * rather than only that a PDF was produced.
+	 *
+	 * @param array<string,mixed> $horizon CashflowForecastHorizon as array.
+	 * @param list<array<string,mixed>> $weeks 13 CashflowWeek records ordered by weeknummer.
+	 * @param array<string,mixed>|null $scenario Optional CashflowScenario to overlay.
+	 * @param list<array<string,mixed>> $topCustomers Top-5 customers by AR balance with betalingsgedrag offsets.
+	 * @param list<array<string,mixed>> $recurringBreakdown CashflowRecurring rows expanded for the horizon.
+	 *
+	 * @return array{filename:string,mimeType:string,payload:string} Filename, `application/pdf`, and the raw PDF bytes.
+	 *
+	 * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
+	 */
+	public function renderPdf(
+		array $horizon,
+		array $weeks,
+		?array $scenario = null,
+		array $topCustomers = [],
+		array $recurringBreakdown = [],
+	): array {
+		$report = $this->render(
+			horizon: $horizon,
+			weeks: $weeks,
+			scenario: $scenario,
+			topCustomers: $topCustomers,
+			recurringBreakdown: $recurringBreakdown
+		);
+
+		$streams = [];
+		if ($weeks !== []) {
+			$streams[] = $this->chartStream(horizon: $horizon, weeks: $weeks);
+		}
+
+		foreach ($this->paginate(lines: explode("\n", $report['payload'])) as $page) {
+			$streams[] = $this->textStream(lines: $page);
+		}
+
+		$filename = 'cashflow-' . ($horizon['horizonId'] ?? 'horizon') . '-' . date('Y-m-d') . '.pdf';
+
+		return [
+			'filename' => $filename,
+			'mimeType' => 'application/pdf',
+			'payload' => $this->document(streams: $streams),
+		];
+
+	}//end renderPdf()
+
+	/**
+	 * Split report lines into fixed-height pages.
+	 *
+	 * @param list<string> $lines The report lines.
+	 *
+	 * @return list<list<string>> One entry per page.
+	 */
+	private function paginate(array $lines): array {
+		$pages = array_chunk($lines, self::LINES_PER_PAGE);
+		if ($pages === []) {
+			return [[]];
+		}
+
+		return $pages;
+	}//end paginate()
+
+	/**
+	 * Build the content stream for one page of monospaced report text.
+	 *
+	 * @param list<string> $lines The page's lines.
+	 *
+	 * @return string A PDF content stream.
+	 */
+	private function textStream(array $lines): string {
+		$ops = ['BT', '/F1 ' . self::FONT_SIZE . ' Tf', self::LEADING . ' TL'];
+		$ops[] = sprintf('%d %d Td', self::MARGIN_X, (self::PAGE_HEIGHT - self::MARGIN_Y));
+
+		foreach ($lines as $line) {
+			$ops[] = '(' . PdfDocument::escapeString(rtrim($line)) . ') Tj';
+			$ops[] = 'T*';
+		}
+
+		$ops[] = 'ET';
+
+		return implode("\n", $ops);
+	}//end textStream()
+
+	/**
+	 * Build the content stream for the closing-balance bar chart (REQ-CF-016 §2).
+	 *
+	 * Bars are scaled against the largest absolute closing balance in the
+	 * horizon, so a horizon that never goes negative uses the full plot height
+	 * and one that does keeps both directions to scale against each other. The
+	 * zero line is always drawn, because a bar chart with no baseline cannot be
+	 * read.
+	 *
+	 * @param array<string,mixed> $horizon The horizon (title metadata only).
+	 * @param list<array<string,mixed>> $weeks The weeks to plot.
+	 *
+	 * @return string A PDF content stream.
+	 */
+	private function chartStream(array $horizon, array $weeks): string {
+		$balances = [];
+		foreach ($weeks as $week) {
+			$balances[] = (float)($week['closingBalance'] ?? 0);
+		}
+
+		$scale = 0.0;
+		foreach ($balances as $balance) {
+			$scale = max($scale, abs($balance));
+		}
+
+		if ($scale <= 0.0) {
+			$scale = 1.0;
+		}
+
+		$plotWidth = (self::PAGE_WIDTH - (2 * self::MARGIN_X));
+		$slot = ($plotWidth / max(count($weeks), 1));
+		$barWidth = max(($slot * 0.6), 1.0);
+		$zeroY = self::CHART_ZERO_Y;
+
+		$ops = [
+			'BT',
+			'/F2 14 Tf',
+			sprintf('%d %d Td', self::MARGIN_X, (self::PAGE_HEIGHT - self::MARGIN_Y)),
+			'(13-WEEK CLOSING BALANCE) Tj',
+			'ET',
+			'BT',
+			'/F1 9 Tf',
+			sprintf('%d %d Td', self::MARGIN_X, (self::PAGE_HEIGHT - self::MARGIN_Y - 18)),
+			'(' . PdfDocument::escapeString(
+				'Horizon ' . (string)($horizon['horizonStart'] ?? '?') . ' .. ' . (string)($horizon['horizonEnd'] ?? '?')
+				. '   blue = above buffer, amber = pre-alert, red = below buffer'
+			) . ') Tj',
+			'ET',
+			// Zero line.
+			'0.4 0.4 0.4 RG',
+			'0.8 w',
+			sprintf('%d %d m', self::MARGIN_X, $zeroY),
+			sprintf('%d %d l', (self::PAGE_WIDTH - self::MARGIN_X), $zeroY),
+			'S',
+		];
+
+		foreach ($weeks as $index => $week) {
+			$balance = (float)($week['closingBalance'] ?? 0);
+			$height = (($balance / $scale) * self::CHART_HALF_HEIGHT);
+			$x = (self::MARGIN_X + ($index * $slot) + (($slot - $barWidth) / 2));
+
+			$y = $zeroY;
+			if ($height < 0) {
+				$y = ($zeroY + $height);
+			}
+
+			$ops[] = $this->bufferColour(status: (string)($week['bufferStatus'] ?? ''));
+			$ops[] = sprintf('%.2f %.2f %.2f %.2f re', $x, $y, $barWidth, abs($height));
+			$ops[] = 'f';
+
+			$ops[] = 'BT';
+			$ops[] = '/F1 7 Tf';
+			$ops[] = sprintf('%.2f %.2f Td', $x, ($zeroY - self::CHART_HALF_HEIGHT - 14));
+			$ops[] = '(' . PdfDocument::escapeString('w' . (string)($week['weekNumber'] ?? '?')) . ') Tj';
+			$ops[] = 'ET';
+		}
+
+		return implode("\n", $ops);
+	}//end chartStream()
+
+	/**
+	 * Map a week's buffer status onto a PDF fill colour operator.
+	 *
+	 * @param string $status The CashflowWeek bufferStatus value.
+	 *
+	 * @return string An `r g b rg` fill-colour operator.
+	 */
+	private function bufferColour(string $status): string {
+		$upper = strtoupper($status);
+		if (str_contains($upper, 'BELOW') === true || str_contains($upper, 'CRISIS') === true) {
+			return '0.80 0.16 0.16 rg';
+		}
+
+		if (str_contains($upper, 'PRE_ALERT') === true || str_contains($upper, 'ALERT') === true) {
+			return '0.90 0.62 0.12 rg';
+		}
+
+		return '0.13 0.40 0.72 rg';
+	}//end bufferColour()
+
+	/**
+	 * Assemble the page tree, fonts and content streams into a PDF document.
+	 *
+	 * Object numbering: 1 Catalog, 2 Pages, 3 Courier, 4 Helvetica-Bold, then
+	 * a (Page, Contents) pair per stream — contiguous from 1, which the xref
+	 * table depends on.
+	 *
+	 * @param list<string> $streams One content stream per page.
+	 *
+	 * @return string The complete PDF document bytes.
+	 */
+	private function document(array $streams): string {
+		$objects = [];
+		$objects[3] = '<< /Type /Font /Subtype /Type1 /BaseFont /Courier /Encoding /WinAnsiEncoding >>';
+		$objects[4] = '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>';
+
+		$next = 5;
+		$kids = [];
+		foreach ($streams as $stream) {
+			$pageNumber = $next;
+			$contentNumber = ($next + 1);
+			$next += 2;
+
+			$kids[] = $pageNumber . ' 0 R';
+			$objects[$pageNumber] = '<< /Type /Page /Parent 2 0 R'
+				. ' /MediaBox [0 0 ' . self::PAGE_WIDTH . ' ' . self::PAGE_HEIGHT . ']'
+				. ' /Resources << /Font << /F1 3 0 R /F2 4 0 R >> >>'
+				. ' /Contents ' . $contentNumber . ' 0 R >>';
+			$objects[$contentNumber] = '<< /Length ' . strlen($stream) . " >>\nstream\n" . $stream . "\nendstream";
+		}
+
+		$objects[1] = '<< /Type /Catalog /Pages 2 0 R >>';
+		$objects[2] = '<< /Type /Pages /Kids [' . implode(' ', $kids) . '] /Count ' . count($kids) . ' >>';
+
+		return PdfDocument::assemble(objects: $objects);
+	}//end document()
 }//end class

--- a/lib/Util/PdfDocument.php
+++ b/lib/Util/PdfDocument.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * PDF Document Assembler
+ *
+ * Serialises a set of numbered PDF objects into a complete, structurally valid
+ * PDF document with a correct cross-reference table and trailer, plus the
+ * escaping rule for a PDF literal string token.
+ *
+ * ## Why this is a util and not a composer dependency
+ *
+ * Extracted verbatim from {@see \OCA\Shillinq\Service\InvoicePdfGenerator},
+ * which already shipped this byte-writer for the NLCIUS hybrid invoice export
+ * (REQ-EINV-002). That class's docblock records the decision and it still
+ * stands: a heavy PDF/A toolchain (mPDF / TCPDF / dompdf) is gold-plating for
+ * documents whose compliance artefact is the embedded XML, and shillinq's
+ * `composer.json` requires nothing but `php` + `ext-zip` at runtime. The
+ * cashflow export (REQ-CF-016) needs the same writer, so it lives here rather
+ * than being copied a second time.
+ *
+ * ⚠️ What this writer does NOT do, stated so nobody infers it: it emits no ICC
+ * `OutputIntent` and embeds no font (the standard-14 Helvetica/Courier faces
+ * are referenced by name). A document built with it therefore meets NO PDF/A
+ * conformance level, and nothing built on it may assert `pdfaid:part` /
+ * `pdfaid:conformance` in its XMP metadata.
+ *
+ * @category Util
+ * @package  OCA\Shillinq\Util
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Util;
+
+/**
+ * Dependency-free PDF object serialiser.
+ *
+ * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
+ */
+final class PdfDocument {
+	/**
+	 * Serialise a set of PDF objects (indexed by object number starting at 1)
+	 * into a complete PDF document with a correct cross-reference table and
+	 * trailer.
+	 *
+	 * Object numbers MUST be contiguous from 1: the xref table is positional,
+	 * so a gap would point a reader at the wrong byte offset.
+	 *
+	 * @param array<int,string> $objects Object bodies keyed by object number
+	 *                                   (without the `N 0 obj` / `endobj` wrapper).
+	 *
+	 * @return string The complete PDF document bytes.
+	 *
+	 * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
+	 */
+	public static function assemble(array $objects): string {
+		ksort($objects);
+		$count = count($objects);
+
+		$out = "%PDF-1.7\n%\xE2\xE3\xCF\xD3\n";
+		$offsets = [0 => 0];
+
+		foreach ($objects as $number => $body) {
+			$offsets[$number] = strlen($out);
+			$out .= $number . " 0 obj\n" . $body . "\nendobj\n";
+		}
+
+		$xrefOffset = strlen($out);
+		$out .= "xref\n0 " . ($count + 1) . "\n";
+		$out .= "0000000000 65535 f \n";
+		for ($i = 1; $i <= $count; $i++) {
+			$out .= sprintf("%010d 00000 n \n", $offsets[$i]);
+		}
+
+		$out .= "trailer\n<< /Size " . ($count + 1) . ' /Root 1 0 R /ID [<' . md5((string)$xrefOffset) . '> <' . md5($xrefOffset . '-2') . ">] >>\n";
+		$out .= 'startxref' . "\n" . $xrefOffset . "\n%%EOF";
+
+		return $out;
+	}//end assemble()
+
+	/**
+	 * Escape a value for a PDF literal string `(...)` token (backslash,
+	 * parentheses, and control characters).
+	 *
+	 * @param string $value Raw value.
+	 *
+	 * @return string The escaped value, safe to place between `(` and `)`.
+	 *
+	 * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
+	 */
+	public static function escapeString(string $value): string {
+		$escaped = str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $value);
+
+		return (string)preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $escaped);
+	}//end escapeString()
+}//end class

--- a/lib/Util/PdfDocument.php
+++ b/lib/Util/PdfDocument.php
@@ -57,6 +57,11 @@ final class PdfDocument {
 	 * Object numbers MUST be contiguous from 1: the xref table is positional,
 	 * so a gap would point a reader at the wrong byte offset.
 	 *
+	 * ℹ️ An instance method rather than a static one so callers can hold it as
+	 * an injected collaborator — `phpmd`'s CleanCode ruleset is enabled here
+	 * and reports static access as a finding, and `development` currently
+	 * carries ZERO phpmd findings across `lib/`.
+	 *
 	 * @param array<int,string> $objects Object bodies keyed by object number
 	 *                                   (without the `N 0 obj` / `endobj` wrapper).
 	 *
@@ -64,7 +69,7 @@ final class PdfDocument {
 	 *
 	 * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
 	 */
-	public static function assemble(array $objects): string {
+	public function assemble(array $objects): string {
 		ksort($objects);
 		$count = count($objects);
 
@@ -99,7 +104,7 @@ final class PdfDocument {
 	 *
 	 * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
 	 */
-	public static function escapeString(string $value): string {
+	public function escapeString(string $value): string {
 		$escaped = str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $value);
 
 		return (string)preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $escaped);

--- a/src/components/cashflow/CashflowDashboard.vue
+++ b/src/components/cashflow/CashflowDashboard.vue
@@ -1,6 +1,20 @@
 <!--
   Cashflow Dashboard Skeleton
 
+  ⚠️ THIS COMPONENT IS AN ORPHAN AND ITS "Export PDF" BUTTON IS NOT THE ONE
+  THAT WORKS. Nothing imports this file, it has no registry entry and no
+  manifest binding, so it never mounts; its @click only $emit's 'export-pdf'
+  and nothing listens. It is left in place because its crisis-banner and
+  scenario-switcher skeletons are still unspent design, but it must not be
+  mistaken for the implementation.
+
+  The live REQ-CF-016 affordance (#865) is the declarative
+  `config.headerActions[]` entry on the CashflowDashboard page in
+  src/manifest.json: an api-call action with `download: true` that POSTs
+  /apps/shillinq/api/cashflow/export-pdf and saves the returned PDF. Its
+  chain is CashflowExportController -> CashflowExportService ->
+  CashflowPdfRenderer::renderPdf().
+
   Per ADR-031: the dashboard is rendered by the manifest-v2 page (type: dashboard)
   using widgets backed by x-openregister-aggregations. This component is a thin
   skeleton mounted by the manifest renderer for any host that wants a

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12205,7 +12205,7 @@
 						"url": "/apps/shillinq/api/cashflow/export-pdf",
 						"download": true,
 						"filename": "cashflow-forecast.pdf",
-						"icon": "FilePdfBox",
+						"icon": "DatabaseExportOutline",
 						"successMessage": "Cashflow forecast exported.",
 						"errorMessage": "No cashflow forecast is available to export yet."
 					}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12195,6 +12195,21 @@
 			"type": "dashboard",
 			"title": "Cashflow Dashboard",
 			"config": {
+				"_note_export_pdf": "REQ-CF-016 / #865. CnDashboardPage passes headerActions[] to CnActionButtons, which renders each entry as a plain visible NcButton — not the collapsed overflow CnActionsBar uses on an index page. download:true makes nc-vue 2.3.0 request responseType blob and save the file. No custom component, so no customComponents.js entry can be forgotten.",
+				"headerActions": [
+					{
+						"id": "export-cashflow-pdf",
+						"label": "Export PDF",
+						"type": "api-call",
+						"method": "POST",
+						"url": "/apps/shillinq/api/cashflow/export-pdf",
+						"download": true,
+						"filename": "cashflow-forecast.pdf",
+						"icon": "FilePdfBox",
+						"successMessage": "Cashflow forecast exported.",
+						"errorMessage": "No cashflow forecast is available to export yet."
+					}
+				],
 				"widgets": [
 					{
 						"id": "cashflow-13week-chart",

--- a/tests/Unit/Controller/CashflowExportControllerTest.php
+++ b/tests/Unit/Controller/CashflowExportControllerTest.php
@@ -1,0 +1,245 @@
+<?php
+
+/**
+ * Unit tests for CashflowExportController — the route half of REQ-CF-016
+ * (#865).
+ *
+ * The double for the export service is HAND-WRITTEN (see
+ * {@see RecordingCashflowExportService} at the bottom of this file) rather
+ * than a `createMock()`. A PHPUnit mock cannot observe a named argument — it
+ * resolves a call against its own signature and then invokes the return
+ * callback positionally — so an argument expectation over this app's
+ * named-argument call style measures the double, not the controller. The fake
+ * records what it was actually asked for and the tests assert on the bytes
+ * that came back.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\CashflowExportController;
+use OCA\Shillinq\Service\CashflowExportService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataDownloadResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use RuntimeException;
+
+/**
+ * Covers the cashflow PDF export endpoint.
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+final class CashflowExportControllerTest extends TestCase {
+
+	/**
+	 * Mock IRequest.
+	 *
+	 * @var IRequest&MockObject
+	 */
+	private IRequest&MockObject $request;
+
+	/**
+	 * Hand-written export-service fake.
+	 *
+	 * @var RecordingCashflowExportService
+	 */
+	private RecordingCashflowExportService $exportService;
+
+	/**
+	 * Mock IUserSession.
+	 *
+	 * @var IUserSession&MockObject
+	 */
+	private IUserSession&MockObject $userSession;
+
+	/**
+	 * Set up shared fixtures — authenticated by default.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->request = $this->createMock(IRequest::class);
+		$this->exportService = new RecordingCashflowExportService();
+		$this->userSession = $this->createMock(IUserSession::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+
+	}//end setUp()
+
+	/**
+	 * Build the controller over the current doubles.
+	 *
+	 * @return CashflowExportController
+	 */
+	private function controller(): CashflowExportController {
+		return new CashflowExportController(
+			$this->request,
+			$this->exportService,
+			$this->userSession,
+			new NullLogger(),
+		);
+	}//end controller()
+
+	/**
+	 * The happy path streams the renderer's bytes as a PDF download with the
+	 * renderer's own filename.
+	 *
+	 * @return void
+	 */
+	public function testExportPdfStreamsThePdfAsADownload(): void {
+		$this->exportService->export = [
+			'filename' => 'cashflow-hz-2026-w22-2026-08-17.pdf',
+			'mimeType' => 'application/pdf',
+			'payload' => "%PDF-1.7\nfake-body\n%%EOF",
+		];
+
+		$response = $this->controller()->exportPdf();
+
+		self::assertInstanceOf(DataDownloadResponse::class, $response);
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertSame("%PDF-1.7\nfake-body\n%%EOF", $response->render());
+		self::assertSame(1, $this->exportService->calls);
+		self::assertStringContainsString(
+			'cashflow-hz-2026-w22-2026-08-17.pdf',
+			(string)$response->getHeaders()['Content-Disposition']
+		);
+		self::assertStringContainsString(
+			'application/pdf',
+			(string)$response->getHeaders()['Content-Type']
+		);
+
+	}//end testExportPdfStreamsThePdfAsADownload()
+
+	/**
+	 * An anonymous caller is refused before the service is consulted.
+	 *
+	 * @return void
+	 */
+	public function testExportPdfRequiresAuthentication(): void {
+		$session = $this->createMock(IUserSession::class);
+		$session->method('getUser')->willReturn(null);
+		$this->userSession = $session;
+
+		$response = $this->controller()->exportPdf();
+
+		self::assertInstanceOf(JSONResponse::class, $response);
+		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		self::assertSame(0, $this->exportService->calls, 'the export ran for an anonymous caller');
+
+	}//end testExportPdfRequiresAuthentication()
+
+	/**
+	 * No forecast to export answers 404 with a stable code — never an empty
+	 * 200 PDF, which a bank would read as "this business has no cashflow".
+	 *
+	 * @return void
+	 */
+	public function testExportPdfAnswers404WhenThereIsNoHorizon(): void {
+		$this->exportService->export = null;
+
+		$response = $this->controller()->exportPdf();
+
+		self::assertInstanceOf(JSONResponse::class, $response);
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame(['error' => 'no_cashflow_horizon'], $response->getData());
+
+	}//end testExportPdfAnswers404WhenThereIsNoHorizon()
+
+	/**
+	 * A failure inside the export answers 500 with a stable code and leaks no
+	 * exception text to the caller.
+	 *
+	 * @return void
+	 */
+	public function testExportPdfAnswers500WithoutLeakingTheException(): void {
+		$this->exportService->throw = new RuntimeException('SQLSTATE[42P01] relation "oc_openregister_objects" does not exist');
+
+		$response = $this->controller()->exportPdf();
+
+		self::assertInstanceOf(JSONResponse::class, $response);
+		self::assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		self::assertSame(['error' => 'export_failed'], $response->getData());
+		self::assertStringNotContainsString('SQLSTATE', json_encode($response->getData()));
+
+	}//end testExportPdfAnswers500WithoutLeakingTheException()
+
+}//end class
+
+/**
+ * Hand-written CashflowExportService double.
+ *
+ * Deliberately overrides the constructor without calling the parent's: the
+ * parent's promoted dependencies are never touched because every method that
+ * would read them is overridden here.
+ *
+ * phpcs:disable
+ */
+final class RecordingCashflowExportService extends CashflowExportService {
+
+	/**
+	 * What buildHorizonExport() answers.
+	 *
+	 * @var array{filename:string,mimeType:string,payload:string}|null
+	 */
+	public ?array $export = null;
+
+	/**
+	 * When set, buildHorizonExport() throws it.
+	 *
+	 * @var \Throwable|null
+	 */
+	public ?\Throwable $throw = null;
+
+	/**
+	 * How many times buildHorizonExport() was called.
+	 *
+	 * @var integer
+	 */
+	public int $calls = 0;
+
+	/**
+	 * Build the double.
+	 */
+	public function __construct() {
+		// Intentionally does NOT call parent::__construct(): this fake answers
+		// buildHorizonExport() itself and never reaches a dependency.
+	}//end __construct()
+
+	/**
+	 * Record the call and answer the configured result.
+	 *
+	 * @return array{filename:string,mimeType:string,payload:string}|null
+	 */
+	public function buildHorizonExport(): ?array {
+		$this->calls++;
+		if ($this->throw !== null) {
+			throw $this->throw;
+		}
+
+		return $this->export;
+	}//end buildHorizonExport()
+}//end class

--- a/tests/Unit/Service/CashflowExportServiceTest.php
+++ b/tests/Unit/Service/CashflowExportServiceTest.php
@@ -40,13 +40,16 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\CashflowExportService;
 use OCA\Shillinq\Service\CashflowPdfRenderer;
 use OCA\Shillinq\Tests\Unit\Service\Support\InMemoryObjectServiceStub;
+use OCA\Shillinq\Tests\Unit\Service\Support\ObjectEntityStub;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use RuntimeException;
 
 /**
  * Export-wiring tests.
@@ -311,5 +314,120 @@ final class CashflowExportServiceTest extends TestCase {
 		self::assertNull($this->subject($rows)->buildHorizonExport());
 
 	}//end testReturnsNullWhenTheAdministrationHasNoHorizon()
+
+	/**
+	 * A store that throws is logged and answered as "no horizon" — the export
+	 * must not surface an OpenRegister exception to the browser.
+	 *
+	 * ⚠️ The double here is a `createMock` on purpose and it observes NOTHING:
+	 * it is configured only to throw. That is the one use of a mock this file's
+	 * header does not warn against — no argument is inspected, so the
+	 * named-argument blindness cannot produce a false pass.
+	 *
+	 * @return void
+	 */
+	public function testAStoreFailureIsSwallowedIntoNoHorizon(): void {
+		$objectService = $this->createMock(ObjectServiceInterface::class);
+		$objectService->method('setRegister')->willReturnSelf();
+		$objectService->method('setSchema')->willReturnSelf();
+		$objectService->method('findAll')->willThrowException(new RuntimeException('connection refused'));
+
+		self::assertNull($this->subjectWith(objectService: $objectService)->buildHorizonExport());
+
+	}//end testAStoreFailureIsSwallowedIntoNoHorizon()
+
+	/**
+	 * OpenRegister answers some call shapes with ObjectEntity instances rather
+	 * than plain arrays, and the export must read those too.
+	 *
+	 * Without this the service would silently produce a horizon-less export the
+	 * moment the store's return shape changed — an empty PDF, not an error.
+	 *
+	 * @return void
+	 */
+	public function testReadsEntityShapedRowsAsWellAsArrays(): void {
+		$horizon = new ObjectEntityStub(
+			[
+				'horizonId' => 'hz-entity-shaped',
+				'administrationId' => 'adm-001',
+				'rolledOn' => '2026-05-25T02:00:00Z',
+			],
+			'shillinq',
+			'CashflowForecastHorizon'
+		);
+
+		$objectService = $this->createMock(ObjectServiceInterface::class);
+		$objectService->method('setRegister')->willReturnSelf();
+		$objectService->method('setSchema')->willReturnSelf();
+		$objectService->method('findAll')->willReturn([$horizon]);
+
+		$export = $this->subjectWith(objectService: $objectService)->buildHorizonExport();
+
+		self::assertNotNull($export);
+		self::assertStringContainsString('hz-entity-shaped', $export['filename']);
+
+	}//end testReadsEntityShapedRowsAsWellAsArrays()
+
+	/**
+	 * An app config that answers an empty register slug falls back to
+	 * `shillinq` rather than querying register `''`, which OpenRegister would
+	 * answer with nothing at all.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyConfiguredRegisterFallsBackToShillinq(): void {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturn('');
+
+		$context = $this->createMock(AdministrationContextService::class);
+		$context->method('accessibleAdministrationIds')->willReturn(['adm-001']);
+
+		$registers = [];
+		$objectService = $this->createMock(ObjectServiceInterface::class);
+		$objectService->method('setRegister')->willReturnCallback(
+			function (string|int $register) use (&$registers, $objectService): ObjectServiceInterface {
+				$registers[] = (string)$register;
+				return $objectService;
+			}
+		);
+		$objectService->method('setSchema')->willReturnSelf();
+		$objectService->method('findAll')->willReturn([]);
+
+		$service = new CashflowExportService(
+			appConfig: $appConfig,
+			logger: new NullLogger(),
+			objectService: $objectService,
+			administrationContext: $context,
+			renderer: new CashflowPdfRenderer(),
+		);
+
+		self::assertNull($service->buildHorizonExport());
+		self::assertSame(['shillinq'], array_unique($registers));
+
+	}//end testAnEmptyConfiguredRegisterFallsBackToShillinq()
+
+	/**
+	 * Build the subject over a caller-supplied object service.
+	 *
+	 * @param ObjectServiceInterface $objectService The store double.
+	 *
+	 * @return CashflowExportService
+	 */
+	private function subjectWith(ObjectServiceInterface $objectService): CashflowExportService {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturn('shillinq');
+
+		$context = $this->createMock(AdministrationContextService::class);
+		$context->method('accessibleAdministrationIds')
+			->willReturnCallback(fn (): array => $this->accessible);
+
+		return new CashflowExportService(
+			appConfig: $appConfig,
+			logger: new NullLogger(),
+			objectService: $objectService,
+			administrationContext: $context,
+			renderer: new CashflowPdfRenderer(),
+		);
+	}//end subjectWith()
 
 }//end class

--- a/tests/Unit/Service/CashflowExportServiceTest.php
+++ b/tests/Unit/Service/CashflowExportServiceTest.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * Unit tests for CashflowExportService — the wiring that makes REQ-CF-016's
+ * "Export PDF" affordance produce an actual document (#865).
+ *
+ * ## What these tests are pointed at
+ *
+ * `CashflowPdfRenderer` was written and had ZERO callers. The gap this closes
+ * is not "does the renderer format a table" (its own test covers that) but
+ * "does anything gather a horizon out of OpenRegister and hand it to the
+ * renderer, scoped to the caller's administration".
+ *
+ * Every assertion here reads the BYTES the service produced. There is no
+ * `expects($this->once())->method('findAll')` anywhere in this file, and that
+ * is deliberate: a PHPUnit mock cannot observe a named argument — it resolves
+ * the call against its OWN signature and then invokes the return callback
+ * POSITIONALLY — so an argument expectation over this app's named-argument
+ * call style pins the double's defaults, not the code. The doubles are the
+ * repo's hand-written `InMemoryObjectServiceStub`, which really does filter,
+ * and the tenant-isolation test proves scoping by seeding a SECOND
+ * administration and asserting its data is absent from the output.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Service;
+
+use OCA\Shillinq\Service\AdministrationContextService;
+use OCA\Shillinq\Service\CashflowExportService;
+use OCA\Shillinq\Service\CashflowPdfRenderer;
+use OCA\Shillinq\Tests\Unit\Service\Support\InMemoryObjectServiceStub;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Export-wiring tests.
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+final class CashflowExportServiceTest extends TestCase {
+
+	/**
+	 * Administration ids the faked membership guard answers with.
+	 *
+	 * @var array<int,string>
+	 */
+	private array $accessible = ['adm-001'];
+
+	/**
+	 * Build the subject over a seeded in-memory OpenRegister.
+	 *
+	 * @param array<string,array<int,array<string,mixed>>> $rows Schema slug => rows.
+	 *
+	 * @return CashflowExportService
+	 */
+	private function subject(array $rows): CashflowExportService {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturn('shillinq');
+
+		$context = $this->createMock(AdministrationContextService::class);
+		$context->method('accessibleAdministrationIds')
+			->willReturnCallback(fn (): array => $this->accessible);
+
+		return new CashflowExportService(
+			appConfig: $appConfig,
+			logger: new NullLogger(),
+			objectService: new InMemoryObjectServiceStub($rows),
+			administrationContext: $context,
+			renderer: new CashflowPdfRenderer(),
+		);
+	}//end subject()
+
+	/**
+	 * A two-week horizon for `adm-001`, plus one AR projection and one
+	 * recurring cost.
+	 *
+	 * @return array<string,array<int,array<string,mixed>>>
+	 */
+	private function seed(): array {
+		return [
+			'CashflowForecastHorizon' => [
+				[
+					'horizonId' => 'hz-2026-w22',
+					'administrationId' => 'adm-001',
+					'horizonStart' => '2026-05-25',
+					'horizonEnd' => '2026-08-23',
+					'rolledOn' => '2026-05-25T02:00:00Z',
+					'modelVersion' => 'v4.1-klantspecifiek-betaalgedrag',
+					'lifecycleState' => 'active',
+				],
+			],
+			'CashflowWeek' => [
+				[
+					'weekId' => 'wk-23',
+					'horizonId' => 'hz-2026-w22',
+					'administrationId' => 'adm-001',
+					'weekNumber' => 23,
+					'inflows_total' => 0.0,
+					'outflows_total' => 9000.0,
+					'netMovement' => -9000.0,
+					'closingBalance' => 11120.0,
+					'bufferStatus' => 'PRE_ALERT',
+				],
+				[
+					'weekId' => 'wk-22',
+					'horizonId' => 'hz-2026-w22',
+					'administrationId' => 'adm-001',
+					'weekNumber' => 22,
+					'inflows_total' => 12500.0,
+					'outflows_total' => 7200.0,
+					'netMovement' => 5300.0,
+					'closingBalance' => 20120.0,
+					'bufferStatus' => 'ABOVE_BUFFER',
+				],
+			],
+			'CashflowARProjection' => [
+				[
+					'projId' => 'ar-1',
+					'horizonId' => 'hz-2026-w22',
+					'administrationId' => 'adm-001',
+					'customerId' => 'klant-municipality-amsterdam',
+					'outstandingAmount' => 48000.0,
+					'payment_history_average_deviation' => 48,
+					'reliabilityScore' => 0.95,
+				],
+			],
+			'CashflowRecurring' => [
+				[
+					'recurId' => 'rec-1',
+					'administrationId' => 'adm-001',
+					'label' => 'Kantoorhuur',
+					'frequency' => 'maandelijks',
+					'standardAmount' => 1450.0,
+					'indexationRule' => 'CPI',
+				],
+			],
+		];
+	}//end seed()
+
+	/**
+	 * The happy path produces a PDF envelope carrying the horizon's weeks.
+	 *
+	 * @return void
+	 */
+	public function testBuildsAPdfForTheCurrentHorizon(): void {
+		$export = $this->subject($this->seed())->buildHorizonExport();
+
+		self::assertNotNull($export);
+		self::assertSame('application/pdf', $export['mimeType']);
+		self::assertStringStartsWith('%PDF-1.7', $export['payload']);
+		self::assertStringEndsWith('%%EOF', $export['payload']);
+		self::assertStringContainsString('hz-2026-w22', $export['filename']);
+		self::assertStringContainsString('ABOVE_BUFFER', $export['payload']);
+		self::assertStringContainsString('PRE_ALERT', $export['payload']);
+
+	}//end testBuildsAPdfForTheCurrentHorizon()
+
+	/**
+	 * Weeks reach the renderer in weeknummer order regardless of the order
+	 * OpenRegister returned them in — the seed above deliberately lists week
+	 * 23 before week 22.
+	 *
+	 * @return void
+	 */
+	public function testWeeksAreOrderedByWeekNumber(): void {
+		$payload = $this->subject($this->seed())->buildHorizonExport()['payload'];
+
+		self::assertLessThan(
+			strpos($payload, 'PRE_ALERT'),
+			strpos($payload, 'ABOVE_BUFFER'),
+			'week 23 was rendered before week 22'
+		);
+
+	}//end testWeeksAreOrderedByWeekNumber()
+
+	/**
+	 * Tenant isolation (REQ-MA-001): a horizon belonging to an administration
+	 * the caller has no membership for is not exported, and its weeks never
+	 * reach the document.
+	 *
+	 * @return void
+	 */
+	public function testDoesNotExportAnotherAdministrationsHorizon(): void {
+		$rows = $this->seed();
+		$rows['CashflowForecastHorizon'][] = [
+			'horizonId' => 'hz-other-tenant',
+			'administrationId' => 'adm-999',
+			'rolledOn' => '2099-01-01T00:00:00Z',
+			'lifecycleState' => 'active',
+		];
+		$rows['CashflowWeek'][] = [
+			'weekId' => 'wk-other',
+			'horizonId' => 'hz-other-tenant',
+			'administrationId' => 'adm-999',
+			'weekNumber' => 1,
+			'closingBalance' => 999999.0,
+			'bufferStatus' => 'OTHER_TENANT_MARKER',
+		];
+
+		$export = $this->subject($rows)->buildHorizonExport();
+
+		self::assertNotNull($export);
+		self::assertStringNotContainsString('hz-other-tenant', $export['payload']);
+		self::assertStringNotContainsString('OTHER_TENANT_MARKER', $export['payload']);
+		self::assertStringContainsString('hz-2026-w22', $export['filename']);
+
+	}//end testDoesNotExportAnotherAdministrationsHorizon()
+
+	/**
+	 * The most recently rolled horizon wins when the administration has more
+	 * than one.
+	 *
+	 * @return void
+	 */
+	public function testPicksTheMostRecentlyRolledHorizon(): void {
+		$rows = $this->seed();
+		$rows['CashflowForecastHorizon'][] = [
+			'horizonId' => 'hz-2026-w30',
+			'administrationId' => 'adm-001',
+			'rolledOn' => '2026-07-20T02:00:00Z',
+			'lifecycleState' => 'active',
+		];
+
+		$export = $this->subject($rows)->buildHorizonExport();
+
+		self::assertNotNull($export);
+		self::assertStringContainsString('hz-2026-w30', $export['filename']);
+
+	}//end testPicksTheMostRecentlyRolledHorizon()
+
+	/**
+	 * The AR projection's schema property `payment_history_average_deviation`
+	 * reaches the renderer's `gemiddeldeAfwijking` slot.
+	 *
+	 * ⚠️ This asymmetry is a real drift, not a preference: `CashflowRecurring`
+	 * / `CashflowARProjection` declare English property names, while the
+	 * renderer (written earlier, against the design document) reads the Dutch
+	 * `gemiddeldeAfwijking`. Nothing had ever called the renderer, so nothing
+	 * had ever noticed. The adaptation is done in the SERVICE — renaming the
+	 * renderer's read key is a change to a published input contract, and
+	 * renaming the schema property is a data migration.
+	 *
+	 * @return void
+	 */
+	public function testMapsArProjectionDeviationIntoTheRenderersCustomerSection(): void {
+		$payload = $this->subject($this->seed())->buildHorizonExport()['payload'];
+
+		// The section heading reaches the page as `TOP CUSTOMERS
+		// \(BETALINGSGEDRAG\)` — a PDF literal string escapes its parentheses,
+		// so asserting the raw heading would fail on a document that carries
+		// it perfectly well.
+		self::assertStringContainsString('TOP CUSTOMERS \\(BETALINGSGEDRAG\\)', $payload);
+		self::assertStringContainsString('klant-municipality-amsterdam', $payload);
+		self::assertStringContainsString('avg offset 48', $payload);
+
+	}//end testMapsArProjectionDeviationIntoTheRenderersCustomerSection()
+
+	/**
+	 * Recurring costs reach the assumptions section (REQ-CF-016 §3).
+	 *
+	 * @return void
+	 */
+	public function testIncludesTheRecurringCostBreakdown(): void {
+		$payload = $this->subject($this->seed())->buildHorizonExport()['payload'];
+
+		self::assertStringContainsString('RECURRING COSTS', $payload);
+		self::assertStringContainsString('Kantoorhuur', $payload);
+
+	}//end testIncludesTheRecurringCostBreakdown()
+
+	/**
+	 * An anonymous caller, or one with no membership anywhere, gets nothing —
+	 * not an empty PDF, which would look like a successful export of an empty
+	 * business.
+	 *
+	 * @return void
+	 */
+	public function testReturnsNullWhenTheCallerHasNoAdministration(): void {
+		$this->accessible = [];
+
+		self::assertNull($this->subject($this->seed())->buildHorizonExport());
+
+	}//end testReturnsNullWhenTheCallerHasNoAdministration()
+
+	/**
+	 * A member of an administration that has no forecast yet gets nothing,
+	 * so the caller can say so rather than hand over a blank document.
+	 *
+	 * @return void
+	 */
+	public function testReturnsNullWhenTheAdministrationHasNoHorizon(): void {
+		$rows = $this->seed();
+		$rows['CashflowForecastHorizon'] = [];
+
+		self::assertNull($this->subject($rows)->buildHorizonExport());
+
+	}//end testReturnsNullWhenTheAdministrationHasNoHorizon()
+
+}//end class

--- a/tests/Unit/Service/CashflowPdfRendererTest.php
+++ b/tests/Unit/Service/CashflowPdfRendererTest.php
@@ -167,4 +167,231 @@ final class CashflowPdfRendererTest extends TestCase {
 
 	}//end testRenderTolerantOfEmptyInput()
 
+	/**
+	 * renderPdf() emits a real PDF binary, not the text payload with a `.pdf`
+	 * name stuck on it (#865).
+	 *
+	 * The distinction is the whole point of the issue: `render()` returns
+	 * `text/plain` and a `.txt` filename, and an export that advertised
+	 * `application/pdf` over those bytes would open as garbage in every
+	 * viewer while every route/status assertion stayed green.
+	 *
+	 * @return void
+	 */
+	public function testRenderPdfEmitsPdfBinary(): void {
+		$result = $this->renderer->renderPdf($this->horizonFixture(), $this->weeksFixture());
+
+		self::assertSame('application/pdf', $result['mimeType']);
+		self::assertStringEndsWith('.pdf', $result['filename']);
+		self::assertStringStartsWith('%PDF-1.7', $result['payload']);
+		self::assertStringEndsWith('%%EOF', $result['payload']);
+
+	}//end testRenderPdfEmitsPdfBinary()
+
+	/**
+	 * Every xref entry points at the byte offset of the object it claims, and
+	 * the trailer's /Size matches the object count.
+	 *
+	 * A PDF with a wrong xref table still *starts* with `%PDF` and still ends
+	 * with `%%EOF`, so the magic-byte assertion above cannot see a broken
+	 * document. This one can.
+	 *
+	 * @return void
+	 */
+	public function testRenderPdfXrefOffsetsPointAtRealObjects(): void {
+		$pdf = $this->renderer->renderPdf($this->horizonFixture(), $this->weeksFixture())['payload'];
+
+		$matched = preg_match_all('/^(\d{10}) 00000 n $/m', $pdf, $entries);
+		self::assertIsInt($matched);
+		self::assertGreaterThan(0, $matched, 'no xref entries were emitted');
+
+		foreach ($entries[1] as $index => $offset) {
+			$objectNumber = ($index + 1);
+			self::assertSame(
+				$objectNumber . ' 0 obj',
+				substr($pdf, (int)$offset, strlen($objectNumber . ' 0 obj')),
+				sprintf('xref entry %d does not point at object %d', $objectNumber, $objectNumber)
+			);
+		}
+
+		self::assertStringContainsString('/Size ' . (count($entries[1]) + 1) . ' ', $pdf);
+
+	}//end testRenderPdfXrefOffsetsPointAtRealObjects()
+
+	/**
+	 * The week-by-week table reaches the page content stream — the PDF carries
+	 * the forecast, not just a title page.
+	 *
+	 * @return void
+	 */
+	public function testRenderPdfCarriesTheWeekTable(): void {
+		$pdf = $this->renderer->renderPdf($this->horizonFixture(), $this->weeksFixture())['payload'];
+
+		self::assertStringContainsString('WEEK-BY-WEEK SUMMARY', $pdf);
+		self::assertStringContainsString('ABOVE_BUFFER', $pdf);
+		self::assertStringContainsString('PRE_ALERT', $pdf);
+		self::assertStringContainsString('METHODOLOGY', $pdf);
+
+	}//end testRenderPdfCarriesTheWeekTable()
+
+	/**
+	 * REQ-CF-016 §2 — the 13-week bar chart is drawn as vector rectangles, and
+	 * it is drawn ONLY when there are weeks to chart.
+	 *
+	 * The negative half is what makes this an assertion rather than a
+	 * decoration: without it, a renderer that emitted the chart preamble
+	 * unconditionally (or never at all) would satisfy the positive half by
+	 * accident.
+	 *
+	 * @return void
+	 */
+	public function testRenderPdfDrawsTheBarChartOnlyWhenThereAreWeeks(): void {
+		$withWeeks = $this->renderer->renderPdf($this->horizonFixture(), $this->weeksFixture())['payload'];
+		$withoutWeeks = $this->renderer->renderPdf($this->horizonFixture(), [])['payload'];
+
+		self::assertStringContainsString('13-WEEK CLOSING BALANCE', $withWeeks);
+		self::assertMatchesRegularExpression('/[\d.]+ [\d.]+ [\d.]+ [\d.]+ re\nf/', $withWeeks);
+
+		self::assertStringNotContainsString('13-WEEK CLOSING BALANCE', $withoutWeeks);
+
+	}//end testRenderPdfDrawsTheBarChartOnlyWhenThereAreWeeks()
+
+	/**
+	 * A week that breaches the buffer is drawn in the alert colour, and a
+	 * negative closing balance is drawn BELOW the zero line rather than as a
+	 * positive bar of the same size.
+	 *
+	 * Without this the chart would be a decoration: three weeks at
+	 * -50k, 0 and +50k would all render identically upward in one colour, and
+	 * the reader of a bank-meeting document would draw exactly the wrong
+	 * conclusion from a chart that "renders correctly".
+	 *
+	 * @return void
+	 */
+	public function testRenderPdfDrawsBreachedWeeksInAlertColourAndBelowTheZeroLine(): void {
+		$weeks = [
+			[
+				'weekNumber' => 22,
+				'closingBalance' => 20000.0,
+				'bufferStatus' => 'ABOVE_BUFFER',
+			],
+			[
+				'weekNumber' => 23,
+				'closingBalance' => -20000.0,
+				'bufferStatus' => 'BELOW_BUFFER',
+			],
+		];
+
+		$pdf = $this->renderer->renderPdf($this->horizonFixture(), $weeks)['payload'];
+
+		$matched = preg_match_all(
+			'/([\d.]+ [\d.]+ [\d.]+) rg\n([\d.]+) ([\d.]+) ([\d.]+) ([\d.]+) re\nf/',
+			$pdf,
+			$bars,
+			PREG_SET_ORDER
+		);
+		self::assertSame(2, $matched, 'expected exactly one bar per week');
+
+		// Above buffer: blue, sitting ON the zero line.
+		self::assertSame('0.13 0.40 0.72', $bars[0][1]);
+		self::assertSame('420.00', $bars[0][3]);
+
+		// Below buffer: red, and its bottom edge is a full bar BELOW the zero
+		// line (420 - 300), i.e. it hangs downward.
+		self::assertSame('0.80 0.16 0.16', $bars[1][1]);
+		self::assertSame('120.00', $bars[1][3]);
+
+	}//end testRenderPdfDrawsBreachedWeeksInAlertColourAndBelowTheZeroLine()
+
+	/**
+	 * A parenthesis in a value cannot break out of the PDF literal-string
+	 * token that carries it.
+	 *
+	 * An unescaped `)` terminates the string early and every following byte is
+	 * read as an operator — the document still opens in a lenient viewer, with
+	 * the rest of the page silently missing.
+	 *
+	 * @return void
+	 */
+	public function testRenderPdfEscapesParenthesesInValues(): void {
+		$horizon = $this->horizonFixture();
+		$horizon['administrationId'] = 'ADM (hoofd) \\ nevenvestiging';
+
+		$pdf = $this->renderer->renderPdf($horizon, $this->weeksFixture())['payload'];
+
+		self::assertStringContainsString('ADM \\(hoofd\\) \\\\ nevenvestiging', $pdf);
+		self::assertStringNotContainsString('(ADM (hoofd)', $pdf);
+
+	}//end testRenderPdfEscapesParenthesesInValues()
+
+	/**
+	 * The filename carries the horizon id so two exports in one download
+	 * folder do not collide.
+	 *
+	 * @return void
+	 */
+	public function testRenderPdfFilenameCarriesTheHorizonId(): void {
+		$result = $this->renderer->renderPdf($this->horizonFixture(), $this->weeksFixture());
+
+		self::assertStringContainsString('horizon-test-001', $result['filename']);
+
+	}//end testRenderPdfFilenameCarriesTheHorizonId()
+
+	/**
+	 * Empty input still yields a structurally valid PDF rather than a fatal —
+	 * the dashboard button must never hand the browser a truncated file.
+	 *
+	 * @return void
+	 */
+	public function testRenderPdfTolerantOfEmptyInput(): void {
+		$result = $this->renderer->renderPdf([], []);
+
+		self::assertStringStartsWith('%PDF-1.7', $result['payload']);
+		self::assertStringEndsWith('%%EOF', $result['payload']);
+		self::assertStringContainsString('13-WEEK CASHFLOW FORECAST', $result['payload']);
+
+	}//end testRenderPdfTolerantOfEmptyInput()
+
+	/**
+	 * Horizon fixture shared by the renderPdf tests.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function horizonFixture(): array {
+		return [
+			'horizonId' => 'horizon-test-001',
+			'horizonStart' => '2026-05-25',
+			'horizonEnd' => '2026-08-23',
+			'administrationId' => 'adm-001',
+			'modelVersion' => 'v4.1-klantspecifiek-betaalgedrag',
+			'rolledOn' => '2026-05-25T02:00:00Z',
+		];
+	}//end horizonFixture()
+
+	/**
+	 * Two-week fixture with one week above and one week under the buffer.
+	 *
+	 * @return list<array<string,mixed>>
+	 */
+	private function weeksFixture(): array {
+		return [
+			[
+				'weekNumber' => 22,
+				'inflows_total' => 12500.0,
+				'outflows_total' => 7200.0,
+				'netMovement' => 5300.0,
+				'closingBalance' => 20120.0,
+				'bufferStatus' => 'ABOVE_BUFFER',
+			],
+			[
+				'weekNumber' => 23,
+				'inflows_total' => 0.0,
+				'outflows_total' => 9000.0,
+				'netMovement' => -9000.0,
+				'closingBalance' => 11120.0,
+				'bufferStatus' => 'PRE_ALERT',
+			],
+		];
+	}//end weeksFixture()
+
 }//end class

--- a/tests/schemas/app-manifest-v2.schema.json
+++ b/tests/schemas/app-manifest-v2.schema.json
@@ -3,9 +3,21 @@
 	"$id": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
 	"title": "Conduction App Manifest v2",
 	"description": "v2 schema for the JSON-driven page and navigation manifest consumed by @conduction/nextcloud-vue. Introduces a uniform widgets[] array on every page type with a per-slot grid coordinate system, a typed actions[] discriminator, and the required $schema field for version detection. v1 manifests continue to validate against app-manifest.schema.json (unchanged).",
-	"version": "2.11.0",
+	"version": "2.22.0",
 	"type": "object",
-	"required": ["$schema", "version", "menu", "pages"],
+	"required": ["$schema", "version"],
+	"allOf": [
+		{
+			"$comment": "UI manifests: a manifest that declares pages MUST also declare menu (unchanged v2 coupling).",
+			"if": { "required": ["pages"] },
+			"then": { "required": ["menu"] }
+		},
+		{
+			"$comment": "Observability-only profile: a manifest with no pages MUST carry an observability block. ADR-040 Tier-0 adopters (e.g. nldesign, planix) ship src/manifest.json solely as AppHost engine config — the app renders no manifest-driven UI, so forcing menu/pages on them produced permanently-failing gate-22 manifests (2026-07-06 fleet audit, item 3b).",
+			"if": { "not": { "required": ["pages"] } },
+			"then": { "required": ["observability"] }
+		}
+	],
 	"additionalProperties": false,
 	"properties": {
 		"$schema": {
@@ -26,8 +38,22 @@
 		"dependencies": {
 			"type": "array",
 			"default": [],
-			"items": { "type": "string" },
-			"description": "Nextcloud app IDs that MUST be installed and enabled for this app to function. CnAppRoot checks each via useAppStatus(appId). Sentinels (@resolve:*) are NOT allowed here — resolved at build time against known app IDs."
+			"items": {
+				"oneOf": [
+					{ "type": "string" },
+					{
+						"type": "object",
+						"additionalProperties": false,
+						"required": ["id"],
+						"properties": {
+							"id": { "type": "string", "description": "Nextcloud app id." },
+							"required": { "type": "boolean", "default": true, "description": "true (default) = HARD: absence blocks the app shell behind CnDependencyMissing. false = SOFT: an optional integration whose absence surfaces a dismissible in-shell notice and never blocks." },
+							"name": { "type": "string", "description": "Human-readable display label; falls back to id." }
+						}
+					}
+				]
+			},
+			"description": "Nextcloud app dependencies. Each entry is either a string (a HARD dependency — the app cannot run without it, absence blocks the shell) or an object { id, required?, name? } where required:false marks a SOFT (optional) dependency (required defaults to true). CnAppRoot checks each via useAppStatus(id); unresolved HARD deps block behind CnDependencyMissing, unresolved SOFT deps show a dismissible NcNoteCard banner. Sentinels (@resolve:*) are NOT allowed here — resolved at build time against known app IDs."
 		},
 		"setup": {
 			"type": "object",
@@ -168,6 +194,27 @@
 				"primaryAction": {
 					"$ref": "#/$defs/primaryAction",
 					"description": "App-wide default primary action rendered as an NcAppNavigationNew button above the main menu list. A page-scoped pages[].primaryAction for the current route wins over this default."
+				},
+				"featureRequestRepo": {
+					"type": "string",
+					"description": "`<owner>/<repo>` slug on the forge that the in-product feature-request deep-link targets (provided to descendants as `cnFeatureRequestRepo`). Falls back to `Conduction/<appId>` when omitted."
+				},
+				"forge": {
+					"type": "object",
+					"additionalProperties": false,
+					"description": "Forge that the in-product feature-request deep-link targets. Switching the whole fleet's forge (back to GitHub, or onto a self-hosted Forgejo/Gitea) is just this one field. Defaults to Codeberg.",
+					"properties": {
+						"type": {
+							"type": "string",
+							"enum": ["codeberg", "forgejo", "gitea", "github"],
+							"default": "codeberg",
+							"description": "Forge type. Selects how the 'new issue' form is pre-filled: `github` uses per-field Issue-Form query params; `codeberg`/`forgejo`/`gitea` assemble a Markdown body (only title + body are supported there)."
+						},
+						"baseUrl": {
+							"type": "string",
+							"description": "Override the forge host. Required for self-hosted `forgejo`/`gitea`; optional for `codeberg`/`github` (their canonical public hosts are used when omitted)."
+						}
+					}
 				}
 			}
 		},
@@ -180,6 +227,10 @@
 					"type": "object",
 					"description": "Per-user runtime context. Populated by the backend for authenticated requests. All fields are optional; the FE predicate evaluator treats missing fields as undefined.",
 					"additionalProperties": true
+				},
+				"theme": {
+					"$ref": "#/$defs/runtimeTheme",
+					"description": "NL Design System scoped theme selection (scoped-theme-applier). Consumed by CnAppRoot's useScopedTheme wiring, not by the backend."
 				}
 			}
 		},
@@ -193,6 +244,46 @@
 			"items": { "$ref": "#/$defs/page" },
 			"description": "Page definitions dispatched by CnPageRenderer. Each page's id is also its vue-router route name. Ids MUST be unique across the array; uniqueness is enforced by validateManifestV2 as a post-schema check."
 		},
+		"adminSettings": {
+			"type": "array",
+			"items": { "$ref": "#/$defs/adminSettingsEntry" },
+			"description": "Admin-only settings sections rendered by CnAppRoot's generic admin NcAppSettingsDialog, gated on app-owner-group membership (not OC.isUserAdmin()). An absent key or an empty array yields no admin nav entry and no admin dialog. See the manifest-admin-settings and admin-settings-owner-gating capabilities."
+		},
+		"credentials": {
+			"type": "array",
+			"description": "External-provider credentials this app can use via the OpenRegister credential broker (github, gitlab, …). Each entry declares which provider, why, and at what scope; the app never receives the secret — the broker performs the outbound call on the user's behalf. See the credential-broker capability.",
+			"items": {
+				"type": "object",
+				"required": ["provider"],
+				"additionalProperties": false,
+				"properties": {
+					"provider": { "type": "string", "description": "Catalogue provider identifier (e.g. \"github\", \"gitlab\") — a key in OpenRegister's credential-providers catalogue." },
+					"reason": { "type": "string", "description": "Human-readable reason shown to the user in credential settings (why the app wants this provider)." },
+					"scopes": { "type": "array", "items": { "type": "string" }, "description": "Advisory scopes the app needs (e.g. [\"repo\"])." }
+				}
+			}
+		},
+		"schedules": {
+			"type": "array",
+			"description": "Declarative scheduled tasks (apphost-scheduling capability). Each entry declares a recurring task the OpenRegister AppHost schedule-reconciler turns into an OpenConnector job that runs on the existing background-job path — so a manifest-driven app (including a pure-virtual OpenBuild app with no PHP on disk) can own its ingestion/maintenance cadence without shipping a TimedJob. The temporal peer of `credentials`/`observability`: consumed by the OpenRegister engine, NOT by the Vue renderer. Optional and additive.",
+			"items": {
+				"type": "object",
+				"required": ["id", "action"],
+				"additionalProperties": false,
+				"oneOf": [
+					{ "required": ["interval"], "not": { "required": ["cron"] } },
+					{ "required": ["cron"], "not": { "required": ["interval"] } }
+				],
+				"properties": {
+					"id": { "type": "string", "description": "Stable identifier for this schedule, unique within the manifest. The reconciled job is keyed on applicationId + this id, so renaming it creates a new job and orphans the old one (which is then garbage-collected)." },
+					"interval": { "type": "integer", "minimum": 1, "description": "Run cadence in seconds (e.g. 604800 = weekly). Exactly one of `interval` or `cron` must be set." },
+					"cron": { "type": "string", "description": "Standard 5-field cron expression (e.g. \"0 3 * * 1\"). The reconciler computes the job's nextRun from it. Exactly one of `interval` or `cron` must be set." },
+					"action": { "type": "string", "pattern": "^[a-z0-9]+:[a-z0-9-]+$", "description": "A server-allow-listed generic action type, NOT a PHP class name. Only vetted types are accepted (v1: \"openconnector:synchronization\"); the reconciler maps the type to a trusted jobClass — a manifest-supplied class name is never executed. A non-allow-listed action is rejected and logged." },
+					"arguments": { "type": "object", "description": "Free-form arguments passed to the action (e.g. the synchronization id/ref). Interpreted by the vetted action, not by the reconciler.", "additionalProperties": true },
+					"enabled": { "type": "boolean", "description": "Whether this schedule is active. Defaults to true. Setting false disables the reconciled job (preserving its run history) rather than deleting it." }
+				}
+			}
+		},
 		"observability": {
 			"$ref": "#/$defs/observability",
 			"description": "Declarative observability block (ADR-040). Consumed at request time by the OpenRegister AppHost observability engine (GenericHealthController + GenericMetricsController), NOT by the Vue renderer. Declares the app's health checks and Prometheus metric descriptors so adopting apps ship zero hand-written observability PHP while keeping their /api/health + /api/metrics URLs and the ADR-006 contract."
@@ -201,9 +292,250 @@
 			"type": "array",
 			"items": { "$ref": "#/$defs/deepLink" },
 			"description": "ADR-040: object deep-link descriptors consumed by the integration registry / cross-app linking, NOT by the Vue renderer. Optional and additive."
+		},
+		"pageTemplates": {
+			"type": "array",
+			"items": { "$ref": "#/$defs/pageTemplate" },
+			"description": "Entity-scaffold page templates (manifest-entity-scaffold-templating). A template declares one reusable index/detail page shape ONCE, with `{{param}}` placeholders for the parts that vary per entity (register/schema binding, label, field/column subset) and a declared parameter list. The expander (utils/expandPageTemplates) materialises `pageInstances[]` into concrete `pages[]` at build/boot time, so CnPageRenderer only ever sees concrete pages and is unchanged by templating. Optional and additive: a manifest without pageTemplates is unaffected."
+		},
+		"pageInstances": {
+			"type": "array",
+			"items": { "$ref": "#/$defs/pageInstance" },
+			"description": "Per-entity template instantiations. Each entry references a `pageTemplates[]` template by `templateRef` and supplies only the values that vary. The expander substitutes them into the referenced template and appends the resulting concrete pages to `pages[]`. Expansion FAILS (named error) on an unknown templateRef or a missing required template parameter. Optional and additive."
+		},
+		"sets": {
+			"type": "object",
+			"description": "Named, reusable field/column/sidebar sets referenced from templates via a `{{set:NAME}}` placeholder, so a repeated field/column/sidebar block is declared ONCE and shared across templates and pages instead of being re-listed. Each value is arbitrary JSON (typically an array of field/column defs or a sidebar object). Optional and additive.",
+			"additionalProperties": true
+		},
+		"mcp": {
+			"type": "object",
+			"title": "MCP tool visibility hints",
+			"description": "OPTIONAL. Advisory visibility/UX hints for MCP tool surfaces (Hermiq agent tool picker, openbuild tool browser). Purely presentational: per ADR-063, OpenRegister's register (x-openregister-mcp dialect + #[McpTool] attributes) is the single source of CRUD-tool truth and OpenRegister RBAC is the authoritative invoke-time gate. This block grants no access and gates nothing; nothing in nextcloud-vue consumes it.",
+			"additionalProperties": false,
+			"properties": {
+				"expose": {
+					"type": "boolean",
+					"title": "App-level exposure hint",
+					"description": "Advisory app-wide default for whether this app's register-derived MCP tools should be shown in agent / tool-picker surfaces. Advisory only — the authoritative gate is OpenRegister RBAC plus per-agent whitelists. Defaults to false (opt-in), matching ADR-063's default-OFF exposure model.",
+					"default": false
+				},
+				"pageTools": {
+					"type": "object",
+					"title": "Per-page tool hints",
+					"description": "Maps a pages[].id to the ordered list of MCP tool ids that are contextually relevant on that page. Advisory grouping for UX surfaces only; it does not grant access. Keys are expected to match an existing pages[].id; the register remains authoritative for whether each listed tool actually exists.",
+					"additionalProperties": {
+						"type": "array",
+						"title": "Relevant tool ids for a page",
+						"description": "Ordered MCP tool ids relevant to the page keyed above. Advisory ordering only.",
+						"items": {
+							"type": "string",
+							"title": "MCP tool id",
+							"description": "A fully-qualified MCP tool id in the register's derived-CRUD shape {appId}.{schemaSlug}.{verb}, verb one of search|get|create|update|delete (ADR-063). Example only: \"pipelinq.lead.search\". The register is authoritative for existence; this is a hint.",
+							"pattern": "^[a-z0-9_-]+\\.[a-zA-Z0-9_-]+\\.(search|get|create|update|delete)$"
+						}
+					}
+				},
+				"agentHints": {
+					"type": "object",
+					"title": "Agent-facing hints",
+					"description": "Advisory metadata for agent surfaces (Hermiq). All values are non-authoritative UX hints. Additional properties are permitted so consuming surfaces can introduce new advisory hints without a schema release (forward compatibility).",
+					"additionalProperties": true,
+					"properties": {
+						"summary": {
+							"type": "string",
+							"title": "App tool summary",
+							"description": "One-line description of what this app's tools help an agent accomplish. Shown in agent / tool-picker surfaces."
+						},
+						"defaultTools": {
+							"type": "array",
+							"title": "Default tool ids",
+							"description": "MCP tool ids to surface first / preselect when an agent has no page context. Advisory ordering hint only; not a grant.",
+							"items": {
+								"type": "string",
+								"title": "MCP tool id",
+								"description": "Fully-qualified MCP tool id {appId}.{schemaSlug}.{verb}. Example only: \"pipelinq.lead.search\"."
+							}
+						},
+						"keywords": {
+							"type": "array",
+							"title": "Discovery keywords",
+							"description": "Keywords helping progressive-disclosure / tool-search surfaces (Hermiq) rank this app's tools. Advisory only.",
+							"items": {
+								"type": "string",
+								"title": "Keyword",
+								"description": "A single discovery keyword."
+							}
+						}
+					}
+				}
+			}
 		}
 	},
 	"$defs": {
+		"runtimeTheme": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["source", "tokenSet"],
+			"description": "A leaf app's NL Design token-set selection, as returned by nldesign's GET /api/token-sets catalogue (app-token-set-selection). Applied by CnAppRoot via useScopedTheme — the ONLY consumer; the backend does not read this field.",
+			"properties": {
+				"source": {
+					"type": "string",
+					"enum": ["nldesign"],
+					"description": "Theme provider. Closed to 'nldesign' — the only scoped-theme source this schema (and useScopedTheme) currently supports."
+				},
+				"tokenSet": {
+					"type": "string",
+					"pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+					"description": "The nldesign token-set id (a GET /api/token-sets entry's `id`), kebab-case. Resolves the token CSS at css/tokens/<tokenSet>.css."
+				},
+				"tokenSetName": {
+					"type": "string",
+					"description": "Optional human-readable name (the matching catalogue entry's `name`), cached at selection time so a picker can display it without a second catalogue fetch."
+				},
+				"preview": {
+					"type": "object",
+					"additionalProperties": false,
+					"description": "Optional cached swatch preview (the matching catalogue entry's theming colors), for a picker to render a preview chip without re-fetching the catalogue.",
+					"properties": {
+						"primaryColor": { "type": "string", "description": "Cached theming.primary_color from the catalogue entry." },
+						"backgroundColor": { "type": "string", "description": "Cached theming.background_color from the catalogue entry." }
+					}
+				}
+			}
+		},
+		"pageTemplate": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["id", "page"],
+			"description": "A reusable page shape declared once and instantiated per entity. `page` is an ordinary v2 page object whose string values may contain `{{param}}` placeholders (and `{{set:NAME}}` set references); `params` declares which placeholders exist and which are required. Fixed structure lives in `page`; only declared params vary per instantiation.",
+			"properties": {
+				"id": {
+					"type": "string",
+					"description": "Unique template identifier — the `templateRef` target. Uniqueness across pageTemplates[] is enforced by validateManifestV2 as a post-schema check."
+				},
+				"_note": {
+					"type": "string",
+					"description": "Free-form maintainer note; ignored by the expander."
+				},
+				"params": {
+					"type": "array",
+					"description": "Declared parameters. A placeholder `{{name}}` in `page` is substituted with the instantiation's value for `name`. A `required` param absent from an instantiation is an expansion error; an optional param absent from an instantiation causes its exact-match placeholder key to be omitted from the expanded page.",
+					"items": {
+						"type": "object",
+						"additionalProperties": false,
+						"required": ["name"],
+						"properties": {
+							"name": { "type": "string", "description": "Parameter name, referenced as `{{name}}` in the template `page`." },
+							"required": { "type": "boolean", "default": false, "description": "When true, an instantiation omitting this parameter is an expansion error." },
+							"description": { "type": "string", "description": "Human-readable description of the parameter." }
+						}
+					}
+				},
+				"page": {
+					"type": "object",
+					"description": "The parameterised page shape. An ordinary v2 page whose string leaves may embed `{{param}}` placeholders and `{{set:NAME}}` set references. After substitution the result MUST be a valid concrete page (it is validated as part of the expanded pages[])."
+				}
+			}
+		},
+		"pageInstance": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": ["templateRef"],
+			"description": "A per-entity instantiation of a pageTemplate. Supplies only the values that vary. `register`, `schema` and `label` are first-class shortcuts folded into the parameter map (equivalent to listing them under `params`); `params` may carry any additional declared parameters (e.g. a field/column subset).",
+			"properties": {
+				"templateRef": {
+					"type": "string",
+					"description": "Id of the `pageTemplates[]` entry to instantiate. An unknown templateRef is an expansion error."
+				},
+				"register": { "type": "string", "description": "Shortcut for the `register` parameter." },
+				"schema": { "type": "string", "description": "Shortcut for the `schema` parameter." },
+				"label": { "type": "string", "description": "Shortcut for the `label` parameter." },
+				"params": {
+					"type": "object",
+					"description": "Parameter values keyed by the template's declared parameter names. Values may be any JSON type (a field/column subset is an array value). Overrides the register/schema/label shortcuts on conflict.",
+					"additionalProperties": true
+				},
+				"override": {
+					"type": "object",
+					"description": "Optional structural delta applied over the substituted page via the SAME base+delta merge semantics as mergeManifestDelta (layered-versioned-app-deltas alignment). Lets an instantiation patch a single widget/field without re-listing the page, and is where a per-user/app override sits on top of the template base. No second merge model is introduced.",
+					"additionalProperties": true
+				}
+			}
+		},
+		"sentinelFilterToken": {
+			"type": "string",
+			"pattern": "^@(?:me|now|today|monthStart|quarterStart|yearStart)$|^@today[+-][0-9]+d$",
+			"description": "Filter-value context: relative fetch-time tokens resolved by resolveFilterTokens (@me, @now, @today, @today±Nd, @monthStart, @quarterStart, @yearStart). Mirrors SENTINEL_TOKEN_PATTERNS.filter in src/utils/sentinelTokens.js (byte-equality enforced by a unit test)."
+		},
+		"sentinelConfigToken": {
+			"type": "string",
+			"pattern": "^@resolve:[a-z][a-z0-9_-]*$|^@config\\.[A-Za-z][A-Za-z0-9_.]*\\??$",
+			"description": "Config context: IAppConfig-sourced values. @resolve:<key> resolved at manifest-load time; @config.<key> (trailing ? optional) at fetch time. Mirrors SENTINEL_TOKEN_PATTERNS.config."
+		},
+		"sentinelObjectToken": {
+			"type": "string",
+			"pattern": "^@objectId$|^@object\\.[A-Za-z][A-Za-z0-9_]*$",
+			"description": "Object context: detail-page object tokens (@objectId, @object.<field>) resolved only when a { objectId, object } ctx is supplied. Mirrors SENTINEL_TOKEN_PATTERNS.object."
+		},
+		"sentinelWorkspaceToken": {
+			"type": "string",
+			"pattern": "^@workspace\\.[A-Za-z][A-Za-z0-9_]*\\??$",
+			"description": "Workspace context: page-level workspace state (@workspace.<key>; trailing ? marks optional). Mirrors SENTINEL_TOKEN_PATTERNS.workspace."
+		},
+		"sentinelRouteToken": {
+			"type": "string",
+			"pattern": "^@route\\.[A-Za-z][A-Za-z0-9_-]*$",
+			"description": "Route context: vue-router param substitution (@route.<param>) resolved by resolveRouteSentinels. Mirrors SENTINEL_TOKEN_PATTERNS.route."
+		},
+		"sentinelDeclarativeToken": {
+			"type": "string",
+			"pattern": "^@self\\.[A-Za-z][A-Za-z0-9_]*$|^@ref:[A-Za-z][A-Za-z0-9_./-]*$|^@aggregate:.+$",
+			"description": "Declarative context (OpenRegister direction, resolved server-side): @self.<field> (the object's own field in a cross-object calc), @ref:<path>, @aggregate:<expr>. @ref/@aggregate are first-class members even though currently unused fleet-wide. Mirrors SENTINEL_TOKEN_PATTERNS.declarative."
+		},
+		"sentinelDeprecatedToken": {
+			"type": "string",
+			"pattern": "^@currentFiscalYear$|^@page\\.[A-Za-z][A-Za-z0-9_]*$|^@runtime(?:\\.[A-Za-z][A-Za-z0-9_]*)?$",
+			"description": "Deprecated single-app inventions kept in the union so deployed manifests still validate during the migration window. The hydra token-vocabulary gate downgrades these to a WARN (see SENTINEL_DEPRECATIONS): @currentFiscalYear → @config.fiscalYear, @page.<key> → @workspace.<key>, @runtime → removal. Mirrors SENTINEL_TOKEN_PATTERNS.deprecated."
+		},
+		"sentinelVisibleWhenToken": {
+			"type": "string",
+			"pattern": "^@total$",
+			"description": "manifest-form-logic: the shared visibleWhen predicate's source-mode collection-total marker, resolved client-side by evaluateVisibleWhen (utils/visibleWhen.js) — NOT one of the four IAppConfig/OpenRegister resolvers, but a pre-existing convention (already documented on $defs.visibleWhen and the banner widget) reachable through the sentinelGuardedValue-guarded pages[].config subtree for the first time via config.fields[].visibleWhen. Mirrors SENTINEL_TOKEN_PATTERNS.visibleWhen."
+		},
+		"sentinelTokenAny": {
+			"$comment": "Union of every canonical context plus the deprecated-during-window overlay. Single source the shared resolver + gate import.",
+			"anyOf": [
+				{ "$ref": "#/$defs/sentinelFilterToken" },
+				{ "$ref": "#/$defs/sentinelConfigToken" },
+				{ "$ref": "#/$defs/sentinelObjectToken" },
+				{ "$ref": "#/$defs/sentinelWorkspaceToken" },
+				{ "$ref": "#/$defs/sentinelRouteToken" },
+				{ "$ref": "#/$defs/sentinelDeclarativeToken" },
+				{ "$ref": "#/$defs/sentinelVisibleWhenToken" },
+				{ "$ref": "#/$defs/sentinelDeprecatedToken" }
+			]
+		},
+		"sentinelTokenLeaf": {
+			"$comment": "A string leaf: either NOT a sentinel (does not start with @) or a member of the closed vocabulary. An @-prefixed out-of-vocabulary string FAILS here instead of passing through additionalProperties:true.",
+			"anyOf": [
+				{ "not": { "pattern": "^@" } },
+				{ "$ref": "#/$defs/sentinelTokenAny" }
+			]
+		},
+		"sentinelGuardedValue": {
+			"$comment": "Recursive guard applied (via allOf) to pages[].config and widgetEntry so every string leaf anywhere beneath is checked against the closed vocabulary. Additive + backward-compatible: only @-prefixed out-of-vocabulary strings newly fail; all other shapes are untouched.",
+			"if": { "type": "string" },
+			"then": { "$ref": "#/$defs/sentinelTokenLeaf" },
+			"else": {
+				"if": { "type": "array" },
+				"then": { "items": { "$ref": "#/$defs/sentinelGuardedValue" } },
+				"else": {
+					"if": { "type": "object" },
+					"then": { "additionalProperties": { "$ref": "#/$defs/sentinelGuardedValue" } }
+				}
+			}
+		},
 		"observability": {
 			"type": "object",
 			"additionalProperties": false,
@@ -245,6 +577,11 @@
 									"key": { "type": "string", "description": "Config key, for the appConfig check." }
 								}
 							}
+						},
+						"cors": {
+							"type": "boolean",
+							"default": false,
+							"description": "ADR-040: when true the engine emits permissive CORS headers on the /api/health response."
 						}
 					}
 				},
@@ -341,6 +678,11 @@
 					"type": "string",
 					"description": "Vue-router route name (matches a pages[].id) that this entry navigates to. Sentinels (@resolve:*) are NOT allowed — this is a router invariant."
 				},
+				"query": {
+					"type": "object",
+					"additionalProperties": { "type": ["string", "number", "boolean"] },
+					"description": "Optional vue-router query parameters merged into the target route link (e.g. a filter like { caseType: '<uuid>' }). Deep-links a nav entry to a pre-filtered index page."
+				},
 				"order": {
 					"type": "integer",
 					"description": "Display order in the menu. Items without an order render last."
@@ -384,8 +726,12 @@
 				},
 				"action": {
 					"type": "string",
-					"enum": ["user-settings"],
-					"description": "Built-in action to invoke when the entry is clicked. Closed enum."
+					"enum": ["user-settings", "admin-settings", "replay-walkthrough"],
+					"description": "Built-in action to invoke when the entry is clicked. Closed enum. 'admin-settings' opens the app-level admin-settings dialog (distinct from the per-user settings dialog). 'replay-walkthrough' re-runs the product walkthrough (ADR-043), optionally for a specific tourId."
+				},
+				"tourId": {
+					"type": "string",
+					"description": "Tour id for the 'replay-walkthrough' action (ADR-043); replays that tour from its first step. Omit to replay the default tour."
 				},
 				"visibleIf": {
 					"$ref": "#/$defs/visibleIfCondition",
@@ -412,6 +758,11 @@
 				"label": { "type": "string" },
 				"icon": { "type": "string" },
 				"route": { "type": "string" },
+				"query": {
+					"type": "object",
+					"additionalProperties": { "type": ["string", "number", "boolean"] },
+					"description": "Optional vue-router query parameters merged into the target route link (e.g. a filter like { caseType: '<uuid>' }). Deep-links a nav entry to a pre-filtered index page."
+				},
 				"order": { "type": "integer" },
 				"permission": { "type": "string" },
 				"section": {
@@ -434,7 +785,11 @@
 				"href": { "type": "string" },
 				"action": {
 					"type": "string",
-					"enum": ["user-settings"]
+					"enum": ["user-settings", "admin-settings", "replay-walkthrough"]
+				},
+				"tourId": {
+					"type": "string",
+					"description": "Tour id for the 'replay-walkthrough' action (ADR-043)."
 				},
 				"visibleIf": {
 					"$ref": "#/$defs/visibleIfCondition"
@@ -474,7 +829,7 @@
 			"type": "object",
 			"required": ["widgetKey", "slot", "gridX", "gridY", "gridWidth", "gridHeight"],
 			"additionalProperties": false,
-			"description": "A uniform widget placement entry used on every page type in v2. Replaces the v1 widgetDef + layoutItem pair with a single shape. The cross-field constraint gridX + gridWidth <= 12 CANNOT be expressed in JSON Schema (arithmetic over sibling fields) — it is documented here and enforced at runtime by validateManifestV2() as a post-schema check. Failure message: \"Widget '{widgetKey}' in slot '{slot}': gridX ({gridX}) + gridWidth ({gridWidth}) exceeds 12\".",
+			"description": "A uniform widget placement entry used on every page type in v2. Replaces the v1 widgetDef + layoutItem pair with a single shape. Its props/dataSource/filter string leaves are guarded against the closed sentinel vocabulary via the sentinelGuardedValue allOf. The cross-field constraint gridX + gridWidth <= 12 CANNOT be expressed in JSON Schema (arithmetic over sibling fields) — it is documented here and enforced at runtime by validateManifestV2() as a post-schema check. Failure message: \"Widget '{widgetKey}' in slot '{slot}': gridX ({gridX}) + gridWidth ({gridWidth}) exceeds 12\".",
 			"properties": {
 				"id": {
 					"type": "string",
@@ -534,6 +889,7 @@
 				}
 			},
 			"allOf": [
+				{ "$ref": "#/$defs/sentinelGuardedValue" },
 				{
 					"description": "sidebar slot: gridWidth MUST equal 1. The sidebar is a fixed-width panel; widgets always span the full width.",
 					"if": {
@@ -552,6 +908,425 @@
 					},
 					"then": {
 						"properties": { "gridY": { "const": 0 } }
+					}
+				},
+				{
+					"description": "object-table built-in widget: when props declares a `source` it must match the declarative self-fetch shape, an `endpointSource` (Wave 2) must match the shared endpoint binding (exactly one of source | endpointSource — post-schema check), and `actions` must be typed manifest actions (incl. type:'object-op'). Other props stay free-form (pass-through to CnDataTable).",
+					"if": {
+						"properties": { "widgetKey": { "const": "object-table" } },
+						"required": ["widgetKey"]
+					},
+					"then": {
+						"properties": {
+							"props": {
+								"type": "object",
+								"properties": {
+									"source": { "$ref": "#/$defs/objectTableSource" },
+									"endpointSource": {
+										"$ref": "#/$defs/endpointSource",
+										"description": "Wave 2 (#91): endpoint-bound rows — the payload at responsePath must be an array; columns / formatters / rowRoute / actions apply unchanged on top. Exactly one of source | endpointSource (post-schema check)."
+									},
+									"actions": {
+										"type": "array",
+										"items": { "$ref": "#/$defs/action" },
+										"description": "Declarative row/widget actions rendered by CnWidgetObjectTable. object-op patch/delete render per row; object-op create renders as a widget-scoped footer affordance."
+									},
+									"rowClass": {
+										"type": "array",
+										"description": "#91: declarative per-row CSS class rules compiled into CnDataTable's rowClass function. Each rule { when: { field, op?, value }, class } adds `class` to a row when the shared visibleWhen predicate holds against that row (field = dot-path into the row, op = eq|neq|gt|gte|lt|lte default eq, value = literal). Rules evaluate in order and every matching class is space-joined — so overdue / at-risk rows can be highlighted from the manifest. A host-supplied rowClass FUNCTION (runtime-only) still passes straight through.",
+										"items": {
+											"type": "object",
+											"additionalProperties": false,
+											"required": ["when", "class"],
+											"properties": {
+												"when": {
+													"type": "object",
+													"additionalProperties": false,
+													"required": ["field", "value"],
+													"description": "The predicate evaluated against the row (shared visibleWhen grammar, LOCAL form).",
+													"properties": {
+														"field": { "type": "string", "description": "Dot-path into the row." },
+														"op": { "type": "string", "enum": ["eq", "neq", "gt", "gte", "lt", "lte"], "default": "eq", "description": "Comparison operator (default eq)." },
+														"value": { "description": "Literal right-hand side of the comparison." }
+													}
+												},
+												"class": { "type": "string", "description": "CSS class added to the row when `when` holds." }
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				{
+					"description": "stats-block built-in widget: when props declares `entries[]` each entry must match the statsBlockEntry shape. The exactly-one-of dataSource | props.entries constraint is a cross-field rule enforced by validateManifestV2() as a post-schema check (clear error message), not by JSON Schema.",
+					"if": {
+						"properties": { "widgetKey": { "const": "stats-block" } },
+						"required": ["widgetKey"]
+					},
+					"then": {
+						"properties": {
+							"props": {
+								"type": "object",
+								"properties": {
+									"entries": {
+										"type": "array",
+										"items": { "$ref": "#/$defs/statsBlockEntry" },
+										"description": "Multi-entry KPI sources — each entry renders one CnStatsBlock within the widget card. Mutually exclusive with a single dataSource."
+									}
+								}
+							}
+						}
+					}
+				},
+				{
+					"description": "banner built-in widget (CnBannerWidget, Wave 1): a declarative notice banner. props { variant, text, visibleWhen?, route? } — visibleWhen is a simple {endpoint|source, field?, op?, value} predicate evaluated at mount (fail-safe: hidden on fetch failure).",
+					"if": {
+						"properties": { "widgetKey": { "const": "banner" } },
+						"required": ["widgetKey"]
+					},
+					"then": {
+						"properties": {
+							"props": {
+								"type": "object",
+								"properties": {
+									"variant": {
+										"type": "string",
+										"enum": ["info", "warning", "error", "success"],
+										"description": "Banner severity variant (NcNoteCard type). Default info."
+									},
+									"text": {
+										"type": "string",
+										"description": "Pre-translated banner text (required for the banner to render)."
+									},
+									"visibleWhen": {
+										"type": "object",
+										"additionalProperties": false,
+										"description": "Optional visibility condition: exactly one of `endpoint` (same-origin JSON URL) or `source` (OpenRegister object query). `field` is a dot-path into the response (source: into the first result; omit or use '@total' for the collection total). Fail-safe: the banner stays hidden until the predicate evaluates true.",
+										"properties": {
+											"endpoint": { "type": "string", "description": "Same-origin URL returning JSON." },
+											"source": {
+												"type": "object",
+												"additionalProperties": false,
+												"required": ["register", "schema"],
+												"description": "OpenRegister object query; `filter` supports the shared @-token grammar.",
+												"properties": {
+													"register": { "type": "string" },
+													"schema": { "type": "string" },
+													"filter": { "type": "object", "additionalProperties": true }
+												}
+											},
+											"field": { "type": "string", "description": "Dot-path into the response ('@total' or omitted = collection total for a source)." },
+											"op": { "type": "string", "enum": ["eq", "neq", "gt", "gte", "lt", "lte"], "default": "eq", "description": "Comparison operator." },
+											"value": { "description": "Literal right-hand side of the comparison." }
+										}
+									},
+									"route": {
+										"description": "Optional click-through: a vue-router route NAME (string) or a full location object. Makes the banner text an accessible button.",
+										"oneOf": [
+											{ "type": "string" },
+											{ "type": "object", "additionalProperties": true }
+										]
+									}
+								}
+							}
+						}
+					}
+				},
+				{
+					"description": "audit-trail built-in widget (CnAuditTrailWidget, Wave 1): the object change-log card. All props are optional — register/schema/objectId normally arrive via the detail-page object-context merge; explicit props win.",
+					"if": {
+						"properties": { "widgetKey": { "const": "audit-trail" } },
+						"required": ["widgetKey"]
+					},
+					"then": {
+						"properties": {
+							"props": {
+								"type": "object",
+								"properties": {
+									"register": { "type": "string", "description": "OpenRegister register slug/id (context merge fallback when omitted)." },
+									"schema": { "type": "string", "description": "OpenRegister schema slug (context merge fallback when omitted)." },
+									"objectId": { "type": "string", "description": "The audited object's id (context merge fallback when omitted)." },
+									"title": { "type": "string", "description": "Optional card title override." },
+									"maxDisplay": { "type": "integer", "minimum": 1, "description": "Maximum audit rows to render (default 5)." }
+								}
+							}
+						}
+					}
+				},
+				{
+					"description": "chart widget display passthrough (Wave 1): additive presentation keys forwarded verbatim to CnChartWidget by CnDashboardPage's dispatcher and the v2 grid. Other chart props stay free-form.",
+					"if": {
+						"properties": { "widgetKey": { "const": "chart" } },
+						"required": ["widgetKey"]
+					},
+					"then": {
+						"properties": {
+							"props": {
+								"type": "object",
+								"properties": {
+									"horizontal": { "type": "boolean", "description": "Render type:'bar' charts horizontally (row bars)." },
+									"legendPosition": { "type": "string", "enum": ["top", "bottom", "left", "right"], "description": "Legend placement override (empty/omitted keeps the automatic placement)." },
+								"valueAxisBaseline": { "type": "string", "enum": ["auto", "zero", "fit"], "description": "Value-axis baseline: 'auto' (the default — zero for bar/area, a bounded window for line/scatter), 'zero' (force a zero baseline), or 'fit' (let ApexCharts frame the data range, for a series living far from zero such as an SLA hovering 95–99%)." },
+									"valueFormat": {
+										"description": "Named value formatter applied to the value axis + tooltip: 'currency' | 'currency-compact' | 'percent', or the object form { name, currency?, decimals? }.",
+										"oneOf": [
+											{ "type": "string", "enum": ["currency", "currency-compact", "percent"] },
+											{
+												"type": "object",
+												"additionalProperties": false,
+												"required": ["name"],
+												"properties": {
+													"name": { "type": "string", "enum": ["currency", "currency-compact", "percent"] },
+													"currency": { "type": "string", "description": "ISO-4217 code (EUR default; invalid codes fall back to EUR)." },
+													"decimals": { "type": "integer", "minimum": 0, "description": "Fraction digits override." }
+												}
+											}
+										]
+									},
+									"colorMap": {
+										"type": "object",
+										"additionalProperties": { "type": "string" },
+										"description": "Per-category colour map ({ categoryLabel: cssColor }) for pie/donut/radialBar slices and (distributed) bar categories."
+									},
+									"emptyLabel": { "type": "string", "description": "Empty-state message rendered instead of the chart when the resolved series contain no data points." },
+									"endpointSource": {
+										"$ref": "#/$defs/chartEndpointSource",
+										"description": "Wave 2 (#91): endpoint-bound series/labels — the shared endpoint transport plus the labelsPath / series[] {name, path} response mapping. Exactly one of dataSource | endpointSource (post-schema check)."
+									}
+								}
+							}
+						}
+					}
+				},
+				{
+					"description": "header / text / divider on the v2 grid (Wave 1): the dashboard catalog's content-only presentation widgets reused as built-ins. Each takes a single `props.content` object with the same shape as its dashboard `content` blob.",
+					"if": {
+						"properties": { "widgetKey": { "enum": ["header", "text", "divider"] } },
+						"required": ["widgetKey"]
+					},
+					"then": {
+						"properties": {
+							"props": {
+								"type": "object",
+								"properties": {
+									"content": {
+										"type": "object",
+										"additionalProperties": true,
+										"description": "The widget's content blob — header: { title, subtitle, backgroundImageUrl, overlayMode, height, cta, … }; text: { text, contentMode, fontSize, … }; divider: { style, lineColor, headingText, … }."
+									}
+								}
+							}
+						}
+					}
+				},
+				{
+					"description": "stat / delta catalog widgets on the v2 grid (Wave 2, #91): the KPI tiles take a `props.content` blob (same shape as their dashboard `content`). The endpoint-binding keys are typed here; the rest of the blob stays free-form (label, icon, format, source, …). Exactly one of content.source | content.endpointSource — a cross-field rule enforced by validateManifestV2() as a post-schema check (stats-block precedent), which also covers the legacy pages[].config.widgets[] placement.",
+					"if": {
+						"properties": { "widgetKey": { "enum": ["stat", "delta"] } },
+						"required": ["widgetKey"]
+					},
+					"then": {
+						"properties": {
+							"props": {
+								"type": "object",
+								"properties": {
+									"content": {
+										"type": "object",
+										"additionalProperties": true,
+										"properties": {
+											"endpointSource": {
+												"$ref": "#/$defs/endpointSource",
+												"description": "Wave 2 (#91): endpoint-bound KPI value(s) — exactly one of source | endpointSource (post-schema check)."
+											},
+											"valueField": {
+												"type": "string",
+												"description": "Dot-path into the endpoint payload for the displayed (current) value. Omitted = the payload itself."
+											},
+											"previousField": {
+												"type": "string",
+												"description": "Dot-path into the endpoint payload for the previous-period value — renders the trend sublabel (arrow + percent-vs-previous; the pipelinq previousPeriod contract)."
+											},
+											"deltaField": {
+												"type": "string",
+												"description": "Dot-path into the endpoint payload for a SERVER-computed delta percent — wins over the client-side previousField computation."
+											},
+											"goodDirection": {
+												"type": "string",
+												"enum": ["up", "down"],
+												"default": "up",
+												"description": "Which trend direction tints green ('up' default; 'down' for cost-like KPIs). The delta widget's source.goodDirection still wins for the OpenRegister form."
+											},
+											"variantWhen": {
+												"type": "array",
+												"description": "First-match threshold styling rules for the stat tile — the matched rule's variant re-tints the value + icon circle, and its optional icon overrides content.icon.",
+												"items": {
+													"type": "object",
+													"required": ["op", "value", "variant"],
+													"additionalProperties": false,
+													"properties": {
+														"op": {
+															"type": "string",
+															"enum": ["eq", "neq", "gt", "gte", "lt", "lte"],
+															"description": "Comparison operator against the resolved display value (numeric when both sides coerce; eq/neq fall back to string equality)."
+														},
+														"value": {
+															"description": "Literal right-hand side of the comparison."
+														},
+														"variant": {
+															"type": "string",
+															"enum": ["default", "primary", "success", "warning", "error"],
+															"description": "Colour variant applied on match ('default' keeps the configured colours). The component also accepts 'danger' as an alias of 'error' for doriath-migrated content."
+														},
+														"icon": {
+															"type": "string",
+															"description": "Optional MDI icon name overriding content.icon while this rule matches."
+														}
+													}
+												}
+											},
+											"clickRoute": {
+												"description": "Whole-tile click-through: a vue-router route NAME (string) or full location object. Alias of content.route (route wins when both are set).",
+												"oneOf": [
+													{ "type": "string" },
+													{ "type": "object", "additionalProperties": true }
+												]
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+				,
+				{
+					"description": "workspace-filter catalog widget (#91 Wave 3): a choice list whose selection writes into the page workspace context so sibling widgets refetch. The endpoint/OR-source binding keys of `props.content` are typed here; the rest stays free-form.",
+					"if": {
+						"properties": { "widgetKey": { "const": "workspace-filter" } },
+						"required": ["widgetKey"]
+					},
+					"then": {
+						"properties": {
+							"props": {
+								"type": "object",
+								"properties": {
+									"content": {
+										"type": "object",
+										"additionalProperties": true,
+										"properties": {
+											"writes": {
+												"type": "string",
+												"description": "The workspace context key the selection writes (`@workspace.<key>` or a bare `<key>`). Sibling widgets whose declarative source interpolates `@workspace.<key>` refetch on change."
+											},
+											"style": {
+												"type": "string",
+												"enum": ["radio", "select"],
+												"default": "radio",
+												"description": "Choice style: 'radio' (default) list or 'select' dropdown."
+											},
+											"allLabel": {
+												"type": "string",
+												"description": "Optional leading 'All' option — writes the empty string so an optional sibling token (`@workspace.<key>?`) drops (unfiltered set)."
+											},
+											"showCounts": {
+												"type": "boolean",
+												"default": true,
+												"description": "Render per-option counts."
+											},
+											"options": {
+												"type": "array",
+												"description": "Static options — each { value, label, count? } (or { id, name } / bare strings, normalised).",
+												"items": { "type": ["object", "string", "number"] }
+											},
+											"source": {
+												"type": "object",
+												"additionalProperties": true,
+												"description": "OpenRegister /grouped facet source { register, schema, groupBy, filter? } — each distinct value becomes an option with its object count.",
+												"properties": {
+													"register": { "type": "string" },
+													"schema": { "type": "string" },
+													"groupBy": { "type": "string" },
+													"filter": { "type": "object", "additionalProperties": true }
+												}
+											},
+											"endpointSource": {
+												"$ref": "#/$defs/endpointSource",
+												"description": "App endpoint returning an array of { value, label, count? } options at responsePath."
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				{
+					"description": "kb-search catalog widget (#91 Wave 3): summary-driven knowledge-base search through a PLUGGABLE PROVIDER. The provider seam keys of `props.content` are typed here; the rest stays free-form.",
+					"if": {
+						"properties": { "widgetKey": { "const": "kb-search" } },
+						"required": ["widgetKey"]
+					},
+					"then": {
+						"properties": {
+							"props": {
+								"type": "object",
+								"properties": {
+									"content": {
+										"type": "object",
+										"additionalProperties": true,
+										"properties": {
+											"provider": {
+												"type": "string",
+												"description": "Provider registry key (default 'default' — the built-in endpoint search). An app registers bespoke providers (the xwiki proxy) on CnAppRoot's kbSearchProviders; the xwiki client stays app-side."
+											},
+											"space": {
+												"type": "string",
+												"description": "Provider-specific KB space filter (passed to provider.search)."
+											},
+											"tags": {
+												"description": "Provider-specific tag filter — a single tag or an array.",
+												"oneOf": [
+													{ "type": "string" },
+													{ "type": "array", "items": { "type": "string" } }
+												]
+											},
+											"endpoint": {
+												"type": "string",
+												"description": "The default provider's search endpoint (OpenRegister xWiki leaf by default)."
+											},
+											"queryParam": {
+												"type": "string",
+												"description": "The default provider's query parameter name (default 'q')."
+											},
+											"bindTo": {
+												"type": "string",
+												"description": "Workspace context key to auto-search on (default 'activeSummary')."
+											},
+											"minChars": {
+												"type": "integer",
+												"minimum": 0,
+												"description": "Minimum characters before a search fires (default 3)."
+											},
+											"limit": {
+												"type": "integer",
+												"minimum": 1,
+												"description": "Result cap passed to the provider (default 8)."
+											},
+											"externalOpen": {
+												"type": "boolean",
+												"description": "Whether result links open in a new tab (defaults to the provider's own externalOpen flag)."
+											},
+											"unavailableFallback": {
+												"type": "string",
+												"description": "Text shown when the provider rejects / is unavailable (replaces the default 'Knowledge base unavailable')."
+											}
+										}
+									}
+								}
+							}
+						}
 					}
 				}
 			]
@@ -600,7 +1375,7 @@
 		},
 		"dataSource": {
 			"type": "object",
-			"description": "Declarative data binding for widgets. Two forms: (a) shorthand {register, schema, filter?, aggregate: 'count'} — the lib builds a count query and resolves to {count}. (b) raw {graphql: {query, variables?, selectors}} — the lib issues the query and runs selectors against the response. Carry-forward from v1.3.0 widgetDef.dataSource.",
+			"description": "Declarative data binding for widgets. Forms: (a) shorthand {register, schema, filter?, aggregate: 'count'} — the lib builds a count query and resolves to {count}. (b) raw {graphql: {query, variables?, selectors}} — the lib issues the query and runs selectors. (c) #91 Wave 3 chart aggregation — `aggregate` as an OBJECT {groupBy, metric?: count|sum, sumField?, topN?, otherBucket?, labelResolve?} grouped over the schema's objects via OpenRegister's /grouped facet (client-side collection fallback), plus an optional sibling `drilldown` {route, filterParam}. Carry-forward from v1.3.0 widgetDef.dataSource.",
 			"additionalProperties": true,
 			"properties": {
 				"register": {
@@ -617,9 +1392,45 @@
 					"additionalProperties": true
 				},
 				"aggregate": {
-					"type": "string",
-					"enum": ["count"],
-					"description": "Shorthand aggregation. Currently only count is supported."
+					"description": "Shorthand aggregation. The STRING 'count' builds a GraphQL count query resolving to {count}. The OBJECT form (#91 Wave 3) is a chart-only categorical group-by served by OpenRegister's /grouped facet.",
+					"oneOf": [
+						{ "type": "string", "enum": ["count"] },
+						{
+							"type": "object",
+							"required": ["groupBy"],
+							"additionalProperties": false,
+							"description": "#91 Wave 3 chart aggregation: group the schema's objects by `groupBy`, count (default) or sum `sumField`, keep the `topN` largest (sorted desc) and optionally fold the remainder into a translated 'Other' slice, resolving reference keys to labels/colours via `labelResolve`.",
+							"properties": {
+								"groupBy": { "type": "string", "description": "The categorical field grouped on." },
+								"metric": { "type": "string", "enum": ["count", "sum"], "default": "count", "description": "count (default) | sum. sum requires sumField." },
+								"sumField": { "type": "string", "description": "Numeric field summed when metric is 'sum' (required for sum)." },
+								"topN": { "type": "integer", "minimum": 1, "description": "Keep the N largest groups (sorted by value desc)." },
+								"otherBucket": { "type": "boolean", "description": "Fold the post-topN remainder into a single translated 'Other' slice (sum of the rest). The Other bucket never drilldown-navigates." },
+								"labelResolve": {
+									"type": "object",
+									"required": ["schema"],
+									"additionalProperties": false,
+									"description": "Resolve reference (uuid) group keys to the referenced objects' display labels (and optional per-category colours) through the shared object store — the fkResolve pattern.",
+									"properties": {
+										"register": { "type": "string", "description": "Register the reference points into (defaults to the dataSource register)." },
+										"schema": { "type": "string", "description": "Schema slug the reference points into." },
+										"labelField": { "type": "string", "description": "Property used as the display label (default 'name')." },
+										"colorField": { "type": "string", "description": "Optional property read as a per-category CSS colour (feeds the chart's colorMap path)." }
+									}
+								}
+							}
+						}
+					]
+				},
+				"drilldown": {
+					"type": "object",
+					"required": ["route", "filterParam"],
+					"additionalProperties": false,
+					"description": "#91 Wave 3 (chart only): a segment/bar click navigates to `route` with the clicked category's RAW key in the query ({ [filterParam]: rawKey }). A `/`-prefixed route is a path, otherwise a route name. Works with the OBJECT `aggregate` and the legacy `groupBy` forms; the folded 'Other' bucket never navigates.",
+					"properties": {
+						"route": { "type": "string", "description": "Destination route name, or a path when it starts with '/'." },
+						"filterParam": { "type": "string", "description": "Query-param name the clicked category's raw key is written to." }
+					}
 				},
 				"graphql": {
 					"type": "object",
@@ -649,7 +1460,7 @@
 			"type": "object",
 			"required": ["id", "label"],
 			"additionalProperties": false,
-			"description": "A typed page action with a discriminator field. The type field determines behaviour: handler (registry function), open-modal (modal by id), open-page (named route), navigate (URL). When type is omitted, it defaults to 'handler' (back-compatibility with v1.3.0 action declarations). The Ajv instance is compiled with useDefaults: true so the default is applied during validation.",
+			"description": "A typed page action with a discriminator field. The type field determines behaviour: handler (registry function), open-modal (modal by id), open-page (named route), navigate (URL), object-op (declarative OpenRegister mutation via useObjectStore), export (opens the shared CnMassExportDialog export launcher), open-form (schema-driven create dialog — CnActionButtons), refresh (bumps the cn:page:refresh signal), api-call (POST/PUT an app endpoint + toast + refresh — CnActionButtons/dispatchAction), toggle (two-way state button — CnActionButtons only, NOT dispatchable). When type is omitted, it defaults to 'handler' (back-compatibility with v1.3.0 action declarations). The Ajv instance is compiled with useDefaults: true so the default is applied during validation.",
 			"properties": {
 				"id": {
 					"type": "string",
@@ -661,9 +1472,24 @@
 				},
 				"type": {
 					"type": "string",
-					"enum": ["handler", "open-modal", "open-page", "navigate"],
+					"enum": ["handler", "open-modal", "open-page", "navigate", "object-op", "export", "open-form", "refresh", "api-call", "agent", "toggle"],
 					"default": "handler",
-					"description": "Action behaviour discriminator. Defaults to 'handler' when omitted (back-compat with v1.3.0). handler: calls a registry function; open-modal: opens a modal by target id; open-page: navigates to a named route; navigate: navigates to a URL."
+					"description": "Action behaviour discriminator. Defaults to 'handler' when omitted (back-compat with v1.3.0). handler: calls a registry function; open-modal: opens a modal by target id; open-page: navigates to a named route; navigate: navigates to a URL; object-op: dispatches a declarative mutation (patch | delete | create) of an OpenRegister object via the shared object store; export: opens the shared CnMassExportDialog export launcher configured via entities[]/formats[] — the confirm payload ({format, entity?}) routes to the action's `handler` in the manifest actions map (the app's export service does the download). open-form (#91 Wave 3): CnActionButtons opens a schema-driven create dialog (CnAdvancedFormDialog) for the action's register/schema, saves + toasts + refreshes + optionally navigates to onSuccessRoute. refresh (#91 Wave 3): bumps the page-level cn:page:refresh event-bus signal so every endpoint-bound widget refetches. api-call (#91 Wave 3): POST/PUT the token-interpolated url with payload/params (JSON body, payload resolves @-tokens recursively at any depth) + success/error toast + auto page-refresh (unless refresh:false); confirm gating is surface-consumed intent (object-op precedent); download:true requests a binary blob and triggers a browser file download instead (auto-refresh defaults to OFF in that mode). agent (hermiq#41): run a governed hermiq agent against the page object — POSTs { register, schema, objectId, resultField?, skill?, prompt? } to /apps/hermiq/api/agents/{agent}/run-on-object (object-RBAC-scoped; dispatches the governed AgentRunRequestedEvent). register/schema/objectId default to the page's @register/@schema/@objectId object context. A first-class companion to api-call (which remains the fallback for a bespoke body); hermiq is NOT hard-required — an app-level 404 surfaces a graceful 'agent runtime unavailable' toast. toggle (#91 Wave 3): a stateful two-way state button rendered by CnActionButtons (GET stateSource on mount, optimistic write on click) — NOT dispatchable through dispatchAction. object-op declares mutation INTENT only — authority is enforced server-side by OpenRegister RBAC (ADR-022/ADR-023); authorization-shaped fields have no client-side effect and are not accepted here."
+				},
+				"op": {
+					"type": "string",
+					"enum": ["patch", "delete", "create"],
+					"description": "object-op only: the mutation verb. patch merges `values` into the row's object (row-scoped); delete removes the row's object (row-scoped, ALWAYS confirm-gated); create adds a new object built from `values` against the widget's source register/schema (widget-scoped footer/header affordance). Required when type is 'object-op'."
+				},
+				"values": {
+					"type": "object",
+					"additionalProperties": true,
+					"description": "object-op only: the verb's payload. For patch: the partial object merged over the row's object. For create: the new object's properties. Omitted for delete."
+				},
+				"confirm": {
+					"type": "boolean",
+					"default": false,
+					"description": "Confirm-gating (object-op + #91 Wave 3 api-call / open-form + agent): when true, the action presents a CnConfirmDialog before running (the dispatcher / CnActionButtons runs AFTER confirmation). object-op delete ALWAYS confirms regardless of this flag."
 				},
 				"target": {
 					"type": "string",
@@ -680,11 +1506,431 @@
 				},
 				"route": {
 					"type": "string",
-					"description": "Destination route name for handler: 'navigate'. The dispatcher (manifestActionDispatch) calls $router.push({ name: route, params }). For row-level actions params include { id: row[rowKey] }; page-level header actions navigate without row context (e.g. a 'New X' action to a detail route)."
+					"description": "Destination route name for handler: 'navigate'. The dispatcher (manifestActionDispatch) calls $router.push({ name: route, params }). For row-level actions params include { id: row[rowKey] } automatically — do NOT restate it as params: { id: \"{id}\" }, though that placeholder does resolve (see `params`). Page-level header actions navigate without row context (e.g. a 'New X' action to a detail route)."
 				},
 				"icon": {
 					"type": "string",
 					"description": "Optional icon for the action, rendered by CnActionsBar. Either an MDI icon name (e.g. 'TextBoxOutline') or a CSS icon class (e.g. 'icon-file')."
+				},
+				"entities": {
+					"type": "array",
+					"description": "export only: selectable entity types offered by the export launcher (e.g. Leads / Requests). Optional — when absent the dialog shows only the format picker. Each entry needs an id + pre-translated label.",
+					"items": {
+						"type": "object",
+						"additionalProperties": false,
+						"required": ["id", "label"],
+						"properties": {
+							"id": { "type": "string", "description": "Entity id handed to the confirm handler." },
+							"label": { "type": "string", "description": "Pre-translated display label." }
+						}
+					}
+				},
+				"formats": {
+					"type": "array",
+					"description": "export only: the offered export formats — bare ids ('excel', 'csv', 'json' — lifted to {id, label} with an upper-cased label) or full {id, label} entries. Optional — the dialog's built-in Excel/CSV defaults apply when absent.",
+					"items": {
+						"oneOf": [
+							{ "type": "string" },
+							{
+								"type": "object",
+								"additionalProperties": false,
+								"required": ["id", "label"],
+								"properties": {
+									"id": { "type": "string", "description": "Format id handed to the confirm handler." },
+									"label": { "type": "string", "description": "Pre-translated display label." }
+								}
+							}
+						]
+					}
+				},
+				"description": {
+					"type": "string",
+					"description": "export only: pre-translated description shown above the export launcher's pickers."
+				},
+				"url": {
+					"type": "string",
+					"description": "api-call / toggle only: the app endpoint (POST/PUT). App-relative (routed through generateUrl) or absolute (http/https). May interpolate @objectId / @object.<field> / @workspace.<key> / @config.<key> tokens inline, as well as the literal {objectId} brace placeholder (unresolved tokens collapse to empty)."
+				},
+				"method": {
+					"type": "string",
+					"enum": ["POST", "PUT"],
+					"description": "api-call: HTTP method (default POST). toggle writeUrl: default PUT."
+				},
+				"payload": {
+					"type": "object",
+					"additionalProperties": true,
+					"description": "api-call only: the JSON request body — PREFERRED over `params`, and used instead of it when both are set. Values run the SAME token grammar as `params` (@me, @now, @today±Nd, @monthStart/@quarterStart/@yearStart, @objectId, @object.<field>, @workspace.<key>/@config.<key> with a trailing `?` marking a value OPTIONAL — dropped when unresolved) but resolve RECURSIVELY at ANY nesting depth, including arrays of objects — e.g. a DocuDesk document-generation body: { \"dataRefs\": [{ \"register\": \"crm\", \"schema\": \"lead\", \"id\": \"@objectId\" }] }. A required (non-`?`) token left unresolved anywhere in the tree BLOCKS the call (error toast) instead of sending the literal token string to the server."
+				},
+				"params": {
+					"type": "object",
+					"additionalProperties": true,
+					"description": "Two distinct uses depending on the action's dispatch. (1) api-call / toggle: the JSON request body (legacy — prefer `payload` for anything with nested objects/arrays; ignored when `payload` is set). Values run the shared filter-token grammar ONE level deep (@me, @today±Nd, @workspace.<key>/@config.<key> with a trailing `?` for optional values dropped when unresolved; a required unresolved token skips the call). (2) handler: 'navigate' (index-page row actions, manifestActionDispatch): vue-router params merged OVER the default { id: row[rowKey] }. OMIT it for the ordinary 'open this row's detail page' action — the row id is already injected. String values run the `{field}` ROW-token grammar (NOT the @-token grammar): \"{id}\" resolves to row.id with its type preserved, \"run-{id}\" interpolates as text, and a brace-less \"new\" stays literal (that is what makes a 'New X' action navigate with { id: 'new' }). A token naming a field the row does not carry is dropped with a console.warn — so `id` falls back to the row id — instead of being pushed as a literal %7Bid%7D path segment."
+				},
+				"download": {
+					"type": "boolean",
+					"default": false,
+					"description": "api-call only: request the response as a binary blob (axios responseType 'blob') and trigger a browser file download instead of a JSON toast+refresh cycle. The filename is taken from the response's Content-Disposition header, else the token-resolved `filename`, else 'download.pdf'. The success toast still shows; unlike a normal api-call the page does NOT auto-refresh afterwards unless `refresh: true` is explicitly set."
+				},
+				"filename": {
+					"type": "string",
+					"description": "api-call `download: true` only: fallback filename used when the response carries no Content-Disposition header (falls back further to 'download.pdf'). Interpolates the same token grammar as `url` (@objectId, @object.<field>, @workspace.<key>, @config.<key>, {objectId})."
+				},
+				"successMessage": {
+					"type": "string",
+					"description": "api-call / open-form / agent / toggle: pre-translated success toast text (a library default applies when absent; agent default 'Run queued')."
+				},
+				"errorMessage": {
+					"type": "string",
+					"description": "api-call / agent / toggle: pre-translated error toast text (falls back to the server's error/message, then a library default; an agent 404 with no structured body toasts 'agent runtime unavailable' instead)."
+				},
+				"refresh": {
+					"type": "boolean",
+					"default": true,
+					"description": "api-call / agent / toggle: bump the page-level cn:page:refresh signal after a successful call (default true; set false to skip). EXCEPTION: for an api-call with download:true the default flips to false — a file download normally shouldn't also force-refetch every widget — set refresh:true explicitly to opt back in."
+				},
+				"agent": {
+					"type": "string",
+					"description": "agent only (REQUIRED): the hermiq agent uuid to run against the page object. POSTed to /apps/hermiq/api/agents/{agent}/run-on-object (hermiq#41) — object-RBAC-scoped, dispatches the governed AgentRunRequestedEvent. May interpolate the shared @-token grammar (@objectId, @object.<field>, @workspace.<key>, @config.<key>)."
+				},
+				"skill": {
+					"type": "string",
+					"description": "agent only: optional skill id folded into the governed run (interpolates the same @-token grammar as `agent`)."
+				},
+				"prompt": {
+					"type": "string",
+					"description": "agent only: optional prompt handed to the governed run. Interpolates the shared @-token grammar inline (@objectId, @object.<field>, @workspace.<key>, @config.<key>) so it can be grounded on the page object — e.g. 'Summarise @object.title'."
+				},
+				"resultField": {
+					"type": "string",
+					"description": "agent only: the object field the agent's result is written back to (falls back to hermiq's default result field when absent)."
+				},
+				"objectId": {
+					"type": "string",
+					"description": "agent only: the target object id. Defaults to the page object context's @objectId; an unresolved required @objectId BLOCKS the call (fail-closed) rather than sending a literal token. May be an explicit id or an @-token string."
+				},
+				"register": {
+					"type": "string",
+					"description": "open-form / agent: OpenRegister register slug. open-form: the create dialog's schema register. agent: the run-on-object register — both fall back to the page object context's @register."
+				},
+				"schema": {
+					"type": "string",
+					"description": "open-form / agent: OpenRegister schema slug. open-form: the create dialog fetches this schema and saves the new object against it. agent: the run-on-object schema — falls back to the page object context's @schema."
+				},
+				"onSuccessRoute": {
+					"description": "open-form only: optional post-save navigation target (#91). A bare route NAME (string) navigates with the saved object's id merged into the route params under `id` (harmless when the route has no `:id` segment — backward compatible). The object form { name, paramField?, objectParam? } names the id param (`paramField`, default `id`) and, when `objectParam` is set, also passes the whole saved object under that param key (for a props:true detail route to render without a refetch). The id is read from saved.id, then saved.uuid, then saved['@self'].id.",
+					"oneOf": [
+						{ "type": "string" },
+						{
+							"type": "object",
+							"additionalProperties": false,
+							"required": ["name"],
+							"properties": {
+								"name": { "type": "string", "description": "The vue-router route NAME pushed after a successful save." },
+								"paramField": { "type": "string", "default": "id", "description": "Route param name populated from the saved object's id (default `id`)." },
+								"objectParam": { "type": "string", "description": "When set, the whole saved object is passed under this route param (props:true detail routes render without a refetch)." }
+							}
+						}
+					]
+				},
+				"labelOn": {
+					"type": "string",
+					"description": "toggle only: button label rendered while the state is ON (true). Falls back to `label`."
+				},
+				"labelOff": {
+					"type": "string",
+					"description": "toggle only: button label rendered while the state is OFF (false). Falls back to `label`."
+				},
+				"stateSource": {
+					"$ref": "#/$defs/endpointSource",
+					"description": "toggle only: the endpoint the initial state is read from on mount (the shared endpointSource shape — url + token-resolved params + responsePath). The `field` dot-path picks the boolean off the payload."
+				},
+				"writeUrl": {
+					"type": "string",
+					"description": "toggle only: the endpoint the flipped state is written to on click (interpolates the same tokens as `url`)."
+				},
+				"field": {
+					"type": "string",
+					"description": "toggle only: the state field — read off the stateSource payload on mount AND sent (as the flipped boolean) in the write body under this key."
+				},
+				"variant": {
+					"type": "string",
+					"description": "CnActionButtons button variant (e.g. 'primary', 'secondary', 'error'). 'error' also styles the confirm dialog as destructive."
+				},
+				"visibleWhen": {
+					"$ref": "#/$defs/visibleWhen",
+					"description": "#91 Wave 3: an optional predicate gating whether the action renders — the shared banner shape ({ endpoint | source | field, op, value }). The `field`-only LOCAL form evaluates against the page object context (a detail action shown only in the right lifecycle state); endpoint / source forms fetch. Fail-safe: a broken predicate hides the action."
+				}
+			},
+			"allOf": [
+				{
+					"description": "object-op actions MUST declare their mutation verb via `op`.",
+					"if": {
+						"properties": { "type": { "const": "object-op" } },
+						"required": ["type"]
+					},
+					"then": { "required": ["op"] }
+				},
+				{
+					"description": "api-call actions MUST declare their endpoint via `url`.",
+					"if": {
+						"properties": { "type": { "const": "api-call" } },
+						"required": ["type"]
+					},
+					"then": { "required": ["url"] }
+				},
+				{
+					"description": "open-form actions MUST declare the create schema via `schema`.",
+					"if": {
+						"properties": { "type": { "const": "open-form" } },
+						"required": ["type"]
+					},
+					"then": { "required": ["schema"] }
+				},
+				{
+					"description": "agent actions MUST declare the target agent uuid via `agent`.",
+					"if": {
+						"properties": { "type": { "const": "agent" } },
+						"required": ["type"]
+					},
+					"then": { "required": ["agent"] }
+				},
+				{
+					"description": "toggle actions MUST declare their write endpoint via `writeUrl`.",
+					"if": {
+						"properties": { "type": { "const": "toggle" } },
+						"required": ["type"]
+					},
+					"then": { "required": ["writeUrl"] }
+				}
+			]
+		},
+		"fieldValidation": {
+			"type": "object",
+			"additionalProperties": false,
+			"description": "manifest-form-logic: per-field validation rules for `type: 'form'` pages, enforced client-side by CnFormPage's validateFieldValue() before dispatch. Per-type semantics: string/password — required = non-empty after trim, min/max = string LENGTH, pattern tested against the value; number — required = finite number, min/max = numeric VALUE, pattern not applicable; boolean — required = value must be true (consent checkboxes), min/max/pattern not applicable; enum — required = a value is selected, min/max/pattern not applicable; json — required = non-null, min/max/pattern not applicable. Type-inapplicable rules are rejected by validateManifestV2() post-schema (pattern only on string/password; min/max only on string/password/number). `message` (i18n-able) overrides the built-in default message for whichever rule fails.",
+			"properties": {
+				"required": {
+					"type": "boolean",
+					"description": "Whether the field must be filled. Default false. Per-type pass condition — see the fieldValidation description."
+				},
+				"min": {
+					"type": "number",
+					"description": "Minimum bound. String length for string/password fields, numeric value for number fields. MUST be <= max when both are set (validateManifestV2 post-schema check)."
+				},
+				"max": {
+					"type": "number",
+					"description": "Maximum bound. String length for string/password fields, numeric value for number fields."
+				},
+				"pattern": {
+					"type": "string",
+					"description": "ECMAScript regex source tested against string/password values (implicit full-value test via new RegExp(pattern).test(value)). MUST compile — validateManifestV2() post-schema check runs `new RegExp(pattern)` in a try/catch."
+				},
+				"message": {
+					"type": "string",
+					"description": "i18n-able override message shown for ANY failing rule on this field, in place of the built-in translated default. Run through the page's `translate` prop, like `field.label`."
+				}
+			}
+		},
+		"visibleWhen": {
+			"type": "object",
+			"additionalProperties": false,
+			"description": "#91 Wave 3: the shared visibility predicate (the Wave-1 banner shape). THREE modes: `endpoint` (GET a JSON endpoint, `field` dot-paths into the body), `source` (an OpenRegister { register, schema, filter? } query — `field` into the first result, or omit / use @total for the collection total), or LOCAL (neither endpoint nor source — `field` dot-paths into the caller's object context, e.g. a detail-page record). `op` defaults to eq. Evaluation is FAIL-SAFE (any error → hidden).",
+			"properties": {
+				"endpoint": {
+					"type": "string",
+					"description": "A same-origin URL returning JSON; `field` is a dot-path into the body."
+				},
+				"source": {
+					"type": "object",
+					"additionalProperties": true,
+					"description": "An OpenRegister object query { register, schema, filter? } (filter supports the shared @-token grammar). `field` dot-paths into the first result; omit it (or use @total) to compare the collection total.",
+					"properties": {
+						"register": { "type": "string" },
+						"schema": { "type": "string" },
+						"filter": { "type": "object", "additionalProperties": true }
+					}
+				},
+				"field": {
+					"type": "string",
+					"description": "Dot-path to the compared value — into the endpoint body, the source's first result, or (LOCAL mode) the caller's object context."
+				},
+				"op": {
+					"type": "string",
+					"enum": ["eq", "neq", "gt", "gte", "lt", "lte"],
+					"default": "eq",
+					"description": "Comparison operator (default eq). eq/neq compare loosely-normalised primitives; ordering operators coerce both sides to Number."
+				},
+				"value": {
+					"description": "The literal right-hand side of the comparison."
+				}
+			}
+		},
+		"objectTableSource": {
+			"type": "object",
+			"required": ["register", "schema"],
+			"additionalProperties": false,
+			"description": "Declarative self-fetch source for the object-table built-in widget (CnWidgetObjectTable). The widget resolves `filter` @-tokens (@me, @today, @today±Nd, @workspace.*, ?-optional suffix) with the shared resolveFilterTokens grammar just before fetching, and drives CnDataTable's existing self-fetch. `register` MAY carry an `@resolve:` sentinel — the widget passes it through unexpanded (resolution is the host loader's responsibility). Externally supplied `rows` always win over `source`.",
+			"properties": {
+				"register": {
+					"type": "string",
+					"description": "OpenRegister register slug (or an `@resolve:<key>` sentinel, passed through unexpanded by the widget)."
+				},
+				"schema": {
+					"type": "string",
+					"description": "OpenRegister schema slug."
+				},
+				"filter": {
+					"type": "object",
+					"additionalProperties": true,
+					"description": "Filter map (`{ field: value | value[] | { op: value | value[] } }`). Values may use the shared @-token grammar: `@me` (current user via @nextcloud/auth), `@now`, `@today`, relative-date arithmetic `@today±Nd` at day granularity (e.g. `@today-30d`, `@today+7d`), `@monthStart`/`@quarterStart`/`@yearStart`, `@objectId`/`@object.<field>` (detail context), `@workspace.<key>`/`@config.<key>` with a trailing `?` for optional clauses that drop when unresolved. IN-lists: an ARRAY value (directly, or via `{ in: [...] }`) matches any of its entries — tokens resolve item-by-item and the widget serializes the list as repeated `field[]` params (the shape OpenRegister parses)."
+				},
+				"order": {
+					"type": "object",
+					"additionalProperties": { "type": "string", "enum": ["asc", "desc"] },
+					"description": "Fetch ordering: field name to direction map (e.g. { \"dueDate\": \"asc\" })."
+				},
+				"limit": {
+					"type": "integer",
+					"minimum": 0,
+					"description": "Row cap. 0 (or omitted) shows all fetched rows; a positive value caps the rendered rows and enables the View-all footer when more rows exist."
+				},
+				"extend": {
+					"type": "array",
+					"items": { "type": "string" },
+					"description": "OpenRegister `_extend[]` values forwarded on the fetch (e.g. [\"calculations\"]) so read-time virtual/derived fields are hydrated and available as columns. Each entry is passed through verbatim."
+				}
+			}
+		},
+		"endpointSource": {
+			"type": "object",
+			"required": ["url"],
+			"additionalProperties": false,
+			"description": "Wave 2 (#91): ONE coherent endpoint data binding shared by the stat / delta / object-table widgets (the chart uses the extended $defs/chartEndpointSource). Reads an arbitrary app REST endpoint through the library's useEndpointSource engine: params pass the SAME @-token grammar widget filters use (@me, @today±Nd, @monthStart, @workspace.<key>/@config.<key> with a trailing `?` for optional values that drop when unresolved — a REQUIRED token that stays unresolved blocks the fetch), requests dedupe + short-TTL cache per (method, url, resolved params), and the widget refetches on cn:page:refresh / a matching cn:widget:refresh. Exactly ONE of the widget's OpenRegister source | endpointSource may be configured — a cross-field rule enforced by validateManifestV2() as a post-schema check (clear error message), matching the stats-block precedent.",
+			"properties": {
+				"url": {
+					"type": "string",
+					"description": "Endpoint URL — app-relative (routed through generateUrl, e.g. '/apps/pipelinq/api/analytics/overview') or absolute (http/https, left untouched). May interpolate @page.<key> / @workspace.<key> / @config.<key> / @objectId / @object.<field> tokens inline; unresolved URL tokens collapse to an empty string."
+				},
+				"method": {
+					"type": "string",
+					"enum": ["GET", "POST"],
+					"default": "GET",
+					"description": "HTTP method. GET (default) sends the resolved params as query parameters; POST sends them as the JSON body."
+				},
+				"params": {
+					"type": "object",
+					"additionalProperties": true,
+					"description": "Request parameters. Values pass the shared filter-token grammar (resolveFilterTokens): @me, @now, @today, @today±Nd, @monthStart/@quarterStart/@yearStart, @objectId/@object.<field> (detail context), @workspace.<key>/@config.<key> with a trailing `?` for optional values (dropped when unresolved; e.g. `{ \"period\": \"@workspace.datePreset?\" }` rides the dashboard date-range pills). A required token that stays unresolved blocks the fetch until the page context provides it."
+				},
+				"responsePath": {
+					"type": "string",
+					"description": "Dot-path pluck of the response payload (e.g. 'summary', 'data.series'). Omitted = the whole response body."
+				}
+			}
+		},
+		"chartEndpointSource": {
+			"type": "object",
+			"required": ["url"],
+			"additionalProperties": false,
+			"description": "The chart widget's endpoint binding: the $defs/endpointSource transport plus the labels/series response mapping. The mapping keys live INSIDE this block (not as sibling props) because the chart's flat `series` / `labels` props already carry the static data. When the plucked payload is an ARRAY of points (e.g. pipelinq /api/analytics/trends → responsePath 'series'), labelsPath / series[].path are PER-ITEM field paths (labelsPath 'date', series [{ name: 'Leads', path: 'value' }]); when it is an OBJECT they point at parallel arrays. Pie-family charts flatten the FIRST mapped series into the flat value array ApexCharts expects. Exactly ONE of dataSource | endpointSource per chart widget (post-schema check).",
+			"properties": {
+				"url": {
+					"type": "string",
+					"description": "Endpoint URL — app-relative (generateUrl) or absolute. Same token interpolation as $defs/endpointSource."
+				},
+				"method": {
+					"type": "string",
+					"enum": ["GET", "POST"],
+					"default": "GET",
+					"description": "HTTP method. GET (default) sends params as query parameters; POST as the JSON body."
+				},
+				"params": {
+					"type": "object",
+					"additionalProperties": true,
+					"description": "Request parameters — the shared filter-token grammar (see $defs/endpointSource.params). Params re-resolve and the chart refetches when the dashboard date range changes (the page publishes dateFrom / dateTo / datePreset into the workspace context)."
+				},
+				"responsePath": {
+					"type": "string",
+					"description": "Dot-path pluck of the response payload. Omitted = the whole response body."
+				},
+				"labelsPath": {
+					"type": "string",
+					"description": "Labels/categories mapping: a per-item field path for an ARRAY payload ('date'), or the path of a parallel label array for an OBJECT payload ('labels')."
+				},
+				"series": {
+					"type": "array",
+					"description": "Series mapping — one entry per rendered series.",
+					"items": {
+						"type": "object",
+						"required": ["path"],
+						"additionalProperties": false,
+						"properties": {
+							"name": {
+								"type": "string",
+								"description": "Series display name (legend / tooltip). Defaults to the path."
+							},
+							"path": {
+								"type": "string",
+								"description": "Value mapping: a per-item field path for an ARRAY payload ('value'), or the path of a parallel number array for an OBJECT payload ('totals')."
+							}
+						}
+					}
+				}
+			}
+		},
+		"statsBlockEntry": {
+			"type": "object",
+			"required": ["register", "schema"],
+			"additionalProperties": false,
+			"description": "One KPI entry inside a multi-entry stats-block widget (CnStatsBlockWidget `entries[]`). Carries the same source contract as a type:'stat' widget: register + schema + metric + token-resolved filter (@today / @me / @workspace.* and ?-optional clauses), plus per-entry presentation (title, variant, countLabel), an optional route deep link, and hideWhenZero.",
+			"properties": {
+				"title": {
+					"type": "string",
+					"description": "KPI title rendered by the inner CnStatsBlock."
+				},
+				"register": {
+					"type": "string",
+					"description": "OpenRegister register slug for this entry's count."
+				},
+				"schema": {
+					"type": "string",
+					"description": "OpenRegister schema slug for this entry's count."
+				},
+				"metric": {
+					"type": "string",
+					"description": "Aggregation metric for the REST /value aggregation (default 'count')."
+				},
+				"field": {
+					"type": "string",
+					"description": "Field the metric aggregates over (metric-dependent; unused for count)."
+				},
+				"filter": {
+					"type": "object",
+					"additionalProperties": true,
+					"description": "Filter map with the shared @-token grammar (@today / @me / @workspace.<key>, trailing `?` for optional clauses)."
+				},
+				"route": {
+					"type": "object",
+					"additionalProperties": true,
+					"description": "Optional vue-router location for the KPI's deep link (renders the entry clickable)."
+				},
+				"variant": {
+					"type": "string",
+					"enum": ["default", "primary", "success", "warning", "error"],
+					"description": "Color variant forwarded to the inner CnStatsBlock."
+				},
+				"countLabel": {
+					"type": "string",
+					"description": "Label displayed next to the count."
+				},
+				"iconClass": {
+					"type": "string",
+					"description": "Optional Nextcloud core icon class (icon-link, icon-mail, …) for the entry."
+				},
+				"hideWhenZero": {
+					"type": "boolean",
+					"default": false,
+					"description": "When true, the entry is omitted from the card when its resolved count is 0."
 				}
 			}
 		},
@@ -744,7 +1990,7 @@
 				"widgets": {
 					"type": "array",
 					"items": { "$ref": "#/$defs/widgetEntry" },
-					"description": "Uniform widget placement array. Available on ALL page types in v2 (not just dashboard). Each entry specifies a widget key, slot, and grid coordinates. The cross-field constraint gridX + gridWidth <= 12 is enforced by validateManifestV2() post-schema check. Single-widget dashboards: a type:'dashboard' page with exactly one body widget covering the full 12×12 grid whose widgetKey resolves to a custom (non-library-built-in) registry component is REJECTED — see ADR-036 Decision 1 (single-widget dashboard anti-pattern). Use type:'custom' with component:'<widgetKey>' or split into N>1 widgets instead. Library built-in widget keys (object-table, card-grid, form-renderer, map-viewer, chart, stats-block) are exempt from the rule. Enforced by validateManifestV2() post-schema check."
+					"description": "Uniform widget placement array. Available on ALL page types in v2 (not just dashboard). Each entry specifies a widget key, slot, and grid coordinates. The cross-field constraint gridX + gridWidth <= 12 is enforced by validateManifestV2() post-schema check. Single-widget dashboards: a type:'dashboard' page with exactly one body widget covering the full 12×12 grid whose widgetKey resolves to a custom (non-library-built-in) registry component is REJECTED — see ADR-036 Decision 1 (single-widget dashboard anti-pattern). Use type:'custom' with component:'<widgetKey>' or split into N>1 widgets instead. Library built-in widget keys (object-table, card-grid, form-renderer, map-viewer, chart, stats-block, banner, audit-trail, header, text, divider) are exempt from the rule. Enforced by validateManifestV2() post-schema check."
 				},
 				"actions": {
 					"type": "array",
@@ -753,8 +1999,9 @@
 				},
 				"config": {
 					"type": "object",
-					"description": "Type-specific configuration. Shape varies by page type — see v1 schema for per-type config shapes (index, detail, dashboard, logs, settings, chat, files, form, map, custom). Config values under pages[].config may use two sentinel forms: `@resolve:<key>` (IAppConfig lookup, resolved by the loader at manifest-load time) and `@route.<param>` (vue-router param lookup, resolved by CnPageRenderer at render time). Carry-forward from v1: register, schema, columns, actions, sidebar, sidebarProps, fields, sections, tabs, content, layout, widgets (dashboard only), cardComponent, columnGroups, etc.",
+					"description": "Type-specific configuration. Shape varies by page type — see v1 schema for per-type config shapes (index, detail, dashboard, logs, settings, chat, files, form, map, custom). Config values under pages[].config may use the closed sentinel vocabulary (see $defs/sentinelTokenAny) — an out-of-vocabulary @-token FAILS validation via the sentinelGuardedValue allOf guard. Carry-forward from v1: register, schema, columns, actions, sidebar, sidebarProps, fields, sections, tabs, content, layout, widgets (dashboard only), cardComponent, columnGroups, etc.",
 					"additionalProperties": true,
+					"allOf": [{ "$ref": "#/$defs/sentinelGuardedValue" }],
 					"properties": {
 						"register": {
 							"type": "string",
@@ -895,10 +2142,53 @@
 						},
 						"fields": {
 							"type": "array",
-							"description": "Form fields (for type='form'). Carry-forward from v1.3.0.",
+							"description": "Form fields (for type='form'). Carry-forward from v1.3.0. manifest-form-logic adds two OPTIONAL typed properties — `visibleWhen` (reuses `$defs/visibleWhen`; LOCAL mode resolves `field` as a dot-path into the live form data) and `validation` (`$defs/fieldValidation`) — while every other carry-forward field shape (`key`, `label`, `type`, `enum`, `widget`, `help`, etc.) stays untyped via `additionalProperties: true` on the item.",
 							"items": {
 								"type": "object",
-								"additionalProperties": true
+								"additionalProperties": true,
+								"properties": {
+									"visibleWhen": {
+										"$ref": "#/$defs/visibleWhen",
+										"description": "manifest-form-logic: optional conditional-visibility predicate. LOCAL mode (neither `endpoint` nor `source`) resolves `field` as a dot-path into the live form data — the first dot-segment MUST match a declared `config.fields[].key` (validateManifestV2 post-schema check). `endpoint` / `source` modes keep their existing fail-safe, evaluated-once-at-mount semantics."
+									},
+									"validation": {
+										"$ref": "#/$defs/fieldValidation",
+										"description": "manifest-form-logic: optional per-field validation rules, enforced client-side by CnFormPage before dispatch. See `$defs/fieldValidation` for the per-type semantics table."
+									}
+								}
+							}
+						},
+						"steps": {
+							"type": "array",
+							"minItems": 1,
+							"description": "manifest-form-logic: for type='form' pages, ordered multi-step wizard groups. Each entry is `{ id, title, description?, fields[] }` where `fields[]` is an ordered array of KEY REFERENCES into `config.fields[].key` — steps do not embed field objects (config.fields[] stays the single source of truth). Absent `steps` = single-step form, byte-for-byte the pre-change rendering. When present, validateManifestV2() post-schema requires: step ids unique within the page, every fields[] entry references a declared field key, and every declared field key appears in EXACTLY ONE step (complete partition — an unassigned field would silently never render; a doubly-assigned field would double-render).",
+							"items": {
+								"type": "object",
+								"required": ["id", "title", "fields"],
+								"additionalProperties": false,
+								"description": "One wizard step. `fields[]` order is the rendering order for that step's fields.",
+								"properties": {
+									"id": {
+										"type": "string",
+										"minLength": 1,
+										"description": "Unique step identifier within the page's `steps[]` array."
+									},
+									"title": {
+										"type": "string",
+										"minLength": 1,
+										"description": "i18n key (or literal) for the step's title, shown in the step indicator."
+									},
+									"description": {
+										"type": "string",
+										"description": "Optional i18n key (or literal) for a short step description/subtitle."
+									},
+									"fields": {
+										"type": "array",
+										"minItems": 1,
+										"items": { "type": "string", "minLength": 1 },
+										"description": "Ordered field KEYS (referencing `config.fields[].key`) rendered on this step."
+									}
+								}
 							}
 						},
 						"fieldWidgets": {
@@ -908,7 +2198,7 @@
 						},
 						"columns": {
 							"type": "array",
-							"description": "Table columns (for type='index' and type='logs'). Items may be strings (legacy shorthand) or column objects.",
+							"description": "Table columns (for type='index' and type='logs'). Items may be strings (legacy shorthand) or column objects ({ key, label, sortable?, width?, formatter?, formatterOptions?, widget?, widgetProps?, format?, aggregate? }). `formatter` resolves against cnFormatters (built-ins incl. currency / conditionalPhrase — configured via `formatterOptions`); `widget` resolves against cnCellWidgets (built-ins incl. badge / fkResolve / link).",
 							"items": {
 								"oneOf": [
 									{ "type": "string" },
@@ -1113,6 +2403,48 @@
 				"displayName": {
 					"type": "string",
 					"description": "Human-readable label for the linked object type."
+				}
+			}
+		},
+		"adminSettingsEntry": {
+			"type": "object",
+			"required": ["id", "label"],
+			"additionalProperties": false,
+			"oneOf": [
+				{ "required": ["type"] },
+				{ "required": ["component"] }
+			],
+			"description": "One admin-only settings section rendered by CnAppRoot's generic admin NcAppSettingsDialog, sorted into the dialog by `order`. Exactly one of `type` (a built-in section) or `component` (a custom section resolved from the renderer registry) MUST be present.",
+			"properties": {
+				"id": {
+					"type": "string",
+					"description": "Unique identifier for this admin-settings entry; also the rendered NcAppSettingsSection id."
+				},
+				"label": {
+					"type": "string",
+					"description": "i18n translation key (English source) resolved by the consuming app's t() function, shown as the section header."
+				},
+				"type": {
+					"type": "string",
+					"enum": ["organisation-credentials"],
+					"description": "Built-in admin-settings section. Closed enum. 'organisation-credentials' renders CnCredentials with scope=\"organisation\" (the OpenRegister credential broker's organisation-scope pane). Mutually exclusive with `component`."
+				},
+				"component": {
+					"type": "string",
+					"description": "Registry key of a custom admin-settings section component, resolved from the CnAppRoot custom-components registry at render time. Mutually exclusive with `type`."
+				},
+				"order": {
+					"type": "integer",
+					"description": "Sort order of this section within the admin dialog. Entries without an order render last, in array position."
+				},
+				"permission": {
+					"type": "string",
+					"description": "Optional permission string that further narrows visibility of this section WITHIN the already owner-gated admin dialog, reusing the existing per-item permission grammar. Narrow-only: it can never widen access to a caller who is not an owner of the app."
+				},
+				"props": {
+					"type": "object",
+					"additionalProperties": true,
+					"description": "Props forwarded to a custom `component` entry. Ignored for built-in `type` entries."
 				}
 			}
 		}


### PR DESCRIPTION
Closes #865.

`CashflowPdfRenderer.php` existed with **zero callers**, `appinfo/routes.php`
registered **no** cashflow export route, and the only "Export PDF" button in the
codebase lived in an **orphan component** that never mounts and whose click
`$emit`s into nothing. REQ-CF-016 was written and unreachable. This builds it.

`tests/e2e/cashflow-13wk.spec.ts:148` was red **on purpose** and is now green by
being **satisfied**. The spec file is byte-identical to `development` — no
retarget, no relax, no skip.

---

## What is wired

| layer | file |
|---|---|
| PDF bytes | `lib/Util/PdfDocument.php` (new) — dependency-free object serialiser + xref/trailer, lifted from `InvoicePdfGenerator`'s existing byte-writer rather than copied a second time |
| document | `CashflowPdfRenderer::renderPdf()` (new method) — the same report as a real `%PDF-1.7` binary, plus the REQ-CF-016 §2 closing-balance bar chart as vector rectangles coloured by `bufferStatus`. `render()` is byte-identical. |
| data | `lib/Service/CashflowExportService.php` (new) — horizon + weeks + top-5 AR customers + recurring costs out of OpenRegister, scoped to the caller's `AdministrationMembership` set |
| route | `lib/Controller/CashflowExportController.php` (new) + `POST /api/cashflow/export-pdf` |
| affordance | `config.headerActions[]` on the `CashflowDashboard` page in `src/manifest.json` |

### Why `render()` was not simply given a `.pdf` name

`render()` returns `text/plain` and a `.txt` filename. Advertising
`application/pdf` over those bytes would produce a file that opens in **no**
viewer while every route, status and "a button exists" assertion stayed green —
which is the exact shape #865 was filed about. `renderPdf()` is why the
`application/pdf` assertion in the new tests means something.

### Why there is no component to register

Board §8 records softwarecatalog/procest shipping a page declared in the
manifest whose component was missing from `customComponents.js`, rendering
*"This page is empty"* while its backend route was live. That shape is
**structurally impossible here**: `CnDashboardPage` passes `config.headerActions[]`
straight to `CnActionButtons`, which renders each entry as a plain **visible**
`NcButton` — not the collapsed `⋯` overflow `CnActionsBar` uses on an *index*
page, which is the trap already recorded in
`src/manifest.d/recurring-invoicing.json`. No custom component participates, so
there is no registration that can be forgotten.

The orphan `src/components/cashflow/CashflowDashboard.vue` is **left in place**
(its crisis-banner and scenario-switcher skeletons are unspent design) but now
says at the top of the file that it is not the export path. Deleting it is a
separate call.

### No IDOR surface, by construction

`exportPdf()` takes **no request parameters**. The horizon is resolved
server-side from `AdministrationContextService::accessibleAdministrationIds()`
(REQ-MA-001). Nothing caller-supplied crosses the boundary, so no per-object
guard appears in the method body — the absence is the design, and the docblock
says so. `#[NoAdminRequired]`, no `#[NoCSRFRequired]`: the SPA POSTs through
`@nextcloud/axios`, which carries the request token.

Every OpenRegister lookup filters on a declared schema property
(`administrationId` / `horizonId`), never on `id`.

---

## Proof the PDF is genuinely produced and downloadable

Not "a route returned 200". Measured on the rig (`sqdev-nc`, :8119), with the
changed `lib/` `docker cp`'d file-by-file and **md5-verified against the served
copy** (the container is a Docker volume, not a bind mount), the app warmed
afterwards, and the built bundle `docker cp`'d with
`md5 js/shillinq-main.js == md5 <served>` = `d7abe16b20c1b2d2c2d6c774a2869cb9`.

**Live red → green on the tenant guard, which is the same call twice:**

```
POST /apps/shillinq/api/cashflow/export-pdf
  -> http=404  {"error":"no_cashflow_horizon"}
```

The rig's seeded horizon belongs to `adm-consultancy-nl`; `admin` held a
membership only for `ADM-001`. The guard was correctly refusing. Granting
`admin` one membership for `adm-consultancy-nl` and repeating the identical call:

```
http=200  type=application/pdf  size=2629
Content-Disposition: attachment; filename=cashflow-hor-2026-w22-erik-2026-08-17.pdf
Content-Type: application/pdf
%PDF-1.7 \n % 342 343 317 323 \n 1 0 obj \n << /Type /Catalog
```

The membership was **deleted again** afterwards and the endpoint re-measured
back to `404` — the rig is as it was found.

**Parsed by an independent library**, not by the code that wrote it
(`pypdf.PdfReader`, 2 pages):

```
page 1: 13-WEEK CLOSING BALANCE
        Horizon 2026-05-25 .. 2026-08-23   blue = above buffer, ...
page 2: 13-WEEK CASHFLOW FORECAST
        Administration: adm-consultancy-nl
        Week   Inflows      Outflows     Net          Eind Saldo   Buffer
        22     12500.00     7225.00      5275.00      77775.00     ABOVE_BUFFER
        TOP CUSTOMERS (BETALINGSGEDRAG)
        klant-acme-bv                  avg offset +13 days, confidence 0.75
        RECURRING COSTS
        Huur kantoor                   MONTHLY      1200.00 EUR (FIXED)
        BAV-verzekering                ANNUALLY     620.00 EUR (CPI_PAST_YEAR)
        METHODOLOGY ...
```

On a 13-week fixture the chart content stream parses to **13 filled rectangles**
with distinct geometry plus the zero line. `file(1)` reports
`PDF document, version 1.7`.

⚠️ Board §6 warned a download path might not even be constructible locally
because `symfony/http-foundation` is absent from shillinq's vendor. **That was
the stale shared vendor, not the lock** — see the findings section.

---

## RED-then-green controls

**Unit, measured one file at a time** because a missing class aborts PHPUnit
collection for the whole run:

| file | without the wiring | with it |
|---|---|---|
| `CashflowPdfRendererTest` | `Tests: 12, Errors: 7` — and the **5 pre-existing `render()` tests still passed**, the control that the file itself is healthy | 13 / 13 |
| `CashflowExportServiceTest` | `Tests: 8, Assertions: 0, Errors: 8` — `Class "…\CashflowExportService" not found` | 8 / 8 |
| `CashflowExportControllerTest` | collection abort, class not found | 4 / 4 |

**No mock observes an argument anywhere in the new tests.** A PHPUnit mock
cannot see a named argument — it resolves the call against its own signature
then invokes the return callback positionally — so an expectation over this
app's named-argument style would pin the double's defaults. The controller's
export-service double is **hand-written**; the export service runs against the
repo's `InMemoryObjectServiceStub`, which really filters. **Tenant scoping is
proved by seeding a SECOND administration and asserting its data is absent from
the produced bytes**, not by asserting a query shape.

Two assertions carry their own negative half, because the positive half alone
would pass on a decoration:
- the chart is asserted **present with weeks and absent without them**;
- a `BELOW_BUFFER` week is asserted **red and below the zero line**, so three
  weeks at −50k / 0 / +50k cannot all render identically upward.

**e2e, on the rig, `PLAYWRIGHT_BASE_URL=http://localhost:8119`:**
`tests/e2e/cashflow-13wk.spec.ts` → **10 passed (2.9m)**, including
`:148 dashboard exposes an Export PDF affordance`.

---

## Local measurements

| check | result |
|---|---|
| PHPUnit full unit suite | base `Tests: 4451, Assertions: 44856, Skipped: 1` → head **`4471 / 44926 / Skipped: 1`**, **0 errors, 0 failures both sides** |
| phpcs `lib/` | exit 0 |
| phpmd `lib/` (both rulesets) | **0 findings** — see below |
| psalm | `No errors found!` |
| phpstan | cannot run locally (`phpstan.neon` points at an uninstalled `nextcloud/ocp` path) — CI is the measurement |
| eslint `src` | 0 errors (96 pre-existing warnings) |
| prettier | clean |
| vitest | 16 files / 177 tests passed |
| `check:manifest` | **PASS with real Ajv**, 228 pages |
| `check:manifest-budget` | PASS — 1,114,863 B of 1,120,000 B |
| `check:registers` / `:seeds` / `:fragment-required` / `:markers` | PASS |
| `test:l10n` | OK |

---

## Two instrument findings worth the reviewer's time

**1. 🔴 `check:manifest` was reporting a pass it had not made.**
`node tests/validate-manifest.js` prints
`Ajv not installed in node_modules … Falling back to a structural lint pass` and
then `structural lint: PASS`. With real Ajv linked in, the **checked-in schema
was stale at 2.11.0** and rejected my action on **seven** counts — its `type`
enum is `handler|open-modal|open-page|navigate` and `additionalProperties` is
`false`, so `api-call` / `url` / `method` / `download` / `filename` /
`successMessage` / `errorMessage` are all refused. nc-vue 2.3.0 — the version
`package-lock.json` resolves — ships schema **2.22.0**, whose `action`
definition declares every one of those fields, and whose runtime
`actionsDispatcher` has implemented them all along. Synced verbatim from
`node_modules/@conduction/nextcloud-vue/src/schemas/`; **all 228 pages pass on
it**. Positive-controlled, because a schema swap that merely widened everything
would also print PASS: with `type: 'total-nonsense-verb'` and a `bogusKey`
planted on the same action, 2.22.0 still reports **both** violations.

**2. `$?` after a pipe is the last stage's code.** My first phpmd run read
`rc=0` through a `| tail` while printing six findings. `phpmd lib text
phpmd.xml` on the whole tree returned **exactly 6**, and **all 6 were mine**
(4× `StaticAccess`, 2× `ShortVariable` `$x`/`$y`) — `development` is
phpmd-clean, so shipping them would have been a regression. `PdfDocument`'s
methods became instance methods injected into the renderer (defaulting to
`new PdfDocument()` so `new CashflowPdfRenderer()` is unchanged) and the
variables were renamed. Now **0**.

---

## Stated, not claimed closed

REQ-CF-016 lists five sections. This ships **§1 (week table)**, **§2 (bar
chart)**, **§3 (assumptions: top-5 customers, recurring breakdown, BTW/IB
methodology)** and **§4 when a scenario is supplied** (unit-covered; production
exports baseline, so no scenario is passed today).

**§5, the "top 3 customers all delay by 14 days" stress test, is NOT built**,
and neither is multi-scenario side-by-side comparison. Both need per-customer,
per-week AR data the renderer's input shape does not carry. I have not marked
them done anywhere.

**A real drift found on the way, adapted rather than renamed:**
`CashflowARProjection` declares `payment_history_average_deviation` while the
renderer reads `gemiddeldeAfwijking`. Nothing had ever called the renderer, so
nothing had noticed. Mapped in the **service** — renaming the renderer's read
key changes a published input contract its own tests pin, and renaming the
schema property is a **data migration**.

---

## Gate parity

Local runner, vendored package `conduction/hydra-gates v1.8.0`, `SCOPE-MODE:
full`. ⚠️ **CI reads the suite from `.github@main`, which moves** — CI's own
numbers are the verdict.

`RESULT: 2 GATE(S) FAILED`:
- **gate-7** `no-admin-idor` — **2 findings, neither is mine**:
  `OssController.php:102 resolveRate` and `SepaAuditController.php:86
  exportMandate`. `CashflowExportController` is **not** in the list. Both files
  are untouched by this diff.
- **gate-19** `e2e-coverage` — 290 scenarios missing `@e2e`, whole-tree debt.
  This PR changes **no** `openspec/**` file.

Base measurement on `origin/development` with the identical package is in the
thread below.
