### PR TITLE
docs(openspec): change proposals for the AI-tooling and leaf-integration sweep

### DIFF
--- a/openspec/changes/integration-leaves-consume/.openspec.yaml
+++ b/openspec/changes/integration-leaves-consume/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/integration-leaves-consume/design.md
+++ b/openspec/changes/integration-leaves-consume/design.md
@@ -1,0 +1,54 @@
+# Design: integration-leaves-consume
+
+## Mechanism choice per leaf
+
+Two consumption mechanisms exist in this repo, both already exercised:
+
+| Mechanism | Where it renders | In-repo precedent |
+|---|---|---|
+| Manifest integration widget `{"type":"integration","integrationId":"..."}` | Detail-page **body** | `invoice-files` on `ARInvoiceDetail`; `tender-files` / `verplichting-files` (tenderned overlay); `contract-decisions` on `ContractDetail` |
+| Schema `configuration.linkedTypes` | **Sidebar** leaf tab + NC Mail sidebar link target | `Invoice: ["mail"]`; `Contract: ["decidesk-decisions"]` |
+
+Decision: **files → manifest widgets** (matches the invoice-files precedent —
+attachments are primary content, they belong in the body), **calendar /
+contacts → `linkedTypes`** (they are reference surfaces, sidebar is right),
+**talk → curated `sidebarProps.tabs` edits** (talk is already a registry-mode
+sidebar leaf; only curated pages need the explicit entry).
+
+## Key decisions
+
+1. **No second calendar publisher.** `ComplianceDeadlineCalendarService`
+   already writes BTW/ICP/VPB filing deadlines (REQ-CDC-002) and opt-in AR
+   due-date VEVENTs (REQ-CDC-004) into the user's `shillinq-deadlines`
+   calendar. The calendar leaf on `BtwAangifteDetail` / `ARInvoiceDetail` is a
+   *view* of the object's linked events. If the OpenRegister calendar leaf
+   turns out at HEAD to be create-capable only (no linked-event listing), the
+   leg is refused per REQ-CPA-003 and recorded — not forced through with a
+   bespoke event query.
+2. **Array-replacement hazard in `deepMergeConfig()`.**
+   `SettingsService::deepMergeConfig()` (lib/Service/SettingsService.php,
+   ADR-037 fragment merge at ~line 1507) recurses into objects but lets a
+   fragment's *array* replace the base wholesale. The new fragment therefore
+   only declares `linkedTypes` on schemas that have none today
+   (`VatReturn`, `ARInvoice`, `CustomerMaster`, `Payee`) and must sort AFTER
+   every fragment defining those schemas — the established `zzz-` prefix trick
+   (`zzz-mcp-tool-surface.json` uses it for exactly this reason). File name:
+   `zzz-integration-leaves.json`.
+3. **Contacts is a link, not a sync.** The contacts leaf surfaces
+   OpenRegister's contact matching (`ContactMatchingService`) against
+   `CustomerMaster.email`/`legalName` and `Payee.email`/`name`. No bulk
+   export of masters into the address book — matching/linking only. `Payee`
+   even has a `contactRef` property reserved for exactly this link.
+4. **Curated tabs stay curated.** REQ-CPA-001's second scenario forbids
+   silently adding registry leaves to a page that opted into
+   `sidebarProps.tabs`. Adding `talk` to such a page is done by editing that
+   page's curated list in the manifest — an explicit, reviewable diff — never
+   by disabling the curation.
+
+## Verification approach
+
+Per-leg live verification on the shared :8080 instance (bind-mounted
+checkout): open each detail page, confirm the leaf renders and round-trips
+(file listed, contact linked, event shown, talk conversation created). API
+green is not UI green — every leg's scenario is phrased against the rendered
+page, not the endpoint.

--- a/openspec/changes/integration-leaves-consume/proposal.md
+++ b/openspec/changes/integration-leaves-consume/proposal.md
@@ -1,0 +1,96 @@
+# Change: integration-leaves-consume
+
+## Why
+
+OpenRegister ships app-agnostic integration leaves (files, mail, contacts,
+calendar, talk, deck, notes, todos — `LinkedEntityService::legacyLinkedTypeIds()`
+— plus registry-provided leaves such as `decidesk-decisions` via
+`IntegrationRegistry`). Shillinq consumes almost none of them. The current,
+repo-verified integration state is:
+
+- **mail**: the `Invoice` schema declares `configuration.linkedTypes: ["mail"]`
+  plus a `mailObjectTemplate` (create-invoice-from-email) —
+  `lib/Settings/register.d/bookkeeping-quote-order-invoice.json`.
+- **files**: exactly four manifest integration widgets —
+  `invoice-files` on `ARInvoiceDetail` (manifest.json + the peppol overlay),
+  `tender-files` on `TenderNedAanbestedingDetail` and `verplichting-files` on
+  `VerplichtingDetail` (`src/manifest.d/20-tenderned-integratie.json`).
+- **decidesk-decisions**: `contract-decisions` on `ContractDetail` +
+  `Contract.configuration.linkedTypes: ["decidesk-decisions"]`
+  (`contract-lifecycle-management.json`).
+
+Meanwhile the app's own manifest `_note` prose already *promises* file surfaces
+that don't exist as widgets: `ReceiptDetail` ("The receipt image lives under
+Files"), `ExpenseClaimDetail` ("source receipt images live under Files"),
+`BtwAangifteDetail` ("The filed attachment lives under Files"), and
+`BankConnectionDetail` lists imported statements whose `Receipt.photoUri` /
+`VatReturn.attachmentUri` / `BankStatement.statementAttachmentUri` properties
+hold the actual URIs. Debtors (`CustomerMaster`: `legalName`, `email`,
+`kvkNumber`, `vatId`) and creditors (`Payee`: `name`, `email`, `phone`,
+`address`, `contactRef`) carry full contact data but never reach the Nextcloud
+address book. A finance dossier (an invoice in dispute, an expense claim under
+approval) has no discussion surface on pages that curate their sidebar tabs.
+
+This change closes those gaps by *consuming* the platform leaves per ADR-022 —
+zero bespoke PHP.
+
+## What changes
+
+1. **Files leaf on more record types** (manifest integration widgets, same
+   pattern as the existing `invoice-files` widget):
+   - `ReceiptDetail` — receipt image (`Receipt.photoUri`).
+   - `ExpenseClaimDetail` — all receipt evidence for the claim
+     (`ExpenseClaimEntry.receiptIds` → `Receipt.photoUri`).
+   - `BankConnectionDetail` — imported statement files for the connection
+     (`BankStatement.bankConnectionId` / `statementAttachmentUri`).
+   - `BtwAangifteDetail` — the filed VAT-return attachment
+     (`VatReturn.attachmentUri`).
+2. **Calendar leaf**: `calendar` linked-type on `VatReturn` (filing deadlines)
+   and `ARInvoice` (payment due dates), rendering the per-object deadline
+   events on `BtwAangifteDetail` / `ARInvoiceDetail`. The events themselves
+   are ALREADY published to CalDAV by `ComplianceDeadlineCalendarService`
+   (REQ-CDC-002/-004, spec `compliance-deadline-calendar`); this change adds
+   the per-object *view* surface only and MUST NOT add a second event
+   publisher.
+3. **Contacts leaf**: `contacts` linked-type on `CustomerMaster` (debtors) and
+   `Payee` (creditors), surfacing address-book links on `CustomerDetail` /
+   `PayeeDetail` via OpenRegister's contacts integration
+   (`ContactsController` / `ContactMatchingService`).
+4. **Talk leaf for dossier discussion**: registry-mode already renders a
+   `talk` tab on every detail page *without* a curated `sidebarProps.tabs`
+   list (REQ-CPA-001). The delta is confined to dossier-bearing pages that
+   curated their tabs: those curated lists gain `talk` explicitly where a
+   dispute/approval conversation belongs (`ARInvoiceDetail`,
+   `ExpenseClaimDetail`, `ContractDetail`), honouring REQ-CPA-001's
+   "curated set is not silently changed" scenario by editing the curated list,
+   not bypassing it.
+
+All schema-side declarations land as one ADR-037 register fragment
+(`lib/Settings/register.d/`), merged by `SettingsService::deepMergeConfig()`.
+Because `deepMergeConfig()` replaces arrays wholesale (only objects merge
+key-wise), any fragment touching an existing `linkedTypes` array MUST restate
+the full array (e.g. `Invoice` stays `["mail"]` untouched; this change touches
+only schemas with no current `linkedTypes`).
+
+## Deck: deliberately excluded
+
+A deck leaf is NOT added. Shillinq's task-shaped state is already first-class
+register state (`ExpenseClaimEntry.approvalState`, PO approval via
+`PurchaseOrderApprovalService`, dunning stages via `DunningRunService`); a
+deck board would be a second, unsynchronised source of truth for the same
+approval state. Revisit only with a concrete workflow that is demonstrably not
+lifecycle-modellable.
+
+## Out of scope / dependencies
+
+- No new event publisher: `ComplianceDeadlineCalendarService` remains the only
+  writer of deadline VEVENTs; `IcsService` (booking-confirmation ICS) is
+  untouched.
+- The `mail` leaf and `mailObjectTemplate` on `Invoice` are untouched.
+- No PHP: this change is register-fragment + manifest-overlay only, per the
+  `consume-platform-abstractions` spec's "consume, don't reimplement" premise.
+- Depends on OpenRegister's leaf implementations already present at HEAD
+  (`LinkedEntityService`, `ContactsController`, mail-sidebar,
+  `IntegrationRegistry`) — verified present; no OpenRegister-side change is
+  required. Per REQ-CPA-003, each leg re-verifies its platform claim against
+  HEAD before code is written, and is refused (not forced) if the claim fails.

--- a/openspec/changes/integration-leaves-consume/specs/consume-platform-abstractions/spec.md
+++ b/openspec/changes/integration-leaves-consume/specs/consume-platform-abstractions/spec.md
@@ -1,0 +1,119 @@
+# Spec: consume-platform-abstractions (delta)
+
+## ADDED Requirements
+
+### Requirement: REQ-CPA-005 — Evidence-bearing record types SHALL expose the files leaf on their detail pages
+
+Every record type whose schema stores a document/attachment URI SHALL render
+OpenRegister's `files` integration widget
+(`{"type": "integration", "integrationId": "files"}`) on its detail page, the
+same pattern as the existing `invoice-files` widget on `ARInvoiceDetail`.
+Concretely this change MUST add the widget to:
+
+- `ReceiptDetail` — the receipt image (`Receipt.photoUri`),
+- `ExpenseClaimDetail` — the claim's receipt evidence
+  (`ExpenseClaimEntry.receiptIds` → `Receipt.photoUri`),
+- `BankConnectionDetail` — imported statement files for the connection
+  (`BankStatement.bankConnectionId`, `BankStatement.statementAttachmentUri`),
+- `BtwAangifteDetail` — the filed return attachment (`VatReturn.attachmentUri`).
+
+No bespoke file-listing PHP service MUST be written; the widget consumes the
+platform leaf.
+
+#### Scenario: a receipt's image is reachable from its detail page
+
+- **GIVEN** a `Receipt` object with `photoUri` set to an uploaded receipt image
+- **WHEN** a user opens `ReceiptDetail` for that object
+- **THEN** the files integration widget MUST list the receipt image
+- **AND** opening it MUST show the stored file, not a broken link
+
+#### Scenario: an expense claim shows all of its receipt evidence
+
+- **GIVEN** an `ExpenseClaimEntry` whose `receiptIds` reference two `Receipt` objects with images
+- **WHEN** a user opens `ExpenseClaimDetail`
+- **THEN** the files surface MUST expose both receipt images from the claim page
+
+#### Scenario: a bank connection's statements are browsable as files
+
+- **GIVEN** a `BankConnection` with two imported `BankStatement` objects carrying `statementAttachmentUri`
+- **WHEN** a user opens `BankConnectionDetail`
+- **THEN** the statement files MUST be reachable from the page's files surface
+
+#### Scenario: a filed VAT return exposes its submitted attachment
+
+- **GIVEN** a `VatReturn` in state `submitted` with `attachmentUri` set
+- **WHEN** a user opens `BtwAangifteDetail`
+- **THEN** the filed attachment MUST be listed by the files widget
+
+### Requirement: REQ-CPA-006 — VAT returns and AR invoices SHALL expose their deadline events through the calendar leaf, without a second event publisher
+
+The `VatReturn` and `ARInvoice` schemas SHALL declare `calendar` in
+`configuration.linkedTypes` (via a last-sorting ADR-037 register fragment), so
+`BtwAangifteDetail` and `ARInvoiceDetail` render the calendar leaf showing the
+object's linked deadline events (filing deadline; `dueDate` payment deadline).
+`ComplianceDeadlineCalendarService` MUST remain the only writer of deadline
+VEVENTs (REQ-CDC-002/-004 of `compliance-deadline-calendar`): the leaf is a
+per-object view/link surface. If OpenRegister's calendar leaf at HEAD cannot
+list linked events for an object, this leg MUST be refused and recorded per
+REQ-CPA-003 rather than satisfied with a bespoke event query.
+
+#### Scenario: a VAT return's filing deadline is visible on its detail page
+
+- **GIVEN** a `VatReturn` for Q2 whose filing deadline `ComplianceDeadlineCalendarService` has published as a VEVENT
+- **WHEN** a user opens `BtwAangifteDetail`
+- **THEN** the calendar leaf MUST show the linked deadline event
+- **AND** no second VEVENT MUST have been created by rendering the page
+
+#### Scenario: an AR invoice's due date surfaces as a calendar entry
+
+- **GIVEN** an `ARInvoice` with a future `dueDate` and the user's AR due-date category opt-in (REQ-CDC-004) enabled
+- **WHEN** the user opens `ARInvoiceDetail`
+- **THEN** the calendar leaf MUST surface the due-date event for that invoice
+
+### Requirement: REQ-CPA-007 — Debtor and creditor masters SHALL link to the Nextcloud address book through the contacts leaf
+
+`CustomerMaster` (debtors — `legalName`, `email`, `kvkNumber`, `vatId`) and
+`Payee` (creditors — `name`, `email`, `phone`, `address`, `contactRef`) SHALL
+declare `contacts` in `configuration.linkedTypes`, so `CustomerDetail` and
+`PayeeDetail` render OpenRegister's contacts leaf
+(`ContactsController` / `ContactMatchingService`). The leaf links or matches an
+address-book contact per object; it MUST NOT bulk-export master records into
+the address book.
+
+#### Scenario: a debtor is linked to an address-book contact
+
+- **GIVEN** a `CustomerMaster` with `email` matching an existing address-book contact
+- **WHEN** a user opens `CustomerDetail`
+- **THEN** the contacts leaf MUST offer/show the matched contact
+- **AND** linking it MUST persist so the link survives a reload
+
+#### Scenario: a creditor with no matching contact can create one
+
+- **GIVEN** a `Payee` whose `email` matches no address-book contact
+- **WHEN** the user uses the contacts leaf on `PayeeDetail`
+- **THEN** it MUST offer creating/linking a contact rather than failing
+- **AND** the register's `Payee` object itself MUST NOT be modified beyond the link
+
+### Requirement: REQ-CPA-008 — Dossier-bearing detail pages with curated sidebar tabs SHALL include the talk leaf explicitly
+
+Detail pages that carry a discussable dossier and declare a curated
+`sidebarProps.tabs` list SHALL include `talk` in that curated list —
+specifically `ARInvoiceDetail` (dispute/dunning discussion),
+`ExpenseClaimDetail` (approval discussion), and `ContractDetail` (contract
+negotiation) where those pages curate their tabs. Pages without a curated list
+already receive the `talk` leaf in registry mode (REQ-CPA-001) and MUST NOT be
+touched. The curated-set rule of REQ-CPA-001 holds: the leaf is added by
+editing the curated list, never by bypassing curation.
+
+#### Scenario: an expense-claim approval discussion happens on the claim
+
+- **GIVEN** `ExpenseClaimDetail` with a curated tab list that includes `talk`
+- **WHEN** an approver opens the claim and starts a conversation in the talk leaf
+- **THEN** a Talk conversation bound to that claim object MUST be created
+- **AND** reopening the claim MUST show the same conversation, not a new one
+
+#### Scenario: a page without curated tabs is not double-modified
+
+- **GIVEN** a shillinq detail page with no `sidebarProps.tabs` override
+- **WHEN** this change is applied
+- **THEN** that page's manifest entry MUST be unchanged — its `talk` tab keeps coming from registry mode

--- a/openspec/changes/integration-leaves-consume/tasks.md
+++ b/openspec/changes/integration-leaves-consume/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: integration-leaves-consume
+
+## 1. HEAD re-verification (REQ-CPA-003 — before any code)
+- [ ] Verify OpenRegister's calendar leaf at HEAD can *list* an object's linked events (not only create); if not, refuse the calendar leg and record the refusal in this change per REQ-CPA-003.
+- [ ] Verify the contacts leaf (`ContactsController` / `ContactMatchingService`) matches on email/name and persists a per-object link; confirm `linkedTypes: ["contacts"]` is the trigger.
+- [ ] Verify which of `ARInvoiceDetail` / `ExpenseClaimDetail` / `ContractDetail` declare curated `sidebarProps.tabs` at HEAD (only curated pages are edited in §4).
+
+## 2. Files widgets (manifest)
+- [ ] Add `{"type":"integration","integrationId":"files"}` widget to `ReceiptDetail` (title "Receipt image") and `ExpenseClaimDetail` (title "Receipt evidence") in `src/manifest.json` (or the owning `src/manifest.d/` overlay), mirroring the `invoice-files` widget shape incl. `layout` entry.
+- [ ] Add the files widget to `BankConnectionDetail` (title "Imported statements") and `BtwAangifteDetail` (title "Filed return attachment").
+
+## 3. Register fragment (linkedTypes)
+- [ ] Add `lib/Settings/register.d/zzz-integration-leaves.json` declaring `configuration.linkedTypes` — `VatReturn: ["calendar"]`, `ARInvoice: ["calendar"]`, `CustomerMaster: ["contacts"]`, `Payee: ["contacts"]` — with `_meta` (SPDX + change id), zzz-sorted so no later fragment's array replaces it. Do NOT touch `Invoice` (`["mail"]`) or `Contract` (`["decidesk-decisions"]`).
+- [ ] Confirm `SettingsService::deepMergeConfig()` array-replacement semantics against the merged output (dump the merged register and assert the four arrays are present and the two existing ones unchanged).
+
+## 4. Talk on curated pages
+- [ ] For each curated dossier page found in §1 (`ARInvoiceDetail`, `ExpenseClaimDetail`, `ContractDetail`), add `talk` to its curated `sidebarProps.tabs` list; leave non-curated pages untouched.
+
+## 5. Verification (live, UI — API green is not UI green)
+- [ ] Receipt: upload a receipt image, open `ReceiptDetail` and `ExpenseClaimDetail`, confirm the image is listed and opens (REQ-CPA-005).
+- [ ] Bank: import a statement, confirm it is reachable from `BankConnectionDetail`; file a VAT return with `attachmentUri`, confirm it lists on `BtwAangifteDetail`.
+- [ ] Calendar: with a published Q2 BTW deadline VEVENT, open `BtwAangifteDetail` and confirm the event shows and that page-render created no duplicate VEVENT (REQ-CPA-006); repeat for an `ARInvoice` `dueDate` with the REQ-CDC-004 opt-in on.
+- [ ] Contacts: match + link a `CustomerMaster` by email; create-and-link for a `Payee` with no match; reload both pages and confirm the links persist (REQ-CPA-007).
+- [ ] Talk: start an approval conversation on `ExpenseClaimDetail`; reopen and confirm the same conversation is rebound (REQ-CPA-008).
+- [ ] Diff-check: a detail page without curated tabs has an unchanged manifest entry.

--- a/openspec/changes/mcp-action-tool-surface/.openspec.yaml
+++ b/openspec/changes/mcp-action-tool-surface/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/mcp-action-tool-surface/design.md
+++ b/openspec/changes/mcp-action-tool-surface/design.md
@@ -1,0 +1,70 @@
+# Design: mcp-action-tool-surface
+
+## Two mechanisms, one surface
+
+```
+declarative (unchanged)                     hand-written (new)
+───────────────────────                     ──────────────────
+register.d/zzz-mcp-tool-surface.json        OCA\Shillinq\Mcp\ShillinqToolProvider
+  x-openregister-mcp on 12 schemas            DI alias IMcpToolProvider::shillinq
+    │ SettingsService::deepMergeConfig()        │ catalogue + dispatch only
+    ▼ register import                           ▼
+OpenRegister SchemaDerivedToolProvider      McpAdministrationGate (authorise)
+  → shillinq.{Schema}.{search|get} ×24      McpArgumentValidator (validate)
+  (McpAnnotationValidator gates filters)    scope resolver (which admin/objects)
+    └────────────┬──────────────────────────────┘
+                 ▼
+   McpToolsService JSON-RPC + ToolRegistry/McpProviderBridge (chat)
+                 ▼
+   hermiq: default-deny grant matrix (ActionAuthService),
+   scope × reach (ToolReachResolver), human approval, audit
+```
+
+Collision safety: `SchemaDerivedToolProvider` self-suppresses a derived tool
+whose id a hand-written provider already claims (hand-written > derived), so
+the action provider can later absorb a CRUD verb without a duplicate.
+
+## Key decisions
+
+1. **Derived CRUD stays declarative; actions are hand-written.** ADR-063's
+   "no hand-written PHP" rule was written when the surface was CRUD-only.
+   `SchemaDerivedToolProvider` emits coarse CRUD per schema; a dunning run, a
+   SEPA export, a Digipoort submission traverse services and have no schema
+   home. REQ-MCP-001 is modified to state the boundary, not repealed: any tool
+   expressible as `x-openregister-mcp` CRUD MUST stay in the fragment.
+2. **Tool = controller action, same session, same guards.** Every action tool
+   delegates to the exact service its controller action calls
+   (e.g. `shillinq.dunning.execute_run` → the path behind
+   `DunningController::executeRun()`), in the caller's ambient NC session. No
+   impersonation, no system account. The decidesk gate pattern is copied:
+   argument validation → object load → not_found → authorise, helpers return
+   `bool` and are never swallowed by `catch(\Throwable)` (hydra
+   unsafe-auth-resolver gate).
+3. **scope × reach is declared per tool, resolved by hermiq.** Scope is the
+   verb class (`read`/`create`/`update`/`delete`); reach is the blast radius
+   (`self`/`user`/`instance`/`external`, `ToolReachResolver` constants).
+   Shillinq only *declares*; enforcement (default-deny, approval gates) is
+   hermiq's. Rule of thumb applied in the catalogue: touching only the
+   caller's own data → `user`; approving/closing something that binds others
+   (PO approval, period close, write-off) → `instance`; anything that leaves
+   the instance (Digipoort, Peppol, SEPA file for the bank, dunning email) →
+   `external`.
+4. **Audit parity with the derived provider.** The derived provider writes one
+   immutable hash-chained audit record per invocation
+   (`AuditTrailMapper::createToolInvocationEntry`, REQ-DERIVED-006). The
+   hand-written provider MUST match that: every invocation — read, write, or
+   failed — is auditable, which is what makes agent-principal attribution
+   real rather than claimed.
+5. **`VatReturn.destroy` is exposed as the only `delete`-scope tool** —
+   VATReturnController already restricts destroy to non-submitted returns;
+   the ledger itself (`GLTransaction`) still has NO delete tool of any kind
+   (append-only, reverse-with-correction).
+
+## Why not x-openregister-mcp write verbs instead of a provider?
+
+Derived `create`/`update` would write raw objects through `ObjectService`,
+bypassing shillinq's domain services (sequential invoice numbering, dunning
+staging, three-way-match tolerances, period-close checks). A raw
+`shillinq.ARInvoice.create` is exactly the "agent-authored invoice" REQ-MCP-003
+feared. Action tools go *through* the domain services, so every existing
+validation and lifecycle guard runs. Derived write verbs stay forbidden.

--- a/openspec/changes/mcp-action-tool-surface/proposal.md
+++ b/openspec/changes/mcp-action-tool-surface/proposal.md
@@ -1,0 +1,92 @@
+# Change: mcp-action-tool-surface
+
+## Why
+
+The product-owner intent for the fleet: **every app provides MCP tooling for
+ALL of its actions**, so any action can in principle be automated by an AI
+agent; the user grants rights per agent, very granularly, through hermiq's
+two-axis **scope × reach** grant model (default-deny for writes); and even
+without automation a user can command the app from chat — chat away while your
+apps execute your commands.
+
+Shillinq's current surface, established by the archived `shillinq-mcp-adoption`
+change (spec `shillinq-mcp-tool-surface`), is deliberately read-only: **24
+derived tools** (12 curated schemas × `search`+`get`), zero writes, zero PHP.
+That was the right call *at the time* — REQ-MCP-003 refused writes because two
+platform capabilities were missing: **agent-principal attribution in the audit
+trail** and a **human-in-the-loop approval gate**. Both now exist: hermiq
+consumes `IMcpToolProvider` tools under a default-deny grant matrix
+(`ActionAuthService` — "config returns an empty array (default-deny)"), with
+per-tool `scope` (`read`/`create`/`update`/`delete`) and `reach`
+(`ToolReachResolver::REACH_SELF/USER/INSTANCE/EXTERNAL`), human approval gates,
+and an audit trail. The precondition REQ-MCP-003 itself named is met; the
+moratorium can be lifted *under those gates* — not removed.
+
+## Reality check — what `zzz-mcp-tool-surface.json` actually produces (verified)
+
+The declarative fragment is **live, not aspirational**. The verified chain:
+
+1. `SettingsService` merges every `lib/Settings/register.d/*.json` fragment
+   (ADR-037, `deepMergeConfig()`, SettingsService.php ~line 1507), so each
+   curated schema's `configuration["x-openregister-mcp"]` reaches the merged
+   register that is imported into OpenRegister.
+2. OpenRegister's `lib/Mcp/BuiltIn/SchemaDerivedToolProvider.php` (ADR-063
+   chain 2/3, present at HEAD) reads every schema's **validated**
+   `x-openregister-mcp` block and, per owning app, emits one tool per declared
+   verb with id `{appId}.{schema}.{verb}` — i.e. `shillinq.ARInvoice.search`
+   … — on both MCP surfaces (`McpToolsService` JSON-RPC +
+   `ToolRegistry`/`McpProviderBridge` chat).
+3. `McpAnnotationValidator` rejects a `search.filters` entry that is not a
+   real schema property, failing the import loudly (REQ-MCP-002 holds).
+
+So this change **builds on** the fragment (it keeps producing the 24 read
+tools) rather than replacing it. What the fragment *cannot* produce is action
+tools: `SchemaDerivedToolProvider` emits **coarse CRUD only**. "Execute the
+dunning run", "export a SEPA payment run", "submit the VAT return to
+Digipoort" traverse services (`DunningRunService`, `PaymentRunController::
+export()`, `VATReturnController::submit()`) — they are not object CRUD and can
+never be derived from a schema block. Those need a hand-written provider.
+
+## What changes
+
+1. **`OCA\Shillinq\Mcp\ShillinqToolProvider`** implementing
+   `OCA\OpenRegister\Mcp\IMcpToolProvider`, registered under the container
+   alias **`OCA\OpenRegister\Mcp\IMcpToolProvider::shillinq`** (OpenRegister's
+   per-app discovery convention, openregister `AppInfo/Application.php`
+   ~3827–3843), exposing **action tools** with ids `shillinq.{toolName}`.
+   The fleet reference is decidesk's `lib/Mcp/` set: `DecideskToolProvider`
+   (dispatcher owning the catalogue), `McpMeetingGate` (per-object authorise
+   ladder: validate → load → not_found → authorise, helpers return `bool`,
+   never wrapped in `catch(\Throwable)`), `McpArgumentValidator`, and
+   `McpMeetingScopeResolver`. Shillinq mirrors that shape:
+   `ShillinqToolProvider` + `McpAdministrationGate` + `McpArgumentValidator`
+   + a scope resolver.
+2. **Full action coverage**: one tool per real user action enumerated from
+   `lib/Controller/` + `lib/Service/` (catalogue in the spec delta — invoicing,
+   dunning, payment runs, bank import/reconciliation, VAT returns, expense
+   claims, requisitions/PO approval, period close, hours). Read tools are
+   strictly separated from write tools; every write is annotated with `scope`
+   and `reach` for hermiq's grant matrix.
+3. **Spec deltas** to `shillinq-mcp-tool-surface`: REQ-MCP-001 (no-PHP rule)
+   and REQ-MCP-003 (write moratorium) are MODIFIED — narrowly; the BSN /
+   credential exclusions of REQ-MCP-003 are **retained verbatim and remain
+   absolute**. REQ-MCP-004 (action coverage) and REQ-MCP-005 (chat command
+   surface + audit) are ADDED.
+4. The derived read surface (`zzz-mcp-tool-surface.json`, 24 tools) is
+   **unchanged**; `SchemaDerivedToolProvider`'s hand-written-beats-derived
+   collision rule guarantees the new provider cannot be shadowed by a future
+   derived duplicate.
+
+## Out of scope / dependencies
+
+- hermiq's grant model, approval UI, and audit pipeline are consumed, not
+  built here (they exist: `hermiq/lib/Mcp/HermiqToolProvider.php`,
+  `Service/Engine/ToolReachResolver.php`, `Service/ActionAuthService.php`).
+- No new REST endpoints: every tool delegates to the same service the
+  controller action calls, in the caller's ambient Nextcloud session — RBAC /
+  IDOR posture identical to the REST path.
+- Payroll, detachering, and bookings-widget schemas stay excluded outright
+  (BSN / credential material) — REQ-MCP-003's exclusion list is untouched.
+- Statutory-filing side effects (Digipoort, Peppol, SEPA) get `reach:
+  external` so hermiq's human-approval gate fronts them; this change does not
+  weaken those transports.

--- a/openspec/changes/mcp-action-tool-surface/specs/shillinq-mcp-tool-surface/spec.md
+++ b/openspec/changes/mcp-action-tool-surface/specs/shillinq-mcp-tool-surface/spec.md
@@ -1,0 +1,185 @@
+# Spec: shillinq-mcp-tool-surface (delta)
+
+## MODIFIED Requirements
+
+### Requirement: REQ-MCP-001 — Derived CRUD tools MUST stay declarative on the schema; action tools MUST live in exactly one hand-written provider
+
+The 24 coarse-CRUD read tools MUST remain derived by OpenRegister's
+`SchemaDerivedToolProvider` from the `x-openregister-mcp` blocks in
+`lib/Settings/register.d/zzz-mcp-tool-surface.json` (ADR-037 key-union merge,
+ADR-063) — no CRUD-shaped tool may be hand-written. Non-CRUD **action tools**
+(verbs that traverse a shillinq service rather than reading/writing one
+object) MUST live in a single hand-written provider
+`OCA\Shillinq\Mcp\ShillinqToolProvider` implementing
+`OCA\OpenRegister\Mcp\IMcpToolProvider`, registered under the container alias
+`OCA\OpenRegister\Mcp\IMcpToolProvider::shillinq` (OpenRegister's per-app
+discovery convention), with every tool id prefixed `shillinq.`. The provider
+MUST follow the decidesk reference shape (`decidesk/lib/Mcp/`): a dispatcher
+owning the catalogue, a per-object authorisation gate
+(`McpAdministrationGate`, mirroring `McpMeetingGate`'s validate → load →
+not_found → authorise ladder with bool-returning helpers never wrapped in
+`catch(\Throwable)`), an `McpArgumentValidator`, and a scope resolver.
+Exposure stays default-OFF: a schema without the dialect and an action without
+a catalogue entry produce no tool.
+
+#### Scenario: the derived read surface is unchanged
+
+- **GIVEN** this change is deployed
+- **WHEN** the MCP tool list is enumerated
+- **THEN** the 24 `shillinq.{Schema}.{search|get}` derived tools still exist, all `scope: "read"` / `readOnlyHint: true`
+- **AND** no CRUD-shaped duplicate of them exists in `ShillinqToolProvider`
+
+#### Scenario: a CRUD-expressible tool is rejected from the provider
+
+- **GIVEN** a proposed provider tool that merely searches or gets one schema's objects
+- **WHEN** the change is reviewed
+- **THEN** it MUST be moved to the `x-openregister-mcp` fragment instead of the provider
+
+#### Scenario: hand-written beats derived on id collision
+
+- **GIVEN** a future fragment declares a verb whose derived id collides with a provider tool id
+- **WHEN** `SchemaDerivedToolProvider` builds shillinq's derived tools
+- **THEN** it self-suppresses the colliding derived duplicate (hand-written > derived)
+
+### Requirement: REQ-MCP-003 — Write tools MUST be exposed only under hermiq's default-deny scope×reach grant model; BSN- and credential-bearing schemas stay excluded outright
+
+The blanket refusal of write verbs is lifted **only because** the two platform
+capabilities it named as prerequisites now exist in hermiq: agent-principal
+attribution with a per-invocation audit record, and a human-in-the-loop
+approval gate, fronted by a **default-deny** grant matrix
+(`ActionAuthService`) keyed on each tool's declared `scope`
+(`read`/`create`/`update`/`delete`) and `reach`
+(`ToolReachResolver::REACH_SELF/USER/INSTANCE/EXTERNAL`). Accordingly:
+
+- Every write tool MUST declare `scope` and `reach`; a write tool without both
+  annotations MUST NOT be published.
+- Writes remain **default-deny**: absent an explicit per-agent grant, every
+  write tool invocation fails.
+- Tools with `reach: external` (Digipoort, Peppol, SEPA, dunning dispatch) and
+  `reach: instance` writes (approvals, period close, write-off) MUST be
+  gateable by hermiq's human-approval step.
+- Every provider invocation — read, write, or failed — MUST write one
+  immutable audit record (parity with the derived provider's
+  `AuditTrailMapper::createToolInvocationEntry` behaviour), so agent action is
+  always distinguishable from human action.
+- `GLTransaction` MUST still have no delete tool of any kind; corrections are
+  postings, not deletions. The only `delete`-scope tool is
+  `shillinq.vat_return.destroy`, which is valid solely for non-submitted
+  returns (the same constraint `VATReturnController::destroy()` enforces).
+- Unchanged and absolute: no schema bearing credential material
+  (`WidgetAccessKey.apiKeyHash`, `ConfirmationToken.tokenString`) or
+  special-category PII (`Employee.bsn`, `Werknemer.bsn`, `IBAangifte.bsn`,
+  `IB47Record.ontvangerBSN`) may be reached through any shillinq tool — read
+  or write, derived or hand-written.
+
+#### Scenario: an ungranted write is refused by default
+
+- **GIVEN** an agent with no explicit grant for `shillinq.dunning.execute_run`
+- **WHEN** it invokes the tool
+- **THEN** hermiq's default-deny matrix refuses the invocation
+- **AND** the refusal is recorded in the audit trail attributed to the agent principal
+
+#### Scenario: an external-reach write requires human approval
+
+- **GIVEN** an agent granted `shillinq.vat_return.submit` (`scope: update`, `reach: external`)
+- **WHEN** it invokes the tool
+- **THEN** the invocation MUST pass hermiq's human-approval gate before `VATReturnController::submit()`'s service path runs
+- **AND** without approval nothing reaches Digipoort
+
+#### Scenario: the ledger still cannot be deleted from
+
+- **WHEN** the MCP tool list is enumerated
+- **THEN** no `shillinq.*` tool with `scope: delete` targets `GLTransaction`
+- **AND** no BSN- or credential-bearing schema is reachable through any tool
+
+## ADDED Requirements
+
+### Requirement: REQ-MCP-004 — The provider SHALL cover every user action, one tool per action, reads separated from writes
+
+`ShillinqToolProvider` SHALL expose one tool per real user action enumerated
+from `lib/Controller/` + `lib/Service/`, delegating to the same service path
+as the controller action, in the caller's ambient Nextcloud session (no
+impersonation — RBAC identical to REST). The initial catalogue, grounded
+action-by-action:
+
+| Tool id | Backing action | scope | reach |
+|---|---|---|---|
+| `shillinq.invoice.draft` | `InvoiceApiController::generate()` / `InvoiceGenerationService` | create | user |
+| `shillinq.invoice.issue` | `InvoiceApiController::post()` (sequential numbering) | update | instance |
+| `shillinq.invoice.render_pdf` | `InvoiceApiController::pdf()` / `InvoicePdfGenerator` | read | user |
+| `shillinq.invoice.send_einvoice` | `ARInvoiceEInvoiceController` (UBL/Peppol dispatch) | update | external |
+| `shillinq.recurring_invoice.generate` | `RecurringInvoiceGenerator` | create | user |
+| `shillinq.dunning.dossier` | `DunningController::dossier()` | read | user |
+| `shillinq.dunning.execute_run` | `DunningController::executeRun()` / `DunningRunService` | update | external |
+| `shillinq.dunning.pause` / `shillinq.dunning.resume` | `DunningController::pause()` / `resumePause()` | update | user |
+| `shillinq.dunning.write_off` | `DunningController::writeOff()` | update | instance |
+| `shillinq.payment_run.export_sepa` | `PaymentRunController::export()` | update | external |
+| `shillinq.payment_run.reconcile` | `PaymentRunController::reconcile()` | update | user |
+| `shillinq.bank_statement.import` | `BankStatementImportController::import()` | create | user |
+| `shillinq.bank_reconciliation.resolve` | `ReconciliationResolutionController::resolve()` / `bulkResolve()` | update | user |
+| `shillinq.vat_return.create` | `VATReturnController::create()` / `VATReturnService` | create | user |
+| `shillinq.vat_return.rebase` | `VATReturnController::rebase()` | update | user |
+| `shillinq.vat_return.submit` | `VATReturnController::submit()` (Digipoort) | update | external |
+| `shillinq.vat_return.destroy` | `VATReturnController::destroy()` (non-submitted only) | delete | user |
+| `shillinq.receipt.book` | receipt-extraction consume flow (`Receipt` + `claimId` link) | create | user |
+| `shillinq.expense_claim.approve` | `ExpenseClaimEntry.approvalState` transition | update | instance |
+| `shillinq.requisition.create` / `shillinq.requisition.submit` | `RequisitionController::create()` / `submit()` | create / update | user |
+| `shillinq.requisition.decide` | `RequisitionController::approve()` / `reject()` | update | instance |
+| `shillinq.requisition.convert` | `RequisitionController::convert()` / `RequisitionConversionService` | create | instance |
+| `shillinq.purchase_order.decide` | `PurchaseOrderApprovalController::decide()` | update | instance |
+| `shillinq.period_close.status` | `PeriodCloseController::show()` / `aiFlags()` | read | user |
+| `shillinq.period_close.start` / `shillinq.period_close.close` / `shillinq.period_close.reopen` | `PeriodCloseController::startClose()` / `close()` / `reopen()` | update | instance |
+| `shillinq.hours.book` | `TimeIntakeService` (`UrenRegistratie`) | create | self |
+
+Read tools MUST carry `readOnlyHint: true` and MUST NOT share a tool id
+namespace entry with a write; a new controller action added later without a
+catalogue entry (or a recorded exclusion rationale) is a spec violation.
+
+#### Scenario: an action tool runs the same guards as its REST twin
+
+- **GIVEN** a caller lacking approval rights on a purchase order
+- **WHEN** the agent invokes `shillinq.purchase_order.decide` for that PO
+- **THEN** `McpAdministrationGate` refuses exactly where `PurchaseOrderApprovalController::decide()` would
+- **AND** the refusal produces an audit record, not a silent skip
+
+#### Scenario: every catalogue write carries both grant axes
+
+- **WHEN** `ShillinqToolProvider::getTools()` is enumerated
+- **THEN** every non-read tool declares both `scope` and `reach`
+- **AND** every read tool declares `readOnlyHint: true`
+
+#### Scenario: a new action cannot ship untooled silently
+
+- **GIVEN** a PR adding a new public controller action
+- **WHEN** the change is verified against this spec
+- **THEN** the action has a catalogue tool OR a recorded exclusion rationale in this spec
+
+### Requirement: REQ-MCP-005 — A user SHALL be able to command shillinq from chat, with agent-facing descriptions carrying the routing knowledge
+
+Every tool description SHALL be agent-facing prose stating what the tool does
+and when to reach for it (the style already used in
+`zzz-mcp-tool-surface.json`, e.g. ARInvoice search: "Use for 'which invoices
+are overdue?'"), so a chat model can route a natural-language command to the
+right tool without shillinq-specific prompting. The surface MUST serve both
+OpenRegister MCP surfaces (JSON-RPC + chat `ToolRegistry`/`McpProviderBridge`).
+
+#### Scenario: "what invoices are overdue?" needs no write grant
+
+- **GIVEN** a user asking an agent "what invoices are overdue?"
+- **WHEN** the agent routes via tool descriptions
+- **THEN** it answers with the derived `shillinq.ARInvoice.search` read tool (amountDue/dunning live there)
+- **AND** no write grant, approval, or provider tool is involved
+
+#### Scenario: "book this receipt" is a granted create with a visible trail
+
+- **GIVEN** a user telling an agent "book this receipt against my open expense claim", and the agent holding a `create`/`user` grant for `shillinq.receipt.book`
+- **WHEN** the agent invokes the tool with the receipt image reference
+- **THEN** a `Receipt` object is created and linked via `claimId` through the same consume flow the UI uses
+- **AND** the invocation is audit-recorded under the agent principal
+
+#### Scenario: "submit the Q2 BTW return" pauses for a human
+
+- **GIVEN** a user instructing an agent to prepare and submit the Q2 VAT return
+- **WHEN** the agent invokes `shillinq.vat_return.create` (granted) and then `shillinq.vat_return.submit`
+- **THEN** the create proceeds under its grant, and the submit — `reach: external` — halts at hermiq's human-approval gate until the user approves
+- **AND** upon approval the return is submitted and `VatReturn.state`/`submittedAt` update as if filed from the UI

--- a/openspec/changes/mcp-action-tool-surface/tasks.md
+++ b/openspec/changes/mcp-action-tool-surface/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: mcp-action-tool-surface
+
+## 1. HEAD re-verification (before any code)
+- [ ] Confirm the derived chain live on the shared instance: import the register, enumerate MCP tools, and count exactly 24 `shillinq.{Schema}.{search|get}` tools (REQ-MCP-002's "24 and nothing else" baseline must be TRUE before extending — a check that did not run looks like one that passed).
+- [ ] Confirm OpenRegister's per-app alias discovery (`IMcpToolProvider::<appId>`, openregister `AppInfo/Application.php` ~3827) accepts a shillinq alias, and confirm the hand-written > derived collision rule in `SchemaDerivedToolProvider`.
+- [ ] Confirm hermiq's grant surface for a foreign app's tools: default-deny matrix (`ActionAuthService`), `scope`/`reach` keys read from the tool descriptor (`ToolReachResolver::REACH_KEY`), human-approval gating for `external`/`instance` writes.
+
+## 2. Provider skeleton (decidesk reference shape)
+- [ ] `lib/Mcp/ShillinqToolProvider.php` — dispatcher + catalogue only; implements `OCA\OpenRegister\Mcp\IMcpToolProvider`; `getAppId(): 'shillinq'`; every id prefixed `shillinq.`; SPDX headers (hydra gate-1).
+- [ ] `lib/Mcp/McpAdministrationGate.php` — validate → load → not_found → authorise ladder per `decidesk/lib/Mcp/McpMeetingGate.php`; bool-returning helpers, no `catch(\Throwable)` swallow (hydra unsafe-auth-resolver gate), administration-scoped via the existing `AdministrationContextService`.
+- [ ] `lib/Mcp/McpArgumentValidator.php` — per-tool argument schemas, mirroring decidesk's validator.
+- [ ] Register the container alias `OCA\OpenRegister\Mcp\IMcpToolProvider::shillinq` in `lib/AppInfo/Application.php` with a string-name alias (no autoload trigger when OpenRegister is absent — decidesk ADR-083 pattern).
+
+## 3. Tool handlers (one per catalogue row, REQ-MCP-004)
+- [ ] Invoicing: `invoice.draft` / `invoice.issue` / `invoice.render_pdf` / `invoice.send_einvoice` / `recurring_invoice.generate` — delegate to the exact service paths behind `InvoiceApiController` (`generate`/`post`/`pdf`), `ARInvoiceEInvoiceController`, `RecurringInvoiceGenerator`.
+- [ ] Dunning: `dunning.dossier` / `dunning.execute_run` / `dunning.pause` / `dunning.resume` / `dunning.write_off` (paths behind `DunningController`).
+- [ ] Payments + bank: `payment_run.export_sepa` / `payment_run.reconcile` (`PaymentRunController::export`/`reconcile`), `bank_statement.import` (`BankStatementImportController::import`), `bank_reconciliation.resolve` (`ReconciliationResolutionController::resolve`/`bulkResolve`).
+- [ ] VAT: `vat_return.create` / `vat_return.rebase` / `vat_return.submit` / `vat_return.destroy` (paths behind `VATReturnController`; destroy keeps the non-submitted-only constraint).
+- [ ] Expenses + time: `receipt.book` (receipt-extraction consume flow + `claimId` link), `expense_claim.approve` (`approvalState` transition), `hours.book` (`TimeIntakeService`).
+- [ ] Procurement + close: `requisition.create`/`submit`/`decide`/`convert` (`RequisitionController`), `purchase_order.decide` (`PurchaseOrderApprovalController::decide`), `period_close.status`/`start`/`close`/`reopen` (`PeriodCloseController`).
+- [ ] Annotate every write with `scope` + `reach` per the catalogue; every read with `readOnlyHint: true`; agent-facing descriptions in the zzz-fragment style (REQ-MCP-005).
+- [ ] Audit: every invocation (incl. refusals/failures) writes one immutable audit record — parity with `AuditTrailMapper::createToolInvocationEntry` (REQ-MCP-003).
+
+## 4. Tests
+- [ ] Unit: gate refusal parity — for at least `purchase_order.decide` and `vat_return.submit`, the gate refuses exactly where the controller twin would (subclass ObjectEntity-backed doubles; accessors are magic `__call` — subclass, don't mock).
+- [ ] Unit: catalogue invariants — every non-read tool declares both `scope` and `reach`; every read declares `readOnlyHint`; every id is `shillinq.`-prefixed; no CRUD-shaped tool duplicates a derived id.
+- [ ] Unit: validator rejects malformed arguments before any service call; a refused invocation still audits.
+
+## 5. Live verification (shared :8080, both surfaces)
+- [ ] Enumerate tools after deploy: 24 derived + the catalogue count, no collisions, no duplicates.
+- [ ] Chat scenario 1 (read): "what invoices are overdue?" answered via `shillinq.ARInvoice.search` with zero grants configured (proves default-deny does not block reads and no write path was touched).
+- [ ] Chat scenario 2 (granted create): grant `receipt.book` (`create`/`user`) to a test agent, run "book this receipt", verify the `Receipt` object + `claimId` link + audit record under the agent principal.
+- [ ] Chat scenario 3 (approval gate): grant `vat_return.submit`, instruct submission, verify the invocation HALTS at the human-approval gate and only proceeds after approval — and that with no grant it is refused outright (prove the gate can say NO first — positive control).
+- [ ] Negative: attempt a `GLTransaction` delete and a payroll-schema read through both surfaces — both must be impossible (allow-list check: assert the expected refusal, not the absence of success).


### PR DESCRIPTION
OpenSpec change proposals — **artifacts only**. Every task box is unticked; nothing here is wired to anything yet, and each change gets picked up by `/opsx-apply` when it is scheduled.

Opened because these were sitting **untracked in the shared dev checkout across ten apps at once**. An untracked directory is one file-sweep away from being swept into an unrelated commit, and one branch switch away from being gone. These carry the design reasoning, not just a title, so losing them loses the thinking.

Each proposal is a complete artifact set — `proposal.md`, `design.md`, `tasks.md` and its spec delta.
