### PR TITLE
fix(security): endpoint guards, error-leak closure, and 4 cross-tenant IDOR fixes (security-endpoint-guards)

### DIFF
--- a/lib/Controller/AccountantPortalController.php
+++ b/lib/Controller/AccountantPortalController.php
@@ -105,9 +105,22 @@ class AccountantPortalController extends Controller {
 	/**
 	 * Return the authenticated user's accountant dashboard (REQ-ACP-001, REQ-ACP-002).
 	 *
+	 * JUSTIFY (security-endpoint-guards REQ-001): this method takes no
+	 * request-supplied administration id — `AccountantDashboardService::
+	 * buildDashboard()` builds one card per entry of
+	 * `AdministrationContextService::buildContext()['administrations']`,
+	 * which is derived purely from the authenticated session uid's own
+	 * `AdministrationMembership` records (verified by reading
+	 * `AdministrationContextService::buildContext()`). There is no
+	 * client-supplied identifier a caller could substitute to reach another
+	 * tenant's dashboard card, so no additional per-object guard applies
+	 * beyond the authentication check below.
+	 *
 	 * @return JSONResponse 200 with the dashboard; 401 when no user is authenticated.
 	 *
 	 * @spec openspec/specs/accountant-portal/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function dashboard(): JSONResponse {

--- a/lib/Controller/AdministrationController.php
+++ b/lib/Controller/AdministrationController.php
@@ -79,10 +79,20 @@ class AdministrationController extends Controller {
 	/**
 	 * Return the authenticated user's administration context (REQ-MA-003).
 	 *
+	 * JUSTIFY (security-endpoint-guards REQ-001): this method takes no
+	 * request-supplied administration id — `AdministrationContextService::
+	 * buildContext()` is derived purely from the authenticated session uid's
+	 * own `AdministrationMembership` records. There is no client-supplied
+	 * identifier a caller could substitute to reach another tenant's
+	 * context, so no additional per-object guard applies beyond the
+	 * authentication check below.
+	 *
 	 * @return JSONResponse 200 with { userId, administrations[], activeAdministrationId };
 	 *                      401 when no user is authenticated.
 	 *
 	 * @spec openspec/changes/bookkeeping-multi-administratie/tasks.md#task-11
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function context(): JSONResponse {

--- a/lib/Controller/BankRuleController.php
+++ b/lib/Controller/BankRuleController.php
@@ -385,7 +385,22 @@ class BankRuleController extends Controller {
 	/**
 	 * Resolve the current administration id server-side (IDOR-safe).
 	 *
+	 * Verified for security-endpoint-guards (Open Question, REQ-001): this
+	 * reads `AdministrationContextService::buildContext()['activeAdministrationId']`,
+	 * which is derived purely from `currentUserId()` (the authenticated
+	 * session uid) via the caller's own `AdministrationMembership` records
+	 * — see `buildContext()` in AdministrationContextService. No request
+	 * parameter, header, or client-supplied value reaches this path; the
+	 * only client-influenceable output is the choice of the FIRST
+	 * accessible administration (a business-logic detail, not an IDOR
+	 * vector, since it is always one the caller is actually a member of).
+	 * `acceptSuggestion()` and every other method in this controller that
+	 * calls this method are therefore already IDOR-safe; no additional
+	 * membership check was added.
+	 *
 	 * @return string
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
 	private function resolveAdministrationId(): string {
 		try {

--- a/lib/Controller/BankStatementImportController.php
+++ b/lib/Controller/BankStatementImportController.php
@@ -46,6 +46,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -85,6 +86,7 @@ class BankStatementImportController extends Controller {
 	 * @param IUserSession $session User session.
 	 * @param LoggerInterface $logger Logger.
 	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
+	 * @param IL10N $l10n Translation service for error-response messages (ADR-050).
 	 */
 	public function __construct(
 		IRequest $request,
@@ -93,6 +95,7 @@ class BankStatementImportController extends Controller {
 		private readonly IUserSession $session,
 		private readonly LoggerInterface $logger,
 		private readonly ObjectServiceInterface $objectService,
+		private readonly IL10N $l10n,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -110,11 +113,16 @@ class BankStatementImportController extends Controller {
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/specs/shillinq-bank-statement-wizard/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function import(): JSONResponse {
 		if ($this->session->getUser() === null) {
-			return new JSONResponse(['error' => 'Not logged in'], Http::STATUS_UNAUTHORIZED);
+			return new JSONResponse(
+				['message' => $this->l10n->t('Not logged in'), 'error' => 'bank-statement-import-unauthenticated'],
+				Http::STATUS_UNAUTHORIZED
+			);
 		}
 
 		try {
@@ -194,10 +202,20 @@ class BankStatementImportController extends Controller {
 				Http::STATUS_OK
 			);
 		} catch (\InvalidArgumentException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			$this->logger->error('BankStatementImportController.import failed', ['exception' => $e]);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Invalid bank statement import request'),
+					'error' => 'bank-statement-import-invalid-input',
+				],
+				Http::STATUS_BAD_REQUEST
+			);
 		} catch (\Throwable $e) {
-			$this->logger->error('BankStatementImportController.import failed: ' . $e->getMessage());
-			return new JSONResponse(['error' => 'Internal error'], Http::STATUS_INTERNAL_SERVER_ERROR);
+			$this->logger->error('BankStatementImportController.import failed', ['exception' => $e]);
+			return new JSONResponse(
+				['message' => $this->l10n->t('Unable to import bank statement'), 'error' => 'bank-statement-import-failed'],
+				Http::STATUS_INTERNAL_SERVER_ERROR
+			);
 		}//end try
 
 	}//end import()
@@ -253,7 +271,10 @@ class BankStatementImportController extends Controller {
 
 		// 1) Multipart file upload.
 		$uploaded = $this->request->getUploadedFile('file');
-		if (is_array($uploaded) === true && isset($uploaded['tmp_name']) === true && is_uploaded_file((string)$uploaded['tmp_name']) === true) {
+		if (is_array($uploaded) === true
+			&& isset($uploaded['tmp_name']) === true
+			&& is_uploaded_file((string)$uploaded['tmp_name']) === true
+		) {
 			$raw = file_get_contents((string)$uploaded['tmp_name']);
 			if ($raw !== false) {
 				$rawContents = $raw;

--- a/lib/Controller/BillingIntakeController.php
+++ b/lib/Controller/BillingIntakeController.php
@@ -44,6 +44,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -62,6 +63,7 @@ class BillingIntakeController extends Controller {
 	 * @param AdministrationContextService $administrationContext Server-resolved tenant scope (ADR-005).
 	 * @param IUserSession $session User session.
 	 * @param LoggerInterface $logger Logger.
+	 * @param IL10N $l10n Translation service for error-response messages (ADR-050).
 	 */
 	public function __construct(
 		IRequest $request,
@@ -69,6 +71,7 @@ class BillingIntakeController extends Controller {
 		private readonly AdministrationContextService $administrationContext,
 		private readonly IUserSession $session,
 		private readonly LoggerInterface $logger,
+		private readonly IL10N $l10n,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -80,12 +83,17 @@ class BillingIntakeController extends Controller {
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/specs/time-expense-invoice-intake/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function timeIntake(): JSONResponse {
 		$user = $this->session->getUser();
 		if ($user === null) {
-			return new JSONResponse(['error' => 'Not logged in'], Http::STATUS_UNAUTHORIZED);
+			return new JSONResponse(
+				['message' => $this->l10n->t('Not logged in'), 'error' => 'billing-time-intake-unauthenticated'],
+				Http::STATUS_UNAUTHORIZED
+			);
 		}
 
 		try {
@@ -97,17 +105,33 @@ class BillingIntakeController extends Controller {
 
 			return new JSONResponse($result, Http::STATUS_OK);
 		} catch (\InvalidArgumentException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			$this->logger->error('BillingIntakeController.timeIntake failed', ['exception' => $e]);
+			return new JSONResponse(
+				['message' => $this->l10n->t('Invalid time-intake batch'), 'error' => 'billing-time-intake-invalid-input'],
+				Http::STATUS_BAD_REQUEST
+			);
 		} catch (\RuntimeException $e) {
-			$message = $e->getMessage();
-			if (str_starts_with($message, 'Conflict:') === true) {
-				return new JSONResponse(['error' => $message], Http::STATUS_CONFLICT);
+			$this->logger->error('BillingIntakeController.timeIntake failed', ['exception' => $e]);
+			if (str_starts_with($e->getMessage(), 'Conflict:') === true) {
+				return new JSONResponse(
+					['message' => $this->l10n->t('This batch has already been processed'), 'error' => 'billing-time-intake-conflict'],
+					Http::STATUS_CONFLICT
+				);
 			}
 
-			return new JSONResponse(['error' => $message], Http::STATUS_UNPROCESSABLE_ENTITY);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Time-intake batch could not be processed'),
+					'error' => 'billing-time-intake-unprocessable',
+				],
+				Http::STATUS_UNPROCESSABLE_ENTITY
+			);
 		} catch (\Throwable $e) {
-			$this->logger->error('BillingIntakeController.timeIntake failed: ' . $e->getMessage());
-			return new JSONResponse(['error' => 'Internal error'], Http::STATUS_INTERNAL_SERVER_ERROR);
+			$this->logger->error('BillingIntakeController.timeIntake failed', ['exception' => $e]);
+			return new JSONResponse(
+				['message' => $this->l10n->t('Unable to process time-intake batch'), 'error' => 'billing-time-intake-failed'],
+				Http::STATUS_INTERNAL_SERVER_ERROR
+			);
 		}//end try
 
 	}//end timeIntake()

--- a/lib/Controller/BookingDepthController.php
+++ b/lib/Controller/BookingDepthController.php
@@ -130,7 +130,7 @@ class BookingDepthController extends Controller {
 				return new JSONResponse(['error' => 'Appointment not found'], Http::STATUS_NOT_FOUND);
 			}
 
-			// security-endpoint-guards REQ-001: per-object tenant guard checked
+			// Security-endpoint-guards REQ-001: per-object tenant guard checked
 			// against the FETCHED target's own administrationId (never the
 			// caller-supplied appointmentId's implied scope).
 			if ($this->context->canAccess((string)($appointment['administrationId'] ?? '')) === false) {
@@ -210,7 +210,7 @@ class BookingDepthController extends Controller {
 			);
 		}
 
-		// security-endpoint-guards REQ-001: the request-supplied administrationId
+		// Security-endpoint-guards REQ-001: the request-supplied administrationId
 		// is what will be stamped on the new AppointmentSeries/Appointment
 		// objects, so checking canAccess() against it here (before the object
 		// exists to fetch) is the correct create-time guard — matches the
@@ -229,7 +229,7 @@ class BookingDepthController extends Controller {
 				return new JSONResponse(['error' => 'Resource not found'], Http::STATUS_NOT_FOUND);
 			}
 
-			// security-endpoint-guards REQ-001 hardening: canAccess() above only
+			// Security-endpoint-guards REQ-001 hardening: canAccess() above only
 			// proved the caller may act within $administrationId — it does NOT
 			// prove the FETCHED $resource actually belongs to that
 			// administration. Without this check a member of administration A

--- a/lib/Controller/BookingDepthController.php
+++ b/lib/Controller/BookingDepthController.php
@@ -51,6 +51,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -75,6 +76,7 @@ class BookingDepthController extends Controller {
 	 * @param NoShowFeeCaptureService $noShowFee No-show fee capture seam.
 	 * @param RecurringSeriesService $series Recurring series expander/planner.
 	 * @param LoggerInterface $logger Logger.
+	 * @param IL10N $l10n Translation service for ADR-050 error-response messages.
 	 */
 	public function __construct(
 		\OCP\IRequest $request,
@@ -84,6 +86,7 @@ class BookingDepthController extends Controller {
 		private readonly NoShowFeeCaptureService $noShowFee,
 		private readonly RecurringSeriesService $series,
 		private readonly LoggerInterface $logger,
+		private readonly IL10N $l10n,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -103,6 +106,8 @@ class BookingDepthController extends Controller {
 	 *                      404 missing; 503 when OpenRegister is unavailable.
 	 *
 	 * @spec openspec/specs/bookings-cancellation-rules/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function captureNoShow(string $appointmentId = ''): JSONResponse {
@@ -125,6 +130,9 @@ class BookingDepthController extends Controller {
 				return new JSONResponse(['error' => 'Appointment not found'], Http::STATUS_NOT_FOUND);
 			}
 
+			// security-endpoint-guards REQ-001: per-object tenant guard checked
+			// against the FETCHED target's own administrationId (never the
+			// caller-supplied appointmentId's implied scope).
 			if ($this->context->canAccess((string)($appointment['administrationId'] ?? '')) === false) {
 				return new JSONResponse(['error' => 'Forbidden'], Http::STATUS_FORBIDDEN);
 			}
@@ -175,6 +183,8 @@ class BookingDepthController extends Controller {
 	 *                      missing; 503 when OpenRegister is unavailable.
 	 *
 	 * @spec openspec/specs/bookings-recurring-series/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function createSeries(): JSONResponse {
@@ -200,6 +210,11 @@ class BookingDepthController extends Controller {
 			);
 		}
 
+		// security-endpoint-guards REQ-001: the request-supplied administrationId
+		// is what will be stamped on the new AppointmentSeries/Appointment
+		// objects, so checking canAccess() against it here (before the object
+		// exists to fetch) is the correct create-time guard — matches the
+		// convention CBSSubmissionController::create() established.
 		if ($this->context->canAccess($administrationId) === false) {
 			return new JSONResponse(['error' => 'Forbidden'], Http::STATUS_FORBIDDEN);
 		}
@@ -212,6 +227,19 @@ class BookingDepthController extends Controller {
 			$resource = $this->loadResource(resourceId: $resourceId);
 			if ($resource === null) {
 				return new JSONResponse(['error' => 'Resource not found'], Http::STATUS_NOT_FOUND);
+			}
+
+			// security-endpoint-guards REQ-001 hardening: canAccess() above only
+			// proved the caller may act within $administrationId — it does NOT
+			// prove the FETCHED $resource actually belongs to that
+			// administration. Without this check a member of administration A
+			// could pass administrationId=A (their own, so canAccess() passes)
+			// together with a resourceId belonging to administration B and book
+			// appointments against B's resource under A's label — a cross-
+			// tenant IDOR on the Resource object itself.
+			$resourceAdministrationId = (string)($resource['administrationId'] ?? '');
+			if ($resourceAdministrationId !== $administrationId) {
+				return new JSONResponse(['error' => 'Forbidden'], Http::STATUS_FORBIDDEN);
 			}
 
 			$plan = $this->series->planSeries(
@@ -279,7 +307,14 @@ class BookingDepthController extends Controller {
 				Http::STATUS_OK,
 			);
 		} catch (\InvalidArgumentException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			$this->logger->error('BookingDepthController.createSeries failed', ['exception' => $e]);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Unable to create the appointment series'),
+					'error' => 'appointment-series-create-failed',
+				],
+				Http::STATUS_BAD_REQUEST,
+			);
 		} catch (Throwable $e) {
 			$this->logger->error(
 				'BookingDepthController: series creation failed',

--- a/lib/Controller/BookingNotificationController.php
+++ b/lib/Controller/BookingNotificationController.php
@@ -269,6 +269,25 @@ class BookingNotificationController extends Controller {
 	 * @throws OCSForbiddenException When not authorised.
 	 *
 	 * @spec openspec/changes/bookings-notification-triggers/tasks.md#task-11
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 *
+	 * RE-VERIFIED for security-endpoint-guards (Open Question / Risk 3):
+	 * re-read against HEAD before any change. This guard is genuine and
+	 * enforcing — admin bypass, then `AdministrationContextService::canAccess()`
+	 * against the booking's own `administrationId`, throwing on both a
+	 * missing booking and a non-member caller. Its docblock's own history
+	 * note documents a PRIOR bug (`findObject()` — a method that does not
+	 * exist on OpenRegister's ObjectService — silently turning every
+	 * non-admin call into a 403 via the catch-all `\Throwable` arm) that
+	 * was already fixed before this change started; that fix is what the
+	 * audit's "confirmed" note was most likely trailing. No code change
+	 * was needed here — verdict: ALREADY-GUARDED. The `#[NoAdminRequired]`
+	 * (`getBookingTriggers`/`updateBookingTriggers`, both per-object,
+	 * guarded by this method) vs `#[AuthorizedAdminSetting]`
+	 * (`getNotificationMonitor`/`disableAllTriggers`, both instance-wide
+	 * admin CRUD across every administration's data) split on this
+	 * controller was also re-checked and is correct for what each method
+	 * actually does — not a finding.
 	 */
 	private function authorizeBookingAccess(string $bookingId): void {
 		$user = $this->userSession->getUser();

--- a/lib/Controller/BudgetBBVMappingController.php
+++ b/lib/Controller/BudgetBBVMappingController.php
@@ -97,6 +97,8 @@ class BudgetBBVMappingController extends Controller {
 	 * @return JSONResponse {register: string, schema: string, detailRoute: string}
 	 *
 	 * @spec openspec/specs/bookkeeping-waterschappen-bbv-variant/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function index(): JSONResponse {
@@ -104,6 +106,13 @@ class BudgetBBVMappingController extends Controller {
 			return new JSONResponse(['error' => $this->l10n->t('Not logged in')], Http::STATUS_UNAUTHORIZED);
 		}
 
+		// security-endpoint-guards REQ-001 JUSTIFY: this envelope reads no
+		// OpenRegister object — `scope` is derived entirely server-side from
+		// the session user via AdministrationContextService::buildContext()
+		// (never a request-supplied id), and the mapping CRUD itself is
+		// mediated by OpenRegister's own admin-write register permissions
+		// (slice 01), not by this controller. No per-object tenant guard
+		// applies because no tenant-scoped object is read here.
 		return new JSONResponse(
 			[
 				'register' => 'shillinq',
@@ -132,6 +141,8 @@ class BudgetBBVMappingController extends Controller {
 	 * @return JSONResponse {id: string, register: string, schema: string, indexRoute: string}
 	 *
 	 * @spec openspec/specs/bookkeeping-waterschappen-bbv-variant/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function show(string $id): JSONResponse {
@@ -139,6 +150,12 @@ class BudgetBBVMappingController extends Controller {
 			return new JSONResponse(['error' => $this->l10n->t('Not logged in')], Http::STATUS_UNAUTHORIZED);
 		}
 
+		// security-endpoint-guards REQ-001 JUSTIFY: $id is echoed back
+		// unread — no OpenRegister lookup happens in this method (see the
+		// method docblock), so there is no tenant-scoped object here for a
+		// per-object guard to protect. The real BudgetBBVMapping read/write
+		// happens through OpenRegister's own object endpoints (slice 07),
+		// which apply register-level RBAC independently of this route.
 		return new JSONResponse(
 			[
 				'id' => $id,

--- a/lib/Controller/BudgetBBVMappingController.php
+++ b/lib/Controller/BudgetBBVMappingController.php
@@ -106,7 +106,7 @@ class BudgetBBVMappingController extends Controller {
 			return new JSONResponse(['error' => $this->l10n->t('Not logged in')], Http::STATUS_UNAUTHORIZED);
 		}
 
-		// security-endpoint-guards REQ-001 JUSTIFY: this envelope reads no
+		// Security-endpoint-guards REQ-001 JUSTIFY: this envelope reads no
 		// OpenRegister object — `scope` is derived entirely server-side from
 		// the session user via AdministrationContextService::buildContext()
 		// (never a request-supplied id), and the mapping CRUD itself is
@@ -150,7 +150,7 @@ class BudgetBBVMappingController extends Controller {
 			return new JSONResponse(['error' => $this->l10n->t('Not logged in')], Http::STATUS_UNAUTHORIZED);
 		}
 
-		// security-endpoint-guards REQ-001 JUSTIFY: $id is echoed back
+		// Security-endpoint-guards REQ-001 JUSTIFY: $id is echoed back
 		// unread — no OpenRegister lookup happens in this method (see the
 		// method docblock), so there is no tenant-scoped object here for a
 		// per-object guard to protect. The real BudgetBBVMapping read/write

--- a/lib/Controller/CBSSubmissionController.php
+++ b/lib/Controller/CBSSubmissionController.php
@@ -189,9 +189,9 @@ class CBSSubmissionController extends Controller {
 
 		$filters = $this->buildIndexFilters();
 
-		$requestedAdministrationId = (string)($filters['administrationId'] ?? '');
-		if ($requestedAdministrationId !== '') {
-			$accessError = $this->requireAdministrationAccess($requestedAdministrationId);
+		$reqAdministrationId = (string)($filters['administrationId'] ?? '');
+		if ($reqAdministrationId !== '') {
+			$accessError = $this->requireAdministrationAccess(administrationId: $reqAdministrationId);
 			if ($accessError !== null) {
 				return $accessError;
 			}
@@ -199,9 +199,9 @@ class CBSSubmissionController extends Controller {
 
 		return $this->run(
 			action: 'list CBS submissions',
-			compute: function () use ($filters, $requestedAdministrationId): array {
+			compute: function () use ($filters, $reqAdministrationId): array {
 				$submissions = array_map(
-					fn (mixed $row): array => $this->toArray($row),
+					fn (mixed $row): array => $this->toArray(row: $row),
 					$this->objectService()
 						->setRegister($this->register())
 						->setSchema('CBSSubmission')
@@ -210,7 +210,7 @@ class CBSSubmissionController extends Controller {
 
 				$uid = (string)($this->userSession->getUser()?->getUID() ?? '');
 				$isAdmin = ($uid !== '' && $this->groupManager->isAdmin($uid) === true);
-				if ($requestedAdministrationId === '' && $isAdmin === false) {
+				if ($reqAdministrationId === '' && $isAdmin === false) {
 					// No explicit filter, non-admin caller: scope the list to
 					// the caller's own accessible administrations rather than
 					// returning every tenant's submissions. An admin caller
@@ -265,7 +265,7 @@ class CBSSubmissionController extends Controller {
 
 		try {
 			$existing = $this->toArray(
-				$this->objectService()
+				row: $this->objectService()
 					->setRegister($this->register())
 					->setSchema('CBSSubmission')
 					->find($id)
@@ -277,7 +277,7 @@ class CBSSubmissionController extends Controller {
 			);
 		}
 
-		$accessError = $this->requireAdministrationAccess((string)($existing['administrationId'] ?? ''));
+		$accessError = $this->requireAdministrationAccess(administrationId: (string)($existing['administrationId'] ?? ''));
 		if ($accessError !== null) {
 			return $accessError;
 		}
@@ -325,7 +325,7 @@ class CBSSubmissionController extends Controller {
 			return $error;
 		}
 
-		$accessError = $this->requireAdministrationAccess((string)$body['administrationId']);
+		$accessError = $this->requireAdministrationAccess(administrationId: (string)$body['administrationId']);
 		if ($accessError !== null) {
 			return $accessError;
 		}
@@ -336,7 +336,7 @@ class CBSSubmissionController extends Controller {
 		return $this->run(
 			action: 'create CBS submission',
 			compute: fn (): array => $this->toArray(
-				$this->objectService()->saveObject(
+				row: $this->objectService()->saveObject(
 					object: $body,
 					register: $this->register(),
 					schema: 'CBSSubmission',
@@ -377,7 +377,7 @@ class CBSSubmissionController extends Controller {
 
 		try {
 			$existing = $this->toArray(
-				$this->objectService()
+				row: $this->objectService()
 					->setRegister($this->register())
 					->setSchema('CBSSubmission')
 					->find($id)
@@ -389,7 +389,7 @@ class CBSSubmissionController extends Controller {
 			);
 		}
 
-		$accessError = $this->requireAdministrationAccess((string)($existing['administrationId'] ?? ''));
+		$accessError = $this->requireAdministrationAccess(administrationId: (string)($existing['administrationId'] ?? ''));
 		if ($accessError !== null) {
 			return $accessError;
 		}
@@ -414,7 +414,7 @@ class CBSSubmissionController extends Controller {
 		return $this->run(
 			action: 'update CBS submission',
 			compute: fn (): array => $this->toArray(
-				$this->objectService()->saveObject(
+				row: $this->objectService()->saveObject(
 					object: $body,
 					register: $this->register(),
 					schema: 'CBSSubmission',
@@ -453,7 +453,7 @@ class CBSSubmissionController extends Controller {
 
 		try {
 			$existing = $this->toArray(
-				$this->objectService()
+				row: $this->objectService()
 					->setRegister($this->register())
 					->setSchema('CBSSubmission')
 					->find($id)
@@ -465,7 +465,7 @@ class CBSSubmissionController extends Controller {
 			);
 		}
 
-		$accessError = $this->requireAdministrationAccess((string)($existing['administrationId'] ?? ''));
+		$accessError = $this->requireAdministrationAccess(administrationId: (string)($existing['administrationId'] ?? ''));
 		if ($accessError !== null) {
 			return $accessError;
 		}
@@ -523,7 +523,7 @@ class CBSSubmissionController extends Controller {
 
 		try {
 			$existing = $this->toArray(
-				$this->objectService()
+				row: $this->objectService()
 					->setRegister($this->register())
 					->setSchema('CBSSubmission')
 					->find($id)
@@ -535,7 +535,7 @@ class CBSSubmissionController extends Controller {
 			);
 		}
 
-		$accessError = $this->requireAdministrationAccess((string)($existing['administrationId'] ?? ''));
+		$accessError = $this->requireAdministrationAccess(administrationId: (string)($existing['administrationId'] ?? ''));
 		if ($accessError !== null) {
 			return $accessError;
 		}
@@ -599,14 +599,14 @@ class CBSSubmissionController extends Controller {
 	 */
 	private function buildShowPayload(string $id): array {
 		$submission = $this->toArray(
-			$this->objectService()
+			row: $this->objectService()
 				->setRegister($this->register())
 				->setSchema('CBSSubmission')
 				->find($id)
 		);
 
 		$lines = array_map(
-			fn (mixed $row): array => $this->toArray($row),
+			fn (mixed $row): array => $this->toArray(row: $row),
 			$this->objectService()
 				->setRegister($this->register())
 				->setSchema('CBSLine')

--- a/lib/Controller/CBSSubmissionController.php
+++ b/lib/Controller/CBSSubmissionController.php
@@ -30,6 +30,7 @@
  * @link https://conduction.nl
  *
  * @spec openspec/changes/bookkeeping-cbs-bestanden-extended/specs.md
+ * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
  * SPDX-License-Identifier: EUPL-1.2
@@ -41,12 +42,14 @@ namespace OCA\Shillinq\Controller;
 
 use DateTimeImmutable;
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\CBSExportService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -74,6 +77,8 @@ class CBSSubmissionController extends Controller {
 	 * @param IUserSession $userSession The session for the acting user id (auth body-guard).
 	 * @param LoggerInterface $logger Logger for diagnostics (no stack traces to client).
 	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
+	 * @param AdministrationContextService $administrationContext Per-administration IDOR guard (ADR-005 Rule 3).
+	 * @param IGroupManager $groupManager Nextcloud admin bypass for the administration guard.
 	 *
 	 * @return void
 	 */
@@ -84,6 +89,8 @@ class CBSSubmissionController extends Controller {
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
 		private readonly ObjectServiceInterface $objectService,
+		private readonly AdministrationContextService $administrationContext,
+		private readonly IGroupManager $groupManager,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -91,12 +98,16 @@ class CBSSubmissionController extends Controller {
 
 	/**
 	 * Authorization guard — every endpoint requires an authenticated
-	 * Nextcloud user (REQ-CBS-001 / ADR-005). The administration scope is
-	 * validated by the IDOR-safe service layer. This helper is the
-	 * in-body counterpart to #[NoAdminRequired] so gate-7 no-admin-idor /
-	 * gate-9 semantic-auth see the explicit auth posture.
+	 * Nextcloud user (REQ-CBS-001 / ADR-005). This is only the
+	 * authentication half of the guard; per-object administration
+	 * membership is separately enforced by
+	 * {@see requireAdministrationAccess()} on every method that reads or
+	 * mutates a specific CBSSubmission, per ADR-005 Rule 3 / OWASP A01:2021
+	 * (security-endpoint-guards, REQ-001).
 	 *
 	 * @return JSONResponse|null A 401 response when unauthenticated, null when ok.
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
 	private function requireUser(): ?JSONResponse {
 		if ($this->userSession->getUser() === null) {
@@ -110,11 +121,64 @@ class CBSSubmissionController extends Controller {
 	}//end requireUser()
 
 	/**
+	 * Per-object administration-membership guard (REQ-001 / ADR-005 Rule 3).
+	 *
+	 * A `CBSSubmission` belongs to exactly one administration
+	 * (`administrationId`); the caller must have a valid
+	 * `AdministrationMembership` for that administration before reading
+	 * beyond existence-check or mutating the record. Unlike the read-side
+	 * masking convention elsewhere in this app, CBS filings return an
+	 * explicit 403 on denial per this change's spec scenario ("A user
+	 * cannot delete another organization's CBS submission" — REQ-001) since
+	 * the endpoint already discloses the submission's existence via its
+	 * own id in the URL.
+	 *
+	 * A Nextcloud admin bypasses the per-administration check, matching the
+	 * established pattern in `BookingNotificationController::authorizeBookingAccess()`
+	 * — back-office admins legitimately manage every administration's
+	 * filings, and requiring an `AdministrationMembership` for them as well
+	 * would make the admin surface unusable.
+	 *
+	 * @param string $administrationId The administration id the target object belongs to.
+	 *
+	 * @return JSONResponse|null A 403 response when the caller is not a member, null when ok.
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 */
+	private function requireAdministrationAccess(string $administrationId): ?JSONResponse {
+		$uid = (string)($this->userSession->getUser()?->getUID() ?? '');
+		if ($uid !== '' && $this->groupManager->isAdmin($uid) === true) {
+			return null;
+		}
+
+		if ($this->administrationContext->canAccess($administrationId) === false) {
+			return new JSONResponse(
+				['error' => 'cbs-submission-forbidden', 'message' => 'Not authorized to access this CBS submission'],
+				Http::STATUS_FORBIDDEN,
+			);
+		}
+
+		return null;
+	}//end requireAdministrationAccess()
+
+	/**
 	 * GET /api/cbs-submissions — list CBS submissions, optionally filtered.
 	 *
 	 * Query params: `status`, `administrationId`, `periodStart`, `periodEnd`.
 	 *
-	 * @return JSONResponse 200 with `{ submissions: [...] }`.
+	 * Found during this change's per-method code read (beyond the audit's
+	 * originally-named create/update/destroy/generate): this endpoint had
+	 * no per-object scoping either — `requireUser()` only checks
+	 * authentication, so any authenticated caller could list every
+	 * administration's submissions. Fixed here alongside the four named
+	 * findings since REQ-001 applies uniformly to every
+	 * `#[NoAdminRequired]` method, not only the ones the audit enumerated.
+	 *
+	 * @return JSONResponse 200 with `{ submissions: [...] }`; 403 when an
+	 *                      explicit `administrationId` filter names an
+	 *                      administration the caller is not a member of.
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
 	#[NoAdminRequired]
 	public function index(): JSONResponse {
@@ -125,14 +189,46 @@ class CBSSubmissionController extends Controller {
 
 		$filters = $this->buildIndexFilters();
 
+		$requestedAdministrationId = (string)($filters['administrationId'] ?? '');
+		if ($requestedAdministrationId !== '') {
+			$accessError = $this->requireAdministrationAccess($requestedAdministrationId);
+			if ($accessError !== null) {
+				return $accessError;
+			}
+		}
+
 		return $this->run(
 			action: 'list CBS submissions',
-			compute: fn (): array => [
-				'submissions' => $this->objectService()
-					->setRegister($this->register())
-					->setSchema('CBSSubmission')
-					->findAll(['filters' => $filters]),
-			],
+			compute: function () use ($filters, $requestedAdministrationId): array {
+				$submissions = array_map(
+					fn (mixed $row): array => $this->toArray($row),
+					$this->objectService()
+						->setRegister($this->register())
+						->setSchema('CBSSubmission')
+						->findAll(['filters' => $filters])
+				);
+
+				$uid = (string)($this->userSession->getUser()?->getUID() ?? '');
+				$isAdmin = ($uid !== '' && $this->groupManager->isAdmin($uid) === true);
+				if ($requestedAdministrationId === '' && $isAdmin === false) {
+					// No explicit filter, non-admin caller: scope the list to
+					// the caller's own accessible administrations rather than
+					// returning every tenant's submissions. An admin caller
+					// (or an explicit, already-vetted administrationId
+					// filter) sees the unfiltered set — matching
+					// requireAdministrationAccess()'s admin bypass above.
+					$submissions = array_values(
+						array_filter(
+							$submissions,
+							fn (array $row): bool => $this->administrationContext->canAccess(
+								(string)($row['administrationId'] ?? '')
+							)
+						)
+					);
+				}
+
+				return ['submissions' => $submissions];
+			},
 			context: $filters,
 		);
 
@@ -141,9 +237,19 @@ class CBSSubmissionController extends Controller {
 	/**
 	 * GET /api/cbs-submissions/{id} — retrieve a single submission + its lines.
 	 *
+	 * Found during this change's per-method code read (beyond the audit's
+	 * originally-named create/update/destroy/generate): `show()` had the
+	 * same missing-guard shape — any authenticated caller could read
+	 * another organization's statutory filing by id. Fixed alongside the
+	 * four named findings for the same reason as `index()` above.
+	 *
 	 * @param string $id The CBSSubmission id.
 	 *
-	 * @return JSONResponse 200 with `{ submission, lines }`; 400 on bad id; 404 when missing.
+	 * @return JSONResponse 200 with `{ submission, lines }`; 400 on bad id;
+	 *                      403 when the caller is not a member of the
+	 *                      submission's administration; 404 when missing.
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
 	#[NoAdminRequired]
 	public function show(string $id): JSONResponse {
@@ -155,6 +261,25 @@ class CBSSubmissionController extends Controller {
 		$error = $this->validateId(value: $id, label: 'id');
 		if ($error !== null) {
 			return $error;
+		}
+
+		try {
+			$existing = $this->toArray(
+				$this->objectService()
+					->setRegister($this->register())
+					->setSchema('CBSSubmission')
+					->find($id)
+			);
+		} catch (\Throwable $e) {
+			return new JSONResponse(
+				['error' => 'cbs-submission-not-found', 'message' => 'CBS submission not found'],
+				Http::STATUS_NOT_FOUND
+			);
+		}
+
+		$accessError = $this->requireAdministrationAccess((string)($existing['administrationId'] ?? ''));
+		if ($accessError !== null) {
+			return $accessError;
 		}
 
 		return $this->run(
@@ -174,6 +299,8 @@ class CBSSubmissionController extends Controller {
 	 * administrationId, description (optional).
 	 *
 	 * @return JSONResponse 201 on success; 400 on missing required field.
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
 	#[NoAdminRequired]
 	public function create(): JSONResponse {
@@ -198,15 +325,22 @@ class CBSSubmissionController extends Controller {
 			return $error;
 		}
 
+		$accessError = $this->requireAdministrationAccess((string)$body['administrationId']);
+		if ($accessError !== null) {
+			return $accessError;
+		}
+
 		$body['status'] = 'draft';
 		$body['currency'] = ($body['currency'] ?? 'EUR');
 
 		return $this->run(
 			action: 'create CBS submission',
-			compute: fn (): array => (array)$this->objectService()->saveObject(
-				object: $body,
-				register: $this->register(),
-				schema: 'CBSSubmission',
+			compute: fn (): array => $this->toArray(
+				$this->objectService()->saveObject(
+					object: $body,
+					register: $this->register(),
+					schema: 'CBSSubmission',
+				)
 			),
 			context: ['administrationId' => (string)$body['administrationId']],
 			status: Http::STATUS_CREATED,
@@ -223,7 +357,11 @@ class CBSSubmissionController extends Controller {
 	 *
 	 * @param string $id The CBSSubmission id.
 	 *
-	 * @return JSONResponse 200 on update; 400 on bad id; 422 on validation failure.
+	 * @return JSONResponse 200 on update; 400 on bad id; 403 when not a
+	 *                      member of the submission's administration; 422
+	 *                      on validation failure.
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
 	#[NoAdminRequired]
 	public function update(string $id): JSONResponse {
@@ -235,6 +373,25 @@ class CBSSubmissionController extends Controller {
 		$error = $this->validateId(value: $id, label: 'id');
 		if ($error !== null) {
 			return $error;
+		}
+
+		try {
+			$existing = $this->toArray(
+				$this->objectService()
+					->setRegister($this->register())
+					->setSchema('CBSSubmission')
+					->find($id)
+			);
+		} catch (\Throwable $e) {
+			return new JSONResponse(
+				['error' => 'cbs-submission-not-found', 'message' => 'CBS submission not found'],
+				Http::STATUS_NOT_FOUND
+			);
+		}
+
+		$accessError = $this->requireAdministrationAccess((string)($existing['administrationId'] ?? ''));
+		if ($accessError !== null) {
+			return $accessError;
 		}
 
 		$body = $this->jsonBody();
@@ -256,10 +413,12 @@ class CBSSubmissionController extends Controller {
 
 		return $this->run(
 			action: 'update CBS submission',
-			compute: fn (): array => (array)$this->objectService()->saveObject(
-				object: $body,
-				register: $this->register(),
-				schema: 'CBSSubmission',
+			compute: fn (): array => $this->toArray(
+				$this->objectService()->saveObject(
+					object: $body,
+					register: $this->register(),
+					schema: 'CBSSubmission',
+				)
 			),
 			context: ['id' => $id],
 		);
@@ -274,7 +433,11 @@ class CBSSubmissionController extends Controller {
 	 *
 	 * @param string $id The CBSSubmission id.
 	 *
-	 * @return JSONResponse 204 on success; 409 when not in draft state.
+	 * @return JSONResponse 204 on success; 403 when not a member of the
+	 *                      submission's administration; 409 when not in
+	 *                      draft state.
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
 	#[NoAdminRequired]
 	public function destroy(string $id): JSONResponse {
@@ -289,15 +452,22 @@ class CBSSubmissionController extends Controller {
 		}
 
 		try {
-			$existing = $this->objectService()
-				->setRegister($this->register())
-				->setSchema('CBSSubmission')
-				->find($id);
+			$existing = $this->toArray(
+				$this->objectService()
+					->setRegister($this->register())
+					->setSchema('CBSSubmission')
+					->find($id)
+			);
 		} catch (\Throwable $e) {
 			return new JSONResponse(
-				['error' => 'not found', 'message' => 'CBS submission not found'],
+				['error' => 'cbs-submission-not-found', 'message' => 'CBS submission not found'],
 				Http::STATUS_NOT_FOUND
 			);
+		}
+
+		$accessError = $this->requireAdministrationAccess((string)($existing['administrationId'] ?? ''));
+		if ($accessError !== null) {
+			return $accessError;
 		}
 
 		$status = (string)($existing['status'] ?? '');
@@ -335,7 +505,9 @@ class CBSSubmissionController extends Controller {
 	 *
 	 * @param string $id The CBSSubmission id.
 	 *
-	 * @return JSONResponse 200 with the regenerated submission; 400/404/409.
+	 * @return JSONResponse 200 with the regenerated submission; 400/403/404/409.
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
 	#[NoAdminRequired]
 	public function generate(string $id): JSONResponse {
@@ -350,15 +522,22 @@ class CBSSubmissionController extends Controller {
 		}
 
 		try {
-			$existing = $this->objectService()
-				->setRegister($this->register())
-				->setSchema('CBSSubmission')
-				->find($id);
+			$existing = $this->toArray(
+				$this->objectService()
+					->setRegister($this->register())
+					->setSchema('CBSSubmission')
+					->find($id)
+			);
 		} catch (\Throwable $e) {
 			return new JSONResponse(
-				['error' => 'not found', 'message' => 'CBS submission not found'],
+				['error' => 'cbs-submission-not-found', 'message' => 'CBS submission not found'],
 				Http::STATUS_NOT_FOUND
 			);
+		}
+
+		$accessError = $this->requireAdministrationAccess((string)($existing['administrationId'] ?? ''));
+		if ($accessError !== null) {
+			return $accessError;
 		}
 
 		if ((string)($existing['status'] ?? 'draft') !== 'draft') {
@@ -419,15 +598,20 @@ class CBSSubmissionController extends Controller {
 	 * @return array<string,mixed>
 	 */
 	private function buildShowPayload(string $id): array {
-		$submission = $this->objectService()
-			->setRegister($this->register())
-			->setSchema('CBSSubmission')
-			->find($id);
+		$submission = $this->toArray(
+			$this->objectService()
+				->setRegister($this->register())
+				->setSchema('CBSSubmission')
+				->find($id)
+		);
 
-		$lines = $this->objectService()
-			->setRegister($this->register())
-			->setSchema('CBSLine')
-			->findAll(['filters' => ['cbsSubmissionId' => $id]]);
+		$lines = array_map(
+			fn (mixed $row): array => $this->toArray($row),
+			$this->objectService()
+				->setRegister($this->register())
+				->setSchema('CBSLine')
+				->findAll(['filters' => ['cbsSubmissionId' => $id]])
+		);
 
 		return [
 			'submission' => $submission,
@@ -435,6 +619,45 @@ class CBSSubmissionController extends Controller {
 		];
 
 	}//end buildShowPayload()
+
+	/**
+	 * Normalise an OpenRegister ObjectService row (ObjectEntityInterface or
+	 * array) to a plain array<string,mixed>. Every method in this
+	 * controller does array-bracket access on find()/findAll() results
+	 * (`$existing['administrationId']` etc.); the real ADR-084
+	 * `ObjectServiceInterface::find()` contract returns
+	 * `?ObjectEntityInterface` (an object, per
+	 * `OCA\Shillinq\Tests\Unit\Service\Support\ObjectEntityStub` /
+	 * `DuckObjectServiceAdapter`), so a raw object must be unwrapped via
+	 * `jsonSerialize()`/`getObject()` before array access is safe — mirrors
+	 * the same normalisation `CalendarController::toArray()` and
+	 * `BankRuleController::toArray()` already perform.
+	 *
+	 * @param mixed $row Raw row from ObjectService::find()/findAll()/saveObject().
+	 *
+	 * @return array<string,mixed> The row as a plain array (empty array when unusable/null).
+	 */
+	private function toArray(mixed $row): array {
+		if (is_array($row) === true) {
+			return $row;
+		}
+
+		if (is_object($row) === true && method_exists($row, 'jsonSerialize') === true) {
+			$serialized = $row->jsonSerialize();
+			if (is_array($serialized) === true) {
+				return $serialized;
+			}
+		}
+
+		if (is_object($row) === true && method_exists($row, 'getObject') === true) {
+			$inner = $row->getObject();
+			if (is_array($inner) === true) {
+				return $inner;
+			}
+		}
+
+		return [];
+	}//end toArray()
 
 	/**
 	 * Decode the JSON request body into an associative array.

--- a/lib/Controller/CalendarController.php
+++ b/lib/Controller/CalendarController.php
@@ -44,6 +44,8 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
+use OCP\IL10N;
 use OCP\IRequest;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -77,6 +79,8 @@ class CalendarController extends Controller {
 	 * @param AdministrationContextService $context Per-administration IDOR guard (ADR-005).
 	 * @param TransactionalGuard $guard Transaction + row-lock facade (production-wired with IDBConnection).
 	 * @param LoggerInterface $logger Logger for fail-closed diagnostics.
+	 * @param IL10N $l10n Localized user-facing error messages (ADR-050).
+	 * @param IGroupManager $groupManager Nextcloud admin bypass for the booking guard.
 	 */
 	public function __construct(
 		IRequest $request,
@@ -86,6 +90,8 @@ class CalendarController extends Controller {
 		private readonly AdministrationContextService $context,
 		private readonly TransactionalGuard $guard,
 		private readonly LoggerInterface $logger,
+		private readonly IL10N $l10n,
+		private readonly IGroupManager $groupManager,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -223,7 +229,11 @@ class CalendarController extends Controller {
 				end: (string)$this->request->getParam('end', ''),
 			);
 		} catch (InvalidArgumentException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			$this->logger->warning('Shillinq: invalid booking range', ['exception' => $e->getMessage()]);
+			return new JSONResponse(
+				['message' => $this->l10n->t('Invalid start/end range.'), 'error' => 'calendar-invalid-range'],
+				Http::STATUS_BAD_REQUEST,
+			);
 		}
 
 		try {
@@ -293,10 +303,12 @@ class CalendarController extends Controller {
 	 * @param string $calendarId Logical calendar identifier.
 	 *
 	 * @return JSONResponse 201 with the booking; 400 on validation;
-	 *                      404 when calendar missing; 409 on conflict;
-	 *                      503 when OR unavailable.
+	 *                      403 when the caller has no booking rights on the
+	 *                      calendar's administration; 404 when calendar
+	 *                      missing; 409 on conflict; 503 when OR unavailable.
 	 *
 	 * @spec openspec/changes/bookings-resource-calendar/tasks.md#task-3
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
 	#[NoAdminRequired]
 	public function createBooking(string $calendarId = ''): JSONResponse {
@@ -317,6 +329,24 @@ class CalendarController extends Controller {
 
 		$calendarRow = $this->toArray(object: $calendar);
 		$resourceId = (string)($calendarRow['resource'] ?? '');
+
+		// Per-object guard (security-endpoint-guards REQ-001): `requireAuth()`
+		// above only checks authentication. Any authenticated user could
+		// otherwise book any calendar/resource with no ownership check —
+		// the confirmed finding for this method. A booking is only valid
+		// when the caller has a membership in the calendar's own
+		// administration. A Nextcloud admin bypasses this check, matching
+		// `BookingNotificationController::authorizeBookingAccess()`'s
+		// established pattern.
+		$callerUid = (string)($this->context->currentUserId() ?? '');
+		$callerIsAdmin = ($callerUid !== '' && $this->groupManager->isAdmin($callerUid) === true);
+		$calendarAdministrationId = (string)($calendarRow['administrationId'] ?? '');
+		if ($callerIsAdmin === false && $this->context->canAccess($calendarAdministrationId) === false) {
+			return new JSONResponse(
+				['error' => 'calendar-booking-forbidden', 'message' => 'Not authorized to book this calendar'],
+				Http::STATUS_FORBIDDEN,
+			);
+		}
 
 		$title = trim((string)$this->request->getParam('title', ''));
 		$startTime = trim((string)$this->request->getParam('startTime', ''));

--- a/lib/Controller/CalendarController.php
+++ b/lib/Controller/CalendarController.php
@@ -330,56 +330,22 @@ class CalendarController extends Controller {
 		$calendarRow = $this->toArray(object: $calendar);
 		$resourceId = (string)($calendarRow['resource'] ?? '');
 
-		// Per-object guard (security-endpoint-guards REQ-001): `requireAuth()`
-		// above only checks authentication. Any authenticated user could
-		// otherwise book any calendar/resource with no ownership check —
-		// the confirmed finding for this method. A booking is only valid
-		// when the caller has a membership in the calendar's own
-		// administration. A Nextcloud admin bypasses this check, matching
-		// `BookingNotificationController::authorizeBookingAccess()`'s
-		// established pattern.
-		$callerUid = (string)($this->context->currentUserId() ?? '');
-		$callerIsAdmin = ($callerUid !== '' && $this->groupManager->isAdmin($callerUid) === true);
-		$calendarAdministrationId = (string)($calendarRow['administrationId'] ?? '');
-		if ($callerIsAdmin === false && $this->context->canAccess($calendarAdministrationId) === false) {
-			return new JSONResponse(
-				['error' => 'calendar-booking-forbidden', 'message' => 'Not authorized to book this calendar'],
-				Http::STATUS_FORBIDDEN,
-			);
+		$authError = $this->authorizeBookingCreation(calendarRow: $calendarRow);
+		if ($authError !== null) {
+			return $authError;
 		}
 
-		$title = trim((string)$this->request->getParam('title', ''));
-		$startTime = trim((string)$this->request->getParam('startTime', ''));
-		$endTime = trim((string)$this->request->getParam('endTime', ''));
-		$attendee = trim((string)$this->request->getParam('attendee', ''));
-		$status = trim((string)$this->request->getParam('status', 'pending'));
-		$override = filter_var($this->request->getParam('overrideConflict', false), FILTER_VALIDATE_BOOLEAN);
-
-		if ($title === '' || $startTime === '' || $endTime === '' || $attendee === '') {
-			return new JSONResponse(
-				['error' => 'title, startTime, endTime and attendee are required'],
-				Http::STATUS_BAD_REQUEST,
-			);
+		$parsed = $this->parseBookingRequest();
+		if ($parsed instanceof JSONResponse) {
+			return $parsed;
 		}
 
-		if (in_array($status, ['pending', 'confirmed', 'cancelled'], true) === false) {
-			return new JSONResponse(['error' => 'status must be pending, confirmed or cancelled'], Http::STATUS_BAD_REQUEST);
-		}
-
-		try {
-			$start = (new DateTimeImmutable($startTime))->setTimezone(new DateTimeZone('UTC'));
-			$end = (new DateTimeImmutable($endTime))->setTimezone(new DateTimeZone('UTC'));
-		} catch (\Throwable) {
-			return new JSONResponse(['error' => 'startTime and endTime must be ISO 8601 timestamps'], Http::STATUS_BAD_REQUEST);
-		}
-
-		$durationSeconds = ($end->getTimestamp() - $start->getTimestamp());
-		if ($durationSeconds < (ConflictDetectionService::MIN_DURATION_MINUTES * 60)) {
-			return new JSONResponse(
-				['error' => 'Booking duration must be at least ' . ConflictDetectionService::MIN_DURATION_MINUTES . ' minutes'],
-				Http::STATUS_BAD_REQUEST,
-			);
-		}
+		$title = $parsed['title'];
+		$attendee = $parsed['attendee'];
+		$status = $parsed['status'];
+		$override = $parsed['override'];
+		$start = $parsed['start'];
+		$end = $parsed['end'];
 
 		if ($this->settings->isOpenRegisterAvailable() === false) {
 			return new JSONResponse(['error' => 'OpenRegister unavailable'], Http::STATUS_SERVICE_UNAVAILABLE);
@@ -458,6 +424,96 @@ class CalendarController extends Controller {
 		}//end try
 
 	}//end createBooking()
+
+	/**
+	 * Per-object booking-creation guard (security-endpoint-guards REQ-001):
+	 * `requireAuth()` in `createBooking()` only checks authentication — any
+	 * authenticated user could otherwise book any calendar/resource with no
+	 * ownership check, the confirmed finding for this method. A booking is
+	 * only valid when the caller has a membership in the calendar's own
+	 * administration. A Nextcloud admin bypasses this check, matching
+	 * `BookingNotificationController::authorizeBookingAccess()`'s
+	 * established pattern. Extracted out of `createBooking()` (rather than
+	 * inlined there) to keep that method's NPath complexity under this
+	 * app's threshold (issue #506) — the branching moves, the check itself
+	 * does not change.
+	 *
+	 * @param array<string,mixed> $calendarRow The fetched calendar row.
+	 *
+	 * @return JSONResponse|null 403 response when not authorized to book
+	 *                           this calendar, null when the caller may.
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 */
+	private function authorizeBookingCreation(array $calendarRow): ?JSONResponse {
+		$callerUid = (string)($this->context->currentUserId() ?? '');
+		$callerIsAdmin = ($callerUid !== '' && $this->groupManager->isAdmin($callerUid) === true);
+		$calendarAdministrationId = (string)($calendarRow['administrationId'] ?? '');
+		if ($callerIsAdmin === false && $this->context->canAccess($calendarAdministrationId) === false) {
+			return new JSONResponse(
+				['error' => 'calendar-booking-forbidden', 'message' => 'Not authorized to book this calendar'],
+				Http::STATUS_FORBIDDEN,
+			);
+		}
+
+		return null;
+	}//end authorizeBookingCreation()
+
+	/**
+	 * Parse and validate the `createBooking()` request body: required
+	 * fields present, `status` in the allowed set, `startTime`/`endTime`
+	 * parseable ISO 8601 timestamps, and the resulting duration at least
+	 * `ConflictDetectionService::MIN_DURATION_MINUTES`. Extracted out of
+	 * `createBooking()` (rather than inlined there) to keep that method's
+	 * NPath complexity under this app's threshold (issue #506) — the
+	 * validation moves, none of the checks change.
+	 *
+	 * @return array{title:string,attendee:string,status:string,override:bool,start:DateTimeImmutable,end:DateTimeImmutable}|JSONResponse
+	 *         The validated fields, or a 400 JSONResponse on validation failure.
+	 */
+	private function parseBookingRequest(): array|JSONResponse {
+		$title = trim((string)$this->request->getParam('title', ''));
+		$startTime = trim((string)$this->request->getParam('startTime', ''));
+		$endTime = trim((string)$this->request->getParam('endTime', ''));
+		$attendee = trim((string)$this->request->getParam('attendee', ''));
+		$status = trim((string)$this->request->getParam('status', 'pending'));
+		$override = filter_var($this->request->getParam('overrideConflict', false), FILTER_VALIDATE_BOOLEAN);
+
+		if ($title === '' || $startTime === '' || $endTime === '' || $attendee === '') {
+			return new JSONResponse(
+				['error' => 'title, startTime, endTime and attendee are required'],
+				Http::STATUS_BAD_REQUEST,
+			);
+		}
+
+		if (in_array($status, ['pending', 'confirmed', 'cancelled'], true) === false) {
+			return new JSONResponse(['error' => 'status must be pending, confirmed or cancelled'], Http::STATUS_BAD_REQUEST);
+		}
+
+		try {
+			$start = (new DateTimeImmutable($startTime))->setTimezone(new DateTimeZone('UTC'));
+			$end = (new DateTimeImmutable($endTime))->setTimezone(new DateTimeZone('UTC'));
+		} catch (\Throwable) {
+			return new JSONResponse(['error' => 'startTime and endTime must be ISO 8601 timestamps'], Http::STATUS_BAD_REQUEST);
+		}
+
+		$durationSeconds = ($end->getTimestamp() - $start->getTimestamp());
+		if ($durationSeconds < (ConflictDetectionService::MIN_DURATION_MINUTES * 60)) {
+			return new JSONResponse(
+				['error' => 'Booking duration must be at least ' . ConflictDetectionService::MIN_DURATION_MINUTES . ' minutes'],
+				Http::STATUS_BAD_REQUEST,
+			);
+		}
+
+		return [
+			'title' => $title,
+			'attendee' => $attendee,
+			'status' => $status,
+			'override' => $override,
+			'start' => $start,
+			'end' => $end,
+		];
+	}//end parseBookingRequest()
 
 	/**
 	 * Require an authenticated user (the controller is #[NoAdminRequired]

--- a/lib/Controller/CashflowExportController.php
+++ b/lib/Controller/CashflowExportController.php
@@ -84,6 +84,8 @@ class CashflowExportController extends Controller {
 	 * @return DataDownloadResponse|JSONResponse The PDF download, or a JSON error envelope.
 	 *
 	 * @spec openspec/specs/bookkeeping-cashflow-13wk/spec.md#req-cf-016
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function exportPdf(): DataDownloadResponse|JSONResponse {
@@ -91,6 +93,12 @@ class CashflowExportController extends Controller {
 			return new JSONResponse(['error' => 'Authentication required'], Http::STATUS_UNAUTHORIZED);
 		}
 
+		// security-endpoint-guards REQ-001 JUSTIFY: this endpoint takes NO
+		// caller-supplied object identifier — buildHorizonExport() resolves
+		// the forecast horizon entirely from the authenticated caller's own
+		// AdministrationMembership set (REQ-MA-001). There is no request-
+		// supplied id to check against another tenant's data, so no
+		// per-object guard applies beyond the authentication check above.
 		try {
 			$export = $this->exportService->buildHorizonExport();
 		} catch (Throwable $e) {

--- a/lib/Controller/CashflowExportController.php
+++ b/lib/Controller/CashflowExportController.php
@@ -93,7 +93,7 @@ class CashflowExportController extends Controller {
 			return new JSONResponse(['error' => 'Authentication required'], Http::STATUS_UNAUTHORIZED);
 		}
 
-		// security-endpoint-guards REQ-001 JUSTIFY: this endpoint takes NO
+		// Security-endpoint-guards REQ-001 JUSTIFY: this endpoint takes NO
 		// caller-supplied object identifier — buildHorizonExport() resolves
 		// the forecast horizon entirely from the authenticated caller's own
 		// AdministrationMembership set (REQ-MA-001). There is no request-

--- a/lib/Controller/ComplianceExportController.php
+++ b/lib/Controller/ComplianceExportController.php
@@ -55,6 +55,7 @@ use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
 use OCP\IGroupManager;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
@@ -92,6 +93,7 @@ class ComplianceExportController extends Controller {
 	 *                                      REQ-RAP-005 scenario 3
 	 *                                      export-of-export logging.
 	 * @param LoggerInterface $logger Logger (no PII).
+	 * @param IL10N $l10n Translation service for ADR-050 error-response messages.
 	 *
 	 * @return void
 	 */
@@ -102,6 +104,7 @@ class ComplianceExportController extends Controller {
 		private readonly IGroupManager $groupManager,
 		private readonly ContainerInterface $container,
 		private readonly LoggerInterface $logger,
+		private readonly IL10N $l10n,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -116,6 +119,8 @@ class ComplianceExportController extends Controller {
 	 *                  403 non-auditor; 500 without stack trace.
 	 *
 	 * @spec openspec/specs/bookkeeping-rekenkamer-audit-pack/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function export(): Response {
@@ -154,7 +159,14 @@ class ComplianceExportController extends Controller {
 				actorFilter: $actorFilter,
 			);
 		} catch (RuntimeException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			$this->logger->error('ComplianceExportController.export failed', ['exception' => $e]);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Unable to generate the compliance export'),
+					'error' => 'compliance-export-invalid-request',
+				],
+				Http::STATUS_BAD_REQUEST,
+			);
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'ComplianceExportController: failed to generate export',

--- a/lib/Controller/DBAController.php
+++ b/lib/Controller/DBAController.php
@@ -39,13 +39,16 @@ use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Enums\DBAConstants;
 use OCA\Shillinq\Guard\DBAOpdrachtGuard;
 use OCA\Shillinq\Guard\DBAScoreCalculator;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\DBAVbarMonitorService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\IAppConfig;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
@@ -78,6 +81,8 @@ class DBAController extends Controller {
 	 * @param DBAOpdrachtGuard $assignmentGuard Save-precondition guard.
 	 * @param DBAVbarMonitorService $vbarMonitor VBAR monitor service.
 	 * @param LoggerInterface $logger Logger.
+	 * @param AdministrationContextService $administrationContext Per-administration IDOR guard (ADR-005 Rule 3).
+	 * @param IGroupManager $groupManager Nextcloud admin bypass for the administration guard.
 	 */
 	public function __construct(
 		IRequest $request,
@@ -88,6 +93,8 @@ class DBAController extends Controller {
 		private readonly DBAOpdrachtGuard $assignmentGuard,
 		private readonly DBAVbarMonitorService $vbarMonitor,
 		private readonly LoggerInterface $logger,
+		private readonly AdministrationContextService $administrationContext,
+		private readonly IGroupManager $groupManager,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -352,6 +359,7 @@ class DBAController extends Controller {
 	 * @return JSONResponse The updated opdracht.
 	 *
 	 * @spec openspec/specs/dba-compliance-marker/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
 	#[NoAdminRequired]
 	public function setTussenkomstMode(): JSONResponse {
@@ -686,28 +694,61 @@ class DBAController extends Controller {
 
 	/**
 	 * Guard per-object authorization. The currently active user MUST belong to the
-	 * object's administrationId — IDOR-protection per ADR-005.
+	 * object's administrationId — IDOR-protection per ADR-005 Rule 3.
 	 *
-	 * Stub: when no administration-membership service is wired (yet), we log and
-	 * permit; the production implementation calls an `AdministrationMembership`
-	 * service.
+	 * Previously a documented stub that logged and unconditionally permitted
+	 * every caller regardless of membership (security-endpoint-guards,
+	 * STUB verdict — flagged because a mechanical scan for a
+	 * `ensure*`/`authorize*`/`require*`-shaped call cannot tell a real
+	 * guard from one that never denies). Now enforces via
+	 * `AdministrationContextService::canAccess()`, the same membership seam
+	 * `BookingNotificationController::authorizeBookingAccess()` already
+	 * uses, and throws on denial instead of merely logging.
 	 *
 	 * @param array<string,mixed> $assignment The fetched object.
 	 *
 	 * @return void
+	 *
+	 * @throws OCSForbiddenException When unauthenticated or not a member of
+	 *                               the object's administration.
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
 	private function ensureAdministrationAccess(array $assignment): void {
 		$administrationId = (string)($assignment['administrationId'] ?? '');
 		$user = $this->userSession->getUser();
 		if ($user === null) {
 			$this->logger->warning('DBA controller: anonymous request rejected');
+			throw new OCSForbiddenException('Authentication required.');
+		}
+
+		// A Nextcloud admin bypasses the membership check, matching the
+		// established pattern in
+		// `BookingNotificationController::authorizeBookingAccess()` — the
+		// admin account carries no `AdministrationMembership` of its own by
+		// default (tests/e2e/ci-seed.sh), so without this bypass an admin
+		// could not manage any administration's DBA records.
+		if ($this->groupManager->isAdmin($user->getUID()) === true) {
 			return;
 		}
 
-		// Real check would call AdministrationMembership::isMember($user, $administrationId).
-		// Until the implementation cycle wires it, we log the guarded access.
+		// An absent/empty administrationId must DENY, never skip the check
+		// — canAccess('') already returns false, but the explicit check
+		// keeps that invariant visible at the call site rather than
+		// relying on a side-effect of the service's own input validation.
+		if ($administrationId === '' || $this->administrationContext->canAccess($administrationId) === false) {
+			$this->logger->warning(
+				'DBA controller: administration access denied',
+				[
+					'user' => $user->getUID(),
+					'administrationId' => $administrationId,
+				]
+			);
+			throw new OCSForbiddenException('Not authorized to access this administration.');
+		}
+
 		$this->logger->debug(
-			'DBA controller: administration access',
+			'DBA controller: administration access granted',
 			[
 				'user' => $user->getUID(),
 				'administrationId' => $administrationId,

--- a/lib/Controller/DBAController.php
+++ b/lib/Controller/DBAController.php
@@ -68,6 +68,21 @@ use Throwable;
  * @SuppressWarnings(PHPMD.ElseExpression)           Pre-existing style debt (issue
  *     #506): early-return refactor deferred pending full behavioral
  *     verification of each branch.
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)   security-endpoint-guards
+ *     REQ-001: this change adds `AdministrationContextService` (the
+ *     per-object tenant guard closing the cross-tenant IDOR on
+ *     ensureAdministrationAccess()) and its `IGroupManager` admin-bypass
+ *     collaborator, pushing coupling from 16 to 19 — one over this app's
+ *     already-raised threshold (13->19, issue #506). Removing either
+ *     collaborator removes the guard, so this is not a rule misfire to
+ *     work around; it is the real, minimal cost of the fix. Seven
+ *     controllers now duplicate the same `groupManager->isAdmin()`
+ *     bypass check (BookingNotificationController, CBSSubmissionController,
+ *     ComplianceExportController, CalendarController, DBAController,
+ *     InventoryMobileScannerController, InventoryScanController);
+ *     centralising it into `AdministrationContextService` would remove
+ *     this collaborator here too, but is a cross-cutting refactor left
+ *     for a dedicated follow-up rather than folded into this security fix.
  */
 class DBAController extends Controller {
 	/**

--- a/lib/Controller/DeadlineCalendarSettingsController.php
+++ b/lib/Controller/DeadlineCalendarSettingsController.php
@@ -76,6 +76,8 @@ class DeadlineCalendarSettingsController extends Controller {
 	 * @return JSONResponse `{categories: {filing: {enabled, leadDays}, …}}`.
 	 *
 	 * @spec openspec/specs/compliance-deadline-calendar/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function index(): JSONResponse {
@@ -87,6 +89,11 @@ class DeadlineCalendarSettingsController extends Controller {
 			);
 		}
 
+		// security-endpoint-guards REQ-001 JUSTIFY: $userId is resolved from
+		// the session ONLY (see class docblock) — no user id is ever accepted
+		// from the request, so there is no other tenant's object this
+		// endpoint could be pointed at. Cross-user access is structurally
+		// impossible, not merely checked.
 		$userId = $user->getUID();
 		$categories = [];
 		foreach (ComplianceDeadlineCalendarService::CATEGORIES as $category) {
@@ -110,6 +117,8 @@ class DeadlineCalendarSettingsController extends Controller {
 	 * @return JSONResponse The saved settings (same shape as index()).
 	 *
 	 * @spec openspec/specs/compliance-deadline-calendar/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function update(): JSONResponse {
@@ -121,6 +130,10 @@ class DeadlineCalendarSettingsController extends Controller {
 			);
 		}
 
+		// security-endpoint-guards REQ-001 JUSTIFY: writes ONLY the session
+		// user's own preferences — no user id parameter exists on this
+		// endpoint (see class docblock), so cross-user mutation (IDOR) is
+		// structurally impossible rather than merely guarded.
 		$userId = $user->getUID();
 		$categories = $this->request->getParam('categories');
 		if (is_array($categories) === false) {

--- a/lib/Controller/DeadlineCalendarSettingsController.php
+++ b/lib/Controller/DeadlineCalendarSettingsController.php
@@ -89,7 +89,7 @@ class DeadlineCalendarSettingsController extends Controller {
 			);
 		}
 
-		// security-endpoint-guards REQ-001 JUSTIFY: $userId is resolved from
+		// Security-endpoint-guards REQ-001 JUSTIFY: $userId is resolved from
 		// the session ONLY (see class docblock) — no user id is ever accepted
 		// from the request, so there is no other tenant's object this
 		// endpoint could be pointed at. Cross-user access is structurally
@@ -130,7 +130,7 @@ class DeadlineCalendarSettingsController extends Controller {
 			);
 		}
 
-		// security-endpoint-guards REQ-001 JUSTIFY: writes ONLY the session
+		// Security-endpoint-guards REQ-001 JUSTIFY: writes ONLY the session
 		// user's own preferences — no user id parameter exists on this
 		// endpoint (see class docblock), so cross-user mutation (IDOR) is
 		// structurally impossible rather than merely guarded.

--- a/lib/Controller/DunningController.php
+++ b/lib/Controller/DunningController.php
@@ -43,15 +43,19 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use DateTimeImmutable;
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\BIKStaffelCalculator;
 use OCA\Shillinq\Service\Dunning\IncassoDossierComposer;
 use OCA\Shillinq\Service\DunningRunService;
+use OCA\Shillinq\Util\ObjectIdentifier;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IAppConfig;
+use OCP\IL10N;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
@@ -76,6 +80,12 @@ class DunningController extends Controller {
 	 * @param IncassoDossierComposer $dossier Stage-5 dossier composer.
 	 * @param AdministrationContextService $context Admin-scope context.
 	 * @param LoggerInterface $logger Logger.
+	 * @param IAppConfig $appConfig App config for the register slug (security-endpoint-guards).
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per
+	 *                                              ADR-084 — used to fetch a DunningPauseDispute
+	 *                                              by id so its OWN administrationId can be
+	 *                                              checked (security-endpoint-guards REQ-001).
+	 * @param IL10N $l10n Localized error messages (ADR-050).
 	 */
 	public function __construct(
 		IRequest $request,
@@ -84,6 +94,9 @@ class DunningController extends Controller {
 		private readonly IncassoDossierComposer $dossier,
 		private readonly AdministrationContextService $context,
 		private readonly LoggerInterface $logger,
+		private readonly IAppConfig $appConfig,
+		private readonly ObjectServiceInterface $objectService,
+		private readonly IL10N $l10n,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -199,6 +212,10 @@ class DunningController extends Controller {
 	 *                      409 when the invoice is paused or admin-error detected.
 	 *
 	 * @spec openspec/changes/bookkeeping-credit-control-dunning/tasks.md#task-16
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 *
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function executeRun(): JSONResponse {
@@ -234,8 +251,14 @@ class DunningController extends Controller {
 		try {
 			$persisted = $this->runs->executeStage(administrationId: $administrationId, params: $params);
 		} catch (\Throwable $e) {
-			$this->logger->info('Shillinq: executeRun rejected: ' . $e->getMessage());
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_CONFLICT);
+			$this->logger->error('DunningController.executeRun failed', ['exception' => $e]);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Unable to execute the dunning run'),
+					'error' => 'dunning-run-execution-failed',
+				],
+				Http::STATUS_CONFLICT,
+			);
 		}
 
 		return new JSONResponse($persisted, Http::STATUS_CREATED);
@@ -314,6 +337,10 @@ class DunningController extends Controller {
 	 * @return JSONResponse 200 with the updated pause; 404 when not found.
 	 *
 	 * @spec openspec/changes/bookkeeping-credit-control-dunning/tasks.md#task-17
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 *
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function resumePause(string $pauseId): JSONResponse {
@@ -341,6 +368,25 @@ class DunningController extends Controller {
 			return new JSONResponse(['error' => 'Administration not found'], Http::STATUS_NOT_FOUND);
 		}
 
+		// GUARD (ownership/tenant) — security-endpoint-guards REQ-001. The
+		// check above only confirms the CALLER belongs to the request-
+		// supplied administration_id; it never confirms the
+		// DunningPauseDispute named by $pauseId actually belongs to that
+		// administration. DunningRunService::resumePause() fetches the
+		// pause purely by id and never reads its own $administrationId
+		// parameter (see that method's own
+		// @SuppressWarnings(PHPMD.UnusedFormalParameter) note) — without
+		// this check, a member of ANY administration could resume/expire
+		// another organisation's dunning pause, and read its details
+		// (reason, evidenceRefs), by guessing/enumerating its id.
+		$existingPause = $this->fetchDunningPauseDispute(pauseId: $pauseId);
+		$pauseAdministrationId = (string)($existingPause['administrationId'] ?? '');
+		if ($existingPause === null || $this->context->canAccess(administrationId: $pauseAdministrationId) === false) {
+			// Masked 404 — matches the sibling not-found response above so
+			// the existence of another tenant's pause is never disclosed.
+			return new JSONResponse(['error' => 'Dunning pause not found'], Http::STATUS_NOT_FOUND);
+		}
+
 		$resolution = (string)$this->request->getParam('resolution', 'resolve');
 		$partial = $this->request->getParam('partialSettlement');
 		if (in_array($resolution, ['resolve', 'expire'], true) === false) {
@@ -360,8 +406,14 @@ class DunningController extends Controller {
 				partialSettlement: $partialSettlement,
 			);
 		} catch (\Throwable $e) {
-			$this->logger->info('Shillinq: resumePause failed: ' . $e->getMessage());
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+			$this->logger->error('DunningController.resumePause failed', ['exception' => $e]);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Unable to resume the dunning pause'),
+					'error' => 'dunning-pause-not-found',
+				],
+				Http::STATUS_NOT_FOUND,
+			);
 		}
 
 		return new JSONResponse($persisted, Http::STATUS_OK);
@@ -566,4 +618,45 @@ class DunningController extends Controller {
 			Http::STATUS_OK
 		);
 	}//end transfer()
+
+	/**
+	 * Fetch a DunningPauseDispute by id via the real ObjectService API, so
+	 * its OWN administrationId can be checked before resumePause() mutates
+	 * it (security-endpoint-guards REQ-001 — see resumePause() above).
+	 *
+	 * @param string $pauseId The pause record id.
+	 *
+	 * @return array<string,mixed>|null The record, or null when genuinely absent.
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 */
+	private function fetchDunningPauseDispute(string $pauseId): ?array {
+		try {
+			$scoped = $this->objectService
+				->setRegister($this->register())
+				->setSchema('DunningPauseDispute');
+		} catch (\Throwable $e) {
+			$this->logger->error(
+				'DunningController.resumePause: failed to scope ObjectService for DunningPauseDispute',
+				['exception' => $e]
+			);
+			return null;
+		}
+
+		return ObjectIdentifier::findOne(scoped: $scoped, id: $pauseId);
+	}//end fetchDunningPauseDispute()
+
+	/**
+	 * Resolve the configured OpenRegister register slug, defaulting to 'shillinq'.
+	 *
+	 * @return string
+	 */
+	private function register(): string {
+		$register = $this->appConfig->getValueString(Application::APP_ID, 'register', 'shillinq');
+		if ($register === '') {
+			return 'shillinq';
+		}
+
+		return $register;
+	}//end register()
 }//end class

--- a/lib/Controller/FinancialDashboardController.php
+++ b/lib/Controller/FinancialDashboardController.php
@@ -9,14 +9,21 @@
  * /api/dashboard/financial-summary returns the KPI bag (turnover, margin,
  * open debtors/creditors, billable hours, all-time cash position) with
  * previous-period trend values. Both endpoints are available to any
- * authenticated user (#[NoAdminRequired]); all reads are delegated to
- * OpenRegister's ObjectService, which enforces RBAC and multitenancy
- * (ADR-005, ADR-022), so the endpoints expose exactly the objects the user
- * could already fetch through /apps/openregister/api/objects — computed
- * server-side over ALL matching objects instead of the client's 2000-object
- * truncation. There is no create/update/delete route and no client-supplied
- * object identifier (no IDOR surface); the only inputs are the optional
- * from/to date bounds, which are format-validated before use.
+ * authenticated user (#[NoAdminRequired]). There is no create/update/delete
+ * route and no client-supplied object identifier (no per-object IDOR
+ * surface); the only inputs are the optional from/to date bounds, which are
+ * format-validated before use.
+ *
+ * ⚠️ (security-endpoint-guards REQ-001) This class previously claimed reads
+ * were scoped by "OpenRegister's ObjectService, which enforces RBAC and
+ * multitenancy" — that claim did not hold: `FinancialDashboardService::
+ * fetchSchema()` issues an unfiltered `findAll([])` per schema, with no
+ * administration/tenant scope at all. `respond()` below now rejects a
+ * caller with zero `AdministrationMembership` records; the deeper fix (a
+ * per-row administration scope on every fetched schema, blocked on `GLLine`
+ * carrying no `administrationId` property — see the guard's own comment in
+ * `respond()`) requires a `FinancialDashboardService` change tracked as
+ * follow-up work, not delivered by this class alone.
  *
  * @category Controller
  * @package  OCA\Shillinq\Controller
@@ -102,6 +109,8 @@ class FinancialDashboardController extends Controller {
 	 * @return JSONResponse The series payload.
 	 *
 	 * @spec openspec/specs/financial-dashboard-graphs/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function series(): JSONResponse {
@@ -125,6 +134,8 @@ class FinancialDashboardController extends Controller {
 	 * @return JSONResponse The summary payload.
 	 *
 	 * @spec openspec/specs/financial-dashboard-graphs/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function summary(): JSONResponse {
@@ -133,11 +144,14 @@ class FinancialDashboardController extends Controller {
 
 	/**
 	 * Shared request handling for both endpoints: authentication gate,
-	 * from/to validation, service dispatch and the no-stack-trace 500 path.
+	 * administration-membership gate, from/to validation, service dispatch
+	 * and the no-stack-trace 500 path.
 	 *
 	 * @param string $endpoint Either 'series' or 'summary'.
 	 *
 	 * @return JSONResponse The endpoint payload or an error envelope.
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
 	private function respond(string $endpoint): JSONResponse {
 		// Authentication gate — the NC SecurityMiddleware already rejects
@@ -148,6 +162,32 @@ class FinancialDashboardController extends Controller {
 			return new JSONResponse(
 				['error' => 'Not authenticated'],
 				Http::STATUS_UNAUTHORIZED
+			);
+		}
+
+		// GUARD (security-endpoint-guards REQ-001): FinancialDashboardService
+		// aggregates GLTransaction/GLLine/Account/UrenRegistratie/ARInvoice/
+		// APTransaction across ALL matching objects with no per-administration
+		// filter at all (verified by reading FinancialDashboardService::
+		// fetchSchema() — every read is an unfiltered findAll([])). The
+		// docblock's claim that "reads are delegated to OpenRegister's
+		// ObjectService, which enforces RBAC and multitenancy" does not hold in
+		// practice: several of the schemas involved (GLLine in particular —
+		// see tests/Unit/Service/SpendAnalyticsServiceTest.php::
+		// testGlBackedViewsCarryNoAdministrationFilterYet) carry no
+		// administrationId property at all, so a full per-row scope cannot be
+		// added without a FinancialDashboardService change (denormalising
+		// administrationId onto GLLine + a backfill) that is out of this
+		// batch's file scope. This check closes the sharpest sub-case in the
+		// meantime: an authenticated caller with ZERO AdministrationMembership
+		// records must not see the platform-wide aggregate of every tenant's
+		// turnover/margin/cashflow. Full cross-tenant row-level scoping for a
+		// user who DOES belong to one administration but not another remains
+		// open — tracked as follow-up work, not silently declared fixed here.
+		if ($this->context->accessibleAdministrationIds() === []) {
+			return new JSONResponse(
+				['error' => 'No accessible administration'],
+				Http::STATUS_FORBIDDEN
 			);
 		}
 

--- a/lib/Controller/GRIRReconciliationController.php
+++ b/lib/Controller/GRIRReconciliationController.php
@@ -46,6 +46,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -72,6 +73,7 @@ class GRIRReconciliationController extends Controller {
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope (ADR-005).
 	 * @param IUserSession $userSession User-session guard.
 	 * @param LoggerInterface $logger Logger (no stack traces to the client).
+	 * @param IL10N $l10n Localized user-facing error messages (ADR-050).
 	 *
 	 * @return void
 	 *
@@ -84,6 +86,7 @@ class GRIRReconciliationController extends Controller {
 		private readonly AdministrationContextService $administrationContext,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly IL10N $l10n,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -103,7 +106,17 @@ class GRIRReconciliationController extends Controller {
 	 *                      validation; 401 anonymous; 404 cross-tenant; 500
 	 *                      without a stack trace.
 	 *
+	 * Re-verified for security-endpoint-guards (REQ-001): the
+	 * `AdministrationContextService::canAccess()` masked-404 guard below was
+	 * already present and enforcing before this change — a false positive of
+	 * the mechanical `hydra-gate-no-admin-idor` scan, which only recognises
+	 * guard calls named `authorize*`/`require*`/`ensure*` and does not match
+	 * `canAccess(`. No guard change was needed; the fix in this change is the
+	 * ADR-050 error-message leak below (REQ-003).
+	 *
 	 * @spec openspec/specs/revive-gl-tax-capabilities/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function saldo(): JSONResponse {
@@ -135,7 +148,25 @@ class GRIRReconciliationController extends Controller {
 				return new JSONResponse(['error' => 'Administration not found'], Http::STATUS_NOT_FOUND);
 			}
 
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			// ADR-050 (security-endpoint-guards REQ-003): the raw exception
+			// message used to reach the client directly here; it now goes only
+			// to the server-side log, and the client gets a stable slug + a
+			// localized message.
+			$this->logger->error(
+				'GRIRReconciliationController: invalid request for the GR/IR saldo',
+				[
+					'administrationId' => $administrationId,
+					'periodId' => $periodId,
+					'exception' => $e->getMessage(),
+				]
+			);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Invalid request for the GR/IR saldo.'),
+					'error' => 'grir-saldo-invalid-request',
+				],
+				Http::STATUS_BAD_REQUEST
+			);
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'GRIRReconciliationController: failed to compute the GR/IR saldo',

--- a/lib/Controller/GoodsReceiptNoteController.php
+++ b/lib/Controller/GoodsReceiptNoteController.php
@@ -94,7 +94,17 @@ class GoodsReceiptNoteController extends Controller {
 	 *                      401 anonymous; 404 on cross-tenant; 500 without
 	 *                      stack trace.
 	 *
+	 * Re-verified for security-endpoint-guards (REQ-001): the
+	 * `AdministrationContextService::canAccess()` masked-404 guard below was
+	 * already present and enforcing before this change — a mechanical
+	 * `hydra-gate-no-admin-idor` false positive (the scan only recognises
+	 * guard calls named `authorize*`/`require*`/`ensure*` and does not match
+	 * `canAccess(`). `GoodsReceiptNoteService::createGRN()` also re-checks
+	 * access. No guard change needed.
+	 *
 	 * @spec openspec/changes/bookkeeping-purchase-order-3way-04-goods-receipt-note/tasks.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function create(): JSONResponse {
@@ -155,7 +165,18 @@ class GoodsReceiptNoteController extends Controller {
 	 *                      401 anonymous; 404 cross-tenant or missing GRN/PO
 	 *                      line.
 	 *
+	 * Re-verified for security-endpoint-guards (REQ-001): the
+	 * `AdministrationContextService::canAccess()` masked-404 guard below was
+	 * already present and enforcing before this change — a mechanical
+	 * `hydra-gate-no-admin-idor` false positive. `GoodsReceiptNoteService::
+	 * addGRNLine()` additionally scopes the GRN lookup by `id` AND
+	 * `administrationId` together, so a caller cannot reach another
+	 * administration's GRN even by supplying an id they guessed. No guard
+	 * change needed.
+	 *
 	 * @spec openspec/changes/bookkeeping-purchase-order-3way-04-goods-receipt-note/tasks.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function addLine(string $id): JSONResponse {
@@ -216,7 +237,17 @@ class GoodsReceiptNoteController extends Controller {
 	 *                      anonymous; 404 cross-tenant or missing GRN; 409 on
 	 *                      lifecycle conflict.
 	 *
+	 * Re-verified for security-endpoint-guards (REQ-001): the
+	 * `AdministrationContextService::canAccess()` masked-404 guard below was
+	 * already present and enforcing before this change — a mechanical
+	 * `hydra-gate-no-admin-idor` false positive.
+	 * `GoodsReceiptNoteService::qualityCheckPass()` additionally scopes the
+	 * GRN lookup by `id` AND `administrationId` together. No guard change
+	 * needed.
+	 *
 	 * @spec openspec/changes/bookkeeping-purchase-order-3way-04-goods-receipt-note/tasks.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function qualityCheck(string $id): JSONResponse {
@@ -267,7 +298,16 @@ class GoodsReceiptNoteController extends Controller {
 	 *                      anonymous; 404 cross-tenant or missing GRN; 409 on
 	 *                      terminal-state conflict.
 	 *
+	 * Re-verified for security-endpoint-guards (REQ-001): the
+	 * `AdministrationContextService::canAccess()` masked-404 guard below was
+	 * already present and enforcing before this change — a mechanical
+	 * `hydra-gate-no-admin-idor` false positive. `GoodsReceiptNoteService::
+	 * acceptGRN()` additionally scopes the GRN lookup by `id` AND
+	 * `administrationId` together. No guard change needed.
+	 *
 	 * @spec openspec/changes/bookkeeping-purchase-order-3way-04-goods-receipt-note/tasks.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function accept(string $id): JSONResponse {
@@ -317,7 +357,18 @@ class GoodsReceiptNoteController extends Controller {
 	 * @return JSONResponse 200 with the updated GRN; 400 on validation; 401
 	 *                      anonymous; 404 cross-tenant or missing GRN.
 	 *
+	 * Re-verified for security-endpoint-guards (REQ-001): the
+	 * `AdministrationContextService::canAccess()` masked-404 guard below was
+	 * already present and enforcing before this change — a mechanical
+	 * `hydra-gate-no-admin-idor` false positive. `GoodsReceiptNoteService::
+	 * uploadPhotos()` additionally scopes the GRN lookup by `id` AND
+	 * `administrationId` together. No guard change needed (REQ-004 test
+	 * coverage for both directions was previously missing and is added by
+	 * this change).
+	 *
 	 * @spec openspec/changes/bookkeeping-purchase-order-3way-04-goods-receipt-note/tasks.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function uploadPhotos(string $id): JSONResponse {

--- a/lib/Controller/InventoryAdjustmentController.php
+++ b/lib/Controller/InventoryAdjustmentController.php
@@ -81,7 +81,18 @@ class InventoryAdjustmentController extends Controller {
 	 *
 	 * @return JSONResponse
 	 *
+	 * Re-verified for security-endpoint-guards (REQ-001): the
+	 * `AdministrationContextService::canAccess()` masked-404 guard below was
+	 * already present and enforcing before this change — a mechanical
+	 * `hydra-gate-no-admin-idor` false positive (the scan only recognises
+	 * guard calls named `authorize*`/`require*`/`ensure*` and does not match
+	 * `canAccess(`). `LandedCostAllocationService::allocate()` also filters
+	 * every downstream read/write by the caller-verified `administrationId`.
+	 * No guard change needed.
+	 *
 	 * @spec openspec/specs/inventory-accounting-correctness/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function landedCost(): JSONResponse {
@@ -148,7 +159,16 @@ class InventoryAdjustmentController extends Controller {
 	 *
 	 * @return JSONResponse
 	 *
+	 * Re-verified for security-endpoint-guards (REQ-001): the
+	 * `AdministrationContextService::canAccess()` masked-404 guard below was
+	 * already present and enforcing before this change — a mechanical
+	 * `hydra-gate-no-admin-idor` false positive. `NrvWriteDownService::
+	 * runForAdministration()` also filters every downstream read/write by
+	 * the caller-verified `administrationId`. No guard change needed.
+	 *
 	 * @spec openspec/specs/inventory-accounting-correctness/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function nrvWriteDown(): JSONResponse {

--- a/lib/Controller/InventoryValuationReportController.php
+++ b/lib/Controller/InventoryValuationReportController.php
@@ -89,7 +89,16 @@ class InventoryValuationReportController extends Controller {
 	 *
 	 * @return JSONResponse
 	 *
+	 * Re-verified for security-endpoint-guards (REQ-001): the
+	 * `AdministrationContextService::canAccess()` masked-404 guard below was
+	 * already present and enforcing before this change — a mechanical
+	 * `hydra-gate-no-admin-idor` false positive. `InventoryValuationReportService`'s
+	 * `valuationAsOf()`/`ageing()` also filter every read by the
+	 * caller-verified `administrationId`. No guard change needed.
+	 *
 	 * @spec openspec/specs/inventory-accounting-correctness/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function report(): JSONResponse {

--- a/lib/Controller/InvoiceApiController.php
+++ b/lib/Controller/InvoiceApiController.php
@@ -82,7 +82,15 @@ class InvoiceApiController extends Controller {
 	/**
 	 * Draft a BillableInvoice (POST /api/v1/invoices/generate).
 	 *
+	 * Authorization: the administration scope is resolved server-side from the
+	 * caller's own session (never accepted from the request body), so the drafted
+	 * invoice is always scoped to an administration the caller is a member of
+	 * (ADR-005 Rule 3 — session-derived, IDOR-safe by construction).
+	 *
 	 * @return JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function generate(): JSONResponse {
@@ -99,15 +107,29 @@ class InvoiceApiController extends Controller {
 
 			return new JSONResponse($invoice, Http::STATUS_OK);
 		} catch (\InvalidArgumentException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_UNPROCESSABLE_ENTITY);
+			$this->logger->error('InvoiceApiController.generate: invalid request: ' . $e->getMessage());
+			return new JSONResponse(
+				['message' => 'The invoice generation request is invalid.', 'error' => 'invoice-generate-invalid'],
+				Http::STATUS_UNPROCESSABLE_ENTITY
+			);
 		} catch (\RuntimeException $e) {
 			$message = $e->getMessage();
-			$status = Http::STATUS_BAD_REQUEST;
+			$this->logger->error('InvoiceApiController.generate: request could not be completed: ' . $message);
+
 			if (str_contains($message, 'Conflict') === true) {
-				$status = Http::STATUS_CONFLICT;
+				return new JSONResponse(
+					[
+						'message' => 'One or more time entries or expenses are already invoiced.',
+						'error' => 'invoice-generate-conflict',
+					],
+					Http::STATUS_CONFLICT
+				);
 			}
 
-			return new JSONResponse(['error' => $message], $status);
+			return new JSONResponse(
+				['message' => 'Unable to generate the invoice.', 'error' => 'invoice-generate-failed'],
+				Http::STATUS_BAD_REQUEST
+			);
 		} catch (\Throwable $e) {
 			$this->logger->error('InvoiceApiController.generate failed: ' . $e->getMessage());
 			return new JSONResponse(['error' => 'Internal error'], Http::STATUS_INTERNAL_SERVER_ERROR);
@@ -118,7 +140,16 @@ class InvoiceApiController extends Controller {
 	/**
 	 * List invoices for the current administration (GET /api/v1/invoices).
 	 *
+	 * Authorization: the administration scope is resolved server-side from the
+	 * caller's own session and applied as a hard filter — the endpoint accepts
+	 * no client-supplied administrationId, so there is no parameter to guess or
+	 * enumerate against another tenant (ADR-005 Rule 3 — session-derived,
+	 * IDOR-safe by construction).
+	 *
 	 * @return JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function index(): JSONResponse {
@@ -163,7 +194,15 @@ class InvoiceApiController extends Controller {
 	 *
 	 * @param string $invoiceId BillableInvoice id.
 	 *
+	 * Authorization: the fetched invoice's own `administrationId` is compared
+	 * against the caller's server-resolved administration; a mismatch (or an
+	 * orphan record with no administrationId) is refused with 403 before any
+	 * line data is read (ADR-005 Rule 3).
+	 *
 	 * @return JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function show(string $invoiceId): JSONResponse {
@@ -221,7 +260,15 @@ class InvoiceApiController extends Controller {
 	 *
 	 * @param string $invoiceId Id.
 	 *
+	 * Authorization: the fetched invoice's own `administrationId` is compared
+	 * against the caller's server-resolved administration; a mismatch (or an
+	 * orphan record with no administrationId) is refused with 403 before any
+	 * posting side-effect runs (ADR-005 Rule 3).
+	 *
 	 * @return JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function post(string $invoiceId): JSONResponse {
@@ -250,12 +297,19 @@ class InvoiceApiController extends Controller {
 			return new JSONResponse($updated, Http::STATUS_OK);
 		} catch (\RuntimeException $e) {
 			$message = $e->getMessage();
-			$status = Http::STATUS_BAD_REQUEST;
+			$this->logger->error('InvoiceApiController.post: request could not be completed: ' . $message);
+
 			if (str_contains($message, 'already posted') === true) {
-				$status = Http::STATUS_CONFLICT;
+				return new JSONResponse(
+					['message' => 'The invoice is already posted.', 'error' => 'invoice-post-conflict'],
+					Http::STATUS_CONFLICT
+				);
 			}
 
-			return new JSONResponse(['error' => $message], $status);
+			return new JSONResponse(
+				['message' => 'Unable to post the invoice.', 'error' => 'invoice-post-failed'],
+				Http::STATUS_BAD_REQUEST
+			);
 		} catch (\Throwable $e) {
 			$this->logger->error('InvoiceApiController.post failed: ' . $e->getMessage());
 			return new JSONResponse(['error' => 'Internal error'], Http::STATUS_INTERNAL_SERVER_ERROR);
@@ -268,7 +322,15 @@ class InvoiceApiController extends Controller {
 	 *
 	 * @param string $invoiceId Id.
 	 *
+	 * Authorization: the fetched invoice's own `administrationId` is compared
+	 * against the caller's server-resolved administration; a mismatch (or an
+	 * orphan record with no administrationId) is refused with 403 before the
+	 * PDF is rendered (ADR-005 Rule 3).
+	 *
 	 * @return DataDisplayResponse|JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function pdf(string $invoiceId): DataDisplayResponse|JSONResponse {

--- a/lib/Controller/KorController.php
+++ b/lib/Controller/KorController.php
@@ -78,9 +78,16 @@ class KorController extends Controller {
 	 * missing/malformed parameter; HTTP 500 (without a stack trace) on an unexpected
 	 * AR-ledger fetch failure.
 	 *
+	 * Authorization: `AdministrationContextService::canAccess()` is checked
+	 * against the requested `administration_id` before the KOR service is ever
+	 * called; a non-member is masked as 404, never a disclosing 403 (ADR-005
+	 * Rule 3 — {@see \OCA\Shillinq\Service\AdministrationContextService::canAccess()}).
+	 *
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/specs/bookkeeping-kor-kleine-ondernemersregeling/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function monitor(): JSONResponse {

--- a/lib/Controller/LeaseReassessmentController.php
+++ b/lib/Controller/LeaseReassessmentController.php
@@ -98,9 +98,16 @@ class LeaseReassessmentController extends Controller {
 	 * Body: lease_id, administration_id, new_payment_amount,
 	 *       trigger_description?, approver?
 	 *
+	 * Authorization: {@see resolveScope()} checks `administrationContext->canAccess()`
+	 * against the request's `administration_id` and {@see LeaseReassessmentService::fetchLease()}
+	 * re-scopes the lease lookup itself to that same administration — a non-member
+	 * or a lease from another tenant is masked as 404 (ADR-005 Rule 3).
+	 *
 	 * @return JSONResponse 201 with the persisted event; 400/401/404/500.
 	 *
 	 * @spec openspec/changes/revive-lease-capabilities/specs/revive-lease-capabilities/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function indexation(): JSONResponse {
@@ -138,9 +145,16 @@ class LeaseReassessmentController extends Controller {
 	 * Body: lease_id, administration_id, extension_options[],
 	 *       trigger_description?, approver?
 	 *
+	 * Authorization: {@see resolveScope()} checks `administrationContext->canAccess()`
+	 * against the request's `administration_id` and {@see LeaseReassessmentService::fetchLease()}
+	 * re-scopes the lease lookup itself to that same administration — a non-member
+	 * or a lease from another tenant is masked as 404 (ADR-005 Rule 3).
+	 *
 	 * @return JSONResponse 201 with the persisted event; 400/401/404/500.
 	 *
 	 * @spec openspec/changes/revive-lease-capabilities/specs/revive-lease-capabilities/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function extensionOption(): JSONResponse {
@@ -178,9 +192,16 @@ class LeaseReassessmentController extends Controller {
 	 * Body: lease_id, administration_id, new_terms{}, approach?,
 	 *       trigger_description?, approver?
 	 *
+	 * Authorization: {@see resolveScope()} checks `administrationContext->canAccess()`
+	 * against the request's `administration_id` and {@see LeaseReassessmentService::fetchLease()}
+	 * re-scopes the lease lookup itself to that same administration — a non-member
+	 * or a lease from another tenant is masked as 404 (ADR-005 Rule 3).
+	 *
 	 * @return JSONResponse 201 with the persisted event; 400/401/404/500.
 	 *
 	 * @spec openspec/changes/revive-lease-capabilities/specs/revive-lease-capabilities/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function modification(): JSONResponse {
@@ -224,9 +245,16 @@ class LeaseReassessmentController extends Controller {
 	 * Body: lease_id, administration_id, recoverable_value,
 	 *       trigger_description?, approver?
 	 *
+	 * Authorization: {@see resolveScope()} checks `administrationContext->canAccess()`
+	 * against the request's `administration_id` and {@see LeaseReassessmentService::fetchLease()}
+	 * re-scopes the lease lookup itself to that same administration — a non-member
+	 * or a lease from another tenant is masked as 404 (ADR-005 Rule 3).
+	 *
 	 * @return JSONResponse 201 with the persisted event; 400/401/404/500.
 	 *
 	 * @spec openspec/changes/revive-lease-capabilities/specs/revive-lease-capabilities/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function impairment(): JSONResponse {

--- a/lib/Controller/MultiPoConsolidationController.php
+++ b/lib/Controller/MultiPoConsolidationController.php
@@ -101,11 +101,22 @@ class MultiPoConsolidationController extends Controller {
 	 * POST /api/three-way-match/consolidate
 	 * Body: administrationId, invoiceId.
 	 *
+	 * Re-verified during security-endpoint-guards (REQ-001): ALREADY-GUARDED —
+	 * `$this->administrationContext->canAccess($administrationId)` below is an
+	 * enforced per-administration membership check (masked 404 on denial), not
+	 * a syntactic no-op. The mechanical `hydra-gate-no-admin-idor` scan flagged
+	 * this method only because `canAccess(` is not shaped like
+	 * `authorize*`/`require*`/`ensure*` — a documented false positive, not a
+	 * missing guard. No code change needed; recorded in the change's verdict
+	 * table for traceability.
+	 *
 	 * @return JSONResponse 200 with per-line results; 400 on validation;
 	 *                      401 anonymous; 404 cross-tenant or missing
 	 *                      invoice; 500 without stack trace.
 	 *
 	 * @spec openspec/changes/bookkeeping-purchase-order-3way-07-multi-po-consolidation/tasks.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function consolidate(): JSONResponse {
@@ -155,11 +166,17 @@ class MultiPoConsolidationController extends Controller {
 	 *
 	 * GET /api/three-way-match/candidates?administrationId=...&invoiceId=...&invoiceLineNumber=...
 	 *
+	 * Re-verified during security-endpoint-guards (REQ-001): ALREADY-GUARDED —
+	 * same enforced `canAccess()` membership check as {@see consolidate()};
+	 * a false positive of the mechanical scan, not a missing guard.
+	 *
 	 * @return JSONResponse 200 with the ordered candidate list; 400 on
 	 *                      validation; 401 anonymous; 404 on cross-tenant
 	 *                      or missing invoice / line.
 	 *
 	 * @spec openspec/changes/bookkeeping-purchase-order-3way-07-multi-po-consolidation/tasks.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function candidates(): JSONResponse {
@@ -241,12 +258,22 @@ class MultiPoConsolidationController extends Controller {
 	 * Body: administrationId, invoiceId, invoiceLineNumber,
 	 *       chosenPoLineId, chosenGrnLineId (optional).
 	 *
+	 * Re-verified during security-endpoint-guards (REQ-001): ALREADY-GUARDED —
+	 * same enforced `canAccess()` membership check as {@see consolidate()};
+	 * a false positive of the mechanical scan, not a missing guard. The
+	 * chosen tuple is additionally re-enumerated server-side by
+	 * `MultiPoConsolidationService` before persistence (class docblock), so a
+	 * forged `chosenPoLineId`/`chosenGrnLineId` cannot smuggle a cross-tenant
+	 * line id past this administration-level guard.
+	 *
 	 * @return JSONResponse 201 with the persisted ThreeWayMatch; 400 on
 	 *                      validation or chosen tuple not in candidate
 	 *                      set; 401 anonymous; 404 cross-tenant or
 	 *                      missing invoice / line.
 	 *
 	 * @spec openspec/changes/bookkeeping-purchase-order-3way-07-multi-po-consolidation/tasks.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function disambiguate(): JSONResponse {

--- a/lib/Controller/OssController.php
+++ b/lib/Controller/OssController.php
@@ -97,6 +97,8 @@ class OssController extends Controller {
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/specs/bookkeeping-btw-oss-eu/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function resolveRate(): JSONResponse {
@@ -104,6 +106,14 @@ class OssController extends Controller {
 			return new JSONResponse(['error' => 'Not logged in'], Http::STATUS_UNAUTHORIZED);
 		}
 
+		// JUSTIFY (security-endpoint-guards REQ-001): intentionally reachable by
+		// any authenticated user with no per-object/administration check. This
+		// endpoint resolves a VAT rate from the TEDB reference table by
+		// (country, category, date) only — there is no `administrationId` param
+		// (see class docblock) and OssRateResolver::resolve() takes no tenant
+		// argument anywhere in its signature. The published EU VAT rate for a
+		// given country/category/date is the same fact for every caller; there
+		// is no per-tenant object here for an IDOR to target.
 		$country = strtoupper(trim((string)$this->request->getParam('country', '')));
 		$category = trim((string)$this->request->getParam('category', 'standard'));
 		$date = trim((string)$this->request->getParam('date', ''));
@@ -143,9 +153,18 @@ class OssController extends Controller {
 	 * Query params: administration_id, period_year (YYYY), period_quarter (Q1..Q4),
 	 * registration_id. Returns 200 with the draft return payload or 400 on bad input.
 	 *
+	 * Re-verified during security-endpoint-guards (REQ-001): ALREADY-GUARDED —
+	 * `$this->context->canAccess($administrationId)` below (added for #520,
+	 * see class docblock) is an enforced per-administration membership check,
+	 * not a syntactic no-op; a non-member gets a masked 404 before the draft
+	 * is generated. No code change needed here; recorded in the change's
+	 * verdict table for traceability.
+	 *
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/specs/bookkeeping-btw-oss-eu/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function generateReturn(): JSONResponse {

--- a/lib/Controller/PaymentRunController.php
+++ b/lib/Controller/PaymentRunController.php
@@ -96,11 +96,22 @@ class PaymentRunController extends Controller {
 	 * Export an approved PaymentRun to a SEPA bank file
 	 * (POST /api/v1/payment-runs/{id}/export).
 	 *
+	 * Re-verified during security-endpoint-guards (REQ-001): ALREADY-GUARDED —
+	 * `$this->administrationContext->canAccess()` below is an enforced
+	 * per-administration membership check (masked 404 on denial), not a
+	 * syntactic no-op. The mechanical `hydra-gate-no-admin-idor` scan flagged
+	 * this method only because `canAccess(` is not shaped like
+	 * `authorize*`/`require*`/`ensure*` — a documented false positive, not a
+	 * missing guard. No code change needed; recorded in the change's verdict
+	 * table for traceability.
+	 *
 	 * @param string $id The PaymentRun id / uuid.
 	 *
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/specs/payment-run-sepa-export/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function export(string $id): JSONResponse {
@@ -145,11 +156,17 @@ class PaymentRunController extends Controller {
 	 * Reconcile an exported PaymentRun against a CAMT.053 statement
 	 * (POST /api/v1/payment-runs/{id}/reconcile).
 	 *
+	 * Re-verified during security-endpoint-guards (REQ-001): ALREADY-GUARDED —
+	 * same enforced `canAccess()` membership check as {@see export()}; a
+	 * false positive of the mechanical scan, not a missing guard.
+	 *
 	 * @param string $id The PaymentRun id / uuid.
 	 *
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/specs/payment-run-sepa-export/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function reconcile(string $id): JSONResponse {

--- a/lib/Controller/PayrollController.php
+++ b/lib/Controller/PayrollController.php
@@ -38,6 +38,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -77,6 +78,7 @@ class PayrollController extends Controller {
 	 * @param IUserSession $userSession User session for authentication guard.
 	 * @param AdministrationContextService $context Membership guard (REQ-MA-001).
 	 * @param LoggerInterface $logger Logger (no stack traces to client, no raw BSN).
+	 * @param IL10N $l10n Localized strings for client-facing error messages (ADR-050).
 	 *
 	 * @return void
 	 */
@@ -86,6 +88,7 @@ class PayrollController extends Controller {
 		private readonly IUserSession $userSession,
 		private readonly AdministrationContextService $context,
 		private readonly LoggerInterface $logger,
+		private readonly IL10N $l10n,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -133,7 +136,17 @@ class PayrollController extends Controller {
 				periodId: $periodId
 			);
 		} catch (\RuntimeException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+			$this->logger->error(
+				'PayrollController: loonstrook not found',
+				['administrationId' => $administrationId, 'periodId' => $periodId, 'exception' => $e->getMessage()]
+			);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Payslip not found for the given employee and period'),
+					'error' => 'payroll-loonstrook-not-found',
+				],
+				Http::STATUS_NOT_FOUND,
+			);
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'PayrollController: failed to compute loonstrook',

--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -57,11 +57,24 @@ class PreferencesController extends Controller {
 	/**
 	 * Read a per-user preference value.
 	 *
+	 * JUSTIFY (security-endpoint-guards REQ-001): intentionally reachable by
+	 * any authenticated user with no per-object/administration check. This
+	 * endpoint is keyed ENTIRELY by `$user->getUID()` — the authenticated
+	 * caller's own uid, resolved server-side from the session — for both the
+	 * read (`getUserValue()`) and the write (`setUserValue()`/
+	 * `deleteUserValue()`) below. The request supplies only a free-text
+	 * preference `key`, never a target user id or object id, and
+	 * `sanitizeKey()` restricts that key to `[a-z0-9-]{1,64}`. There is no
+	 * cross-user or cross-administration object here for an IDOR to reach —
+	 * a caller can only ever read/write their own IConfig values.
+	 *
 	 * @param string $key The preference key (kebab/alphanumeric).
 	 *
 	 * @return JSONResponse `{value: string|null}`.
 	 *
 	 * @spec openspec/specs/apphost-adoption/spec.md#requirement-mechanical-boilerplate-served-by-apphost-generics
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 *
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
@@ -97,12 +110,21 @@ class PreferencesController extends Controller {
 	/**
 	 * Write a per-user preference value. An empty value clears it.
 	 *
+	 * JUSTIFY (security-endpoint-guards REQ-001): same reasoning as
+	 * {@see getPreference()} — `setUserValue()`/`deleteUserValue()` below are
+	 * keyed exclusively by `$user->getUID()` (the authenticated caller's own
+	 * uid). No request parameter names a target user or object; a caller can
+	 * only ever write their own preference value. No per-object/
+	 * administration check applies.
+	 *
 	 * @param string $key The preference key (kebab/alphanumeric).
 	 * @param string $value The value to store (empty string clears it).
 	 *
 	 * @return JSONResponse `{value: string|null}`.
 	 *
 	 * @spec openspec/specs/apphost-adoption/spec.md#requirement-mechanical-boilerplate-served-by-apphost-generics
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 *
 	 * @NoAdminRequired
 	 */

--- a/lib/Controller/PurchaseOrderController.php
+++ b/lib/Controller/PurchaseOrderController.php
@@ -40,6 +40,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -65,6 +66,7 @@ class PurchaseOrderController extends Controller {
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope.
 	 * @param IUserSession $userSession User session guard.
 	 * @param LoggerInterface $logger Logger (no stack traces to client).
+	 * @param IL10N $l10n Translation service for error-response messages (ADR-050).
 	 *
 	 * @return void
 	 */
@@ -74,6 +76,7 @@ class PurchaseOrderController extends Controller {
 		private readonly AdministrationContextService $administrationContext,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly IL10N $l10n,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -91,6 +94,8 @@ class PurchaseOrderController extends Controller {
 	 *                      401 anonymous; 404 on cross-tenant; 500 without stack trace.
 	 *
 	 * @spec openspec/changes/bookkeeping-purchase-order-3way-02-purchase-order-core/tasks.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function create(): JSONResponse {
@@ -123,13 +128,29 @@ class PurchaseOrderController extends Controller {
 				payload: $payload
 			);
 		} catch (\RuntimeException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			$this->logger->error(
+				'PurchaseOrderController: purchase order creation rejected',
+				['administrationId' => $administrationId, 'exception' => $e->getMessage()]
+			);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Unable to create purchase order — check the required fields'),
+					'error' => 'purchase-order-create-invalid',
+				],
+				Http::STATUS_BAD_REQUEST
+			);
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'PurchaseOrderController: failed to create purchase order',
 				['administrationId' => $administrationId, 'exception' => $e->getMessage()]
 			);
-			return new JSONResponse(['error' => 'Could not create purchase order'], Http::STATUS_INTERNAL_SERVER_ERROR);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Unable to create purchase order'),
+					'error' => 'purchase-order-create-failed',
+				],
+				Http::STATUS_INTERNAL_SERVER_ERROR
+			);
 		}
 
 		return new JSONResponse($po, Http::STATUS_CREATED);

--- a/lib/Controller/ReconciliationResolutionController.php
+++ b/lib/Controller/ReconciliationResolutionController.php
@@ -43,6 +43,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -73,6 +74,9 @@ class ReconciliationResolutionController extends Controller {
 	 * @param LoggerInterface $logger Logger for
 	 *                                fail-closed
 	 *                                diagnostics.
+	 * @param IL10N $l10n Localized strings for
+	 *                    client-facing error
+	 *                    messages (ADR-050).
 	 *
 	 * @return void
 	 */
@@ -81,6 +85,7 @@ class ReconciliationResolutionController extends Controller {
 		private readonly ReconciliationResolutionService $service,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly IL10N $l10n,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -141,9 +146,29 @@ class ReconciliationResolutionController extends Controller {
 				actor: $actor,
 			);
 		} catch (\OutOfBoundsException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+			$this->logger->error(
+				'ReconciliationResolutionController: resolve target not found',
+				['reconId' => $reconId, 'matchId' => $matchId, 'exception' => $e->getMessage()]
+			);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Unable to find the reconciliation match'),
+					'error' => 'reconciliation-match-not-found',
+				],
+				Http::STATUS_NOT_FOUND,
+			);
 		} catch (\DomainException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_CONFLICT);
+			$this->logger->error(
+				'ReconciliationResolutionController: resolve rejected by domain rule',
+				['reconId' => $reconId, 'matchId' => $matchId, 'exception' => $e->getMessage()]
+			);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Unable to resolve a match on a locked reconciliation'),
+					'error' => 'reconciliation-match-locked',
+				],
+				Http::STATUS_CONFLICT,
+			);
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'ReconciliationResolutionController: resolve failed',

--- a/lib/Controller/ReportingController.php
+++ b/lib/Controller/ReportingController.php
@@ -119,7 +119,21 @@ class ReportingController extends Controller {
 	 * so the overview can render one section per ReportCatalogue::CATEGORIES with its
 	 * report cards, in catalogue order.
 	 *
+	 * JUSTIFY (security-endpoint-guards, REQ-001b): `ReportCatalogue::CATEGORIES`
+	 * and `ReportCatalogue::all()` are a compile-time constant list of report
+	 * definitions (id, label, category, supported formats) baked into
+	 * `ReportCatalogue.php` — the method names no administration, tenant, or
+	 * object and reads no per-tenant data, so there is nothing here to scope
+	 * per-object. Any authenticated user may read the catalogue; only
+	 * `generate()`/`generated()`/`download()` touch actual report data and
+	 * those already check `AdministrationContextService::canAccess()`.
+	 *
 	 * @return JSONResponse The grouped catalogue.
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude Consumed by ReportingComplianceOverview.vue (a real UI surface),
+	 *      but this change adds no code here beyond a justification comment — no
+	 *      guard/behaviour change requires new e2e coverage (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function types(): JSONResponse {

--- a/lib/Controller/RequisitionController.php
+++ b/lib/Controller/RequisitionController.php
@@ -40,6 +40,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -66,6 +67,7 @@ class RequisitionController extends Controller {
 	 * @param AdministrationContextService $administrationContext IDOR + tenant scope.
 	 * @param IUserSession $userSession User session guard.
 	 * @param LoggerInterface $logger Logger (no stack traces to client).
+	 * @param IL10N $l10n Localized user-facing error messages (ADR-050).
 	 *
 	 * @return void
 	 */
@@ -76,6 +78,7 @@ class RequisitionController extends Controller {
 		private readonly AdministrationContextService $administrationContext,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly IL10N $l10n,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -93,6 +96,7 @@ class RequisitionController extends Controller {
 	 *                      401 anonymous; 404 on cross-tenant; 500 without stack trace.
 	 *
 	 * @spec openspec/specs/purchase-requisition/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
 	 */
 	#[NoAdminRequired]
 	public function create(): JSONResponse {
@@ -125,7 +129,21 @@ class RequisitionController extends Controller {
 				payload: $payload
 			);
 		} catch (\RuntimeException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			// Validation refusal from the service (missing/invalid field, no
+			// lines, non-positive total) — the exception's own text is never
+			// placed in the response body (ADR-050 / REQ-003); it is logged
+			// server-side and the client gets a stable slug + localized text.
+			$this->logger->error(
+				'RequisitionController.create rejected',
+				['administrationId' => $administrationId, 'exception' => $e]
+			);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Requisition could not be created; check the required fields'),
+					'error' => 'requisition-create-invalid',
+				],
+				Http::STATUS_BAD_REQUEST,
+			);
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'RequisitionController: failed to create requisition',
@@ -150,6 +168,7 @@ class RequisitionController extends Controller {
 	 *                      invalid state; 500 without stack trace.
 	 *
 	 * @spec openspec/specs/purchase-requisition/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
 	 */
 	#[NoAdminRequired]
 	public function submit(string $id): JSONResponse {
@@ -203,6 +222,7 @@ class RequisitionController extends Controller {
 	 *                      not submitted or budget insufficient; 500 without stack trace.
 	 *
 	 * @spec openspec/specs/purchase-requisition/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
 	 */
 	#[NoAdminRequired]
 	public function approve(string $id): JSONResponse {
@@ -256,6 +276,7 @@ class RequisitionController extends Controller {
 	 *                      invalid state; 500 without stack trace.
 	 *
 	 * @spec openspec/specs/purchase-requisition/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
 	 */
 	#[NoAdminRequired]
 	public function reject(string $id): JSONResponse {
@@ -315,6 +336,7 @@ class RequisitionController extends Controller {
 	 *                      500 without stack trace.
 	 *
 	 * @spec openspec/specs/purchase-requisition/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
 	 */
 	#[NoAdminRequired]
 	public function convert(string $id): JSONResponse {
@@ -358,17 +380,35 @@ class RequisitionController extends Controller {
 	 * status: "not found" messages -> 404, everything else (invalid state,
 	 * budget exceeded, missing supplier/lines) -> 409 Conflict.
 	 *
+	 * The exception's own message text is used only to pick the status code
+	 * (a closed set of curated strings this app's own service layer throws)
+	 * — it is never placed in the response body itself (ADR-050 / REQ-003).
+	 * The real message is logged server-side; the client gets a stable slug
+	 * plus a localized, generic message.
+	 *
 	 * @param \RuntimeException $e The exception to map.
 	 *
 	 * @return JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
 	 */
 	private function mapRuntimeError(\RuntimeException $e): JSONResponse {
-		$message = $e->getMessage();
-		if (str_contains($message, 'not found') === true) {
-			return new JSONResponse(['error' => $message], Http::STATUS_NOT_FOUND);
+		$this->logger->error('RequisitionController: requisition action rejected', ['exception' => $e]);
+
+		if (str_contains($e->getMessage(), 'not found') === true) {
+			return new JSONResponse(
+				['message' => $this->l10n->t('Requisition not found'), 'error' => 'requisition-not-found'],
+				Http::STATUS_NOT_FOUND,
+			);
 		}
 
-		return new JSONResponse(['error' => $message], Http::STATUS_CONFLICT);
+		return new JSONResponse(
+			[
+				'message' => $this->l10n->t('Requisition is not in a state that allows this action'),
+				'error' => 'requisition-invalid-state',
+			],
+			Http::STATUS_CONFLICT,
+		);
 	}//end mapRuntimeError()
 
 	/**

--- a/lib/Controller/VATReturnController.php
+++ b/lib/Controller/VATReturnController.php
@@ -58,6 +58,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
@@ -84,6 +85,7 @@ class VATReturnController extends Controller {
 	 * @param IUserSession $session User session (for actor identity).
 	 * @param AdministrationContextService $context RBAC guard — resolves the user's administration memberships.
 	 * @param LoggerInterface $logger Logger.
+	 * @param IL10N $l10n Localized strings for client-facing error messages (ADR-050).
 	 */
 	public function __construct(
 		IRequest $request,
@@ -92,6 +94,7 @@ class VATReturnController extends Controller {
 		private readonly IUserSession $session,
 		private readonly AdministrationContextService $context,
 		private readonly LoggerInterface $logger,
+		private readonly IL10N $l10n,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -342,6 +345,8 @@ class VATReturnController extends Controller {
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function submit(string $returnId): JSONResponse {
@@ -365,7 +370,15 @@ class VATReturnController extends Controller {
 
 			$vatReturn = $this->service->submitReturn(returnId: $returnId, userId: $userId);
 		} catch (\RuntimeException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_CONFLICT);
+			$this->logger->error(
+				'VATReturnController.submit failed',
+				['returnId' => $returnId, 'exception' => $e]
+			);
+
+			return new JSONResponse(
+				['message' => $this->l10n->t('Unable to submit VAT return'), 'error' => 'vat-return-submit-failed'],
+				Http::STATUS_CONFLICT,
+			);
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'VATReturnController: failed to submit VAT return',
@@ -386,6 +399,8 @@ class VATReturnController extends Controller {
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/specs/bookkeeping-vat-btw-filing/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function rebase(string $returnId): JSONResponse {
@@ -408,7 +423,15 @@ class VATReturnController extends Controller {
 
 			$vatReturn = $this->service->rebaseReturn(returnId: $returnId, userId: $userId);
 		} catch (\RuntimeException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_CONFLICT);
+			$this->logger->error(
+				'VATReturnController.rebase failed',
+				['returnId' => $returnId, 'exception' => $e]
+			);
+
+			return new JSONResponse(
+				['message' => $this->l10n->t('Unable to rebase VAT return'), 'error' => 'vat-return-rebase-failed'],
+				Http::STATUS_CONFLICT,
+			);
 		} catch (\Throwable $e) {
 			$this->logger->error(
 				'VATReturnController: failed to rebase VAT return',

--- a/lib/Controller/WbsoAccountApiController.php
+++ b/lib/Controller/WbsoAccountApiController.php
@@ -193,6 +193,8 @@ class WbsoAccountApiController extends Controller {
 	 * POST /api/v1/accounts (administrator only).
 	 *
 	 * @return JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
 	 */
 	#[NoAdminRequired]
 	public function create(): JSONResponse {
@@ -250,6 +252,8 @@ class WbsoAccountApiController extends Controller {
 	 * @param string $accountNumber Account to update.
 	 *
 	 * @return JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
 	 */
 	#[NoAdminRequired]
 	public function update(string $accountNumber): JSONResponse {

--- a/lib/Controller/WbsoAccountApiController.php
+++ b/lib/Controller/WbsoAccountApiController.php
@@ -44,6 +44,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -70,6 +71,7 @@ class WbsoAccountApiController extends Controller {
 	 * @param WbsoRbacResolver $rbac Role resolver.
 	 * @param IUserSession $userSession Session.
 	 * @param LoggerInterface $logger Logger (no stack traces to client).
+	 * @param IL10N $l10n Localized strings for client-facing error messages (ADR-050).
 	 */
 	public function __construct(
 		IRequest $request,
@@ -77,6 +79,7 @@ class WbsoAccountApiController extends Controller {
 		private readonly WbsoRbacResolver $rbac,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly IL10N $l10n,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -223,7 +226,17 @@ class WbsoAccountApiController extends Controller {
 		try {
 			$row = $this->accounts->createAccount(administrationId: $administrationId, payload: $payload);
 		} catch (InvalidArgumentException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			$this->logger->error(
+				'WbsoAccountApiController: account creation payload rejected',
+				['administrationId' => $administrationId, 'exception' => $e->getMessage()]
+			);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Unable to create account: the submitted details are invalid'),
+					'error' => 'wbso-account-create-failed',
+				],
+				Http::STATUS_BAD_REQUEST,
+			);
 		} catch (\Throwable $e) {
 			return $this->fail(message: 'Failed to create account', context: ['exception' => $e->getMessage()]);
 		}
@@ -281,7 +294,17 @@ class WbsoAccountApiController extends Controller {
 				return new JSONResponse(['error' => 'Account not found'], Http::STATUS_NOT_FOUND);
 			}
 
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			$this->logger->error(
+				'WbsoAccountApiController: account update payload rejected',
+				['administrationId' => $administrationId, 'accountNumber' => $accountNumber, 'exception' => $e->getMessage()]
+			);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Unable to update account: the submitted details are invalid'),
+					'error' => 'wbso-account-update-failed',
+				],
+				Http::STATUS_BAD_REQUEST,
+			);
 		} catch (\Throwable $e) {
 			return $this->fail(message: 'Failed to update account', context: ['exception' => $e->getMessage()]);
 		}

--- a/lib/Controller/WbsoAdministratieController.php
+++ b/lib/Controller/WbsoAdministratieController.php
@@ -6,11 +6,16 @@
  * Tier-1 read-only WBSO realisatie API (REQ-WBSO-010). Exposes a single GET
  * endpoint that returns, per WbsoBeschikking, the granted versus realised S&O
  * hours for one administration. The endpoint is available to any authenticated
- * user (#[NoAdminRequired]); the administration scope is validated and reads are
- * delegated to OpenRegister's ObjectService, which enforces multitenancy / RBAC,
- * so no cross-administration data leaks (REQ-WBSO-004). The realisatie is
- * read-only — there is no create/update/delete route here; the WBSO entities are
- * authored through the declarative manifest pages backed by OpenRegister CRUD.
+ * user (#[NoAdminRequired]); the administration scope named by the request is
+ * validated in this controller against the caller's own
+ * AdministrationMembership via {@see AdministrationContextService::canAccess()}
+ * (ADR-005 Rule 3 / security-endpoint-guards REQ-001) before any read runs — a
+ * prior version of this paragraph claimed OpenRegister's ObjectService itself
+ * enforced that scoping, which was false (no schema in this app declares an
+ * `authorization` block, so OpenRegister grants every read to every
+ * authenticated user). The realisatie is read-only — there is no
+ * create/update/delete route here; the WBSO entities are authored through the
+ * declarative manifest pages backed by OpenRegister CRUD.
  *
  * @category Controller
  * @package  OCA\Shillinq\Controller
@@ -32,6 +37,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Controller;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\WbsoAdministratieService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -52,6 +58,7 @@ class WbsoAdministratieController extends Controller {
 	 * @param IRequest $request The request object.
 	 * @param WbsoAdministratieService $service The realisatie computation service.
 	 * @param LoggerInterface $logger Logger for diagnostics (no stack traces to client).
+	 * @param AdministrationContextService $administrationContext Per-administration IDOR guard (ADR-005 Rule 3).
 	 *
 	 * @return void
 	 */
@@ -59,6 +66,7 @@ class WbsoAdministratieController extends Controller {
 		IRequest $request,
 		private readonly WbsoAdministratieService $service,
 		private readonly LoggerInterface $logger,
+		private readonly AdministrationContextService $administrationContext,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 
@@ -77,11 +85,8 @@ class WbsoAdministratieController extends Controller {
 	 * @return JSONResponse
 	 *
 	 * @spec openspec/changes/bookkeeping-wbso-sno-administratie/specs.md
-	 *
-	 * @no-admin-idor-exempt read-only WBSO realisatie summary; administration scope
-	 *   is validated against the caller's membership by OpenRegister's ObjectService
-	 *   RBAC layer (REQ-WBSO-004) — the administration_id input is format-validated
-	 *   and all data reads are multitenancy-scoped server-side before return.
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function realisatie(): JSONResponse {
@@ -100,6 +105,24 @@ class WbsoAdministratieController extends Controller {
 			return new JSONResponse(
 				['error' => 'administration_id must be a valid administration identifier'],
 				Http::STATUS_BAD_REQUEST
+			);
+		}
+
+		// ADR-005 Rule 3 / REQ-001 (security-endpoint-guards). The docblock above
+		// USED to claim "administration scope is validated against the caller's
+		// membership by OpenRegister's ObjectService RBAC layer" — false, per the
+		// same fleet-wide finding documented on VATReturnController/VATLineController:
+		// none of this app's ~871 schemas declares an `authorization` block, so
+		// OpenRegister grants every read to every authenticated user. Without this
+		// check, any authenticated caller could read another organization's
+		// statutory WBSO S&O realisatie by quoting its administration_id. Masked
+		// as 404 (not 403) per AdministrationContextService::canAccess()'s own
+		// contract — a non-member must not be able to distinguish "wrong
+		// administration" from "administration does not exist".
+		if ($this->administrationContext->canAccess($administrationId) === false) {
+			return new JSONResponse(
+				['error' => 'Administration not found'],
+				Http::STATUS_NOT_FOUND
 			);
 		}
 

--- a/lib/Controller/WbsoDocumentApiController.php
+++ b/lib/Controller/WbsoDocumentApiController.php
@@ -39,6 +39,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -70,6 +71,7 @@ class WbsoDocumentApiController extends Controller {
 	 * @param WbsoRbacResolver $rbac Role resolver.
 	 * @param IUserSession $userSession Session.
 	 * @param LoggerInterface $logger Logger.
+	 * @param IL10N $l10n Localized strings for client-facing error messages (ADR-050).
 	 */
 	public function __construct(
 		IRequest $request,
@@ -77,6 +79,7 @@ class WbsoDocumentApiController extends Controller {
 		private readonly WbsoRbacResolver $rbac,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly IL10N $l10n,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -108,7 +111,17 @@ class WbsoDocumentApiController extends Controller {
 				$rows = $this->documents->getDocumentsByAdministration(administrationId: $administrationId);
 			}
 		} catch (InvalidArgumentException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			$this->logger->error(
+				'WbsoDocumentApiController: document list filter rejected',
+				['administrationId' => $administrationId, 'type' => $type, 'exception' => $e->getMessage()]
+			);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Unable to load documents: the filter is invalid'),
+					'error' => 'wbso-document-list-failed',
+				],
+				Http::STATUS_BAD_REQUEST,
+			);
 		} catch (\Throwable $e) {
 			return $this->fail(message: 'Failed to load documents', context: ['exception' => $e->getMessage()]);
 		}
@@ -213,7 +226,17 @@ class WbsoDocumentApiController extends Controller {
 		try {
 			$row = $this->documents->createDocument(administrationId: $administrationId, payload: $payload);
 		} catch (InvalidArgumentException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			$this->logger->error(
+				'WbsoDocumentApiController: document creation payload rejected',
+				['administrationId' => $administrationId, 'exception' => $e->getMessage()]
+			);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Unable to create document: the submitted details are invalid'),
+					'error' => 'wbso-document-create-failed',
+				],
+				Http::STATUS_BAD_REQUEST,
+			);
 		} catch (\Throwable $e) {
 			return $this->fail(message: 'Failed to create document', context: ['exception' => $e->getMessage()]);
 		}
@@ -262,9 +285,26 @@ class WbsoDocumentApiController extends Controller {
 				approver: $approver,
 			);
 		} catch (InvalidArgumentException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+			$this->logger->error(
+				'WbsoDocumentApiController: document to file not found',
+				['administrationId' => $administrationId, 'documentId' => $id, 'exception' => $e->getMessage()]
+			);
+			return new JSONResponse(
+				['message' => $this->l10n->t('Document not found'), 'error' => 'wbso-document-not-found'],
+				Http::STATUS_NOT_FOUND,
+			);
 		} catch (RuntimeException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_CONFLICT);
+			$this->logger->error(
+				'WbsoDocumentApiController: document file transition rejected',
+				['administrationId' => $administrationId, 'documentId' => $id, 'exception' => $e->getMessage()]
+			);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Unable to file this document in its current state'),
+					'error' => 'wbso-document-file-conflict',
+				],
+				Http::STATUS_CONFLICT,
+			);
 		} catch (\Throwable $e) {
 			return $this->fail(message: 'Failed to file document', context: ['exception' => $e->getMessage()]);
 		}
@@ -315,9 +355,26 @@ class WbsoDocumentApiController extends Controller {
 				allowEarly: $allowEarly,
 			);
 		} catch (InvalidArgumentException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+			$this->logger->error(
+				'WbsoDocumentApiController: document to archive not found',
+				['administrationId' => $administrationId, 'documentId' => $id, 'exception' => $e->getMessage()]
+			);
+			return new JSONResponse(
+				['message' => $this->l10n->t('Document not found'), 'error' => 'wbso-document-not-found'],
+				Http::STATUS_NOT_FOUND,
+			);
 		} catch (RuntimeException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_CONFLICT);
+			$this->logger->error(
+				'WbsoDocumentApiController: document archive transition rejected',
+				['administrationId' => $administrationId, 'documentId' => $id, 'exception' => $e->getMessage()]
+			);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Unable to archive this document in its current state'),
+					'error' => 'wbso-document-archive-conflict',
+				],
+				Http::STATUS_CONFLICT,
+			);
 		} catch (\Throwable $e) {
 			return $this->fail(message: 'Failed to archive document', context: ['exception' => $e->getMessage()]);
 		}

--- a/lib/Controller/WbsoDocumentApiController.php
+++ b/lib/Controller/WbsoDocumentApiController.php
@@ -88,6 +88,8 @@ class WbsoDocumentApiController extends Controller {
 	 * GET /api/v1/documents.
 	 *
 	 * @return JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
 	 */
 	#[NoAdminRequired]
 	public function index(): JSONResponse {
@@ -195,6 +197,8 @@ class WbsoDocumentApiController extends Controller {
 	 * POST /api/v1/documents (bookkeeper or admin).
 	 *
 	 * @return JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
 	 */
 	#[NoAdminRequired]
 	public function create(): JSONResponse {
@@ -250,6 +254,8 @@ class WbsoDocumentApiController extends Controller {
 	 * @param string $id Document id.
 	 *
 	 * @return JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
 	 */
 	#[NoAdminRequired]
 	public function file(string $id): JSONResponse {
@@ -318,6 +324,8 @@ class WbsoDocumentApiController extends Controller {
 	 * @param string $id Document id.
 	 *
 	 * @return JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
 	 */
 	#[NoAdminRequired]
 	public function archive(string $id): JSONResponse {

--- a/lib/Controller/WbsoTransactionApiController.php
+++ b/lib/Controller/WbsoTransactionApiController.php
@@ -39,6 +39,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -66,6 +67,7 @@ class WbsoTransactionApiController extends Controller {
 	 * @param WbsoRbacResolver $rbac Role resolver.
 	 * @param IUserSession $userSession Session.
 	 * @param LoggerInterface $logger Logger.
+	 * @param IL10N $l10n Localized strings for client-facing error messages (ADR-050).
 	 */
 	public function __construct(
 		IRequest $request,
@@ -73,6 +75,7 @@ class WbsoTransactionApiController extends Controller {
 		private readonly WbsoRbacResolver $rbac,
 		private readonly IUserSession $userSession,
 		private readonly LoggerInterface $logger,
+		private readonly IL10N $l10n,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -157,6 +160,9 @@ class WbsoTransactionApiController extends Controller {
 	 * POST /api/v1/transactions (bookkeeper or admin).
 	 *
 	 * @return JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function create(): JSONResponse {
@@ -185,7 +191,15 @@ class WbsoTransactionApiController extends Controller {
 		try {
 			$row = $this->transactions->createTransaction(administrationId: $administrationId, payload: $payload);
 		} catch (InvalidArgumentException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			$this->logger->error('WbsoTransactionApiController.create failed', ['exception' => $e]);
+
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Invalid transaction data'),
+					'error' => 'wbso-transaction-invalid-input',
+				],
+				Http::STATUS_BAD_REQUEST,
+			);
 		} catch (\Throwable $e) {
 			return $this->fail(message: 'Failed to create transaction', context: ['exception' => $e->getMessage()]);
 		}
@@ -199,6 +213,9 @@ class WbsoTransactionApiController extends Controller {
 	 * @param string $id Transaction id.
 	 *
 	 * @return JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function post(string $id): JSONResponse {
@@ -223,9 +240,19 @@ class WbsoTransactionApiController extends Controller {
 		try {
 			$row = $this->transactions->postTransaction(administrationId: $administrationId, transactionId: $id);
 		} catch (InvalidArgumentException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+			$this->logger->error('WbsoTransactionApiController.post failed', ['exception' => $e]);
+
+			return new JSONResponse(
+				['message' => $this->l10n->t('Transaction not found'), 'error' => 'wbso-transaction-not-found'],
+				Http::STATUS_NOT_FOUND,
+			);
 		} catch (RuntimeException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_CONFLICT);
+			$this->logger->error('WbsoTransactionApiController.post failed', ['exception' => $e]);
+
+			return new JSONResponse(
+				['message' => $this->l10n->t('Unable to post transaction'), 'error' => 'wbso-transaction-conflict'],
+				Http::STATUS_CONFLICT,
+			);
 		} catch (\Throwable $e) {
 			return $this->fail(message: 'Failed to post transaction', context: ['exception' => $e->getMessage()]);
 		}
@@ -239,6 +266,9 @@ class WbsoTransactionApiController extends Controller {
 	 * @param string $id Transaction id.
 	 *
 	 * @return JSONResponse
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 * @e2e exclude API-only endpoint, no UI surface (security-endpoint-guards)
 	 */
 	#[NoAdminRequired]
 	public function reverse(string $id): JSONResponse {
@@ -269,14 +299,29 @@ class WbsoTransactionApiController extends Controller {
 				reason: $reason,
 			);
 		} catch (InvalidArgumentException $e) {
-			$status = Http::STATUS_BAD_REQUEST;
+			$this->logger->error('WbsoTransactionApiController.reverse failed', ['exception' => $e]);
+
 			if ($e->getMessage() === 'Transaction not found') {
-				$status = Http::STATUS_NOT_FOUND;
+				return new JSONResponse(
+					['message' => $this->l10n->t('Transaction not found'), 'error' => 'wbso-transaction-not-found'],
+					Http::STATUS_NOT_FOUND,
+				);
 			}
 
-			return new JSONResponse(['error' => $e->getMessage()], $status);
+			return new JSONResponse(
+				[
+					'message' => $this->l10n->t('Invalid reversal request'),
+					'error' => 'wbso-transaction-invalid-input',
+				],
+				Http::STATUS_BAD_REQUEST,
+			);
 		} catch (RuntimeException $e) {
-			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_CONFLICT);
+			$this->logger->error('WbsoTransactionApiController.reverse failed', ['exception' => $e]);
+
+			return new JSONResponse(
+				['message' => $this->l10n->t('Unable to reverse transaction'), 'error' => 'wbso-transaction-conflict'],
+				Http::STATUS_CONFLICT,
+			);
 		} catch (\Throwable $e) {
 			return $this->fail(message: 'Failed to reverse transaction', context: ['exception' => $e->getMessage()]);
 		}

--- a/lib/Service/InvoiceGenerationService.php
+++ b/lib/Service/InvoiceGenerationService.php
@@ -72,11 +72,18 @@ class InvoiceGenerationService {
 	 * Draft an invoice from a generation request — saves BillableInvoice +
 	 * BillableInvoiceLine rows in draft status.
 	 *
+	 * Every id the request references (timeEntryIds/expenseIds/
+	 * meterReadingIds/milestoneId) is resolved through a lookup scoped to
+	 * $request->administrationId — a cross-tenant id can never resolve
+	 * (REQ-001; see loadTimeEntries()/loadExpenses()/loadMeterReadings()/
+	 * loadMilestone()/findScoped()).
+	 *
 	 * @param InvoiceGenerationRequest $request Validated request.
 	 *
 	 * @return array<string,mixed> Persisted BillableInvoice (with id).
 	 *
 	 * @spec openspec/specs/usage-metered-billing/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
 	public function draftInvoice(InvoiceGenerationRequest $request): array {
 		// 1. Deduplicate source IDs.
@@ -94,9 +101,15 @@ class InvoiceGenerationService {
 			);
 		}
 
-		// 2. Resolve time entries → BillingModelEngine input shape.
-		$timeEntries = $this->loadTimeEntries(ids: $request->timeEntryIds, rateCardId: $request->rateCardId);
-		$expenses = $this->loadExpenses(ids: $request->expenseIds);
+		// 2. Resolve time entries → BillingModelEngine input shape. Every
+		// referenced id below (timeEntryIds/expenseIds/meterReadingIds/
+		// milestoneId) is client-supplied on the request — loadTimeEntries()/
+		// loadExpenses() (and, via driveModel(), loadMeterReadings()/
+		// loadMilestone()) each scope their lookup to
+		// $request->administrationId so a cross-tenant id can never resolve
+		// (REQ-001).
+		$timeEntries = $this->loadTimeEntries(ids: $request->timeEntryIds, rateCardId: $request->rateCardId, administrationId: $request->administrationId);
+		$expenses = $this->loadExpenses(ids: $request->expenseIds, administrationId: $request->administrationId);
 		$hoursLogged = array_sum(array_column($timeEntries, 'hours'));
 
 		// 3. Drive the model.
@@ -419,7 +432,7 @@ class InvoiceGenerationService {
 
 			case 'milestone':
 				return $this->billingEngine->calculateMilestone(
-					milestone: $this->loadMilestone(milestoneId: (string)$request->milestoneId),
+					milestone: $this->loadMilestone(milestoneId: (string)$request->milestoneId, administrationId: $request->administrationId),
 					expenses: $expenses
 				);
 
@@ -438,7 +451,8 @@ class InvoiceGenerationService {
 				return $this->billingEngine->calculateUsage(
 					ratedReadings: $this->loadMeterReadings(
 						ids: $request->meterReadingIds,
-						defaultRatePlanId: $request->usageRatePlanId
+						defaultRatePlanId: $request->usageRatePlanId,
+						administrationId: $request->administrationId
 					),
 					expenses: $expenses
 				);
@@ -470,19 +484,28 @@ class InvoiceGenerationService {
 	/**
 	 * Load time entries and attach rate snapshots.
 	 *
+	 * Each id is client-supplied on the request; the lookup itself is scoped
+	 * to $administrationId (compound id+administrationId filter, matching
+	 * GoodsReceiptNoteService's findOne() pattern) so a cross-tenant
+	 * timeEntryId can never resolve — it is silently skipped, the same as an
+	 * unknown id (REQ-001).
+	 *
 	 * @param array<int,string> $ids UrenRegistratie ids.
 	 * @param string|null $rateCardId Rate card to resolve against.
+	 * @param string $administrationId Caller's server-resolved administration scope.
 	 *
 	 * @return array<int,array<string,mixed>>
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
-	private function loadTimeEntries(array $ids, ?string $rateCardId): array {
+	private function loadTimeEntries(array $ids, ?string $rateCardId, string $administrationId): array {
 		if (count($ids) === 0) {
 			return [];
 		}
 
 		$entries = [];
 		foreach ($ids as $id) {
-			$loaded = $this->find(schema: 'UrenRegistratie', id: $id);
+			$loaded = $this->findScoped(schema: 'UrenRegistratie', id: $id, administrationId: $administrationId);
 			if ($loaded === null) {
 				continue;
 			}
@@ -521,18 +544,26 @@ class InvoiceGenerationService {
 	/**
 	 * Load expense records into engine input shape.
 	 *
+	 * Each id is client-supplied on the request; the lookup itself is scoped
+	 * to $administrationId (compound id+administrationId filter) so a
+	 * cross-tenant expenseId can never resolve — it is silently skipped, the
+	 * same as an unknown id (REQ-001).
+	 *
 	 * @param array<int,string> $ids ExpenseClaimEntry ids.
+	 * @param string $administrationId Caller's server-resolved administration scope.
 	 *
 	 * @return array<int,array<string,mixed>>
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
-	private function loadExpenses(array $ids): array {
+	private function loadExpenses(array $ids, string $administrationId): array {
 		if (count($ids) === 0) {
 			return [];
 		}
 
 		$rows = [];
 		foreach ($ids as $id) {
-			$loaded = $this->find(schema: 'ExpenseClaimEntry', id: $id);
+			$loaded = $this->findScoped(schema: 'ExpenseClaimEntry', id: $id, administrationId: $administrationId);
 			if ($loaded === null) {
 				continue;
 			}
@@ -555,21 +586,30 @@ class InvoiceGenerationService {
 	 * the request-level default. Readings whose plan cannot be resolved are
 	 * skipped (never billed at a zero rate).
 	 *
+	 * Both lookups are client-reachable ids (`ids` from the request's
+	 * meterReadingIds, and `defaultRatePlanId` from the request's own
+	 * usageRatePlanId) — both are scoped to $administrationId (compound
+	 * id+administrationId filter) so a cross-tenant MeterReading or
+	 * UsageRatePlan can never resolve; it is silently skipped, the same as an
+	 * unknown id (REQ-001).
+	 *
 	 * @param array<int,string> $ids MeterReading ids.
 	 * @param string|null $defaultRatePlanId Fallback UsageRatePlan id.
+	 * @param string $administrationId Caller's server-resolved administration scope.
 	 *
 	 * @return array<int,array<string,mixed>>
 	 *
 	 * @spec openspec/specs/usage-metered-billing/spec.md
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
-	private function loadMeterReadings(array $ids, ?string $defaultRatePlanId): array {
+	private function loadMeterReadings(array $ids, ?string $defaultRatePlanId, string $administrationId): array {
 		if (count($ids) === 0) {
 			return [];
 		}
 
 		$rated = [];
 		foreach ($ids as $id) {
-			$reading = $this->find(schema: 'MeterReading', id: $id);
+			$reading = $this->findScoped(schema: 'MeterReading', id: $id, administrationId: $administrationId);
 			if ($reading === null) {
 				continue;
 			}
@@ -580,7 +620,7 @@ class InvoiceGenerationService {
 				continue;
 			}
 
-			$plan = $this->find(schema: 'UsageRatePlan', id: $planId);
+			$plan = $this->findScoped(schema: 'UsageRatePlan', id: $planId, administrationId: $administrationId);
 			if ($plan === null) {
 				$this->logger->warning(sprintf('UsageRatePlan %s not found for MeterReading %s; skipping.', $planId, $id));
 				continue;
@@ -622,12 +662,21 @@ class InvoiceGenerationService {
 	/**
 	 * Load milestone metadata or return a stub on lookup failure.
 	 *
+	 * $milestoneId is client-supplied on the request; the lookup itself is
+	 * scoped to $administrationId (compound id+administrationId filter) so a
+	 * cross-tenant milestoneId can never resolve — it falls back to the same
+	 * generic stub as an unknown id, never a cross-tenant milestone's own
+	 * name/budget (REQ-001).
+	 *
 	 * @param string $milestoneId Milestone id.
+	 * @param string $administrationId Caller's server-resolved administration scope.
 	 *
 	 * @return array{milestoneId:string,milestoneName:string,milestoneCompletedAt:string,milestoneBudgetCents:int}
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
 	 */
-	private function loadMilestone(string $milestoneId): array {
-		$loaded = $this->find(schema: 'Milestone', id: $milestoneId);
+	private function loadMilestone(string $milestoneId, string $administrationId): array {
+		$loaded = $this->findScoped(schema: 'Milestone', id: $milestoneId, administrationId: $administrationId);
 		if ($loaded === null) {
 			return [
 				'milestoneId' => $milestoneId,
@@ -772,6 +821,58 @@ class InvoiceGenerationService {
 		}
 
 	}//end find()
+
+	/**
+	 * Find a single record scoped to the caller's administrationId — the id
+	 * AND administrationId are compounded into the query itself (an equality
+	 * filter pair on findAll()) so a cross-tenant id can never resolve, rather
+	 * than being fetched by id alone and then checked. Mirrors
+	 * GoodsReceiptNoteService::findOne()'s pattern (REQ-001).
+	 *
+	 * Used for every id draftInvoice() resolves that originates on the
+	 * client-supplied request (timeEntryIds/expenseIds/meterReadingIds/
+	 * milestoneId, and the UsageRatePlan a MeterReading or the request's
+	 * usageRatePlanId points at) — an unresolvable id (unknown OR
+	 * cross-tenant) is indistinguishable to the caller, matching this file's
+	 * existing "skip / fall back to stub" convention for a missing id.
+	 *
+	 * @param string $schema Schema slug.
+	 * @param string $id Record id.
+	 * @param string $administrationId Caller's server-resolved administration scope.
+	 *
+	 * @return array<string,mixed>|null
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 */
+	private function findScoped(string $schema, string $id, string $administrationId): ?array {
+		try {
+			$rows = $this->objectService
+				->setRegister($this->register())
+				->setSchema($schema)
+				->findAll(
+					[
+						'filters' => [
+							'id' => $id,
+							'administrationId' => $administrationId,
+						],
+					]
+				);
+		} catch (\Throwable $e) {
+			return null;
+		}
+
+		if (is_array($rows) === false) {
+			return null;
+		}
+
+		foreach ($rows as $row) {
+			if (is_array($row) === true) {
+				return $row;
+			}
+		}
+
+		return null;
+	}//end findScoped()
 
 	/**
 	 * Save (create or update) via the real OR ObjectService API.

--- a/openspec/changes/security-endpoint-guards/.openspec.yaml
+++ b/openspec/changes/security-endpoint-guards/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: conduction
+created: 2026-08-19

--- a/openspec/changes/security-endpoint-guards/design.md
+++ b/openspec/changes/security-endpoint-guards/design.md
@@ -1,0 +1,217 @@
+# Design: security-endpoint-guards
+
+## Context
+
+shillinq's controllers default to Nextcloud's `#[NoAdminRequired]` attribute for any
+endpoint a non-admin user should be able to call. Per ADR-005 Rule 3, that attribute
+alone is not authorization — it only removes the framework's admin-only default. The
+method body must independently establish that the calling user is entitled to act on
+the specific object/administration/tenant the request names. `hydra-gate-no-admin-idor`
+mechanically checks for this, but it is diff-scoped (ADR-020) and pattern-based (looks
+for a call shaped like `authorize*`/`require*`/`ensure*`/`isAdmin(`/`OCSForbiddenException`
+in the method body) — it cannot tell a real guard from a same-shaped stub. The
+completed audit that scoped this change found 64 of 195 `#[NoAdminRequired]` methods
+with no enforced guard at all, plus one case (`DBAController`) where a guard call
+exists but does nothing.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Close all 64 confirmed missing-guard findings with the ADR-005-correct posture.
+- Fix the one confirmed "fake guard" (`DBAController::ensureAdministrationAccess()`).
+- Close all 29 confirmed exception-message leaks per ADR-050.
+- Leave behind PHPUnit + Playwright evidence that each new guard actually enforces
+  (not just "a call exists").
+
+**Non-Goals:**
+- Building ADR-023's action↔group admin-configurable matrix (`requireAction()`,
+  `ActionAuthorization` service). That is cross-cutting infrastructure work with its
+  own design surface; this change stays within ADR-005's existing per-object/
+  tenant/admin guard vocabulary.
+- Building the ADR-055 §5 `TenantScopedObjectService` shared primitive. Per-controller
+  guards in this change hand-roll the membership check they need and document why,
+  exactly as ADR-055 §5 instructs multi-tenant apps to do until that primitive ships.
+- Re-auditing methods outside the audit's 195-method `#[NoAdminRequired]` population.
+
+## Enumeration & Triage Methodology
+
+### Step 1 — Mechanical candidate generation
+
+The audit's number (64 confirmed) is the output of human triage on top of a
+mechanical scan; it is not directly reproducible by grep alone. To ground this
+change, `hydra-gate-no-admin-idor`'s exact check logic (see
+`.claude/skills/hydra-gate-no-admin-idor/SKILL.md`, Step 1) was re-run **non-diff-
+scoped** against all of `lib/Controller/*.php` at HEAD:
+
+```bash
+for f in lib/Controller/*.php; do
+    [ -f "$f" ] || continue
+    grep -nE "^\s*public\s+function\s+[a-zA-Z0-9_]+\s*\(" "$f" \
+        | while IFS=: read line_no _; do
+        method=$(sed -n "${line_no}p" "$f" | grep -oE 'function\s+[a-zA-Z0-9_]+' | awk '{print $2}')
+        [ -z "$method" ] && continue
+        start=$((line_no > 20 ? line_no - 20 : 1))
+        head_block=$(sed -n "${start},${line_no}p" "$f")
+        echo "$head_block" | grep -qE '#\[NoAdminRequired\b|@NoAdminRequired\b' || continue
+        body=$(awk -v start="${line_no}" 'NR >= start { print; if (NR > start && /^    \}/) exit }' "$f")
+        if ! echo "$body" | grep -qE 'OCSForbiddenException|isAdmin\s*\(|->\s*(authorize|require|ensure)[A-Z][a-zA-Z0-9_]*\s*\(|#\[PublicPage\]|@PublicPage\b'; then
+            echo "FAIL ${f}:${line_no} method=${method}"
+        fi
+    done
+done
+```
+
+**Result at HEAD: 105 candidates across 49 files** — a superset of the confirmed 64.
+The gap runs both directions:
+
+- **Over-triggers**: some of the 105 are already correctly guarded through a shape
+  the regex doesn't recognize (e.g., a guard delegated to a private helper called
+  under a different name, or an admin check expressed as
+  `$this->groupManager->isAdmin($uid)` stored in a variable before branching).
+- **Under-triggers**: the regex accepts *any* `->requireX(`/`->ensureX(` call as
+  proof of a guard. `CBSSubmissionController::requireUser()` and
+  `DBAController::ensureAdministrationAccess()` both match the pattern by name while
+  enforcing nothing beyond "is logged in" (the former) or nothing at all (the
+  latter, a documented stub). **Both would mechanically PASS gate-7 today.**
+
+### Step 2 — Per-candidate manual triage (this change's Wave-1 task)
+
+Every one of the 105 candidates gets a one-line verdict, following the
+`orphan-auth-remediation` change's precedent (verdict table in design.md, one row
+per finding, four possible verdicts):
+
+| Verdict | Meaning | Action |
+|---|---|---|
+| **GUARD (ownership)** | User-scoped object; needs a fetch→compare-owner/administration→throw pattern | Add the guard, call it from every mutating method on the resource |
+| **GUARD (admin)** | Instance-wide administrative CRUD wrongly left `#[NoAdminRequired]` | Swap to `#[AuthorizedAdminSetting(settings: ...)]` |
+| **JUSTIFY** | Genuinely open-to-all-authenticated-users behavior (e.g., a read already scoped server-side by the caller's own uid downstream) | Add a code comment explaining why, per the `hydra-gate-no-admin-idor` false-positive guidance |
+| **ALREADY-GUARDED (false positive)** | The regex missed an existing guard | No code change; note in the verdict table so re-runs don't re-flag it |
+| **STUB (fix the fake guard)** | A guard call exists but its body doesn't enforce anything | Wire the real check or delete the misleading stub and replace it honestly |
+
+The five worst / most illustrative findings, verified against HEAD for this design
+document (not guessed):
+
+| File:line | Method | Verdict | Evidence |
+|---|---|---|---|
+| `lib/Controller/CBSSubmissionController.php:280` (also `:179 create`, `:229 update`, `:341 generate`) | `destroy` et al. | **GUARD (ownership/tenant)** | `requireUser()` (`:101-110`) checks only `getUser() !== null`. `destroy()` fetches by id, checks only `status`, calls `deleteObject($id)` — zero ownership/administration check. Docblock's claim of service-layer validation is false (verified: `objectService()`/`register()` at `:541-556` do no such thing). |
+| `lib/Controller/DBAController.php:357` | `setTussenkomstMode` | **STUB (fix the fake guard)** | `ensureAdministrationAccess()` (`:699-714`) is a documented no-op: "Real check would call `AdministrationMembership::isMember($user, $administrationId)`. Until the implementation cycle wires it, we log the guarded access." It never throws. |
+| `lib/Controller/BankRuleController.php:238` | `acceptSuggestion` | **NEEDS VERIFICATION** (see Open Question in proposal.md) | `requireAuthenticatedSession()` (`:420`) is auth-only (throws `OCSForbiddenException` only on `getUser() === null`). The created `MatchingRule`'s `administrationId` comes from `resolveAdministrationId()` (`:390`), which reads `AdministrationContextService::buildContext()['activeAdministrationId']`. Whether that context can be influenced by request-supplied input was not resolved before this design was written — the apply phase must read `AdministrationContextService` first. |
+| `lib/Controller/CalendarController.php:302` | `createBooking` | **GUARD (ownership/tenant)** | `requireAuth()` (`:438-444`) checks only `$this->context->currentUserId() !== null`. No check that the caller is entitled to book the resolved `$resourceId`. |
+| `lib/Controller/BookingNotificationController.php:91,123` | `getBookingTriggers`, `updateBookingTriggers` | **ALREADY-GUARDED (re-verify)** | `authorizeBookingAccess()` (`:272-`) does check admin-or-`AdministrationContextService`-membership against the booking's `administrationId`, and its docblock documents a prior `findObject()`/`find()` bug that made the guard fail-open-as-403-to-everyone (already fixed — it now calls the real `find()`). This may be a resolved finding; the audit's "confirmed" note may predate the fix, or point at the annotation split (`:164`/`:220` use `#[AuthorizedAdminSetting]` on the same resource type) as the actual concern rather than a missing guard. **Do not blindly re-add a guard here — re-read the method first.** |
+
+The remaining ~100 candidates (105 minus the 5 above) are enumerated in
+`tasks.md` Wave 2 as a batch triage-and-fix task, working file-by-file through the
+mechanical scan's output, applying the same five-verdict process.
+
+### Step 3 — Convergence with the audit's "64"
+
+The audit's 64 is the already-triaged count (candidates with a real GUARD or STUB
+verdict, excluding ALREADY-GUARDED false positives and JUSTIFY cases). This design
+does not force the Wave-2 batch triage to land on exactly 64 — the true number is
+whatever the per-method evidence supports. If Wave 2's triage converges on a
+materially different number, that is expected (grep-based candidate generation is
+intentionally over-inclusive) and should be recorded, not treated as a discrepancy
+to explain away.
+
+## Error-response hardening (ADR-050)
+
+29 occurrences across 16 controllers return
+`new JSONResponse(['error' => $e->getMessage()], <status>)`. Per ADR-050's envelope
+convention, replace with:
+
+```php
+} catch (\Throwable $e) {
+    $this->logger->error('CBSSubmissionController.destroy failed', ['exception' => $e]);
+    return new JSONResponse(
+        ['message' => $this->l10n->t('Unable to delete CBS submission'), 'error' => 'cbs-submission-delete-failed'],
+        Http::STATUS_INTERNAL_SERVER_ERROR,
+    );
+}
+```
+
+- `message` — localized, human-readable, shown in the UI.
+- `error` — kebab-case, machine-readable, stable slug for frontend dispatch/testing.
+  Convention: `<resource>-<verb>-failed` or a more specific slug when the exception
+  maps to a known condition (e.g. `cbs-submission-not-found`,
+  `cbs-submission-not-draft`).
+- The real exception goes to `$this->logger->error()` (already the pattern used by
+  several sibling controllers in the same files, e.g.
+  `WbsoTransactionApiController::fail()` at `:107`), never to the response body.
+
+Each of the 16 files gets its slugs chosen per call site based on the specific
+exception/condition being handled — this is enumerated per-file in tasks.md rather
+than here, since the exact slug text is implementation detail, not a design
+decision.
+
+## Nextcloud Integration
+
+- Controllers: all 16+ files listed in proposal.md's Impact section.
+- Services: no new services. `DBAController::ensureAdministrationAccess()` either
+  gets a real body (calling whatever membership-check service the app already uses
+  elsewhere — same pattern as `BookingNotificationController::authorizeBookingAccess()`'s
+  `AdministrationContextService` check) or is deleted in favor of an inline check.
+- No new Mappers/Entities, no new Events/Hooks — this is guard logic inside existing
+  controller methods.
+
+## Security Considerations
+
+This entire change IS the security consideration — see Context above. One
+implementation rule carried over from ADR-005 / ADR-055: **never suppress a
+`hydra-gate-no-admin-idor` finding by removing `#[NoAdminRequired]`** — that
+silently makes the endpoint admin-only and breaks the non-admin flow it exists for.
+Every fix in this change either adds an enforced guard or (rarely, for the JUSTIFY
+verdict) documents why none is needed; none of them removes the attribute to make
+the gate stop complaining.
+
+## Seed Data
+
+None. This change adds authorization logic and error-response shape changes to
+existing controller methods — no new OpenRegister schema, no new object types, no
+`lib/Settings/shillinq_register.json` change.
+
+## ADR-031 alignment
+
+ADR-031 (schema-declarative business logic over service classes) does not apply
+here — per-request authorization decisions (compare the caller's identity against
+the target object's owner/administration) are exactly the kind of imperative,
+per-request check ADR-031 does not ask apps to express declaratively; OpenRegister's
+own `x-openregister-*` declarative surfaces cover object-level RBAC
+(register/schema permissions), not the app-level "does this specific authenticated
+user own this specific object" check that ADR-005 Rule 3 requires in the controller.
+No new `x-openregister-*` metadata is introduced or needed.
+
+## Risks / Trade-offs
+
+- **[Risk] Scope too large for one Hydra build cycle** → **Mitigation**: tasks.md
+  orders work in priority waves (named worst cases first) so a partial cycle still
+  lands the highest-value fixes; `HYDRA_BUILDER_MAX_TURNS=400` / `budget:large` are
+  available if needed rather than re-scoping the finding set down.
+- **[Risk] Over-guarding breaks a legitimate cross-administration workflow** (e.g., an
+  accountant-portal user who is meant to act across multiple client administrations)
+  → **Mitigation**: every guard addition is checked against
+  `openspec/specs/accountant-portal/spec.md` and `openspec/specs/app-administration/spec.md`
+  before landing, and gets a positive-direction test proving the legitimate
+  cross-administration caller (where one exists) still succeeds.
+- **[Risk] The `DBAController` stub-fix requires a real membership-check dependency
+  that may not exist yet** → **Mitigation**: if no membership service exists,
+  the fallback is an explicit `administrationId` match against the authenticated
+  user's own session-scoped administration context (same pattern
+  `BookingNotificationController::authorizeBookingAccess()` already uses via
+  `AdministrationContextService`) — not a new shared service, reusing what's already
+  proven correct in this codebase.
+
+## Migration Plan
+
+No data migration. Deploy is a normal PHP code change:
+1. Merge to `development`.
+2. Existing objects are unaffected — guards evaluate at request time, not stored
+   state.
+3. Rollback is `git revert` (see proposal.md Rollback Strategy) — no forward-only
+   state to unwind.
+
+## Open Questions
+
+See proposal.md's Open Questions section — carried here for reference:
+`AdministrationContextService`'s input surface (BankRuleController), whether the
+`BookingNotificationController` finding is already resolved, and whether the Wave-2
+batch triage converges near 64 or a different number.

--- a/openspec/changes/security-endpoint-guards/design.md
+++ b/openspec/changes/security-endpoint-guards/design.md
@@ -110,6 +110,7 @@ Resolved against HEAD during implementation (code read, not guessed):
 | `BankRuleController::acceptSuggestion()` | — | **ALREADY-GUARDED (session-derived, IDOR-safe) — Open Question resolved, no code change** | Read `AdministrationContextService::buildContext()` (`lib/Service/AdministrationContextService.php:113-162`): `activeAdministrationId` is `$administrations[0]['administrationId']`, derived from `membershipsForUser($this->currentUserId())` — i.e. purely from the authenticated session uid via the caller's own `AdministrationMembership` records. No request parameter, header, or client-supplied value reaches `buildContext()` anywhere in its call graph. The only client-observable effect is that a multi-administration user always lands on their FIRST accessible administration (a business-logic limitation — they cannot choose which — not an IDOR vector, since it is always an administration they are a genuine member of). Verdict: confirmed already IDOR-safe by construction. Documented in the method's docblock (`resolveAdministrationId()`) rather than adding a redundant membership check. |
 | `CalendarController::createBooking()` | — | **GUARD (ownership/tenant) — fixed** | Added a check after `loadCalendar()`: `$this->context->canAccess($calendarRow['administrationId'])`, returning 403 (`calendar-booking-forbidden`) before the transactional conflict-check/write runs. `$this->context` (`AdministrationContextService`) was already injected for `resolveAdministrationId()`'s read-side filtering — reused, no new dependency. |
 | `BookingNotificationController::getBookingTriggers/updateBookingTriggers` | — | **ALREADY-GUARDED — Open Question resolved, no code change** | Re-read `authorizeBookingAccess()` (`:273-323`) against HEAD before touching the file, per Risk 3's mitigation. The guard is genuine: admin bypass via `IGroupManager::isAdmin()`, then `AdministrationContextService::canAccess($booking['administrationId'])`, throwing `OCSForbiddenException` on both a missing booking and a non-member caller. The docblock's own history note (the `findObject()` vs `find()` bug) documents a PRIOR defect that was already fixed before this change started — that fix, not a still-open gap, is what the audit's "confirmed" note most likely trailed. The `#[NoAdminRequired]` (per-object: `getBookingTriggers`/`updateBookingTriggers`) vs `#[AuthorizedAdminSetting]` (instance-wide: `getNotificationMonitor`/`disableAllTriggers`) annotation split was also re-checked and is correct for what each method does — not a finding. Verdict recorded in the method's docblock. |
+| `lib/Service/InvoiceGenerationService.php::draftInvoice()` | `loadTimeEntries`/`loadExpenses`/`loadMeterReadings`/`loadMilestone` | **GUARD (ownership/tenant) — fixed** | Second-order IDOR found during Wave-2 triage of `InvoiceApiController` (recorded below as an Incomplete Item, now closed for this half). Each of the four private loaders resolved its client-supplied id (`timeEntryIds`/`expenseIds`/`meterReadingIds`/`milestoneId` on `InvoiceGenerationRequest`) via `ObjectService::find($id)` alone — no `administrationId` check — so a member of administration A could reference administration B's `UrenRegistratie`/`ExpenseClaimEntry`/`MeterReading`/`Milestone` records and have B's hours/expense amounts/metered usage/milestone name+budget billed onto A's invoice. Fixed by adding `findScoped()` — a compound `id`+`administrationId` equality filter via `findAll()` (mirrors `GoodsReceiptNoteService::findOne()`'s scoping-the-lookup pattern rather than fetch-then-check) — and threading `$request->administrationId` through all four loaders plus the `UsageRatePlan` lookup inside `loadMeterReadings()` (a `MeterReading`'s own `ratePlanId`, or the request's `usageRatePlanId`, could also point at another tenant's price book). A cross-tenant id is now indistinguishable from an unknown one: silently excluded (time entry/expense/meter reading) or falls back to the existing generic stub (milestone) — matching this file's own pre-existing convention for an unresolvable reference, not a new error path. 6 new tests in `tests/Unit/Service/InvoiceGenerationServiceIdorTest.php` cover all four id types + the nested UsageRatePlan reference, both directions (cross-tenant excluded, own-tenant still drafts); verified with a temporary negative control (guard reverted to the pre-fix `find()` call) showing the cross-tenant time-entry test fail red (`1300.0` leaked vs `500.0` expected) before restoring green. `RateCardResolver`/`RetainerResolver` (the `rateCardId`/`retainerScheduleId` half of the original finding) remain open — see Incomplete Items. |
 
 ### Wave 2 — full 105-candidate triage (complete)
 
@@ -346,14 +347,19 @@ batch triage converges near 64 or a different number.
   redundant defense-in-depth, not currently exploitable, but worth wiring for
   defense-in-depth in a follow-up (`lib/Service/DunningRunService.php` was outside
   this change's assigned file list).
-- **`InvoiceGenerationService::draftInvoice()`** (discovered during Wave-2 triage of
-  `InvoiceApiController`, not fixed — outside the assigned file list) — loads
-  `timeEntryIds`/`expenseIds`/`meterReadingIds`/`milestoneId`/`rateCardId`/
-  `retainerScheduleId` purely by client-supplied id, with no check that each
-  referenced record's own `administrationId` matches the caller's server-resolved
-  administration. A second-order IDOR distinct from the guard candidates this change
-  was scoped to (`InvoiceApiController`'s own methods are all correctly guarded).
-  **Recommended as a follow-up finding**, not part of this change's fix set.
+- **`InvoiceGenerationService::draftInvoice()` — `rateCardId`/`retainerScheduleId`
+  half only, still open** (discovered during Wave-2 triage of
+  `InvoiceApiController`; the `timeEntryIds`/`expenseIds`/`meterReadingIds`/
+  `milestoneId` half of this finding is now **GUARD-fixed**, see the Apply-phase
+  table above). `RateCardResolver::resolveRate()` and
+  `RetainerResolver::resolveRetainerAmount()` (both `lib/Service/`, both outside
+  this change's assigned file list) still resolve `rateCardId`/`retainerScheduleId`
+  purely by client-supplied id with no `administrationId` filter at all — a caller
+  can reference another administration's `RateCard`/`RateRecord`/`RetainerSchedule`
+  and have its negotiated rate applied to their own invoice. A second-order IDOR of
+  the same shape, requiring a signature change across two service classes and their
+  ~13 existing unit-test call sites — **recommended as a focused follow-up change**,
+  not silently left looking "done."
 - **Two ADR-050 leak variants outside the literal grep's exact-line match, found but
   not fixed** (both explicitly out of the assigned per-file leak-fix scope):
   `GoodsReceiptNoteController::mapRuntimeException()` (`lib/Controller/GoodsReceiptNoteController.php:390-404`)

--- a/openspec/changes/security-endpoint-guards/design.md
+++ b/openspec/changes/security-endpoint-guards/design.md
@@ -99,9 +99,99 @@ document (not guessed):
 | `lib/Controller/CalendarController.php:302` | `createBooking` | **GUARD (ownership/tenant)** | `requireAuth()` (`:438-444`) checks only `$this->context->currentUserId() !== null`. No check that the caller is entitled to book the resolved `$resourceId`. |
 | `lib/Controller/BookingNotificationController.php:91,123` | `getBookingTriggers`, `updateBookingTriggers` | **ALREADY-GUARDED (re-verify)** | `authorizeBookingAccess()` (`:272-`) does check admin-or-`AdministrationContextService`-membership against the booking's `administrationId`, and its docblock documents a prior `findObject()`/`find()` bug that made the guard fail-open-as-403-to-everyone (already fixed — it now calls the real `find()`). This may be a resolved finding; the audit's "confirmed" note may predate the fix, or point at the annotation split (`:164`/`:220` use `#[AuthorizedAdminSetting]` on the same resource type) as the actual concern rather than a missing guard. **Do not blindly re-add a guard here — re-read the method first.** |
 
-The remaining ~100 candidates (105 minus the 5 above) are enumerated in
-`tasks.md` Wave 2 as a batch triage-and-fix task, working file-by-file through the
-mechanical scan's output, applying the same five-verdict process.
+### Apply-phase resolution of the five named findings
+
+Resolved against HEAD during implementation (code read, not guessed):
+
+| File:line | Method | Final Verdict | Resolution |
+|---|---|---|---|
+| `CBSSubmissionController` `create/update/destroy/generate` | — | **GUARD (ownership/tenant) — fixed** | Injected `AdministrationContextService`; added `requireAdministrationAccess(administrationId)` (403 on non-member, matching this change's spec scenario) called after fetching the existing object (`update`/`destroy`/`generate`) or against the request-body `administrationId` (`create`, before the object is persisted). **Also found and fixed during the same code read, beyond the audit's named 4**: `index()` and `show()` had the identical missing-guard shape (`requireUser()` is auth-only) — any authenticated user could list or read another organization's filing. `index()` now scopes an unfiltered list to the caller's own accessible administrations and 403s an explicit out-of-scope `administrationId` filter; `show()` 403s on a non-member. Fixed for consistency since REQ-001 applies to every `#[NoAdminRequired]` method on the file, not only the four the audit enumerated. |
+| `DBAController::ensureAdministrationAccess()` | `setTussenkomstMode` + 6 other call sites | **STUB — fixed** | Injected `AdministrationContextService`; the stub now calls `canAccess($administrationId)` and throws `OCSForbiddenException` on denial (anonymous, empty administrationId, or non-member) instead of logging-and-returning unconditionally. All 7 call sites (`saveIntake`, `computeScore`-adjacent flows, `uploadWba`, `setTussenkomstMode`, `evidenceConsent`, and 2 more) inherit the fix with no per-call-site change needed, since they all funnel through this one helper. |
+| `BankRuleController::acceptSuggestion()` | — | **ALREADY-GUARDED (session-derived, IDOR-safe) — Open Question resolved, no code change** | Read `AdministrationContextService::buildContext()` (`lib/Service/AdministrationContextService.php:113-162`): `activeAdministrationId` is `$administrations[0]['administrationId']`, derived from `membershipsForUser($this->currentUserId())` — i.e. purely from the authenticated session uid via the caller's own `AdministrationMembership` records. No request parameter, header, or client-supplied value reaches `buildContext()` anywhere in its call graph. The only client-observable effect is that a multi-administration user always lands on their FIRST accessible administration (a business-logic limitation — they cannot choose which — not an IDOR vector, since it is always an administration they are a genuine member of). Verdict: confirmed already IDOR-safe by construction. Documented in the method's docblock (`resolveAdministrationId()`) rather than adding a redundant membership check. |
+| `CalendarController::createBooking()` | — | **GUARD (ownership/tenant) — fixed** | Added a check after `loadCalendar()`: `$this->context->canAccess($calendarRow['administrationId'])`, returning 403 (`calendar-booking-forbidden`) before the transactional conflict-check/write runs. `$this->context` (`AdministrationContextService`) was already injected for `resolveAdministrationId()`'s read-side filtering — reused, no new dependency. |
+| `BookingNotificationController::getBookingTriggers/updateBookingTriggers` | — | **ALREADY-GUARDED — Open Question resolved, no code change** | Re-read `authorizeBookingAccess()` (`:273-323`) against HEAD before touching the file, per Risk 3's mitigation. The guard is genuine: admin bypass via `IGroupManager::isAdmin()`, then `AdministrationContextService::canAccess($booking['administrationId'])`, throwing `OCSForbiddenException` on both a missing booking and a non-member caller. The docblock's own history note (the `findObject()` vs `find()` bug) documents a PRIOR defect that was already fixed before this change started — that fix, not a still-open gap, is what the audit's "confirmed" note most likely trailed. The `#[NoAdminRequired]` (per-object: `getBookingTriggers`/`updateBookingTriggers`) vs `#[AuthorizedAdminSetting]` (instance-wide: `getNotificationMonitor`/`disableAllTriggers`) annotation split was also re-checked and is correct for what each method does — not a finding. Verdict recorded in the method's docblock. |
+
+### Wave 2 — full 105-candidate triage (complete)
+
+All 105 mechanical-scan candidates were triaged file-by-file, read (method body +
+any guard helper), and classified. Work was split three ways by file (Group A: 34
+candidates across 17 files; Group B: 36 candidates across 14 files; Group C: 35
+candidates across 18 files — 105 total, reconciling exactly with the Step-1 scan
+count). Full per-candidate verdict tables with evidence live in the scratch
+reports the triage passes produced; the counts below are the authoritative
+roll-up.
+
+**Verdict counts (Wave 2, 105/105 candidates)**:
+
+| Verdict | Count | Notes |
+|---|---|---|
+| GUARD (ownership/tenant) — fixed/hardened | 5 | `FinancialDashboardController::series/summary` (partial — see note below), `DunningController::resumePause`, `BookingDepthController::createSeries`, `WbsoAdministratieController::realisatie` |
+| GUARD (admin) | 0 | No candidate was genuinely instance-wide admin CRUD mis-annotated as `#[NoAdminRequired]` |
+| JUSTIFY | 14 | Methods with no caller-reachable cross-tenant object (session-only scope, global reference data, or no OpenRegister read at all) — inline comment + `@spec`/`@e2e` tags added, no behavior change |
+| ALREADY-GUARDED (false positive) | 86 | A real, enforcing guard already existed under a shape the mechanical regex doesn't recognize — see below |
+| STUB | 0 | The only STUB in the whole change was `DBAController::ensureAdministrationAccess()`, found and fixed as one of the five named findings (not part of the 105) |
+| **Total** | **105** | |
+
+**Why 86 of 105 were false positives — the dominant, systemic cause**: the
+mechanical scan's regex (`.claude/skills/hydra-gate-no-admin-idor`, and this
+change's Step 1 reproduction) recognizes a guard only when it is shaped
+`authorize*(`/`require*(`/`ensure*(`/`isAdmin(`/`OCSForbiddenException`/
+`#[PublicPage]`. This app's actual canonical per-object/tenant guard call is
+**`AdministrationContextService::canAccess(administrationId: …)`**, called
+either inline in the controller method or one hop away in a service/helper
+(`resolveScope()`, `mayAccessReturn()`, `guardDraftAccess()`, or a service-layer
+`accessibleAdministrationIds()`/double-filtered `findOne(['id' => …,
+'administrationId' => …])` lookup). None of those shapes match the regex's verb
+list. **Every one of the 86 ALREADY-GUARDED verdicts was independently verified
+by reading the guard's actual implementation** (not inferred from its presence)
+— `AdministrationContextService::canAccess()` performs a real
+`AdministrationMembership` lookup and returns `false` for a non-member, and
+several batches additionally ran a live negative-control (temporarily disabling
+the guard and re-running the existing test) to confirm it denies under the
+removal, not just exists. **Recommendation**: extend
+`hydra-gate-no-admin-idor`'s regex to also match `->canAccess(` (and, ideally,
+delegated-service scoping shapes like `accessibleAdministrationIds()`) so this
+false-positive class does not recur on the next non-diff-scoped re-run — flagged
+here as a follow-up gate-fix, not implemented as part of this change (out of
+scope: this change fixes findings, it does not modify the gate scripts).
+
+**The 5 real GUARD fixes, briefly** (full evidence in the per-batch scratch
+reports):
+- `FinancialDashboardController::series()`/`summary()` — the underlying
+  `FinancialDashboardService::fetchSchema()` reads several schemas via an
+  unfiltered `findAll([])`; **partially fixed** within this task's file scope
+  (`respond()` now 403s a caller with zero accessible administrations), but a
+  full per-row scope fix needs `GLLine` (which carries no `administrationId`
+  property at all — a documented, already-pinned gap) and touches
+  `lib/Service/FinancialDashboardService.php`, outside this task's assigned
+  file list. **Flagged as an incomplete item, not silently closed** — see
+  Incomplete Items below.
+- `DunningController::resumePause()` — the controller's own `canAccess()` guard
+  checked the *request-supplied* `administration_id`, but the target
+  `DunningPauseDispute` (addressed by a separate `pauseId` path param) was never
+  re-checked against its *own* `administrationId` — `DunningRunService::resumePause()`
+  fetches by id alone and never reads its `$administrationId` parameter
+  (flagged by its own pre-existing `@SuppressWarnings(PHPMD.UnusedFormalParameter)`
+  note). A member of administration A supplying `administration_id=A` (passes)
+  and a guessed/enumerated `pauseId` from administration B could resume/read B's
+  dunning pause. Fixed entirely at the controller layer: fetch the pause first,
+  then check `canAccess()` against its real `administrationId`.
+- `BookingDepthController::createSeries()` — the request-supplied
+  `administrationId` was correctly checked, but the caller-supplied `resourceId`
+  was never checked to actually belong to that administration — a member of A
+  could pass `administrationId=A` (their own) with a `resourceId` from B and
+  book against B's resource. Fixed with an explicit
+  `$resource['administrationId'] !== $administrationId` check before persistence.
+- `WbsoAdministratieController::realisatie()` — no guard at all; the method's own
+  `@no-admin-idor-exempt` docblock claimed "OpenRegister's ObjectService RBAC
+  layer" validates the scope, which is false (no schema in this app declares an
+  `authorization` block — the same false-claim pattern this change's Motivation
+  section already documented for `CBSSubmissionController`). Fixed with a new
+  `canAccess()` check, masked 404 on denial.
+
+Full per-candidate evidence (105 rows) is preserved in the triage passes' scratch
+output; summarized here to keep this file navigable. Ask the orchestrator for the
+raw per-batch tables if a specific candidate's reasoning needs re-verification.
 
 ### Step 3 — Convergence with the audit's "64"
 
@@ -215,3 +305,82 @@ See proposal.md's Open Questions section — carried here for reference:
 `AdministrationContextService`'s input surface (BankRuleController), whether the
 `BookingNotificationController` finding is already resolved, and whether the Wave-2
 batch triage converges near 64 or a different number.
+
+**All three resolved during implementation:**
+- `AdministrationContextService`'s input surface (BankRuleController) — session-derived,
+  confirmed IDOR-safe by construction (no code change). See the five-named-findings
+  table above.
+- `BookingNotificationController` — already resolved before this change started
+  (ALREADY-GUARDED, no code change). See the five-named-findings table above.
+- The Wave-2 batch triage converged on **105 candidates, 5 real guard fixes (+ 1 more
+  in the CBS index/show bonus find), 0 admin-mis-annotations, 14 JUSTIFY, 86
+  false-positive ALREADY-GUARDED**, materially different from the audit's original
+  "64 confirmed" figure. This is not a discrepancy to explain away — the audit's 64
+  was itself an estimate ahead of the per-method code read this change's methodology
+  section calls for, and the true number (per-method evidence, not a target) is 5
+  fixes out of 105 mechanically-flagged candidates. The dominant reason the audit's
+  64 overshot: `AdministrationContextService::canAccess()` is this app's canonical
+  guard and was already wired into the overwhelming majority of flagged methods, just
+  under a call shape (`canAccess(`, not `authorize*`/`require*`/`ensure*`) neither the
+  audit's manual read nor the mechanical scan's regex fully accounted for ahead of time.
+
+## Incomplete Items (honest ledger, not silently closed)
+
+- **`FinancialDashboardController::series()`/`summary()`** — only partially fixed.
+  A caller with zero accessible administrations is now rejected (403), but a caller
+  who belongs to administration A still receives dashboard aggregates computed across
+  **every** administration's `Account`/`GLTransaction`/`GLLine`/`UrenRegistratie`/
+  `ARInvoice`/`APTransaction` data, because `FinancialDashboardService::fetchSchema()`
+  reads via an unfiltered `findAll([])`. A full fix needs per-row administration
+  scoping in `lib/Service/FinancialDashboardService.php` — outside this change's
+  assigned file list (the Wave-2 batch that found this was scoped to
+  `lib/Controller/FinancialDashboardController.php` only) — and, for `GLLine`
+  specifically, that schema carries no `administrationId` property at all (a
+  documented, already-pinned gap per `SpendAnalyticsServiceTest`), so closing this
+  fully may need a schema/data migration, not just a code change. **Recommended as a
+  focused follow-up change**, not silently left looking "done."
+- **`DunningRunService::resumePause()`'s dead `$administrationId` parameter** — the
+  `resumePause()` IDOR was fixed entirely at the controller layer (fetch-then-check
+  before calling the service); the service method's own unread `$administrationId`
+  parameter (and its `@SuppressWarnings(PHPMD.UnusedFormalParameter)` note) is now
+  redundant defense-in-depth, not currently exploitable, but worth wiring for
+  defense-in-depth in a follow-up (`lib/Service/DunningRunService.php` was outside
+  this change's assigned file list).
+- **`InvoiceGenerationService::draftInvoice()`** (discovered during Wave-2 triage of
+  `InvoiceApiController`, not fixed — outside the assigned file list) — loads
+  `timeEntryIds`/`expenseIds`/`meterReadingIds`/`milestoneId`/`rateCardId`/
+  `retainerScheduleId` purely by client-supplied id, with no check that each
+  referenced record's own `administrationId` matches the caller's server-resolved
+  administration. A second-order IDOR distinct from the guard candidates this change
+  was scoped to (`InvoiceApiController`'s own methods are all correctly guarded).
+  **Recommended as a follow-up finding**, not part of this change's fix set.
+- **Two ADR-050 leak variants outside the literal grep's exact-line match, found but
+  not fixed** (both explicitly out of the assigned per-file leak-fix scope):
+  `GoodsReceiptNoteController::mapRuntimeException()` (`lib/Controller/GoodsReceiptNoteController.php:390-404`)
+  returns `['error' => $exception->getMessage()]` on 3 status branches via a
+  `$message` intermediate variable — not literally
+  `JSONResponse(['error' => $e->getMessage()]`, so the exact grep this change's
+  acceptance criteria specifies does not catch it, but it is the same defect class.
+  `ReconciliationResolutionController::bulkResolve()` similarly returns
+  `$failed[$matchId] = $e->getMessage()` in a per-item partial-failure map inside a
+  200 response — a batch-operation variant of the same pattern, also outside the
+  literal grep and this change's explicit per-file leak-fix assignment list.
+- **Missing PHPUnit coverage for two files with no test file at all**:
+  `ThreeWayMatchController` and `ThreeWayMatchAuditController` have zero existing
+  PHPUnit coverage (`tests/Unit/Controller/ThreeWayMatchControllerTest.php` /
+  `ThreeWayMatchAuditControllerTest.php` do not exist). Their guards are real and
+  already enforce (ALREADY-GUARDED, confirmed by code read), so REQ-004 does not
+  require new tests here (no posture was added/changed), but the fleet-wide absence
+  of a test file for either controller is worth a dedicated follow-up.
+- **Two real UI surfaces with zero e2e coverage, neither touched by this change's
+  guard fixes**: Requisitions (`/inkoop/requisitions`) and the Reporting & Compliance
+  overview (`ReportingComplianceOverview.vue`) both have live manifest routes and no
+  Playwright spec. This change's own e2e scope (per proposal.md) is limited to the
+  CBS Submissions surface (Task 8); authoring new coverage for these two is a
+  separate, larger task.
+- **Mechanical scan false-positive rate (systemic, for a follow-up gate-fix)**: 86 of
+  105 Wave-2 candidates (82%) were false positives because
+  `hydra-gate-no-admin-idor`'s regex does not recognize `->canAccess(` as a guard
+  shape. Recommend extending the regex (see the Wave-2 section above) — not
+  implemented here, since this change's scope is fixing findings, not modifying gate
+  scripts.

--- a/openspec/changes/security-endpoint-guards/proposal.md
+++ b/openspec/changes/security-endpoint-guards/proposal.md
@@ -1,0 +1,258 @@
+---
+kind: code
+depends_on: []
+---
+
+# Proposal: security-endpoint-guards
+
+## Summary
+
+A completed security audit of shillinq's `lib/Controller/` found two confirmed,
+verified defect classes: (1) 64 of 195 `#[NoAdminRequired]` controller methods carry
+no per-object, tenant, or admin authorization guard in the method body (ADR-005 Rule
+3 / OWASP A01:2021), and (2) 29 call sites across 16 controllers return the raw PHP
+exception message (`$e->getMessage()`) to the HTTP client, leaking internal
+implementation detail (ADR-050). This change enumerates every finding, applies the
+ADR-005-correct guard posture per method (per-object ownership, admin-only, or a
+documented open-to-all justification), replaces the 29 leaks with kebab-case error
+slugs logged server-side, and adds PHPUnit + Playwright coverage proving each new
+guard actually rejects the unauthorized case.
+
+## Motivation
+
+The worst confirmed instance is `CBSSubmissionController` — `create()`, `update()`,
+`destroy()` (`:280`), and `generate()` operate on instance-wide statutory CBS
+(Centraal Bureau voor de Statistiek) filings and are guarded only by a private
+`requireUser()` helper that checks authentication, not authorization:
+
+```php
+// lib/Controller/CBSSubmissionController.php:92-97
+/**
+ * Authorization guard — every endpoint requires an authenticated
+ * Nextcloud user (REQ-CBS-001 / ADR-005). The administration scope is
+ * validated by the IDOR-safe service layer. This helper is the
+ * in-body counterpart to #[NoAdminRequired] so gate-7 no-admin-idor /
+ * gate-9 semantic-auth see the explicit auth posture.
+ */
+private function requireUser(): ?JSONResponse { ... }
+```
+
+`destroy()` (verified at `:280-326`) fetches the target `CBSSubmission` by `$id`,
+checks only its `status` (`draft`), and calls `deleteObject($id)` — no ownership,
+administration-membership, or admin check anywhere in the call chain. The docblock's
+claim that "the administration scope is validated by the IDOR-safe service layer" is
+false: `objectService()->setRegister(...)->setSchema('CBSSubmission')->find($id)` /
+`->deleteObject($id)` perform no such validation. **Any authenticated user can delete
+any other organization's draft statutory filing by guessing or enumerating its ID.**
+
+A second, more insidious pattern was found in `DBAController::setTussenkomstMode()`
+(`:356-385`): the method DOES call a named guard, `ensureAdministrationAccess()` —
+but that guard is a documented stub:
+
+```php
+// lib/Controller/DBAController.php:699-714
+private function ensureAdministrationAccess(array $assignment): void {
+    ...
+    // Real check would call AdministrationMembership::isMember($user, $administrationId).
+    // Until the implementation cycle wires it, we log the guarded access.
+    $this->logger->debug('DBA controller: administration access', [...]);
+}
+```
+
+It never throws, never denies — it logs and returns unconditionally. A naive
+mechanical scan for "a method call named `authorize*`/`require*`/`ensure*`" (the
+exact heuristic `hydra-gate-no-admin-idor` uses) treats this as PASS. **This is why
+the change requires a per-method code read, not a grep-and-add pass**: a syntactically
+present guard is not evidence of an enforced one.
+
+Also confirmed by the audit: `BankRuleController::acceptSuggestion()` (creates a
+`MatchingRule` scoped to an administration resolved server-side, but the
+apply phase must confirm that resolution path cannot be influenced by request
+input) and `CalendarController::createBooking()` (guarded only by
+`requireAuth()`, an authentication-only check — any authenticated user can book any
+calendar/resource with no ownership check).
+
+`BookingNotificationController` was flagged by the audit for mixing
+`#[NoAdminRequired]` (`:89`, `:122`) with `#[AuthorizedAdminSetting]` (`:164`,
+`:220`) on the same resource type (`Booking` / `BookingNotificationTrigger`). Our own
+code read of `authorizeBookingAccess()` (`:272-`) found what looks like a genuine
+per-object guard (admin bypass + `AdministrationContextService` membership check,
+with a docblocked history of a prior `findObject()` vs `find()` bug that turned the
+guard into a blanket 403). **We could not independently confirm this is still broken
+as of HEAD — it may be that the audit's "confirmed" classification predates a fix, or
+that the concern is really about the annotation split rather than a missing guard.**
+This is flagged as an Open Question below rather than guessed at.
+
+On the second defect class: 29 occurrences of
+`new JSONResponse(['error' => $e->getMessage()], ...)` across 16 controllers
+(confirmed via `grep -rlF "JSONResponse(['error' => \$e->getMessage()]" lib/Controller`)
+return raw exception text — which can include database error fragments, file paths,
+or third-party API error bodies — directly to any authenticated client.
+
+## Affected Projects
+
+- [x] Project: `shillinq` — 64 controller-method authorization guards, 29
+      error-response hardenings, new PHPUnit + Playwright coverage. No other
+      ConductionNL app is touched.
+
+## Scope
+
+### In Scope
+
+- Mechanically enumerate every `#[NoAdminRequired]` / `@NoAdminRequired` controller
+  method in `lib/Controller/` (195 total per the audit) and produce the definitive,
+  human-triaged list of the ones lacking an enforced per-object, tenant, or admin
+  guard (starting from the 64 the audit already confirmed).
+- Per flagged method, apply exactly one of three ADR-005-correct postures:
+  1. **Per-object / tenant ownership guard** — user-scoped objects (the common
+     case): fetch the object, verify the caller owns it / is a member of its
+     administration / tenant, throw `OCSForbiddenException` on failure.
+  2. **`#[AuthorizedAdminSetting(settings: ...)]`** — methods that mutate
+     instance-wide administrative state (per ADR-005's admin-surface-CRUD rule).
+  3. **Documented open-to-all justification** — a code comment explaining why the
+     method is intentionally reachable by any authenticated user with no
+     per-object check (e.g., a read that is itself scoped server-side by the
+     caller's own uid), for the rare case that is genuinely correct as-is.
+- Fix the specific "fake guard" pattern found in `DBAController::ensureAdministrationAccess()` —
+  either wire the real membership check or remove the misleading stub and replace it
+  with an honest guard.
+- Replace all 29 confirmed `$e->getMessage()` leaks with a machine-readable
+  kebab-case error slug (ADR-050 error-shape convention) plus server-side
+  `LoggerInterface->error()` logging of the real exception.
+- PHPUnit coverage for every re-guarded method: the unauthorized case is rejected
+  AND the authorized case still succeeds (positive direction, per ADR-055's
+  guard-gaming lesson — a guard that only denies is as unproven as one that only
+  logs).
+- Playwright e2e coverage for the CBS Submissions manifest-v2 UI surface
+  (`src/manifest.d/bookkeeping-cbs-bestanden-extended.json`, route
+  `/bookkeeping/cbs-submissions`), since a real UI surface exists there.
+- `@spec` (gate-16) and `@e2e` (gate-19) traceability on every changed method;
+  reason-bearing `@e2e exclude` for API-only endpoints with no UI surface.
+
+### Out of Scope
+
+- **ADR-023's full `requireAction()`/`ActionAuthorization` declarative action-RBAC
+  machinery** — building an admin-configurable action↔group matrix service is a
+  separate, larger change. This change uses the narrower per-object/tenant/admin
+  guard vocabulary ADR-005 Rule 3 already defines, which is sufficient to close the
+  64 confirmed findings without introducing new shared infrastructure.
+- Any controller method not in the audit's 195-method `#[NoAdminRequired]`
+  population (e.g., `#[PublicPage]` or unannotated admin-default methods) — those
+  are governed by different gates (`hydra-gate-route-auth`,
+  `hydra-gate-semantic-auth`) and are not re-examined here.
+- Multi-tenant `TenantScopedObjectService` (ADR-055 §5) — that shared primitive does
+  not exist yet; this change documents per-controller why a guard is tenant-safe
+  instead of depending on infrastructure that hasn't shipped.
+- UI/UX changes beyond what's needed to keep the CBS Submissions page functioning
+  after the guard change (no new screens, no new nav entries).
+
+## Approach
+
+1. Re-run the audit's mechanical enumeration (`hydra-gate-no-admin-idor`'s check
+   logic, non-diff-scoped, across all of `lib/Controller/*.php`) to produce a
+   candidate list. A naive run of this logic against current HEAD returns 105
+   candidates across 49 files — a superset of the confirmed 64, because the regex
+   both over-triggers (some candidates are already correctly guarded through a
+   pattern the regex doesn't recognize) and under-triggers (`requireUser()` /
+   `ensureAdministrationAccess()`-shaped stub or auth-only helpers pass the naive
+   "a `require*`/`ensure*` call exists" check even though they enforce nothing
+   beyond authentication).
+2. Triage every candidate by reading the method body and any guard helper it calls
+   — classify DELETE-nothing-add-guard / re-wire-stub-guard / already-guarded /
+   needs-admin-attribute / needs-justification-comment. Record the verdict table in
+   design.md (pattern established by the `orphan-auth-remediation` change).
+3. Apply guards per the classified posture, controller by controller, in priority
+   order: the named worst cases first (CBS, DBA, BankRule, Calendar,
+   BookingNotification re-verification), then the remaining candidates.
+4. Replace the 29 error-leak call sites with slugs + logging.
+5. Add PHPUnit tests (positive + negative direction) per re-guarded method, and
+   Playwright e2e for the CBS Submissions UI surface.
+6. Re-run `hydra-gate-no-admin-idor`, `hydra-gate-semantic-auth`, gate-16, gate-19,
+   and the full `composer check:strict` suite before PR.
+
+## New Dependencies
+
+None.
+
+## Impact
+
+- `lib/Controller/CBSSubmissionController.php` — worst confirmed case: 4 methods on
+  instance-wide statutory filings guarded only by authentication.
+- `lib/Controller/DBAController.php` — a named guard call that is a no-op stub.
+- `lib/Controller/BankRuleController.php`, `lib/Controller/CalendarController.php` —
+  confirmed missing per-object/tenant guards.
+- `lib/Controller/BookingNotificationController.php` — re-verification of a
+  possibly-already-fixed finding.
+- ~55-60 additional controller methods across the remaining `lib/Controller/*.php`
+  files, enumerated and triaged per the process above.
+- 16 controllers with `$e->getMessage()` leaks: `BankStatementImportController`,
+  `BillingIntakeController`, `BookingDepthController`, `CalendarController`,
+  `ComplianceExportController`, `DunningController`, `GRIRReconciliationController`,
+  `InvoiceApiController`, `PayrollController`, `PurchaseOrderController`,
+  `ReconciliationResolutionController`, `RequisitionController`,
+  `VATReturnController`, `WbsoAccountApiController`, `WbsoDocumentApiController`,
+  `WbsoTransactionApiController`.
+- New/expanded `tests/Unit/Controller/*Test.php` files for every re-guarded
+  method.
+- New `tests/e2e/cbs-submissions.spec.ts` (or an addition to an existing bookkeeping
+  e2e spec) for the CBS Submissions UI surface.
+
+## Cross-Project Dependencies
+
+None — this is a self-contained shillinq change. It draws on company-wide ADR-005,
+ADR-050, and ADR-055 (all already accepted, no changes requested to them) and
+explicitly does not build ADR-023's cross-app action-RBAC machinery.
+
+## Risks
+
+### Risk 1: The full 64+29 remediation may not fit one Hydra build cycle
+
+**Severity:** High — **Mitigation:** Per ADR-032, this is a `kind: code` change; the
+default 200-turn Sonnet budget may not cover ~64 method-level guard additions plus
+29 error-response edits plus their tests in one pass. tasks.md groups the work into
+priority-ordered waves so a partial cycle still lands the highest-severity fixes
+(CBS, DBA stub, BankRule, Calendar) first. If the builder times out before finishing
+all waves, set `HYDRA_BUILDER_MAX_TURNS=400` (or `budget:large` label) on the retry
+rather than re-scoping — the finding set is fixed by the audit, not negotiable down.
+
+### Risk 2: A guard added in the wrong place breaks a legitimate cross-user workflow
+
+**Severity:** Medium — **Mitigation:** Every method gets BOTH a negative test (guard
+rejects) and a positive test (the legitimate caller still succeeds) before merge —
+this is the change's core testing requirement, chosen specifically because ADR-055's
+review round found guards that only prove the negative direction are unproven in the
+positive one.
+
+### Risk 3: The `BookingNotificationController` finding may already be resolved
+
+**Severity:** Low — **Mitigation:** Flagged as an Open Question; the apply phase
+re-verifies `authorizeBookingAccess()` against current HEAD before touching the file,
+and either confirms the fix already landed (no-op, document in design.md) or finds
+the residual gap the audit meant.
+
+## Rollback Strategy
+
+Every change in this set is additive at the guard layer (a new authorization check
+that runs before existing business logic) or a response-shape change (error body
+only, not the success path). Revert is a straight `git revert` of the merged PR(s) —
+no data migration, no schema change, nothing to unwind. If a specific guard proves
+too strict in production (blocks a legitimate caller), the fix is a follow-up PR
+narrowing that one guard's condition, not a global rollback.
+
+## Open Questions
+
+- Is `BankRuleController::acceptSuggestion()`'s `resolveAdministrationId()` — which
+  reads `AdministrationContextService::buildContext()['activeAdministrationId']` —
+  ever influenced by request-supplied input (header, session value the client can
+  set), or is it always derived purely server-side from the authenticated session?
+  This determines whether the fix is "add an explicit membership check" or "confirm
+  and document why session-derived scope is already IDOR-safe." Needs a code read of
+  `AdministrationContextService` before the apply phase touches this controller.
+- Is the `BookingNotificationController` finding still live at HEAD, or did
+  `authorizeBookingAccess()`'s fix (referenced in its own docblock as a past bug fix)
+  already close it? See Risk 3.
+- Should the ~55-60 not-yet-individually-verified candidate methods from the 105-item
+  mechanical scan be triaged as part of this change's Wave 2 task, or does the true
+  count converge closer to the audit's 64 once stubs/false-positives are excluded?
+  design.md's enumeration methodology section is written so the apply phase can
+  answer this empirically rather than guessing a number now.

--- a/openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md
+++ b/openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md
@@ -1,0 +1,170 @@
+# security-endpoint-guards Specification
+
+**Status**: in-progress
+**Scope**: shillinq
+**OpenSpec changes**:
+- security-endpoint-guards
+
+## Purpose
+
+Establishes and enforces the authorization posture every `#[NoAdminRequired]`
+controller method in `lib/Controller/` must carry (ADR-005 Rule 3 / OWASP A01:2021),
+and the error-response shape every controller method must use when translating a
+caught exception into an HTTP response (ADR-050). Closes a completed audit's 64
+confirmed missing-guard findings and 29 confirmed exception-message leaks. Does not
+build ADR-023's action↔group RBAC matrix — see Notes.
+
+## ADDED Requirements
+
+### Requirement: REQ-001: Every `#[NoAdminRequired]` method SHALL carry an enforced authorization guard
+
+Every controller method annotated `#[NoAdminRequired]` / `@NoAdminRequired` MUST
+either (a) verify the authenticated caller owns, is a member of the administration/
+tenant of, or is an admin for the specific object/resource the request names, before
+performing any read beyond existence-check or any mutation, or (b) carry an inline
+code comment justifying why the method is intentionally reachable by any
+authenticated user with no per-object check. A guard that is present syntactically
+(a method call shaped like `authorize*`/`require*`/`ensure*`) but whose body does
+not actually deny unauthorized callers does NOT satisfy this requirement — the guard
+MUST enforce, not merely exist.
+
+#### Scenario: A user cannot delete another organization's CBS submission
+
+- **GIVEN** two authenticated users, A and B, in different administrations, and a
+  `CBSSubmission` object in `draft` status owned by administration A
+- **WHEN** user B calls `DELETE /api/cbs-submissions/{id}` naming administration A's
+  submission
+- **THEN** the response is 403 Forbidden and the submission is NOT deleted
+
+#### Scenario: A user can delete their own administration's draft CBS submission
+
+- **GIVEN** an authenticated user A who is a member of administration A, and a
+  `CBSSubmission` object in `draft` status owned by administration A
+- **WHEN** user A calls `DELETE /api/cbs-submissions/{id}` naming that submission
+- **THEN** the response is 200 and the submission is deleted
+
+#### Scenario: A guard call that never denies is treated as no guard
+
+- **GIVEN** a controller method body containing a call to a helper named
+  `ensure*`/`authorize*`/`require*`
+- **WHEN** that helper's implementation cannot throw, return an error response, or
+  otherwise deny the request under any input
+- **THEN** the method is classified as ungated and MUST be fixed with an enforcing
+  guard, regardless of the helper's name
+
+### Requirement: REQ-002: Instance-wide administrative CRUD SHALL use `#[AuthorizedAdminSetting]`, not `#[NoAdminRequired]`
+
+A controller method that mutates instance-wide administrative state (not scoped to
+a single user's or administration's own objects) MUST be annotated
+`#[AuthorizedAdminSetting(settings: <AdminSettingsClass>::class)]` (or the
+positional `#[AuthorizedAdminSetting(Application::APP_ID)]` form), never
+`#[NoAdminRequired]`.
+
+#### Scenario: An admin-only monitoring endpoint rejects a non-admin caller
+
+- **GIVEN** an authenticated user who is not a Nextcloud admin
+- **WHEN** they call an endpoint annotated `#[AuthorizedAdminSetting]`
+- **THEN** the framework middleware rejects the request before the controller body
+  runs
+
+### Requirement: REQ-003: Exception responses SHALL NOT leak raw exception text
+
+No controller method may return `new JSONResponse(['error' => $e->getMessage()], ...)`
+or any equivalent shape that places the caught `\Throwable`'s message text directly
+in the HTTP response body. Every caught exception translated to an error response
+MUST return a flat `{message, error}` body per ADR-050 — `message` MUST be a static,
+localized, human-readable string (`IL10N::t()`), `error` MUST be a stable
+machine-readable kebab-case slug — and the real exception MUST be logged
+server-side via `LoggerInterface->error()`.
+
+#### Scenario: A failed CBS submission deletion returns a slug, not exception text
+
+- **GIVEN** `CBSSubmissionController::destroy()` catches a `\Throwable` while
+  deleting the underlying object
+- **WHEN** the exception is translated to an HTTP response
+- **THEN** the response body is `{"message": "<localized text>", "error": "cbs-submission-delete-failed"}`
+  and contains no fragment of `$e->getMessage()`
+- **AND** the real exception is logged via `$this->logger->error(...)`
+
+#### Scenario: No response body across the fixed 16 controllers contains raw exception text
+
+- **GIVEN** the 16 controllers this change modifies
+  (`BankStatementImportController`, `BillingIntakeController`,
+  `BookingDepthController`, `CalendarController`, `ComplianceExportController`,
+  `DunningController`, `GRIRReconciliationController`, `InvoiceApiController`,
+  `PayrollController`, `PurchaseOrderController`,
+  `ReconciliationResolutionController`, `RequisitionController`,
+  `VATReturnController`, `WbsoAccountApiController`, `WbsoDocumentApiController`,
+  `WbsoTransactionApiController`)
+- **WHEN** `grep -rlF "JSONResponse(['error' => \$e->getMessage()]" lib/Controller`
+  is run at the changed HEAD
+- **THEN** it returns zero matches
+
+### Requirement: REQ-004: Every re-guarded method SHALL have a positive-direction and negative-direction test
+
+Every controller method whose authorization posture is added or changed by this
+change MUST have PHPUnit coverage proving BOTH: an unauthorized caller is rejected,
+AND the legitimate/authorized caller still succeeds. A negative-only test is
+insufficient — it cannot distinguish "the guard works" from "the guard denies
+everyone."
+
+#### Scenario: A re-guarded method's test suite covers both directions
+
+- **GIVEN** a controller method fixed by this change
+- **WHEN** its `tests/Unit/Controller/*Test.php` coverage is inspected
+- **THEN** it contains at least one test asserting a 403/rejection for an
+  unauthorized caller AND at least one test asserting success (2xx, correct payload)
+  for the authorized caller
+
+## Non-Functional Requirements
+
+- **Performance:** Guard checks add at most one additional `find()`/membership
+  lookup per request; no method may introduce an N+1 pattern (e.g., looping a
+  membership check per list item where a single scoped query would do).
+- **Accessibility:** N/A — this change is API-layer only; no new UI is introduced
+  beyond the existing CBS Submissions manifest-v2 page, which is unchanged in
+  layout/markup.
+- **Internationalization:** Dutch and English MUST be supported for every new
+  `message` string introduced by REQ-003 (ADR-005 / ADR-007).
+
+## Acceptance Criteria
+
+- [ ] Every candidate from the non-diff-scoped `hydra-gate-no-admin-idor` scan
+      (see design.md's enumeration methodology) carries a recorded verdict —
+      GUARD, JUSTIFY, ALREADY-GUARDED, or STUB-fixed.
+- [ ] `CBSSubmissionController::create/update/destroy/generate`,
+      `DBAController::setTussenkomstMode`, `BankRuleController::acceptSuggestion`,
+      and `CalendarController::createBooking` each carry an enforced guard.
+- [ ] `DBAController::ensureAdministrationAccess()` no longer unconditionally
+      returns without checking membership.
+- [ ] `BookingNotificationController`'s finding is re-verified against HEAD and
+      either confirmed already-fixed (documented) or fixed.
+- [ ] All 29 confirmed `$e->getMessage()` leak sites return `{message, error}` with
+      no raw exception text.
+- [ ] `hydra-gate-no-admin-idor` run non-diff-scoped against `lib/Controller/`
+      shows zero remaining GUARD/STUB-verdict findings that were in scope for this
+      change (JUSTIFY-verdict methods remain, by design, with their justification
+      comment).
+- [ ] Every re-guarded method has both a rejection test and a success test.
+- [ ] Playwright e2e coverage exists for the CBS Submissions UI surface
+      (`/bookkeeping/cbs-submissions`), or a reason-bearing `@e2e exclude` is
+      recorded for any API-only endpoint with no UI surface.
+
+## Notes
+
+- **ADR-023 out of scope**: this spec deliberately does not introduce
+  `requireAction()` or an admin-configured action↔group matrix. The guard
+  vocabulary here (per-object/tenant ownership, `#[AuthorizedAdminSetting]`,
+  documented justification) is the narrower ADR-005 Rule 3 mechanism, sufficient
+  to close the confirmed findings without new shared infrastructure. A future
+  change may migrate some of these guards onto ADR-023's machinery once it exists
+  for shillinq; that is not this change.
+- **ADR-055 alignment**: this spec's REQ-001 "guard call that never denies" clause
+  directly extends ADR-055's semantic-auth hard-fail principle (§4) — a guard-
+  shaped call with no enforcing body is treated identically to no guard at all.
+- Related ADRs: ADR-005 (security baseline), ADR-020 (gate scope = diff, does not
+  limit this change's non-diff-scoped enumeration pass), ADR-050 (response
+  envelope), ADR-055 (authorization gate extensions).
+- See `openspec/changes/security-endpoint-guards/design.md` for the full
+  enumeration methodology, the five-way verdict table, and the worked evidence for
+  the named worst-case findings.

--- a/openspec/changes/security-endpoint-guards/tasks.md
+++ b/openspec/changes/security-endpoint-guards/tasks.md
@@ -16,8 +16,8 @@
     GUARD (ownership) / GUARD (admin) / JUSTIFY / ALREADY-GUARDED / STUB
   - GIVEN the five named worst-case findings already verified in design.md WHEN this
     task starts THEN they are carried forward, not re-derived from scratch
-- [ ] Implement
-- [ ] Test
+- [x] Implement
+- [x] Test
 
 ### Task 2: Fix CBSSubmissionController — worst confirmed case
 - **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001`
@@ -29,8 +29,8 @@
   - GIVEN the same methods WHEN called by a member of the submission's own
     administration THEN they behave exactly as before (no regression to the
     existing draft/status business rules)
-- [ ] Implement
-- [ ] Test
+- [x] Implement
+- [x] Test
 
 ### Task 3: Fix the named confirmed cluster — DBAController stub, BankRuleController, CalendarController
 - **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001`
@@ -46,8 +46,8 @@
     documented, or an explicit membership check is added
   - GIVEN `CalendarController::createBooking()` WHEN called against a calendar/
     resource the caller has no booking rights to THEN the request is denied
-- [ ] Implement
-- [ ] Test
+- [x] Implement
+- [x] Test
 
 ### Task 4: Re-verify and resolve the BookingNotificationController finding
 - **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001`
@@ -61,8 +61,8 @@
   - GIVEN the `#[NoAdminRequired]` vs `#[AuthorizedAdminSetting]` split across this
     controller's four methods WHEN reviewed THEN each method's annotation is
     confirmed correct for what it actually does (per-object vs instance-wide)
-- [ ] Implement
-- [ ] Test
+- [x] Implement (no code change needed — re-verified ALREADY-GUARDED, documented in design.md and the method's docblock)
+- [x] Test (pre-existing BookingNotificationControllerTest already covers both directions; re-run green, no change needed)
 
 ### Task 5: Guard or reclassify the remaining enumerated candidates (Wave 2)
 - **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001`, `#req-002`
@@ -77,8 +77,8 @@
     an inline comment explaining why no per-object check applies
   - GIVEN every candidate verdicted STUB WHEN this task completes THEN the guard
     call's body actually enforces (throws/denies on failure)
-- [ ] Implement
-- [ ] Test
+- [x] Implement (105/105 triaged; 5 real GUARD fixes, 0 GUARD-admin, 14 JUSTIFY, 86 ALREADY-GUARDED false positives, 0 STUB — see design.md Wave 2 section)
+- [x] Test
 
 ### Task 6: Replace all 29 exception-message leaks with ADR-050 error slugs
 - **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003`
@@ -97,8 +97,8 @@
   - GIVEN each replaced call site WHEN an exception is thrown THEN the response body
     is `{message, error}` (kebab-case slug) and the real exception is logged via
     `LoggerInterface->error()`
-- [ ] Implement
-- [ ] Test
+- [x] Implement (`grep -rn "getMessage()" lib/Controller/ | grep -i "JSONResponse"` → zero matches, verified)
+- [x] Test
 
 ### Task 7: PHPUnit coverage — positive and negative direction per re-guarded method
 - **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-004`
@@ -114,8 +114,8 @@
     authorized-caller-succeeds test
   - GIVEN the full PHPUnit suite WHEN run THEN it is green with no regression
     against the pre-change baseline
-- [ ] Implement
-- [ ] Test
+- [x] Implement
+- [x] Test (see final verification report for the full-suite tally)
 
 ### Task 8: Playwright e2e for the CBS Submissions UI + gate-19 traceability sweep
 - **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001`
@@ -129,8 +129,8 @@
   - GIVEN every API-only endpoint fixed in this change with no corresponding UI
     surface WHEN checked for `@e2e` traceability THEN it carries a reason-bearing
     `@e2e exclude` comment (e.g., "API-only endpoint, no UI surface")
-- [ ] Implement
-- [ ] Test
+- [x] Implement (`tests/e2e/cbs-submissions.spec.ts` created; `@e2e exclude` tags added across all Wave-2 API-only methods)
+- [x] Test (spec authored against the real component testids per static source read; not executed against a live instance in this session — see final report)
 
 ### Task 9: Gate compliance sweep and final verification
 - **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001`, `#req-002`, `#req-003`, `#req-004`
@@ -143,8 +143,8 @@
     coverage), `phpcs`, `phpstan`, `psalm`, `phpmd` WHEN run against the changed
     files THEN all are clean
   - GIVEN `composer check:strict` WHEN run THEN it passes with no new findings
-- [ ] Implement
-- [ ] Test
+- [x] Implement (leak-grep zero hits, php -l clean on all 65 changed/new files, psalm clean on all 37 changed lib/ files after fixing a pre-existing ADR-084 allowlist gap in psalm.xml, openspec validate passes, final PHPUnit suite 4618 tests/0 failures/0 errors)
+- [x] Test (phpcs/phpstan/phpmd cannot run in this environment — pre-existing `vendor/conduction/hydra-gates` package absent, not caused by this change, not fixable without `composer install` which was out of scope per the apply-phase instructions; hydra-gate-no-admin-idor/semantic-auth were not executed as standalone gate scripts but their check logic was manually reproduced across all 105 candidates per design.md's Wave 2 section)
 
 ## Quality checklist
 

--- a/openspec/changes/security-endpoint-guards/tasks.md
+++ b/openspec/changes/security-endpoint-guards/tasks.md
@@ -1,0 +1,165 @@
+# Tasks: security-endpoint-guards
+
+## Implementation Tasks
+
+### Task 1: Reproduce the mechanical enumeration and build the definitive verdict table
+- **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001`
+- **files**: `openspec/changes/security-endpoint-guards/design.md` (extend the
+  verdict table)
+- **acceptance_criteria**:
+  - GIVEN the non-diff-scoped `hydra-gate-no-admin-idor` check logic run against
+    `lib/Controller/*.php` at the branch's HEAD WHEN it is re-run THEN it reproduces
+    the ~105-candidate baseline recorded in design.md (or a materially explained
+    delta if HEAD has moved)
+  - GIVEN each of the 105 candidates WHEN its method body and any guard helper it
+    calls are read THEN it is recorded in design.md's verdict table with one of
+    GUARD (ownership) / GUARD (admin) / JUSTIFY / ALREADY-GUARDED / STUB
+  - GIVEN the five named worst-case findings already verified in design.md WHEN this
+    task starts THEN they are carried forward, not re-derived from scratch
+- [ ] Implement
+- [ ] Test
+
+### Task 2: Fix CBSSubmissionController — worst confirmed case
+- **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001`
+- **files**: `lib/Controller/CBSSubmissionController.php`
+- **acceptance_criteria**:
+  - GIVEN `create()`, `update()`, `destroy()`, `generate()` WHEN called by a user
+    outside the target `CBSSubmission`'s administration THEN the response is 403
+    and no mutation occurs
+  - GIVEN the same methods WHEN called by a member of the submission's own
+    administration THEN they behave exactly as before (no regression to the
+    existing draft/status business rules)
+- [ ] Implement
+- [ ] Test
+
+### Task 3: Fix the named confirmed cluster — DBAController stub, BankRuleController, CalendarController
+- **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001`
+- **files**: `lib/Controller/DBAController.php`, `lib/Controller/BankRuleController.php`,
+  `lib/Controller/CalendarController.php`
+- **acceptance_criteria**:
+  - GIVEN `DBAController::ensureAdministrationAccess()` WHEN a non-member calls
+    `setTussenkomstMode()` THEN the request is denied (the stub's unconditional
+    return is replaced with an enforcing membership check)
+  - GIVEN `BankRuleController::acceptSuggestion()` WHEN
+    `AdministrationContextService` is read (resolving proposal.md's Open Question)
+    THEN either the existing session-derived scoping is confirmed IDOR-safe and
+    documented, or an explicit membership check is added
+  - GIVEN `CalendarController::createBooking()` WHEN called against a calendar/
+    resource the caller has no booking rights to THEN the request is denied
+- [ ] Implement
+- [ ] Test
+
+### Task 4: Re-verify and resolve the BookingNotificationController finding
+- **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001`
+- **files**: `lib/Controller/BookingNotificationController.php`
+- **acceptance_criteria**:
+  - GIVEN `authorizeBookingAccess()` as it exists at task start WHEN re-read against
+    the audit's original finding THEN design.md records whether the finding is
+    already resolved (no code change, document only) or still live (fix + document)
+  - GIVEN the finding is still live WHEN `getBookingTriggers()`/
+    `updateBookingTriggers()` are called by a non-member THEN they are denied
+  - GIVEN the `#[NoAdminRequired]` vs `#[AuthorizedAdminSetting]` split across this
+    controller's four methods WHEN reviewed THEN each method's annotation is
+    confirmed correct for what it actually does (per-object vs instance-wide)
+- [ ] Implement
+- [ ] Test
+
+### Task 5: Guard or reclassify the remaining enumerated candidates (Wave 2)
+- **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001`, `#req-002`
+- **files**: remaining `lib/Controller/*.php` files listed in design.md's verdict
+  table (the ~100 candidates not covered by Tasks 2-4)
+- **acceptance_criteria**:
+  - GIVEN every candidate verdicted GUARD (ownership) in Task 1's table WHEN this
+    task completes THEN it has an enforcing per-object/tenant guard
+  - GIVEN every candidate verdicted GUARD (admin) WHEN this task completes THEN its
+    attribute is `#[AuthorizedAdminSetting(settings: ...)]`, not `#[NoAdminRequired]`
+  - GIVEN every candidate verdicted JUSTIFY WHEN this task completes THEN it carries
+    an inline comment explaining why no per-object check applies
+  - GIVEN every candidate verdicted STUB WHEN this task completes THEN the guard
+    call's body actually enforces (throws/denies on failure)
+- [ ] Implement
+- [ ] Test
+
+### Task 6: Replace all 29 exception-message leaks with ADR-050 error slugs
+- **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003`
+- **files**: `lib/Controller/BankStatementImportController.php`,
+  `lib/Controller/BillingIntakeController.php`, `lib/Controller/BookingDepthController.php`,
+  `lib/Controller/CalendarController.php`, `lib/Controller/ComplianceExportController.php`,
+  `lib/Controller/DunningController.php`, `lib/Controller/GRIRReconciliationController.php`,
+  `lib/Controller/InvoiceApiController.php`, `lib/Controller/PayrollController.php`,
+  `lib/Controller/PurchaseOrderController.php`, `lib/Controller/ReconciliationResolutionController.php`,
+  `lib/Controller/RequisitionController.php`, `lib/Controller/VATReturnController.php`,
+  `lib/Controller/WbsoAccountApiController.php`, `lib/Controller/WbsoDocumentApiController.php`,
+  `lib/Controller/WbsoTransactionApiController.php`
+- **acceptance_criteria**:
+  - GIVEN `grep -rlF "JSONResponse(['error' => \$e->getMessage()]" lib/Controller`
+    WHEN run after this task THEN it returns zero matches
+  - GIVEN each replaced call site WHEN an exception is thrown THEN the response body
+    is `{message, error}` (kebab-case slug) and the real exception is logged via
+    `LoggerInterface->error()`
+- [ ] Implement
+- [ ] Test
+
+### Task 7: PHPUnit coverage — positive and negative direction per re-guarded method
+- **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-004`
+- **files**: `tests/Unit/Controller/CBSSubmissionControllerTest.php`,
+  `tests/Unit/Controller/DBAControllerTest.php`,
+  `tests/Unit/Controller/BankRuleControllerTest.php`,
+  `tests/Unit/Controller/CalendarControllerTest.php`,
+  `tests/Unit/Controller/BookingNotificationControllerTest.php`, plus one test file
+  per Wave-2 controller touched in Task 5
+- **acceptance_criteria**:
+  - GIVEN every method fixed in Tasks 2-5 WHEN its test file is inspected THEN it
+    contains at least one unauthorized-caller-rejected test and at least one
+    authorized-caller-succeeds test
+  - GIVEN the full PHPUnit suite WHEN run THEN it is green with no regression
+    against the pre-change baseline
+- [ ] Implement
+- [ ] Test
+
+### Task 8: Playwright e2e for the CBS Submissions UI + gate-19 traceability sweep
+- **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001`
+- **files**: `tests/e2e/cbs-submissions.spec.ts` (new), plus `@spec`/`@e2e` PHPDoc
+  tags on every method changed in Tasks 2-6
+- **acceptance_criteria**:
+  - GIVEN the manifest-v2 CBS Submissions page (`/bookkeeping/cbs-submissions`,
+    declared in `src/manifest.d/bookkeeping-cbs-bestanden-extended.json`) WHEN a
+    Playwright spec is run against it THEN it exercises at least the list view and
+    a delete-own-draft flow
+  - GIVEN every API-only endpoint fixed in this change with no corresponding UI
+    surface WHEN checked for `@e2e` traceability THEN it carries a reason-bearing
+    `@e2e exclude` comment (e.g., "API-only endpoint, no UI surface")
+- [ ] Implement
+- [ ] Test
+
+### Task 9: Gate compliance sweep and final verification
+- **spec_ref**: `openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001`, `#req-002`, `#req-003`, `#req-004`
+- **files**: N/A — verification pass across all files touched by Tasks 1-8
+- **acceptance_criteria**:
+  - GIVEN `hydra-gate-no-admin-idor` run non-diff-scoped WHEN executed after all
+    prior tasks THEN it reports zero GUARD/STUB-verdict findings from design.md's
+    table (JUSTIFY-verdict methods remain, by design)
+  - GIVEN `hydra-gate-semantic-auth`, gate-16 (spec coverage), gate-19 (e2e
+    coverage), `phpcs`, `phpstan`, `psalm`, `phpmd` WHEN run against the changed
+    files THEN all are clean
+  - GIVEN `composer check:strict` WHEN run THEN it passes with no new findings
+- [ ] Implement
+- [ ] Test
+
+## Quality checklist
+
+<!-- These are reminders for the builder, not tracked checkboxes.
+     Keeping them as plain text avoids inflating the Hydra cap count. -->
+
+- All new/changed authorization logic covered by PHPUnit unit tests (`tests/Unit/`),
+  both positive and negative direction (REQ-004)
+- New/changed API endpoints covered by Newman/Postman tests where the app's existing
+  Postman collection already covers the sibling endpoints on the same controller
+- The CBS Submissions UI change covered by a Playwright browser test (Task 8)
+- All tests pass (`composer test`, `newman run` where applicable)
+- No new user-facing strings beyond the `message` field on error responses (Dutch +
+  English via `IL10N::t()`, ADR-005/ADR-007)
+- `openspec validate` passes
+- Never remove `#[NoAdminRequired]` to silence a gate finding — every fix adds an
+  enforcing guard, swaps to `#[AuthorizedAdminSetting]` where instance-wide admin
+  CRUD was mis-annotated, or documents a genuine JUSTIFY case

--- a/psalm.xml
+++ b/psalm.xml
@@ -60,6 +60,14 @@
                 <referencedClass name="OCP\Notification\IManager"/>
                 <referencedClass name="OCP\Share\IManager"/>
                 <!-- OpenRegister cross-app classes (loaded dynamically) -->
+                <!-- ADR-084 published contract (adopted by commit ef9c8fa5, pre-dates
+                     security-endpoint-guards) — missing from this allowlist since that
+                     adoption; every controller injecting these two (CBSSubmissionController,
+                     InvoiceApiController, and others) already failed UndefinedClass here.
+                     Not introduced by this change; fixed alongside since this change's own
+                     verification pass is what surfaced it. -->
+                <referencedClass name="OCA\OpenRegister\Contract\ObjectServiceInterface"/>
+                <referencedClass name="OCA\OpenRegister\Contract\ObjectEntityInterface"/>
                 <referencedClass name="OCA\OpenRegister\Db\ObjectEntity"/>
                 <referencedClass name="OCA\OpenRegister\Db\RegisterMapper"/>
                 <referencedClass name="OCA\OpenRegister\Db\SchemaMapper"/>

--- a/tests/Unit/Controller/ARInvoiceEInvoiceControllerTest.php
+++ b/tests/Unit/Controller/ARInvoiceEInvoiceControllerTest.php
@@ -1,0 +1,373 @@
+<?php
+
+/**
+ * Unit tests for ARInvoiceEInvoiceController.
+ *
+ * Covers the security-endpoint-guards re-verification of send-einvoice's
+ * authorization posture: the audit's mechanical scan flagged send() as a
+ * candidate because its guard is expressed as `$this->context->canAccess()`
+ * rather than the `authorize*`/`require*`/`ensure*` shape the scan looks
+ * for. Reading the method body confirmed a genuine, enforcing guard already
+ * existed (masked 404 on non-membership, matching
+ * AdministrationContextService's own IDOR-safety contract) — this file adds
+ * the PHPUnit coverage that was previously missing so the verdict has
+ * measured evidence, per REQ-004's both-directions requirement.
+ *
+ * `EInvoiceService` is final and cannot be doubled, so the tests build the
+ * REAL service over an in-memory duck-typed ObjectService (the exact
+ * pattern of tests/Unit/Service/EInvoice/EInvoiceServiceTest.php) — the
+ * positive-direction test therefore exercises the full controller→service
+ * pipeline, not a mock's canned answer.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\ARInvoiceEInvoiceController;
+use OCA\Shillinq\Service\AdministrationContextService;
+use OCA\Shillinq\Service\EInvoice\ArInvoiceUblMapper;
+use OCA\Shillinq\Service\EInvoice\EInvoiceService;
+use OCA\Shillinq\Service\EInvoice\EInvoiceValidationService;
+use OCA\Shillinq\Service\InvoicePdfGenerator;
+use OCA\Shillinq\Service\Peppol\PeppolTransmissionPortInterface;
+use OCA\Shillinq\Service\ViesService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
+use OCP\AppFramework\Http;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use RuntimeException;
+
+/**
+ * Tests for ARInvoiceEInvoiceController's already-enforced membership guard.
+ *
+ * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+ */
+final class ARInvoiceEInvoiceControllerTest extends TestCase {
+
+	/**
+	 * Rows saved through the duck ObjectService (captured by reference).
+	 *
+	 * @var array<int,array<string,mixed>>
+	 */
+	private array $saved = [];
+
+	/**
+	 * A realistic issued ARInvoice ready to send, owned by adm-1
+	 * (mirrors EInvoiceServiceTest::issuedInvoice()).
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function issuedInvoice(): array {
+		return [
+			'id' => 'invoice-obj-1',
+			'invoiceNumber' => '2026-0042',
+			'customerId' => 'DEB-0001',
+			'administrationId' => 'adm-1',
+			'invoiceDate' => '2026-06-10',
+			'dueDate' => '2026-07-10',
+			'netAmount' => 1000.0,
+			'vatAmount' => 210.0,
+			'grossAmount' => 1210.0,
+			'currency' => 'EUR',
+			'lifecycleState' => 'issued',
+			'deliveryStatus' => 'not-sent',
+			'sellerName' => 'Shillinq Consultancy B.V.',
+			'sellerVatId' => 'NL809876543B01',
+			'buyerVatId' => 'NL001234567B01',
+			'buyerLegalRegId' => '12340001',
+		];
+
+	}//end issuedInvoice()
+
+	/**
+	 * Build the controller over the REAL EInvoiceService and an in-memory
+	 * ARInvoice store.
+	 *
+	 * @param string|null $userId The acting uid, or null for anonymous.
+	 * @param array<int,string> $accessible Administration ids canAccess() allows.
+	 * @param string $administrationId The administrationId request param.
+	 *
+	 * @return ARInvoiceEInvoiceController
+	 */
+	private function build(
+		?string $userId,
+		array $accessible,
+		string $administrationId = 'adm-1',
+	): ARInvoiceEInvoiceController {
+		$request = $this->createMock(IRequest::class);
+		$request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($administrationId): mixed {
+				if ($key === 'administrationId') {
+					return $administrationId;
+				}
+
+				return $default;
+			}
+		);
+
+		$session = $this->createMock(IUserSession::class);
+		if ($userId === null) {
+			$session->method('getUser')->willReturn(null);
+		} else {
+			$user = $this->createMock(IUser::class);
+			$user->method('getUID')->willReturn($userId);
+			$session->method('getUser')->willReturn($user);
+		}
+
+		$context = $this->createMock(AdministrationContextService::class);
+		$context->method('canAccess')->willReturnCallback(
+			static fn (string $id): bool => in_array($id, $accessible, true)
+		);
+
+		return new ARInvoiceEInvoiceController(
+			$request,
+			$this->buildRealService(context: $context),
+			$session,
+			$context,
+			new NullLogger(),
+		);
+
+	}//end build()
+
+	/**
+	 * Build the real (final, non-doublable) EInvoiceService over an
+	 * in-memory duck store seeded with one issued adm-1 invoice.
+	 *
+	 * @param AdministrationContextService $context The membership seam shared with the controller.
+	 *
+	 * @return EInvoiceService
+	 */
+	private function buildRealService(AdministrationContextService $context): EInvoiceService {
+		$this->saved = [];
+		$store = new class(['ARInvoice' => [$this->issuedInvoice()]], $this->saved) {
+			/**
+			 * @var array<string,array<int,array<string,mixed>>>
+			 */
+			private array $data;
+
+			/**
+			 * @var array<int,array<string,mixed>>
+			 */
+			private array $saved;
+
+			/**
+			 * @var string
+			 */
+			private string $schema = '';
+
+			/**
+			 * @param array<string,array<int,array<string,mixed>>> $data Schema rows.
+			 * @param array<int,array<string,mixed>> $saved Capture ref.
+			 */
+			public function __construct(array $data, array &$saved) {
+				$this->data = $data;
+				$this->saved = &$saved;
+			}
+
+			/**
+			 * @param string $register Register slug.
+			 *
+			 * @return static
+			 */
+			public function setRegister(string $register): static {
+				unset($register);
+				return $this;
+			}
+
+			/**
+			 * @param string $schema Schema slug.
+			 *
+			 * @return static
+			 */
+			public function setSchema(string $schema): static {
+				$this->schema = $schema;
+				return $this;
+			}
+
+			/**
+			 * @param array<string,mixed> $params Query params.
+			 *
+			 * @return array<int,array<string,mixed>>
+			 */
+			public function findAll(array $params = []): array {
+				$rows = ($this->data[$this->schema] ?? []);
+				$filters = ($params['filters'] ?? []);
+				if ($filters === []) {
+					return $rows;
+				}
+
+				return array_values(
+					array_filter(
+						$rows,
+						static function (array $row) use ($filters): bool {
+							foreach ($filters as $key => $value) {
+								if (($row[$key] ?? null) !== $value) {
+									return false;
+								}
+							}
+
+							return true;
+						}
+					)
+				);
+			}
+
+			/**
+			 * @param array<string,mixed> $object Object payload.
+			 *
+			 * @return array<string,mixed>
+			 */
+			public function saveObject(array $object): array {
+				$this->saved[] = ['schema' => $this->schema, 'object' => $object];
+				return $object;
+			}
+		};
+
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturn('shillinq');
+
+		$vies = $this->createMock(ViesService::class);
+		$vies->method('validate')->willReturn(['valid' => true, 'outage' => false]);
+
+		$port = new class() implements PeppolTransmissionPortInterface {
+			/**
+			 * @inheritDoc
+			 */
+			public function lookupParticipant(string $administrationId, string $partyId): ?string {
+				unset($administrationId, $partyId);
+				return '0106:00000000';
+			}
+
+			/**
+			 * @inheritDoc
+			 */
+			public function submit(string $participantId, string $documentType, string $payloadFileUri): string {
+				unset($documentType, $payloadFileUri);
+				if ($participantId === '') {
+					throw new RuntimeException('no participant');
+				}
+
+				return 'urn:uuid:test-transmission';
+			}
+		};
+
+		return new EInvoiceService(
+			appConfig: $appConfig,
+			administrationContext: $context,
+			logger: new NullLogger(),
+			eventDispatcher: $this->createMock(IEventDispatcher::class),
+			ublMapper: new ArInvoiceUblMapper(),
+			pdfGenerator: new InvoicePdfGenerator(),
+			validationService: new EInvoiceValidationService(vies: $vies, peppolPort: $port),
+			peppolPort: $port,
+			objectService: new DuckObjectServiceAdapter($store),
+		);
+
+	}//end buildRealService()
+
+	/**
+	 * An anonymous caller is rejected with 401 before any access check runs.
+	 *
+	 * @return void
+	 */
+	public function testSendRejectsAnonymousCaller(): void {
+		$controller = $this->build(userId: null, accessible: []);
+
+		$response = $controller->send('2026-0042');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame([], $this->saved, 'No invoice may be mutated by an anonymous caller');
+
+	}//end testSendRejectsAnonymousCaller()
+
+	/**
+	 * NEGATIVE CONTROL: a caller with no membership in the administration
+	 * named by the request is masked as a 404 (never 403 — per
+	 * AdministrationContextService::canAccess()'s own documented contract,
+	 * this endpoint must not become an enumeration oracle for the tenant
+	 * list) and the send pipeline never mutates the invoice.
+	 *
+	 * @return void
+	 */
+	public function testSendMasksNonMemberAdministrationAs404(): void {
+		$controller = $this->build(userId: 'mallory', accessible: ['adm-2']);
+
+		$response = $controller->send('2026-0042');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame([], $this->saved, 'The invoice must NOT be transmitted or mutated');
+
+	}//end testSendMasksNonMemberAdministrationAs404()
+
+	/**
+	 * POSITIVE direction: a member of the invoice's own administration
+	 * drives the full send pipeline to a 200 with deliveryStatus queued
+	 * (no regression).
+	 *
+	 * @return void
+	 */
+	public function testSendSucceedsForAdministrationMember(): void {
+		$controller = $this->build(userId: 'alice', accessible: ['adm-1']);
+
+		$response = $controller->send('2026-0042');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$data = $response->getData();
+		$this->assertSame('queued', $data['deliveryStatus']);
+		$this->assertNotNull($data['transmissionId']);
+		$this->assertNotSame([], $this->saved, 'The invoice must be persisted with its new deliveryStatus');
+
+	}//end testSendSucceedsForAdministrationMember()
+
+	/**
+	 * A malformed invoice number is rejected before any access check runs.
+	 *
+	 * @return void
+	 */
+	public function testSendRejectsInvalidInvoiceNumber(): void {
+		$controller = $this->build(userId: 'alice', accessible: ['adm-1']);
+
+		$response = $controller->send('../etc/passwd');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame([], $this->saved);
+
+	}//end testSendRejectsInvalidInvoiceNumber()
+
+	/**
+	 * A missing administrationId is rejected before any access check runs.
+	 *
+	 * @return void
+	 */
+	public function testSendRequiresAdministrationId(): void {
+		$controller = $this->build(userId: 'alice', accessible: ['adm-1'], administrationId: '');
+
+		$response = $controller->send('2026-0042');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$this->assertSame([], $this->saved);
+
+	}//end testSendRequiresAdministrationId()
+}//end class

--- a/tests/Unit/Controller/BankStatementImportControllerTest.php
+++ b/tests/Unit/Controller/BankStatementImportControllerTest.php
@@ -28,6 +28,7 @@ use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -90,6 +91,13 @@ class BankStatementImportControllerTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 
 	/**
+	 * Mock IL10N.
+	 *
+	 * @var IL10N&MockObject
+	 */
+	private IL10N&MockObject $l10n;
+
+	/**
 	 * The capturing ObjectService stub the container returns.
 	 *
 	 * @var object
@@ -109,6 +117,8 @@ class BankStatementImportControllerTest extends TestCase {
 		$this->container = $this->createMock(ContainerInterface::class);
 		$this->session = $this->createMock(IUserSession::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnCallback(static fn (string $text, $params = []): string => $text);
 
 		$this->objectService = $this->buildObjectServiceStub();
 		$this->container->method('get')->willReturn($this->objectService);
@@ -196,6 +206,7 @@ class BankStatementImportControllerTest extends TestCase {
 			session: $this->session,
 			logger: $this->logger,
 			objectService: new DuckObjectServiceAdapter($this->objectService),
+			l10n: $this->l10n,
 		);
 	}//end controller()
 

--- a/tests/Unit/Controller/BillingIntakeControllerTest.php
+++ b/tests/Unit/Controller/BillingIntakeControllerTest.php
@@ -27,6 +27,7 @@ use OCA\Shillinq\Controller\BillingIntakeController;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\TimeIntakeService;
 use OCP\AppFramework\Http;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -69,6 +70,11 @@ final class BillingIntakeControllerTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 
 	/**
+	 * @var IL10N&MockObject
+	 */
+	private IL10N&MockObject $l10n;
+
+	/**
 	 * @var BillingIntakeController
 	 */
 	private BillingIntakeController $controller;
@@ -80,6 +86,8 @@ final class BillingIntakeControllerTest extends TestCase {
 		$this->administrationContext = $this->createMock(AdministrationContextService::class);
 		$this->session = $this->createMock(IUserSession::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnCallback(static fn (string $text, $params = []): string => $text);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('alice');
@@ -97,6 +105,7 @@ final class BillingIntakeControllerTest extends TestCase {
 			administrationContext: $this->administrationContext,
 			session: $this->session,
 			logger: $this->logger,
+			l10n: $this->l10n,
 		);
 
 	}//end setUp()
@@ -116,6 +125,7 @@ final class BillingIntakeControllerTest extends TestCase {
 			administrationContext: $this->administrationContext,
 			session: $session,
 			logger: $this->logger,
+			l10n: $this->l10n,
 		);
 
 		$this->service->expects(self::never())->method('ingest');
@@ -192,7 +202,8 @@ final class BillingIntakeControllerTest extends TestCase {
 
 	/**
 	 * An unexpected Throwable maps to HTTP 500 with a generic message (no
-	 * internal detail leakage).
+	 * internal detail leakage) — ADR-050: a stable kebab-case slug and a
+	 * localized message, never the raw exception text ('boom').
 	 *
 	 * @return void
 	 */
@@ -201,7 +212,8 @@ final class BillingIntakeControllerTest extends TestCase {
 
 		$response = $this->controller->timeIntake();
 		self::assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
-		self::assertSame('Internal error', $response->getData()['error']);
+		self::assertSame('billing-time-intake-failed', $response->getData()['error']);
+		self::assertStringNotContainsString('boom', (string)$response->getData()['message']);
 
 	}//end testUnexpectedThrowableMapsTo500()
 

--- a/tests/Unit/Controller/BookingDepthControllerTest.php
+++ b/tests/Unit/Controller/BookingDepthControllerTest.php
@@ -38,6 +38,7 @@ use OCA\Shillinq\Service\SlotService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\ICacheFactory;
+use OCP\IL10N;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -128,9 +129,25 @@ final class BookingDepthControllerTest extends TestCase {
 			),
 			series: new RecurringSeriesService(slotService: $slotService, logger: $logger),
 			logger: $logger,
+			l10n: $this->makeL10n(),
 		);
 
 	}//end makeController()
+
+	/**
+	 * Build a translation-service stub that echoes its input back, so
+	 * assertions can match on the source string.
+	 *
+	 * @return IL10N&MockObject
+	 */
+	private function makeL10n(): IL10N&MockObject {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(
+			static fn (string $text, $parameters = []): string => $text
+		);
+		return $l10n;
+
+	}//end makeL10n()
 
 	/**
 	 * A schema-aware fake ObjectService: findAll returns the canned records for
@@ -311,7 +328,14 @@ final class BookingDepthControllerTest extends TestCase {
 
 		$objectService = $this->makeObjectService(
 			[
-				'Resource' => [['resourceId' => 'res-a', 'openingTime' => '09:00', 'closingTime' => '17:00']],
+				'Resource' => [
+					[
+						'resourceId' => 'res-a',
+						'administrationId' => 'admin-1',
+						'openingTime' => '09:00',
+						'closingTime' => '17:00',
+					],
+				],
 				'Appointment' => [],
 			]
 		);
@@ -343,4 +367,115 @@ final class BookingDepthControllerTest extends TestCase {
 		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 
 	}//end testCreateSeriesRejectsAnonymous()
+
+	/**
+	 * NEGATIVE CONTROL / security-endpoint-guards REQ-001 hardening: a
+	 * caller who has access to their OWN administration (canAccess() ===
+	 * true) is still rejected when the named resourceId belongs to a
+	 * DIFFERENT administration — the create-time canAccess($administrationId)
+	 * check alone does not prove the fetched Resource is in scope. Before
+	 * this fix, this exact call would have booked appointments against
+	 * another tenant's resource under the caller's own administrationId.
+	 *
+	 * @return void
+	 */
+	public function testCreateSeriesRejectsResourceFromAnotherAdministration(): void {
+		$this->context->method('currentUserId')->willReturn('user-1');
+		$this->context->method('canAccess')->willReturnCallback(
+			static fn (string $administrationId): bool => $administrationId === 'admin-1'
+		);
+
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) {
+				$params = [
+					'administrationId' => 'admin-1',
+					'seriesId' => 'series-1',
+					'serviceId' => 'svc-yoga',
+					'resourceId' => 'res-b',
+					'startTime' => '2030-01-07T09:00:00Z',
+					'durationMinutes' => 60,
+					'recurrenceRule' => 'FREQ=WEEKLY;BYDAY=MO;COUNT=4',
+					'customerId' => 'cust-1',
+				];
+				return ($params[$key] ?? $default);
+			}
+		);
+
+		$objectService = $this->makeObjectService(
+			[
+				// res-b belongs to a DIFFERENT administration than the
+				// caller-supplied/authorized administrationId (admin-1).
+				'Resource' => [
+					[
+						'resourceId' => 'res-b',
+						'administrationId' => 'admin-2',
+						'openingTime' => '09:00',
+						'closingTime' => '17:00',
+					],
+				],
+				'Appointment' => [],
+			]
+		);
+		$this->container->method('get')->willReturn($objectService);
+
+		$response = $this->makeController()->createSeries();
+		self::assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		self::assertSame([], $objectService->saved, 'No AppointmentSeries/Appointment must be persisted');
+
+	}//end testCreateSeriesRejectsResourceFromAnotherAdministration()
+
+	/**
+	 * A validation failure from RecurringSeriesService::planSeries()
+	 * (security-endpoint-guards REQ-003) returns a stable slug and a
+	 * localized message — never the raw exception text.
+	 *
+	 * @return void
+	 */
+	public function testCreateSeriesValidationFailureDoesNotLeakExceptionText(): void {
+		$this->context->method('currentUserId')->willReturn('user-1');
+		$this->context->method('canAccess')->willReturn(true);
+
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) {
+				$params = [
+					'administrationId' => 'admin-1',
+					'seriesId' => 'series-1',
+					'serviceId' => 'svc-yoga',
+					'resourceId' => 'res-a',
+					'startTime' => '2030-01-07T09:00:00Z',
+					'durationMinutes' => 60,
+					// Unsupported FREQ -> RecurringSeriesService throws
+					// InvalidArgumentException.
+					'recurrenceRule' => 'FREQ=YEARLY',
+					'customerId' => 'cust-1',
+				];
+				return ($params[$key] ?? $default);
+			}
+		);
+
+		$objectService = $this->makeObjectService(
+			[
+				'Resource' => [
+					[
+						'resourceId' => 'res-a',
+						'administrationId' => 'admin-1',
+						'openingTime' => '09:00',
+						'closingTime' => '17:00',
+					],
+				],
+				'Appointment' => [],
+			]
+		);
+		$this->container->method('get')->willReturn($objectService);
+
+		$response = $this->makeController()->createSeries();
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+
+		$data = $response->getData();
+		self::assertSame('appointment-series-create-failed', $data['error']);
+		self::assertArrayHasKey('message', $data);
+		self::assertStringNotContainsString('FREQ', $data['message']);
+		self::assertStringNotContainsString('RRULE', json_encode($data));
+
+	}//end testCreateSeriesValidationFailureDoesNotLeakExceptionText()
 }//end class

--- a/tests/Unit/Controller/BudgetBBVMappingControllerTest.php
+++ b/tests/Unit/Controller/BudgetBBVMappingControllerTest.php
@@ -1,0 +1,236 @@
+<?php
+
+/**
+ * Unit tests for BudgetBBVMappingController.
+ *
+ * Covers security-endpoint-guards REQ-001's JUSTIFY verdict for both
+ * `index()` and `show()`: neither method reads an OpenRegister object —
+ * `index()` returns a session-derived scope envelope and `show()` echoes
+ * the URL `$id` back unread — so no per-object tenant guard applies
+ * beyond the anonymous-rejection check already present. These tests prove
+ * that check actually rejects anonymous callers (negative direction) and
+ * that an authenticated caller still succeeds (positive direction), per
+ * REQ-004.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\BudgetBBVMappingController;
+use OCA\Shillinq\Service\AdministrationContextService;
+use OCA\Shillinq\Service\FiscalYearContextService;
+use OCP\AppFramework\Http;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the Budget BBV Mapping index + detail page envelopes.
+ *
+ * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+ */
+final class BudgetBBVMappingControllerTest extends TestCase {
+
+	/**
+	 * Mock IRequest.
+	 *
+	 * @var IRequest&MockObject
+	 */
+	private IRequest&MockObject $request;
+
+	/**
+	 * Mock IUserSession.
+	 *
+	 * @var IUserSession&MockObject
+	 */
+	private IUserSession&MockObject $userSession;
+
+	/**
+	 * Mock AdministrationContextService.
+	 *
+	 * @var AdministrationContextService&MockObject
+	 */
+	private AdministrationContextService&MockObject $administrationContext;
+
+	/**
+	 * Mock FiscalYearContextService.
+	 *
+	 * @var FiscalYearContextService&MockObject
+	 */
+	private FiscalYearContextService&MockObject $fiscalYearContext;
+
+	/**
+	 * Set up shared fixtures.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// phpcs:disable CustomSniffs.Functions.NamedParameters
+		$this->request = $this->createMock(IRequest::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->administrationContext = $this->createMock(AdministrationContextService::class);
+		$this->fiscalYearContext = $this->createMock(FiscalYearContextService::class);
+		// phpcs:enable CustomSniffs.Functions.NamedParameters
+
+	}//end setUp()
+
+	/**
+	 * Build the controller under test.
+	 *
+	 * @return BudgetBBVMappingController
+	 */
+	private function controller(): BudgetBBVMappingController {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
+
+		return new BudgetBBVMappingController(
+			$this->request,
+			$this->userSession,
+			$l10n,
+			$this->administrationContext,
+			$this->fiscalYearContext,
+		);
+
+	}//end controller()
+
+	/**
+	 * Put a session user in place.
+	 *
+	 * @param string $uid The user id.
+	 *
+	 * @return void
+	 */
+	private function actAs(string $uid): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$this->userSession->method('getUser')->willReturn($user);
+
+	}//end actAs()
+
+	/**
+	 * NEGATIVE CONTROL: index() rejects an anonymous caller with 401
+	 * before any scope resolution runs.
+	 *
+	 * @return void
+	 */
+	public function testIndexRejectsAnonymous(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+
+		$response = $this->controller()->index();
+		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+	}//end testIndexRejectsAnonymous()
+
+	/**
+	 * POSITIVE CONTROL: an authenticated caller with an accessible
+	 * administration receives the index envelope with a resolved scope.
+	 *
+	 * @return void
+	 */
+	public function testIndexSucceedsForAuthenticatedCaller(): void {
+		$this->actAs(uid: 'alice');
+		$this->administrationContext->method('buildContext')->willReturn(
+			['activeAdministrationId' => 'adm-1']
+		);
+		$this->fiscalYearContext->method('resolveActiveWindow')->willReturn(
+			[
+				'fiscalYear' => 2026,
+				'startDate' => '2026-01-01',
+				'endDate' => '2027-01-01',
+			]
+		);
+
+		$response = $this->controller()->index();
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+
+		$data = $response->getData();
+		self::assertSame('shillinq', $data['register']);
+		self::assertSame('BudgetBBVMapping', $data['schema']);
+		self::assertSame('adm-1', $data['scope']['administrationId']);
+		self::assertSame(2026, $data['scope']['fiscalYear']);
+
+	}//end testIndexSucceedsForAuthenticatedCaller()
+
+	/**
+	 * NEGATIVE CONTROL: show() rejects an anonymous caller with 401.
+	 *
+	 * @return void
+	 */
+	public function testShowRejectsAnonymous(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+
+		$response = $this->controller()->show('mapping-1');
+		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+	}//end testShowRejectsAnonymous()
+
+	/**
+	 * POSITIVE CONTROL: an authenticated caller receives the detail
+	 * envelope for the id named in the URL. show() performs no
+	 * OpenRegister lookup (see class docblock), so any authenticated
+	 * caller reaching this route sees only routing metadata, never
+	 * another tenant's stored data.
+	 *
+	 * @return void
+	 */
+	public function testShowSucceedsForAuthenticatedCaller(): void {
+		$this->actAs(uid: 'alice');
+		$this->administrationContext->method('buildContext')->willReturn(
+			['activeAdministrationId' => 'adm-1']
+		);
+		$this->fiscalYearContext->method('resolveActiveWindow')->willReturn(
+			[
+				'fiscalYear' => 2026,
+				'startDate' => '2026-01-01',
+				'endDate' => '2027-01-01',
+			]
+		);
+
+		$response = $this->controller()->show('mapping-1');
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+
+		$data = $response->getData();
+		self::assertSame('mapping-1', $data['id']);
+		self::assertSame('BudgetBBVMapping', $data['schema']);
+
+	}//end testShowSucceedsForAuthenticatedCaller()
+
+	/**
+	 * When the caller has no accessible administration, the scope
+	 * envelope answers null-valued fields rather than erroring (an empty
+	 * / no-administrations state, not a security failure).
+	 *
+	 * @return void
+	 */
+	public function testIndexScopeIsEmptyWhenNoActiveAdministration(): void {
+		$this->actAs(uid: 'bob');
+		$this->administrationContext->method('buildContext')->willReturn([]);
+
+		$response = $this->controller()->index();
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+
+		$data = $response->getData();
+		self::assertNull($data['scope']['administrationId']);
+
+	}//end testIndexScopeIsEmptyWhenNoActiveAdministration()
+}//end class

--- a/tests/Unit/Controller/CBSSubmissionControllerTest.php
+++ b/tests/Unit/Controller/CBSSubmissionControllerTest.php
@@ -1,0 +1,531 @@
+<?php
+
+/**
+ * Unit tests for CBSSubmissionController.
+ *
+ * Covers the security-endpoint-guards fix for the worst confirmed finding
+ * in that change: `create()`/`update()`/`destroy()`/`generate()` (plus
+ * `index()`/`show()`, found during the same code read) were guarded only
+ * by `requireUser()` — authentication, not authorization — so any
+ * authenticated user could read or mutate another organization's
+ * statutory CBS filing. Every test below proves BOTH directions per
+ * REQ-004: the unauthorized caller is rejected, and the legitimate caller
+ * still succeeds exactly as before.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\CBSSubmissionController;
+use OCA\Shillinq\Service\AdministrationContextService;
+use OCA\Shillinq\Service\CBSExportService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
+use OCP\AppFramework\Http;
+use OCP\IAppConfig;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests for CBSSubmissionController's authorization guards.
+ *
+ * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+ */
+class CBSSubmissionControllerTest extends TestCase {
+
+	/**
+	 * IRequest stub for parameter reads.
+	 *
+	 * @var IRequest&MockObject
+	 */
+	private IRequest&MockObject $request;
+
+	/**
+	 * Export service stub (not exercised by the guard tests).
+	 *
+	 * @var CBSExportService&MockObject
+	 */
+	private CBSExportService&MockObject $exportService;
+
+	/**
+	 * App config stub.
+	 *
+	 * @var IAppConfig&MockObject
+	 */
+	private IAppConfig&MockObject $appConfig;
+
+	/**
+	 * Fake ObjectService — in-memory CBSSubmission store.
+	 *
+	 * @var object
+	 */
+	private object $fakeObjectService;
+
+	/**
+	 * Per-request query/body param overrides.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private array $params = [];
+
+	/**
+	 * Build the fake stack for each test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->exportService = $this->createMock(CBSExportService::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->appConfig->method('getValueString')->willReturn('shillinq');
+
+		$this->request->method('getParam')->willReturnCallback(
+			function (string $key, mixed $default = null): mixed {
+				return $this->params[$key] ?? $default;
+			}
+		);
+		$this->request->method('getParams')->willReturnCallback(
+			fn (): array => $this->params
+		);
+
+		$this->fakeObjectService = $this->buildFakeObjectService();
+	}//end setUp()
+
+	/**
+	 * Build a user session mock for a given uid (or anonymous when null).
+	 *
+	 * @param string|null $uid The acting uid, or null for anonymous.
+	 *
+	 * @return IUserSession&MockObject
+	 */
+	private function buildUserSession(?string $uid): IUserSession&MockObject {
+		$session = $this->createMock(IUserSession::class);
+		if ($uid === null) {
+			$session->method('getUser')->willReturn(null);
+			return $session;
+		}
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		$session->method('getUser')->willReturn($user);
+		return $session;
+	}//end buildUserSession()
+
+	/**
+	 * Build an AdministrationContextService stub whose canAccess() only
+	 * grants the given administration id(s).
+	 *
+	 * @param list<string> $accessible The administration ids the caller may access.
+	 *
+	 * @return AdministrationContextService&MockObject
+	 */
+	private function buildAdministrationContext(array $accessible): AdministrationContextService&MockObject {
+		$context = $this->createMock(AdministrationContextService::class);
+		$context->method('canAccess')->willReturnCallback(
+			static fn (string $administrationId): bool => in_array($administrationId, $accessible, true)
+		);
+		return $context;
+	}//end buildAdministrationContext()
+
+	/**
+	 * Build the controller under test.
+	 *
+	 * @param IUserSession $userSession The session to inject.
+	 * @param AdministrationContextService $administrationContext The membership seam to inject.
+	 * @param bool $isAdmin Whether the acting user is a Nextcloud admin (bypasses the guard).
+	 *
+	 * @return CBSSubmissionController
+	 */
+	private function buildController(
+		IUserSession $userSession,
+		AdministrationContextService $administrationContext,
+		bool $isAdmin = false,
+	): CBSSubmissionController {
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('isAdmin')->willReturn($isAdmin);
+
+		return new CBSSubmissionController(
+			$this->request,
+			$this->exportService,
+			$this->appConfig,
+			$userSession,
+			$this->createMock(LoggerInterface::class),
+			new DuckObjectServiceAdapter($this->fakeObjectService),
+			$administrationContext,
+			$groupManager,
+		);
+	}//end buildController()
+
+	/**
+	 * Duck-typed in-memory ObjectService double, wrapped in
+	 * {@see DuckObjectServiceAdapter} by buildController() so it satisfies
+	 * the ADR-084 `ObjectServiceInterface` the controller is constructed
+	 * against — the established pattern in this suite (see commit
+	 * ef9c8fa5, "wire the seeded OpenRegister store back into 128 test
+	 * classes") rather than hand-implementing the full ~25-method contract
+	 * per test file.
+	 *
+	 * @return object
+	 */
+	private function buildFakeObjectService(): object {
+		return new class() {
+			public array $records = [
+				'CBSSubmission' => [
+					[
+						'id' => 'cbs-001',
+						'administrationId' => 'adm-1',
+						'status' => 'draft',
+						'reportingPeriodStartDate' => '2026-01-01',
+						'reportingPeriodEndDate' => '2026-03-31',
+						'organizationLegalName' => 'Alice BV',
+						'kvkNumber' => '12345678',
+						'taxIdentificationNumber' => 'NL123456789B01',
+						'currency' => 'EUR',
+					],
+				],
+			];
+
+			public array $deleted = [];
+
+			public array $saved = [];
+
+			private string $currentSchema = '';
+
+			public function setRegister(string $register): static {
+				return $this;
+			}
+
+			public function setSchema(string $schema): static {
+				$this->currentSchema = $schema;
+				return $this;
+			}
+
+			public function find(string $id, ?string $register = null, ?string $schema = null): mixed {
+				foreach (($this->records[$this->currentSchema] ?? []) as $row) {
+					if (($row['id'] ?? '') === $id) {
+						return $row;
+					}
+				}
+
+				throw new \RuntimeException('not found');
+			}
+
+			public function findAll(array $config = []): array {
+				$rows = ($this->records[$this->currentSchema] ?? []);
+				$filters = ($config['filters'] ?? []);
+				$matched = [];
+				foreach ($rows as $row) {
+					$ok = true;
+					foreach ($filters as $field => $value) {
+						if (($row[$field] ?? null) !== $value) {
+							$ok = false;
+							break;
+						}
+					}
+
+					if ($ok === true) {
+						$matched[] = $row;
+					}
+				}
+
+				return $matched;
+			}
+
+			public function saveObject(array $object, ?string $register = null, ?string $schema = null): mixed {
+				$object['id'] ??= 'cbs-new';
+				$this->saved[] = $object;
+				return $object;
+			}
+
+			public function deleteObject(string $id): bool {
+				$this->deleted[] = $id;
+				return true;
+			}
+		};
+	}//end buildFakeObjectService()
+
+	/**
+	 * A member of the submission's own administration can delete its
+	 * draft submission (positive direction, spec scenario "A user can
+	 * delete their own administration's draft CBS submission").
+	 *
+	 * @return void
+	 */
+	public function testDestroyByOwnAdministrationMemberSucceeds(): void {
+		$controller = $this->buildController(
+			$this->buildUserSession('alice'),
+			$this->buildAdministrationContext(['adm-1']),
+		);
+
+		$response = $controller->destroy('cbs-001');
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['cbs-001'], $this->fakeObjectService->deleted);
+	}//end testDestroyByOwnAdministrationMemberSucceeds()
+
+	/**
+	 * NEGATIVE CONTROL / spec scenario "A user cannot delete another
+	 * organization's CBS submission": a user with no membership in the
+	 * submission's administration is rejected with 403, and nothing is
+	 * deleted. Before this change's guard was added, this exact call
+	 * returned 200 and deleted the record — see design.md's verdict
+	 * table for the pre-fix evidence.
+	 *
+	 * @return void
+	 */
+	public function testDestroyByNonMemberIsForbidden(): void {
+		$controller = $this->buildController(
+			$this->buildUserSession('mallory'),
+			$this->buildAdministrationContext(['adm-2']),
+		);
+
+		$response = $controller->destroy('cbs-001');
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame([], $this->fakeObjectService->deleted, 'The submission must NOT be deleted');
+	}//end testDestroyByNonMemberIsForbidden()
+
+	/**
+	 * An anonymous caller is rejected with 401 before the administration
+	 * guard even runs.
+	 *
+	 * @return void
+	 */
+	public function testDestroyByAnonymousIsUnauthorized(): void {
+		$controller = $this->buildController(
+			$this->buildUserSession(null),
+			$this->buildAdministrationContext([]),
+		);
+
+		$response = $controller->destroy('cbs-001');
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		$this->assertSame([], $this->fakeObjectService->deleted);
+	}//end testDestroyByAnonymousIsUnauthorized()
+
+	/**
+	 * Update by the owning administration's member still works (positive
+	 * direction, no regression to the existing draft/status business
+	 * rules).
+	 *
+	 * @return void
+	 */
+	public function testUpdateByOwnAdministrationMemberSucceeds(): void {
+		$this->params = ['status' => 'draft', 'description' => 'updated'];
+		$controller = $this->buildController(
+			$this->buildUserSession('alice'),
+			$this->buildAdministrationContext(['adm-1']),
+		);
+
+		$response = $controller->update('cbs-001');
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testUpdateByOwnAdministrationMemberSucceeds()
+
+	/**
+	 * Update by a non-member is forbidden (negative direction).
+	 *
+	 * @return void
+	 */
+	public function testUpdateByNonMemberIsForbidden(): void {
+		$this->params = ['status' => 'draft'];
+		$controller = $this->buildController(
+			$this->buildUserSession('mallory'),
+			$this->buildAdministrationContext(['adm-2']),
+		);
+
+		$response = $controller->update('cbs-001');
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}//end testUpdateByNonMemberIsForbidden()
+
+	/**
+	 * Create is allowed when the caller is a member of the
+	 * administration named in the request body (positive direction).
+	 *
+	 * @return void
+	 */
+	public function testCreateByMemberOfTargetAdministrationSucceeds(): void {
+		$this->params = [
+			'reportingPeriodStartDate' => '2026-04-01',
+			'reportingPeriodEndDate' => '2026-06-30',
+			'organizationLegalName' => 'Alice BV',
+			'kvkNumber' => '12345678',
+			'taxIdentificationNumber' => 'NL123456789B01',
+			'administrationId' => 'adm-1',
+		];
+		$controller = $this->buildController(
+			$this->buildUserSession('alice'),
+			$this->buildAdministrationContext(['adm-1']),
+		);
+
+		$response = $controller->create();
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+	}//end testCreateByMemberOfTargetAdministrationSucceeds()
+
+	/**
+	 * Create is rejected when the caller names an administration they are
+	 * not a member of — an authenticated user could otherwise plant a
+	 * filing under another organization's administrationId (negative
+	 * direction).
+	 *
+	 * @return void
+	 */
+	public function testCreateForForeignAdministrationIsForbidden(): void {
+		$this->params = [
+			'reportingPeriodStartDate' => '2026-04-01',
+			'reportingPeriodEndDate' => '2026-06-30',
+			'organizationLegalName' => 'Mallory Inc',
+			'kvkNumber' => '87654321',
+			'taxIdentificationNumber' => 'NL987654321B01',
+			'administrationId' => 'adm-1',
+		];
+		$controller = $this->buildController(
+			$this->buildUserSession('mallory'),
+			$this->buildAdministrationContext(['adm-2']),
+		);
+
+		$response = $controller->create();
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame([], $this->fakeObjectService->saved);
+	}//end testCreateForForeignAdministrationIsForbidden()
+
+	/**
+	 * show() is readable by a member of the submission's administration.
+	 *
+	 * @return void
+	 */
+	public function testShowByOwnAdministrationMemberSucceeds(): void {
+		$controller = $this->buildController(
+			$this->buildUserSession('alice'),
+			$this->buildAdministrationContext(['adm-1']),
+		);
+
+		$response = $controller->show('cbs-001');
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}//end testShowByOwnAdministrationMemberSucceeds()
+
+	/**
+	 * show() is forbidden for a non-member — found during this change's
+	 * code read, beyond the audit's originally-named 4 methods.
+	 *
+	 * @return void
+	 */
+	public function testShowByNonMemberIsForbidden(): void {
+		$controller = $this->buildController(
+			$this->buildUserSession('mallory'),
+			$this->buildAdministrationContext(['adm-2']),
+		);
+
+		$response = $controller->show('cbs-001');
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}//end testShowByNonMemberIsForbidden()
+
+	/**
+	 * index() with no explicit filter scopes results to the caller's own
+	 * accessible administrations rather than returning every tenant's
+	 * submissions.
+	 *
+	 * @return void
+	 */
+	public function testIndexScopesToAccessibleAdministrations(): void {
+		$this->fakeObjectService->records['CBSSubmission'][] = [
+			'id' => 'cbs-002',
+			'administrationId' => 'adm-2',
+			'status' => 'draft',
+		];
+
+		$controller = $this->buildController(
+			$this->buildUserSession('alice'),
+			$this->buildAdministrationContext(['adm-1']),
+		);
+
+		$response = $controller->index();
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$ids = array_column($response->getData()['submissions'], 'id');
+		$this->assertSame(['cbs-001'], $ids, 'Only the caller\'s own administration\'s submission is listed');
+	}//end testIndexScopesToAccessibleAdministrations()
+
+	/**
+	 * generate() is forbidden for a non-member (negative direction).
+	 *
+	 * @return void
+	 */
+	public function testGenerateByNonMemberIsForbidden(): void {
+		$controller = $this->buildController(
+			$this->buildUserSession('mallory'),
+			$this->buildAdministrationContext(['adm-2']),
+		);
+
+		$response = $controller->generate('cbs-001');
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}//end testGenerateByNonMemberIsForbidden()
+
+	/**
+	 * A Nextcloud admin bypasses the per-administration membership check —
+	 * matching the established pattern in
+	 * `BookingNotificationController::authorizeBookingAccess()`. Without
+	 * this, an admin with no `AdministrationMembership` record of their own
+	 * (the default state for the Nextcloud admin account — see
+	 * tests/e2e/ci-seed.sh's note that "the setup wizard does not create"
+	 * one) would be locked out of every administration's filings, which
+	 * would break the back-office admin surface and the e2e suite that
+	 * runs as that account.
+	 *
+	 * @return void
+	 */
+	public function testDestroyByAdminBypassesMembershipCheck(): void {
+		$controller = $this->buildController(
+			$this->buildUserSession('admin'),
+			$this->buildAdministrationContext([]), // no memberships at all
+			isAdmin: true,
+		);
+
+		$response = $controller->destroy('cbs-001');
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame(['cbs-001'], $this->fakeObjectService->deleted);
+	}//end testDestroyByAdminBypassesMembershipCheck()
+
+	/**
+	 * An admin's unfiltered index() call sees every administration's
+	 * submissions, not just an empty list from having no memberships.
+	 *
+	 * @return void
+	 */
+	public function testIndexByAdminSeesAllAdministrations(): void {
+		$this->fakeObjectService->records['CBSSubmission'][] = [
+			'id' => 'cbs-002',
+			'administrationId' => 'adm-2',
+			'status' => 'draft',
+		];
+
+		$controller = $this->buildController(
+			$this->buildUserSession('admin'),
+			$this->buildAdministrationContext([]),
+			isAdmin: true,
+		);
+
+		$response = $controller->index();
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$ids = array_column($response->getData()['submissions'], 'id');
+		sort($ids);
+		$this->assertSame(['cbs-001', 'cbs-002'], $ids);
+	}//end testIndexByAdminSeesAllAdministrations()
+
+}//end class

--- a/tests/Unit/Controller/CalendarControllerTest.php
+++ b/tests/Unit/Controller/CalendarControllerTest.php
@@ -37,6 +37,8 @@ use OCA\Shillinq\Service\Booking\TransactionalGuard;
 use OCA\Shillinq\Service\ConflictDetectionService;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\AppFramework\Http;
+use OCP\IGroupManager;
+use OCP\IL10N;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -128,6 +130,12 @@ class CalendarControllerTest extends TestCase {
 			'administrations' => [['administrationId' => 'adm-1']],
 			'activeAdministrationId' => 'adm-1',
 		]);
+		// Default: alice is a member of adm-1 (the seeded calendars'
+		// administration) — the positive-direction case for the
+		// per-object booking guard (security-endpoint-guards REQ-001).
+		$this->context->method('canAccess')->willReturnCallback(
+			static fn (string $administrationId): bool => $administrationId === 'adm-1'
+		);
 
 		$this->request->method('getParam')->willReturnCallback(
 			function (string $key, mixed $default = null): mixed {
@@ -172,8 +180,34 @@ class CalendarControllerTest extends TestCase {
 			$this->context,
 			$this->guard,
 			$this->createMock(LoggerInterface::class),
+			$this->buildL10n(),
+			$this->buildGroupManager(false),
 		);
 	}//end buildController()
+
+	/**
+	 * Build an IL10N stub that echoes its input (no real translation catalog in unit tests).
+	 *
+	 * @return IL10N&MockObject
+	 */
+	private function buildL10n(): IL10N&MockObject {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(static fn (string $text, $params = []): string => $text);
+		return $l10n;
+	}//end buildL10n()
+
+	/**
+	 * Build an IGroupManager stub whose isAdmin() is fixed to $isAdmin.
+	 *
+	 * @param bool $isAdmin Whether every uid should be treated as an admin.
+	 *
+	 * @return IGroupManager&MockObject
+	 */
+	private function buildGroupManager(bool $isAdmin): IGroupManager&MockObject {
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('isAdmin')->willReturn($isAdmin);
+		return $groupManager;
+	}//end buildGroupManager()
 
 	/**
 	 * Fake ObjectService that mimics the OR query-builder fluent API.
@@ -501,6 +535,8 @@ class CalendarControllerTest extends TestCase {
 			$context,
 			$this->guard,
 			$this->createMock(LoggerInterface::class),
+			$this->buildL10n(),
+			$this->buildGroupManager(false),
 		);
 
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $controller->index()->getStatus());
@@ -508,5 +544,121 @@ class CalendarControllerTest extends TestCase {
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $controller->listBookings('cal-001')->getStatus());
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $controller->createBooking('cal-001')->getStatus());
 	}//end testUnauthenticatedCallsReturn401()
+
+	/**
+	 * POST /bookings rejects a caller with no membership in the calendar's
+	 * administration — the confirmed missing-guard finding for
+	 * `createBooking()` (security-endpoint-guards REQ-001, negative
+	 * direction). Before this change's guard was added, this exact call
+	 * returned 201 and created the booking; see
+	 * testCreateBookingReturns201OnSuccess() for the positive-direction
+	 * counterpart proving the guard does not just deny everyone.
+	 *
+	 * @return void
+	 */
+	public function testCreateBookingRejectsNonMemberCaller(): void {
+		$context = $this->createMock(AdministrationContextService::class);
+		$context->method('currentUserId')->willReturn('mallory');
+		$context->method('buildContext')->willReturn([
+			'userId' => 'mallory',
+			'administrations' => [['administrationId' => 'adm-2']],
+			'activeAdministrationId' => 'adm-2',
+		]);
+		// Mallory is only a member of adm-2; cal-001 belongs to adm-1.
+		$context->method('canAccess')->willReturnCallback(
+			static fn (string $administrationId): bool => $administrationId === 'adm-2'
+		);
+
+		$this->params = [
+			'title' => 'Klant: Mallory',
+			'startTime' => '2026-05-21T14:00:00Z',
+			'endTime' => '2026-05-21T14:30:00Z',
+			'attendee' => 'Mallory',
+			'status' => 'pending',
+		];
+
+		$controller = new CalendarController(
+			$this->request,
+			$this->container,
+			$this->settings,
+			$this->conflicts,
+			$context,
+			$this->guard,
+			$this->createMock(LoggerInterface::class),
+			$this->buildL10n(),
+			$this->buildGroupManager(false),
+		);
+
+		$response = $controller->createBooking('cal-001');
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame('calendar-booking-forbidden', $response->getData()['error']);
+		$this->assertCount(0, $this->fakeObjectService->savedObjects, 'No booking is created for a non-member caller');
+	}//end testCreateBookingRejectsNonMemberCaller()
+
+	/**
+	 * A Nextcloud admin bypasses the per-administration booking guard —
+	 * matching `BookingNotificationController::authorizeBookingAccess()`'s
+	 * established pattern. Without this, the Nextcloud admin account (which
+	 * carries no `AdministrationMembership` of its own by default — see
+	 * tests/e2e/ci-seed.sh) would be locked out of booking on every
+	 * calendar.
+	 *
+	 * @return void
+	 */
+	public function testCreateBookingByAdminBypassesMembershipCheck(): void {
+		$context = $this->createMock(AdministrationContextService::class);
+		$context->method('currentUserId')->willReturn('admin');
+		$context->method('buildContext')->willReturn([
+			'userId' => 'admin',
+			'administrations' => [],
+			'activeAdministrationId' => null,
+		]);
+		// No memberships at all — canAccess() would deny every administration.
+		$context->method('canAccess')->willReturn(false);
+
+		$this->params = [
+			'title' => 'Klant: Admin',
+			'startTime' => '2026-05-21T14:00:00Z',
+			'endTime' => '2026-05-21T14:30:00Z',
+			'attendee' => 'Admin',
+			'status' => 'pending',
+		];
+		$this->conflicts->method('checkConflicts')->willReturn([]);
+		$this->conflicts->method('lockResource')->willReturn(true);
+
+		$controller = new CalendarController(
+			$this->request,
+			$this->container,
+			$this->settings,
+			$this->conflicts,
+			$context,
+			$this->guard,
+			$this->createMock(LoggerInterface::class),
+			$this->buildL10n(),
+			$this->buildGroupManager(true),
+		);
+
+		$response = $controller->createBooking('cal-001');
+		$this->assertSame(Http::STATUS_CREATED, $response->getStatus());
+	}//end testCreateBookingByAdminBypassesMembershipCheck()
+
+	/**
+	 * GET /bookings with an invalid (inverted) range returns a static
+	 * slug/message, not the raw exception text (security-endpoint-guards
+	 * REQ-003).
+	 *
+	 * @return void
+	 */
+	public function testListBookingsInvalidRangeDoesNotLeakExceptionText(): void {
+		$this->params['start'] = '2026-05-22';
+		$this->params['end'] = '2026-05-21';
+		$controller = $this->buildController();
+		$response = $controller->listBookings('cal-001');
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		$data = $response->getData();
+		$this->assertSame('calendar-invalid-range', $data['error']);
+		$this->assertArrayHasKey('message', $data);
+		$this->assertStringNotContainsString('end must be after start', (string)($data['error'] ?? '') . (string)($data['message'] ?? ''));
+	}//end testListBookingsInvalidRangeDoesNotLeakExceptionText()
 
 }//end class

--- a/tests/Unit/Controller/ComplianceExportControllerTest.php
+++ b/tests/Unit/Controller/ComplianceExportControllerTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * Unit tests for ComplianceExportController.
+ *
+ * Covers security-endpoint-guards REQ-003: `export()`'s
+ * `catch (RuntimeException $e)` branch used to return
+ * `['error' => $e->getMessage()]`, leaking raw exception text (which can
+ * include filter/validation detail) straight to the client. These tests
+ * prove the fixed shape — a stable kebab-case slug plus a localized
+ * message, with the real exception logged server-side instead.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\ComplianceExportController;
+use OCA\Shillinq\Service\ComplianceExportService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Tests for the RBAC-scoped compliance export endpoint's error handling.
+ *
+ * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+ */
+final class ComplianceExportControllerTest extends TestCase {
+
+	/**
+	 * Mock IRequest.
+	 *
+	 * @var IRequest&MockObject
+	 */
+	private IRequest&MockObject $request;
+
+	/**
+	 * Mock export service.
+	 *
+	 * @var ComplianceExportService&MockObject
+	 */
+	private ComplianceExportService&MockObject $complianceExportService;
+
+	/**
+	 * Mock IUserSession, authenticated as an auditor by default.
+	 *
+	 * @var IUserSession&MockObject
+	 */
+	private IUserSession&MockObject $userSession;
+
+	/**
+	 * Mock IGroupManager, granting the auditor group by default.
+	 *
+	 * @var IGroupManager&MockObject
+	 */
+	private IGroupManager&MockObject $groupManager;
+
+	/**
+	 * Set up shared fixtures — an authenticated auditor caller.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// phpcs:disable CustomSniffs.Functions.NamedParameters
+		$this->request = $this->createMock(IRequest::class);
+		$this->complianceExportService = $this->createMock(ComplianceExportService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		// phpcs:enable CustomSniffs.Functions.NamedParameters
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('auditor-alice');
+		$this->userSession->method('getUser')->willReturn($user);
+		$this->groupManager->method('isAdmin')->willReturn(false);
+		$this->groupManager->method('isInGroup')->willReturn(true);
+
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) {
+				$params = ['from' => '2026-01-01', 'to' => '2026-03-31'];
+				return ($params[$key] ?? $default);
+			}
+		);
+
+	}//end setUp()
+
+	/**
+	 * Build the controller under test.
+	 *
+	 * @return ComplianceExportController
+	 */
+	private function controller(): ComplianceExportController {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
+
+		return new ComplianceExportController(
+			$this->request,
+			$this->complianceExportService,
+			$this->userSession,
+			$this->groupManager,
+			$this->createMock(ContainerInterface::class),
+			$this->createMock(LoggerInterface::class),
+			$l10n,
+		);
+
+	}//end controller()
+
+	/**
+	 * A validation RuntimeException from the export service answers a
+	 * stable slug and a localized message — never the raw exception text
+	 * (REQ-003).
+	 *
+	 * @return void
+	 */
+	public function testExportValidationFailureDoesNotLeakExceptionText(): void {
+		$this->complianceExportService->method('generateExport')->willThrowException(
+			new RuntimeException('Invalid date range: from (2026-03-31) is after to (2026-01-01) [actor=auditor-alice]')
+		);
+
+		$response = $this->controller()->export();
+
+		self::assertInstanceOf(JSONResponse::class, $response);
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+
+		$data = $response->getData();
+		self::assertSame('compliance-export-invalid-request', $data['error']);
+		self::assertArrayHasKey('message', $data);
+		self::assertStringNotContainsString('auditor-alice', json_encode($data));
+		self::assertStringNotContainsString('2026-03-31', json_encode($data));
+
+	}//end testExportValidationFailureDoesNotLeakExceptionText()
+
+	/**
+	 * A non-auditor, non-admin caller is rejected with 403 before the
+	 * export service is ever consulted (pre-existing guard, re-verified
+	 * still intact after the leak fix).
+	 *
+	 * @return void
+	 */
+	public function testExportRejectsNonAuditorCaller(): void {
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->groupManager->method('isAdmin')->willReturn(false);
+		$this->groupManager->method('isInGroup')->willReturn(false);
+
+		$response = $this->controller()->export();
+
+		self::assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+
+	}//end testExportRejectsNonAuditorCaller()
+}//end class

--- a/tests/Unit/Controller/DBAControllerTest.php
+++ b/tests/Unit/Controller/DBAControllerTest.php
@@ -26,11 +26,14 @@ use OCA\Shillinq\Controller\DBAController;
 use OCA\Shillinq\Enums\DBAConstants;
 use OCA\Shillinq\Guard\DBAOpdrachtGuard;
 use OCA\Shillinq\Guard\DBAScoreCalculator;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\DBAVbarMonitorService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\IAppConfig;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -415,6 +418,27 @@ final class DBAControllerTest extends TestCase {
 	private FakeDBAObjectService $objectService;
 
 	/**
+	 * Administration-membership seam (security-endpoint-guards REQ-001).
+	 * Defaults in setUp() to granting 'adm-1' — every seeded fixture in
+	 * this file uses that administration id — so the pre-existing
+	 * positive-path tests keep passing once `ensureAdministrationAccess()`
+	 * actually enforces membership instead of unconditionally logging.
+	 *
+	 * @var AdministrationContextService&MockObject
+	 */
+	private AdministrationContextService&MockObject $administrationContext;
+
+	/**
+	 * Group manager stub — non-admin by default in setUp() so the
+	 * membership check is genuinely exercised by the pre-existing tests;
+	 * see testSetTussenkomstModeByAdminBypassesMembershipCheck() for the
+	 * admin-bypass positive control.
+	 *
+	 * @var IGroupManager&MockObject
+	 */
+	private IGroupManager&MockObject $groupManager;
+
+	/**
 	 * Whether the container should fail to resolve the ObjectService.
 	 *
 	 * @var bool
@@ -452,6 +476,12 @@ final class DBAControllerTest extends TestCase {
 		$this->vbarMonitor     = $this->createMock(DBAVbarMonitorService::class);
 		$this->logger          = $this->createMock(LoggerInterface::class);
 		$this->objectService   = new FakeDBAObjectService();
+		$this->administrationContext = $this->createMock(AdministrationContextService::class);
+		$this->administrationContext->method('canAccess')->willReturnCallback(
+			static fn (string $administrationId): bool => $administrationId === 'adm-1'
+		);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->groupManager->method('isAdmin')->willReturn(false);
 
 		$this->request->method('getHeader')->willReturnCallback(
 			function (string $name): string {
@@ -486,6 +516,8 @@ final class DBAControllerTest extends TestCase {
 			assignmentGuard: $this->assignmentGuard,
 			vbarMonitor: $this->vbarMonitor,
 			logger: $this->logger,
+			administrationContext: $this->administrationContext,
+			groupManager: $this->groupManager,
 		);
 
 	}//end setUp()
@@ -1108,6 +1140,103 @@ final class DBAControllerTest extends TestCase {
 	}//end testSetTussenkomstModePersistsBooleanFlag()
 
 	/**
+	 * NEGATIVE CONTROL (security-endpoint-guards REQ-001): a caller with no
+	 * membership in the assignment's administration is rejected —
+	 * `ensureAdministrationAccess()` was a documented stub that logged and
+	 * unconditionally permitted every caller (STUB verdict); before this
+	 * change's fix this exact call would have persisted the write. Fixed
+	 * via `AdministrationContextService::canAccess()`, throwing
+	 * `OCSForbiddenException` instead. See
+	 * testSetTussenkomstModePersistsBooleanFlag() above for the
+	 * positive-direction counterpart (an 'adm-1' member still succeeds).
+	 *
+	 * @return void
+	 */
+	public function testSetTussenkomstModeRejectsNonMemberCaller(): void {
+		$this->seed(['DBAOpdracht' => [$this->assignmentRow()]]);
+		$this->administrationContext = $this->createMock(AdministrationContextService::class);
+		$this->administrationContext->method('canAccess')->willReturnCallback(
+			static fn (string $administrationId): bool => $administrationId === 'adm-2'
+		);
+		$controller = new DBAController(
+			request: $this->request,
+			container: $this->container,
+			appConfig: $this->appConfig,
+			userSession: $this->userSession,
+			scoreCalc: $this->scoreCalc,
+			assignmentGuard: $this->assignmentGuard,
+			vbarMonitor: $this->vbarMonitor,
+			logger: $this->logger,
+			administrationContext: $this->administrationContext,
+			groupManager: $this->groupManager,
+		);
+
+		$this->expectException(OCSForbiddenException::class);
+		$this->withBody(
+			['assignmentId' => 'opd-1', 'intermediaryMode' => true],
+			fn (): JSONResponse => $controller->setTussenkomstMode()
+		);
+
+		self::assertCount(0, $this->objectService->savedFor('DBAOpdracht'), 'No write for a non-member caller');
+
+	}//end testSetTussenkomstModeRejectsNonMemberCaller()
+
+	/**
+	 * A Nextcloud admin bypasses the per-administration membership check —
+	 * matching `BookingNotificationController::authorizeBookingAccess()`'s
+	 * established pattern. Without this, the admin account (which carries
+	 * no `AdministrationMembership` of its own by default — see
+	 * tests/e2e/ci-seed.sh) would be locked out of managing any
+	 * administration's DBA records.
+	 *
+	 * @return void
+	 */
+	public function testSetTussenkomstModeByAdminBypassesMembershipCheck(): void {
+		$this->seed(['DBAOpdracht' => [$this->assignmentRow()]]);
+		$administrationContext = $this->createMock(AdministrationContextService::class);
+		$administrationContext->method('canAccess')->willReturn(false);
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('isAdmin')->willReturn(true);
+
+		$controller = new DBAController(
+			request: $this->request,
+			container: $this->container,
+			appConfig: $this->appConfig,
+			userSession: $this->userSession,
+			scoreCalc: $this->scoreCalc,
+			assignmentGuard: $this->assignmentGuard,
+			vbarMonitor: $this->vbarMonitor,
+			logger: $this->logger,
+			administrationContext: $administrationContext,
+			groupManager: $groupManager,
+		);
+
+		$response = $this->withBody(
+			['assignmentId' => 'opd-1', 'intermediaryMode' => true],
+			fn (): JSONResponse => $controller->setTussenkomstMode()
+		);
+
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+
+	}//end testSetTussenkomstModeByAdminBypassesMembershipCheck()
+
+	/**
+	 * An anonymous caller is rejected before any membership check runs.
+	 *
+	 * @return void
+	 */
+	public function testSetTussenkomstModeRejectsAnonymousCaller(): void {
+		$this->seed(['DBAOpdracht' => [$this->assignmentRow()]]);
+
+		$this->expectException(OCSForbiddenException::class);
+		$this->withBody(
+			['assignmentId' => 'opd-1', 'intermediaryMode' => true],
+			fn (): JSONResponse => $this->anonymousController()->setTussenkomstMode()
+		);
+
+	}//end testSetTussenkomstModeRejectsAnonymousCaller()
+
+	/**
 	 * A failing write surfaces as HTTP 500, not a false success.
 	 *
 	 * @return void
@@ -1416,6 +1545,8 @@ final class DBAControllerTest extends TestCase {
 			assignmentGuard: $this->assignmentGuard,
 			vbarMonitor: $this->vbarMonitor,
 			logger: $this->logger,
+			administrationContext: $this->administrationContext,
+			groupManager: $this->groupManager,
 		);
 
 	}//end anonymousController()

--- a/tests/Unit/Controller/DunningControllerTest.php
+++ b/tests/Unit/Controller/DunningControllerTest.php
@@ -28,8 +28,11 @@ use OCA\Shillinq\Service\BIKStaffelCalculator;
 use OCA\Shillinq\Service\Dunning\DunningChannelSendResult;
 use OCA\Shillinq\Service\Dunning\IncassoDossierComposer;
 use OCA\Shillinq\Service\DunningRunService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IAppConfig;
+use OCP\IL10N;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -97,11 +100,37 @@ final class DunningControllerTest extends TestCase {
 	private ?string $userId = 'alice';
 
 	/**
-	 * Whether the context grants access to the requested administration.
+	 * Whether the context grants access to the requested administration —
+	 * the default answer when an administration id has no entry in
+	 * {@see $canAccessMap}.
 	 *
 	 * @var boolean
 	 */
 	private bool $canAccess = true;
+
+	/**
+	 * Per-administration-id overrides for canAccess(), so a single test can
+	 * grant access to the caller's own administration while denying access
+	 * to a DIFFERENT administration a target object actually belongs to
+	 * (the resumePause() cross-tenant guard, security-endpoint-guards).
+	 * Falls back to {@see $canAccess} for any id not listed here.
+	 *
+	 * @var array<string,bool>
+	 */
+	private array $canAccessMap = [];
+
+	/**
+	 * In-memory DunningPauseDispute rows, keyed by id, consulted by the
+	 * fake ObjectService's find().
+	 *
+	 * Public: read directly by the anonymous ObjectService stub class
+	 * below, which is a distinct class from this TestCase and so cannot
+	 * see a private property (mirrors the pattern already used by
+	 * ExtractionRequestControllerTest::$stubRows).
+	 *
+	 * @var array<string,array<string,mixed>>
+	 */
+	public array $pauseRecords = [];
 
 	/**
 	 * The controller under test.
@@ -130,24 +159,128 @@ final class DunningControllerTest extends TestCase {
 			}
 		);
 		$this->context->method('canAccess')->willReturnCallback(
-			function (): bool {
-				return $this->canAccess;
+			function (string $administrationId): bool {
+				return ($this->canAccessMap[$administrationId] ?? $this->canAccess);
 			}
 		);
 
 		// The 14-day B2C grace gate is open unless a test closes it.
 		$this->bik->method('isCalculationPermitted')->willReturn(true);
 
-		$this->controller = new DunningController(
+		$this->controller = $this->buildController();
+
+	}//end setUp()
+
+	/**
+	 * Build a controller wired to the shared mocks, with an ObjectService
+	 * double backed by {@see $pauseRecords} (security-endpoint-guards —
+	 * resumePause() fetches the target DunningPauseDispute directly).
+	 *
+	 * @param BIKStaffelCalculator|null $bikOverride Substitute BIK calculator, when a test needs one.
+	 *
+	 * @return DunningController
+	 */
+	private function buildController(?BIKStaffelCalculator $bikOverride = null): DunningController {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturn('shillinq');
+
+		return new DunningController(
 			request: $this->request,
-			bik: $this->bik,
+			bik: ($bikOverride ?? $this->bik),
 			runs: $this->runs,
 			dossier: $this->dossier,
 			context: $this->context,
 			logger: $this->logger,
+			appConfig: $appConfig,
+			objectService: new DuckObjectServiceAdapter($this->makePauseObjectServiceStub()),
+			l10n: $this->makeL10n(),
 		);
 
-	}//end setUp()
+	}//end buildController()
+
+	/**
+	 * Build a duck-typed in-memory ObjectService double for
+	 * `DunningPauseDispute`, wrapped in {@see DuckObjectServiceAdapter} so
+	 * it satisfies the ADR-084 `ObjectServiceInterface` the controller is
+	 * now constructed against.
+	 *
+	 * @return object
+	 */
+	private function makePauseObjectServiceStub(): object {
+		$test = $this;
+		return new class($test) {
+			/**
+			 * Back-reference to the test case.
+			 *
+			 * @var DunningControllerTest
+			 */
+			private $test;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param DunningControllerTest $test Test case.
+			 */
+			public function __construct($test) {
+				$this->test = $test;
+			}//end __construct()
+
+			/**
+			 * No-op fluent register selector.
+			 *
+			 * @param string $r Register slug.
+			 *
+			 * @return self
+			 */
+			public function setRegister(string $r): self {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * No-op fluent schema selector (the stub is single-schema).
+			 *
+			 * @param string $s Schema slug.
+			 *
+			 * @return self
+			 */
+			public function setSchema(string $s): self {
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Single-object lookup by id. THROWS on a miss, matching the real
+			 * ObjectService contract.
+			 *
+			 * @param string $id Object id.
+			 *
+			 * @return array<string,mixed>
+			 *
+			 * @throws \RuntimeException When no record matches.
+			 */
+			public function find(string $id): array {
+				if (isset($this->test->pauseRecords[$id]) === true) {
+					return $this->test->pauseRecords[$id];
+				}
+
+				throw new \RuntimeException(sprintf("Object with identifier '%s' not found", $id));
+			}//end find()
+		};
+
+	}//end makePauseObjectServiceStub()
+
+	/**
+	 * Build a minimal IL10N stub that echoes the string handed to t().
+	 *
+	 * @return IL10N&MockObject
+	 */
+	private function makeL10n(): IL10N&MockObject {
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(
+			static fn (string $text, $params = []): string => $text
+		);
+		return $l10n;
+
+	}//end makeL10n()
 
 	/**
 	 * Configure request params (getParam and getParams) from one map.
@@ -276,14 +409,7 @@ final class DunningControllerTest extends TestCase {
 		$bik = $this->createMock(BIKStaffelCalculator::class);
 		$bik->method('isCalculationPermitted')->willReturn(false);
 		$bik->expects($this->never())->method('compose');
-		$controller = new DunningController(
-			request: $this->request,
-			bik: $bik,
-			runs: $this->runs,
-			dossier: $this->dossier,
-			context: $this->context,
-			logger: $this->logger,
-		);
+		$controller = $this->buildController(bikOverride: $bik);
 		$this->withParams(
 			[
 				'administration_id' => 'adm-1',
@@ -466,9 +592,126 @@ final class DunningControllerTest extends TestCase {
 		$response = $this->controller->executeRun();
 
 		self::assertSame(Http::STATUS_CONFLICT, $response->getStatus());
-		self::assertStringContainsString('active dunning pause', (string)$response->getData()['error']);
+		// ADR-050: the response carries a stable slug, never the raw
+		// exception text (security-endpoint-guards REQ-003).
+		self::assertSame('dunning-run-execution-failed', $response->getData()['error']);
+		self::assertStringNotContainsString('inv-7', (string)$response->getData()['message']);
 
 	}//end testExecuteRunPausedInvoiceReturns409()
+
+	/**
+	 * An anonymous caller cannot resume a dunning pause.
+	 *
+	 * @return void
+	 */
+	public function testResumePauseAnonymousReturns401(): void {
+		$this->userId = null;
+		$this->withParams(['administration_id' => 'adm-1']);
+		$this->runs->expects($this->never())->method('resumePause');
+
+		$response = $this->controller->resumePause('pause-1');
+
+		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+	}//end testResumePauseAnonymousReturns401()
+
+	/**
+	 * A caller who is not a member of the request-supplied
+	 * administration_id at all sees a masked HTTP 404.
+	 *
+	 * @return void
+	 */
+	public function testResumePauseForeignAdministrationParamReturns404(): void {
+		$this->canAccess = false;
+		$this->withParams(['administration_id' => 'adm-other']);
+		$this->runs->expects($this->never())->method('resumePause');
+
+		$response = $this->controller->resumePause('pause-1');
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testResumePauseForeignAdministrationParamReturns404()
+
+	/**
+	 * NEGATIVE CONTROL / IDOR (security-endpoint-guards REQ-001): the
+	 * caller IS a genuine member of the request-supplied administration_id
+	 * (adm-1, so the first canAccess() check passes) but the
+	 * DunningPauseDispute named by $pauseId actually belongs to a
+	 * DIFFERENT administration (adm-OTHER, which the caller cannot
+	 * access). Before this change's guard was added,
+	 * DunningRunService::resumePause() never read its own
+	 * $administrationId parameter, so this call would have resumed and
+	 * returned another organisation's pause. It must now be rejected with
+	 * a masked 404, and the service must never be called.
+	 *
+	 * @return void
+	 */
+	public function testResumePauseCrossTenantPauseIsRejected(): void {
+		$this->canAccessMap = ['adm-1' => true, 'adm-OTHER' => false];
+		$this->pauseRecords['pause-1'] = [
+			'id' => 'pause-1',
+			'administrationId' => 'adm-OTHER',
+			'invoiceId' => 'inv-secret',
+			'reason' => 'DISPUTED',
+		];
+		$this->withParams(['administration_id' => 'adm-1']);
+		$this->runs->expects($this->never())->method('resumePause');
+
+		$response = $this->controller->resumePause('pause-1');
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testResumePauseCrossTenantPauseIsRejected()
+
+	/**
+	 * POSITIVE CONTROL: a member of the pause's OWN administration can
+	 * still resume it exactly as before (no regression).
+	 *
+	 * @return void
+	 */
+	public function testResumePauseOwnAdministrationSucceeds(): void {
+		$this->canAccessMap = ['adm-1' => true];
+		$this->pauseRecords['pause-1'] = [
+			'id' => 'pause-1',
+			'administrationId' => 'adm-1',
+			'invoiceId' => 'inv-7',
+			'reason' => 'DISPUTED',
+		];
+		$this->withParams(['administration_id' => 'adm-1', 'resolution' => 'resolve']);
+		$updated = ['id' => 'pause-1', 'administrationId' => 'adm-1', 'lifecycleState' => 'resolved'];
+		$this->runs->expects($this->once())
+			->method('resumePause')
+			->with('adm-1', 'pause-1', 'resolve', null)
+			->willReturn($updated);
+
+		$response = $this->controller->resumePause('pause-1');
+
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertSame($updated, $response->getData());
+
+	}//end testResumePauseOwnAdministrationSucceeds()
+
+	/**
+	 * A resume failure (e.g. the pause is already resolved) is reported as
+	 * a stable slug, never the raw exception text (REQ-003).
+	 *
+	 * @return void
+	 */
+	public function testResumePauseServiceFailureReturnsSlug(): void {
+		$this->canAccessMap = ['adm-1' => true];
+		$this->pauseRecords['pause-1'] = ['id' => 'pause-1', 'administrationId' => 'adm-1'];
+		$this->withParams(['administration_id' => 'adm-1']);
+		$this->runs->method('resumePause')->willThrowException(
+			new \RuntimeException('DunningPauseDispute pause-1 not found.')
+		);
+
+		$response = $this->controller->resumePause('pause-1');
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame('dunning-pause-not-found', $response->getData()['error']);
+		self::assertStringNotContainsString('pause-1', (string)$response->getData()['message']);
+
+	}//end testResumePauseServiceFailureReturnsSlug()
 
 	/**
 	 * An anonymous caller cannot dispatch a dossier to a collection agency.

--- a/tests/Unit/Controller/FinancialDashboardControllerTest.php
+++ b/tests/Unit/Controller/FinancialDashboardControllerTest.php
@@ -91,8 +91,12 @@ final class FinancialDashboardControllerTest extends TestCase {
 		$this->context = $this->createMock(AdministrationContextService::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 
-		// Default: an authenticated user.
+		// Default: an authenticated user who is a member of at least one
+		// administration (security-endpoint-guards REQ-001 guard — see
+		// testSeriesRejectsCallerWithNoAccessibleAdministration for the
+		// negative direction).
 		$this->context->method('currentUserId')->willReturn('alice');
+		$this->context->method('accessibleAdministrationIds')->willReturn(['adm-1']);
 
 		$this->controller = new FinancialDashboardController(
 			request: $this->request,
@@ -150,6 +154,62 @@ final class FinancialDashboardControllerTest extends TestCase {
 		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 
 	}//end testSeriesRejectsUnauthenticatedRequests()
+
+	/**
+	 * NEGATIVE CONTROL (security-endpoint-guards REQ-001): an authenticated
+	 * user with zero AdministrationMembership records is rejected with 403
+	 * before the unscoped FinancialDashboardService read runs. Before this
+	 * guard, such a caller received the platform-wide aggregate of every
+	 * tenant's turnover/margin/cashflow — see the guard's docblock in
+	 * FinancialDashboardController::respond() for the full evidence.
+	 *
+	 * @return void
+	 */
+	public function testSeriesRejectsCallerWithNoAccessibleAdministration(): void {
+		$context = $this->createMock(AdministrationContextService::class);
+		$context->method('currentUserId')->willReturn('mallory');
+		$context->method('accessibleAdministrationIds')->willReturn([]);
+
+		$controller = new FinancialDashboardController(
+			request: $this->request,
+			dashboard: $this->service,
+			context: $context,
+			logger: $this->logger,
+		);
+
+		$this->service->expects($this->never())->method('series');
+
+		$response = $controller->series();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+
+	}//end testSeriesRejectsCallerWithNoAccessibleAdministration()
+
+	/**
+	 * Same negative direction for summary() — both endpoints share the
+	 * respond() guard.
+	 *
+	 * @return void
+	 */
+	public function testSummaryRejectsCallerWithNoAccessibleAdministration(): void {
+		$context = $this->createMock(AdministrationContextService::class);
+		$context->method('currentUserId')->willReturn('mallory');
+		$context->method('accessibleAdministrationIds')->willReturn([]);
+
+		$controller = new FinancialDashboardController(
+			request: $this->request,
+			dashboard: $this->service,
+			context: $context,
+			logger: $this->logger,
+		);
+
+		$this->service->expects($this->never())->method('summary');
+
+		$response = $controller->summary();
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+
+	}//end testSummaryRejectsCallerWithNoAccessibleAdministration()
 
 	/**
 	 * Providing only one of from/to is a 400.

--- a/tests/Unit/Controller/GRIRReconciliationControllerTest.php
+++ b/tests/Unit/Controller/GRIRReconciliationControllerTest.php
@@ -37,6 +37,7 @@ use OCA\Shillinq\Tests\Unit\Service\InMemoryObjectService;
 use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
 use OCP\AppFramework\Http;
 use OCP\IAppConfig;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -138,12 +139,16 @@ class GRIRReconciliationControllerTest extends TestCase {
 
 		$userSession->method('getUser')->willReturn($user);
 
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
+
 		return new GRIRReconciliationController(
 			request: $request,
 			grirClearingService: $service,
 			administrationContext: $administrationContext,
 			userSession: $userSession,
 			logger: $this->createMock(LoggerInterface::class),
+			l10n: $l10n,
 		);
 
 	}//end controller()
@@ -221,4 +226,60 @@ class GRIRReconciliationControllerTest extends TestCase {
 		self::assertSame(Http::STATUS_BAD_REQUEST, $controller->saldo()->getStatus());
 
 	}//end testMissingPeriodIdIsABadRequest()
+
+	/**
+	 * A non-"not found" `\RuntimeException` from the service no longer
+	 * reaches the client as raw exception text (ADR-050 / security-endpoint-
+	 * guards REQ-003) — it is mapped to a stable slug + localized message,
+	 * and the real exception is logged server-side only.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 */
+	public function testInvalidRuntimeExceptionDoesNotLeakRawExceptionText(): void {
+		$administrationContext = $this->createMock(AdministrationContextService::class);
+		$administrationContext->method('canAccess')->willReturn(true);
+
+		$service = $this->createMock(GRIRClearingService::class);
+		$service->method('reconcileGRIRSaldoForPeriod')->willThrowException(
+			new \RuntimeException('SQLSTATE[42S02]: internal detail the client must never see')
+		);
+
+		$request = $this->createMock(IRequest::class);
+		$request->method('getParam')->willReturnCallback(
+			static function (string $name, $default = '') {
+				$params = ['administrationId' => 'adm-1', 'periodId' => '2026-Q2'];
+				return ($params[$name] ?? $default);
+			}
+		);
+
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn($this->createMock(IUser::class));
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$logger->expects($this->once())->method('error');
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
+
+		$controller = new GRIRReconciliationController(
+			request: $request,
+			grirClearingService: $service,
+			administrationContext: $administrationContext,
+			userSession: $userSession,
+			logger: $logger,
+			l10n: $l10n,
+		);
+
+		$response = $controller->saldo();
+
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		self::assertSame('grir-saldo-invalid-request', $response->getData()['error']);
+		self::assertStringNotContainsStringIgnoringCase(
+			'SQLSTATE',
+			(string)json_encode($response->getData())
+		);
+
+	}//end testInvalidRuntimeExceptionDoesNotLeakRawExceptionText()
 }//end class

--- a/tests/Unit/Controller/GoodsReceiptNoteControllerTest.php
+++ b/tests/Unit/Controller/GoodsReceiptNoteControllerTest.php
@@ -158,6 +158,69 @@ final class GoodsReceiptNoteControllerTest extends TestCase {
 	}//end withParams()
 
 	/**
+	 * An anonymous caller cannot create a GRN (HTTP 401).
+	 *
+	 * Guard coverage for security-endpoint-guards (REQ-004): `create()` was a
+	 * mechanically-flagged candidate with no prior test exercising its
+	 * `AdministrationContextService::canAccess()` guard in either direction —
+	 * added here alongside the sibling methods' existing coverage.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-004
+	 */
+	public function testCreateAnonymousReturns401(): void {
+		$this->user = null;
+		$this->withParams(['administrationId' => 'adm-1']);
+		$this->grnService->expects($this->never())->method('createGRN');
+
+		$response = $this->controller->create();
+
+		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+	}//end testCreateAnonymousReturns401()
+
+	/**
+	 * A non-member sees a masked HTTP 404 on create (ADR-005, no IDOR) — the
+	 * negative direction of REQ-004's guard proof for `create()`.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-004
+	 */
+	public function testCreateForeignAdministrationReturns404(): void {
+		$this->canAccess = false;
+		$this->withParams(['administrationId' => 'adm-other']);
+		$this->grnService->expects($this->never())->method('createGRN');
+
+		$response = $this->controller->create();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testCreateForeignAdministrationReturns404()
+
+	/**
+	 * A member of the target administration can create a GRN (HTTP 201) — the
+	 * positive direction of REQ-004's guard proof for `create()`.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-004
+	 */
+	public function testCreateValidReturns201(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'poIds' => ['po-1']]);
+		$this->grnService->expects($this->once())->method('createGRN')->willReturn(
+			['grnId' => 'grn-9', 'administrationId' => 'adm-1', 'statusCode' => 'received']
+		);
+
+		$response = $this->controller->create();
+
+		self::assertSame(Http::STATUS_CREATED, $response->getStatus());
+		self::assertSame('grn-9', $response->getData()['grnId']);
+
+	}//end testCreateValidReturns201()
+
+	/**
 	 * An anonymous caller cannot append a GRN line (HTTP 401).
 	 *
 	 * @return void
@@ -442,6 +505,68 @@ final class GoodsReceiptNoteControllerTest extends TestCase {
 		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 
 	}//end testAcceptMalformedIdReturns400()
+
+	/**
+	 * An anonymous caller cannot attach photos to a GRN (HTTP 401).
+	 *
+	 * Guard coverage for security-endpoint-guards (REQ-004): `uploadPhotos()`
+	 * was a mechanically-flagged candidate with no prior test exercising its
+	 * `AdministrationContextService::canAccess()` guard in either direction.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-004
+	 */
+	public function testUploadPhotosAnonymousReturns401(): void {
+		$this->user = null;
+		$this->withParams(['administrationId' => 'adm-1', 'photos' => ['file-1']]);
+		$this->grnService->expects($this->never())->method('uploadPhotos');
+
+		$response = $this->controller->uploadPhotos('grn-1');
+
+		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+	}//end testUploadPhotosAnonymousReturns401()
+
+	/**
+	 * A non-member sees a masked HTTP 404 on photo upload (ADR-005, no IDOR)
+	 * — the negative direction of REQ-004's guard proof for `uploadPhotos()`.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-004
+	 */
+	public function testUploadPhotosForeignAdministrationReturns404(): void {
+		$this->canAccess = false;
+		$this->withParams(['administrationId' => 'adm-other', 'photos' => ['file-1']]);
+		$this->grnService->expects($this->never())->method('uploadPhotos');
+
+		$response = $this->controller->uploadPhotos('grn-1');
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testUploadPhotosForeignAdministrationReturns404()
+
+	/**
+	 * A member of the target administration can attach photos (HTTP 200) —
+	 * the positive direction of REQ-004's guard proof for `uploadPhotos()`.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-004
+	 */
+	public function testUploadPhotosValidReturns200(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'photos' => ['file-1', 'file-2']]);
+		$this->grnService->expects($this->once())->method('uploadPhotos')->willReturn(
+			['grnId' => 'grn-1', 'photos' => ['file-1', 'file-2']]
+		);
+
+		$response = $this->controller->uploadPhotos('grn-1');
+
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertCount(2, $response->getData()['photos']);
+
+	}//end testUploadPhotosValidReturns200()
 
 	// phpcs:enable CustomSniffs.Functions.NamedParameters
 }//end class

--- a/tests/Unit/Controller/InvoiceApiControllerTest.php
+++ b/tests/Unit/Controller/InvoiceApiControllerTest.php
@@ -338,5 +338,227 @@ final class InvoiceApiControllerTest extends TestCase {
 
 	}//end testPdfRendererFailureReturns500WithoutStackTrace()
 
+	/**
+	 * index() scopes every read to the server-resolved administration and
+	 * exposes no request parameter that could change that scope
+	 * (security-endpoint-guards REQ-001 — session-derived, IDOR-safe).
+	 *
+	 * @return void
+	 */
+	public function testIndexScopesToServerResolvedAdministration(): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static fn (string $key, mixed $default = null): mixed => $default
+		);
+
+		$seenFilters = null;
+		$this->objectService->method('findAll')->willReturnCallback(
+			function (array $params) use (&$seenFilters): array {
+				$seenFilters = ($params['filters'] ?? []);
+				return [];
+			}
+		);
+
+		$response = $this->controller->index();
+
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertSame(['administrationId' => 'adm-1'], $seenFilters);
+
+	}//end testIndexScopesToServerResolvedAdministration()
+
+	/**
+	 * An anonymous caller is rejected with HTTP 401 before any list read.
+	 *
+	 * @return void
+	 */
+	public function testIndexAnonymousReturns401(): void {
+		$this->user = null;
+		$this->objectService->expects($this->never())->method('findAll');
+
+		$response = $this->controller->index();
+
+		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+	}//end testIndexAnonymousReturns401()
+
+	/**
+	 * An invoice owned by another administration yields HTTP 403 for show()
+	 * and the lines are never fetched (security-endpoint-guards REQ-001).
+	 *
+	 * @return void
+	 */
+	public function testShowCrossTenantInvoiceReturns403(): void {
+		$this->objectService->method('find')->willReturn(
+			$this->entity(['invoiceNumber' => 'F-2026-0007', 'administrationId' => 'adm-someone-else'])
+		);
+		$this->objectService->expects($this->never())->method('findAll');
+
+		$response = $this->controller->show('inv-1');
+
+		self::assertInstanceOf(JSONResponse::class, $response);
+		self::assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+
+	}//end testShowCrossTenantInvoiceReturns403()
+
+	/**
+	 * An invoice owned by the caller's own administration is returned with
+	 * its lines — the positive control for testShowCrossTenantInvoiceReturns403().
+	 *
+	 * @return void
+	 */
+	public function testShowOwnAdministrationReturnsInvoiceAndLines(): void {
+		$invoice = ['invoiceNumber' => 'F-2026-0007', 'administrationId' => 'adm-1'];
+		$lines = [['description' => 'Advies']];
+		$this->objectService->method('find')->willReturn($this->entity($invoice));
+		$this->objectService->method('findAll')->willReturn($lines);
+
+		$response = $this->controller->show('inv-1');
+
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		$data = $response->getData();
+		self::assertSame($invoice, $data['invoice']);
+		self::assertSame($lines, $data['lines']);
+
+	}//end testShowOwnAdministrationReturnsInvoiceAndLines()
+
+	/**
+	 * An unknown invoice id yields HTTP 404 for show().
+	 *
+	 * @return void
+	 */
+	public function testShowUnknownInvoiceReturns404(): void {
+		$this->objectService->method('find')->willReturn(null);
+
+		$response = $this->controller->show('inv-missing');
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testShowUnknownInvoiceReturns404()
+
+	/**
+	 * An invoice owned by another administration yields HTTP 403 for post()
+	 * and postInvoice() is never called (security-endpoint-guards REQ-001).
+	 *
+	 * @return void
+	 */
+	public function testPostCrossTenantInvoiceReturns403(): void {
+		$this->objectService->method('find')->willReturn(
+			$this->entity(['invoiceNumber' => 'F-2026-0007', 'administrationId' => 'adm-someone-else'])
+		);
+		$this->service->expects($this->never())->method('postInvoice');
+
+		$response = $this->controller->post('inv-1');
+
+		self::assertInstanceOf(JSONResponse::class, $response);
+		self::assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+
+	}//end testPostCrossTenantInvoiceReturns403()
+
+	/**
+	 * An invoice owned by the caller's own administration is posted —
+	 * the positive control for testPostCrossTenantInvoiceReturns403().
+	 *
+	 * @return void
+	 */
+	public function testPostOwnAdministrationReturns200(): void {
+		$invoice = ['invoiceNumber' => 'F-2026-0007', 'administrationId' => 'adm-1', 'status' => 'draft'];
+		$posted = array_merge($invoice, ['status' => 'posted']);
+		$this->objectService->method('find')->willReturn($this->entity($invoice));
+		$this->service->method('postInvoice')->with($invoice)->willReturn($posted);
+
+		$response = $this->controller->post('inv-1');
+
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertSame($posted, $response->getData());
+
+	}//end testPostOwnAdministrationReturns200()
+
+	/**
+	 * A failed post() maps a RuntimeException to a slug, never the raw
+	 * exception text (ADR-050 / security-endpoint-guards REQ-003).
+	 *
+	 * @return void
+	 */
+	public function testPostAlreadyPostedReturnsConflictSlugWithoutLeakingMessage(): void {
+		$invoice = ['invoiceNumber' => 'F-2026-0007', 'administrationId' => 'adm-1', 'status' => 'posted'];
+		$this->objectService->method('find')->willReturn($this->entity($invoice));
+		$this->service->method('postInvoice')->willThrowException(new \RuntimeException('Invoice is already posted.'));
+		$this->logger->expects($this->once())->method('error');
+
+		$response = $this->controller->post('inv-1');
+
+		self::assertSame(Http::STATUS_CONFLICT, $response->getStatus());
+		$data = $response->getData();
+		self::assertSame('invoice-post-conflict', $data['error']);
+		self::assertArrayHasKey('message', $data);
+
+	}//end testPostAlreadyPostedReturnsConflictSlugWithoutLeakingMessage()
+
+	/**
+	 * generate() ignores any administrationId the client tries to smuggle into
+	 * the request body — the drafted invoice is always scoped to the caller's
+	 * own session-resolved administration (security-endpoint-guards REQ-001).
+	 *
+	 * @return void
+	 */
+	public function testGenerateIgnoresClientSuppliedAdministrationId(): void {
+		$body = [
+			'administrationId' => 'adm-attacker',
+			'billingModel' => 't_and_m',
+			'customerId' => 'cust-1',
+			'fromDate' => '2026-01-01',
+			'toDate' => '2026-01-31',
+			'rateCardId' => 'rc-1',
+		];
+		$this->request->method('getParams')->willReturn($body);
+
+		$seenAdministrationId = null;
+		$this->service->method('draftInvoice')->willReturnCallback(
+			function (\OCA\Shillinq\Request\InvoiceGenerationRequest $req) use (&$seenAdministrationId): array {
+				$seenAdministrationId = $req->administrationId;
+				return ['administrationId' => $req->administrationId];
+			}
+		);
+
+		$response = $this->controller->generate();
+
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertSame('adm-1', $seenAdministrationId);
+
+	}//end testGenerateIgnoresClientSuppliedAdministrationId()
+
+	/**
+	 * An anonymous caller is rejected with HTTP 401 before any drafting work.
+	 *
+	 * @return void
+	 */
+	public function testGenerateAnonymousReturns401(): void {
+		$this->user = null;
+		$this->service->expects($this->never())->method('draftInvoice');
+
+		$response = $this->controller->generate();
+
+		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+	}//end testGenerateAnonymousReturns401()
+
+	/**
+	 * An invalid generation request maps to a static slug/message, never the
+	 * raw validation exception text (ADR-050 / security-endpoint-guards REQ-003).
+	 *
+	 * @return void
+	 */
+	public function testGenerateInvalidRequestReturnsSlugWithoutLeakingMessage(): void {
+		$this->request->method('getParams')->willReturn([]);
+		$this->logger->expects($this->once())->method('error');
+
+		$response = $this->controller->generate();
+
+		self::assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
+		$data = $response->getData();
+		self::assertSame('invoice-generate-invalid', $data['error']);
+		self::assertStringNotContainsStringIgnoringCase('billingModel must be one of', (string)json_encode($data));
+
+	}//end testGenerateInvalidRequestReturnsSlugWithoutLeakingMessage()
+
 	// phpcs:enable CustomSniffs.Functions.NamedParameters
 }//end class

--- a/tests/Unit/Controller/MultiPoConsolidationControllerTest.php
+++ b/tests/Unit/Controller/MultiPoConsolidationControllerTest.php
@@ -500,6 +500,27 @@ final class MultiPoConsolidationControllerTest extends TestCase {
 	}//end testCandidatesAnonymousReturns401()
 
 	/**
+	 * candidates() masks a cross-tenant administration as HTTP 404 (ADR-005 /
+	 * security-endpoint-guards REQ-001) — a non-member of the requested
+	 * administration is rejected before the invoice lookup runs.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 */
+	public function testCandidatesCrossTenantReturns404(): void {
+		$this->administrationContext = $this->createMock(AdministrationContextService::class);
+		$this->administrationContext->method('canAccess')->willReturn(false);
+		$this->withParams(['administrationId' => 'adm-other', 'invoiceId' => 'inv-9', 'invoiceLineNumber' => 1]);
+
+		$response = $this->controller()->candidates();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame('Administration not found', $response->getData()['error']);
+
+	}//end testCandidatesCrossTenantReturns404()
+
+	/**
 	 * disambiguate() persists the chosen tuple and answers HTTP 201 with the
 	 * ThreeWayMatch.
 	 *
@@ -591,6 +612,35 @@ final class MultiPoConsolidationControllerTest extends TestCase {
 		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
 
 	}//end testDisambiguateAnonymousReturns401()
+
+	/**
+	 * disambiguate() masks a cross-tenant administration as HTTP 404 (ADR-005 /
+	 * security-endpoint-guards REQ-001) — a non-member of the requested
+	 * administration is rejected before the chosen tuple is persisted.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 */
+	public function testDisambiguateCrossTenantReturns404(): void {
+		$this->administrationContext = $this->createMock(AdministrationContextService::class);
+		$this->administrationContext->method('canAccess')->willReturn(false);
+		$this->withParams(
+			[
+				'administrationId' => 'adm-other',
+				'invoiceId' => 'inv-9',
+				'invoiceLineNumber' => 1,
+				'chosenPoLineId' => 'pol-7',
+			]
+		);
+		$this->consolidation->expects($this->never())->method('disambiguateAmbiguousMatches');
+
+		$response = $this->controller()->disambiguate();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame('Administration not found', $response->getData()['error']);
+
+	}//end testDisambiguateCrossTenantReturns404()
 
 	// phpcs:enable CustomSniffs.Functions.NamedParameters
 }//end class

--- a/tests/Unit/Controller/PaymentRunControllerTest.php
+++ b/tests/Unit/Controller/PaymentRunControllerTest.php
@@ -82,6 +82,11 @@ class PaymentRunControllerTest extends TestCase {
 	 * @param bool $canAccess canAccess() return value.
 	 * @param PaymentRunExportService $export Export service (mock).
 	 * @param PaymentRunReconciliationService $reconcile Reconciliation service (mock).
+	 * @param IRequest|null $request Optional request stub (default: an
+	 *                               unconfigured mock, params/uploads all
+	 *                               empty) — pass a stubbed one when a test
+	 *                               needs a request param, e.g. reconcile()'s
+	 *                               `contents` fallback.
 	 *
 	 * @return PaymentRunController
 	 */
@@ -90,6 +95,7 @@ class PaymentRunControllerTest extends TestCase {
 		bool $canAccess,
 		PaymentRunExportService $export,
 		PaymentRunReconciliationService $reconcile,
+		?IRequest $request = null,
 	): PaymentRunController {
 		$objects   = $this->objectServiceReturning($run);
 		$container = $this->createMock(ContainerInterface::class);
@@ -104,7 +110,7 @@ class PaymentRunControllerTest extends TestCase {
 		$session->method('getUser')->willReturn($user);
 
 		return new PaymentRunController(
-			$this->createMock(IRequest::class),
+			($request ?? $this->createMock(IRequest::class)),
 			$export,
 			$reconcile,
 			$adminContext,
@@ -204,4 +210,39 @@ class PaymentRunControllerTest extends TestCase {
 
 		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
 	}//end testUnauthorisedReconcileRejected()
+
+	/**
+	 * HAPPY: an authorised reconcile (positive control for the
+	 * security-endpoint-guards ADR-005 guard — REQ-004) still delegates to the
+	 * service and returns 200 exactly as before the guard existed.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-004
+	 */
+	public function testAuthorisedReconcileSucceeds(): void {
+		$request = $this->createMock(IRequest::class);
+		$request->method('getUploadedFile')->willReturn(null);
+		$request->method('getParam')->willReturnCallback(
+			static fn (string $key, mixed $default = null): mixed => ($key === 'contents' ? '<Document/>' : $default)
+		);
+
+		$reconcile = $this->createMock(PaymentRunReconciliationService::class);
+		$reconcile->expects(self::once())->method('reconcile')->willReturn(
+			['reconciledAt' => 'now', 'lifecycleState' => 'reconciled', 'matchedCount' => 1, 'unmatched' => []]
+		);
+
+		$controller = $this->controller(
+			['id' => 'pr-1', 'administrationId' => 'adm-1', 'lifecycleState' => 'exported'],
+			true,
+			$this->createMock(PaymentRunExportService::class),
+			$reconcile,
+			$request,
+		);
+
+		$response = $controller->reconcile('pr-1');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('reconciled', $response->getData()['lifecycleState']);
+	}//end testAuthorisedReconcileSucceeds()
 }//end class

--- a/tests/Unit/Controller/PayrollControllerTest.php
+++ b/tests/Unit/Controller/PayrollControllerTest.php
@@ -27,6 +27,7 @@ use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\PayrollService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -80,6 +81,13 @@ final class PayrollControllerTest extends TestCase {
 	private AdministrationContextService&MockObject $context;
 
 	/**
+	 * Mock IL10N.
+	 *
+	 * @var IL10N&MockObject
+	 */
+	private IL10N&MockObject $l10n;
+
+	/**
 	 * What canAccess() answers. Flipped by the REQ-MA-001 refusal tests.
 	 *
 	 * @var bool
@@ -116,12 +124,16 @@ final class PayrollControllerTest extends TestCase {
 		$this->context = $this->createMock(AdministrationContextService::class);
 		$this->context->method('canAccess')->willReturnCallback(fn (): bool => $this->canAccess);
 
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
+
 		$this->controller = new PayrollController(
 			request: $this->request,
 			payrollService: $this->service,
 			userSession: $this->userSession,
 			context: $this->context,
 			logger: $this->logger,
+			l10n: $this->l10n,
 		);
 
 	}//end setUp()

--- a/tests/Unit/Controller/PurchaseOrderControllerTest.php
+++ b/tests/Unit/Controller/PurchaseOrderControllerTest.php
@@ -27,6 +27,7 @@ use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\PurchaseOrderService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -83,6 +84,13 @@ final class PurchaseOrderControllerTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 
 	/**
+	 * Mock IL10N.
+	 *
+	 * @var IL10N&MockObject
+	 */
+	private IL10N&MockObject $l10n;
+
+	/**
 	 * Set up shared fixtures — authenticated with an accessible
 	 * administration by default.
 	 *
@@ -95,6 +103,8 @@ final class PurchaseOrderControllerTest extends TestCase {
 		$this->administrationContext = $this->createMock(AdministrationContextService::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnCallback(static fn (string $text, $params = []): string => $text);
 
 		$this->administrationContext->method('canAccess')->willReturn(true);
 
@@ -143,9 +153,183 @@ final class PurchaseOrderControllerTest extends TestCase {
 			$this->administrationContext,
 			$this->userSession,
 			$this->logger,
+			$this->l10n,
 		);
 
 	}//end controller()
+
+	/**
+	 * create() persists the purchase order and returns it with HTTP 201, for
+	 * the legitimate caller (REQ-001 positive direction).
+	 *
+	 * @return void
+	 */
+	public function testCreateReturns201WithPersistedOrder(): void {
+		$this->withParams(
+			[
+				'administrationId' => 'adm-1',
+				'supplierId' => 'sup-1',
+				'costCenter' => 'cc-1',
+				'lines' => [['productCode' => 'p1', 'quantity' => 2, 'unitPrice' => 10.0, 'vatRate' => 21, 'glAccount' => 'gl-1']],
+			]
+		);
+		$po = ['id' => 'po-1', 'administrationId' => 'adm-1', 'status' => 'draft'];
+		$this->purchaseOrderService->expects($this->once())
+			->method('createPurchaseOrder')
+			->willReturnCallback(
+				static function (string $administrationId, array $payload) use ($po): array {
+					self::assertSame('adm-1', $administrationId);
+					self::assertSame('sup-1', $payload['supplierId']);
+					return $po;
+				}
+			);
+
+		$response = $this->controller()->create();
+
+		self::assertSame(Http::STATUS_CREATED, $response->getStatus());
+		self::assertSame($po, $response->getData());
+
+	}//end testCreateReturns201WithPersistedOrder()
+
+	/**
+	 * create() rejects an anonymous caller with HTTP 401 (REQ-001 negative
+	 * direction — no session at all).
+	 *
+	 * @return void
+	 */
+	public function testCreateAnonymousReturns401(): void {
+		$this->anonymous();
+		$this->withParams(['administrationId' => 'adm-1']);
+		$this->purchaseOrderService->expects($this->never())->method('createPurchaseOrder');
+
+		$response = $this->controller()->create();
+
+		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+	}//end testCreateAnonymousReturns401()
+
+	/**
+	 * create() masks a cross-tenant administrationId as HTTP 404 rather than
+	 * creating the order (REQ-001 negative direction — authenticated but not a
+	 * member of the named administration).
+	 *
+	 * @return void
+	 */
+	public function testCreateCrossTenantReturns404(): void {
+		$this->administrationContext = $this->createMock(AdministrationContextService::class);
+		$this->administrationContext->method('canAccess')->willReturn(false);
+		$this->withParams(['administrationId' => 'adm-other', 'supplierId' => 'sup-1', 'costCenter' => 'cc-1']);
+		$this->purchaseOrderService->expects($this->never())->method('createPurchaseOrder');
+
+		$response = $this->controller()->create();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testCreateCrossTenantReturns404()
+
+	/**
+	 * A validation failure from the service (RuntimeException) answers a
+	 * static localized message and a kebab-case slug — never the raw
+	 * exception text (REQ-003 / ADR-050).
+	 *
+	 * @return void
+	 */
+	public function testCreateValidationFailureReturns400WithoutLeakingException(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'supplierId' => '', 'costCenter' => 'cc-1']);
+		$this->purchaseOrderService->method('createPurchaseOrder')
+			->willThrowException(new \RuntimeException('supplierId is required'));
+
+		$response = $this->controller()->create();
+
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		self::assertSame('purchase-order-create-invalid', $response->getData()['error']);
+		self::assertArrayHasKey('message', $response->getData());
+		self::assertStringNotContainsString('supplierId is required', (string)json_encode($response->getData()));
+
+	}//end testCreateValidationFailureReturns400WithoutLeakingException()
+
+	/**
+	 * An unexpected failure yields HTTP 500 with a static slug and leaks no
+	 * exception text (REQ-003 / ADR-050).
+	 *
+	 * @return void
+	 */
+	public function testCreateUnexpectedFailureReturns500WithoutStackTrace(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'supplierId' => 'sup-1', 'costCenter' => 'cc-1']);
+		$this->purchaseOrderService->method('createPurchaseOrder')
+			->willThrowException(new \LogicException('SQLSTATE[08006] connection refused'));
+		$this->logger->expects($this->once())->method('error');
+
+		$response = $this->controller()->create();
+
+		self::assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		self::assertSame('purchase-order-create-failed', $response->getData()['error']);
+		self::assertStringNotContainsStringIgnoringCase(
+			'SQLSTATE',
+			(string)json_encode($response->getData())
+		);
+
+	}//end testCreateUnexpectedFailureReturns500WithoutStackTrace()
+
+	/**
+	 * send() advances the order and returns it with HTTP 200, for the
+	 * legitimate caller (REQ-001 positive direction).
+	 *
+	 * @return void
+	 */
+	public function testSendReturns200WithUpdatedOrder(): void {
+		$this->withParams(['administrationId' => 'adm-1']);
+		$po = ['id' => 'po-1', 'status' => 'sent'];
+		$this->purchaseOrderService->expects($this->once())
+			->method('blockSendUntilApproved')
+			->willReturnCallback(
+				static function (string $administrationId, string $purchaseOrderId) use ($po): array {
+					self::assertSame('adm-1', $administrationId);
+					self::assertSame('po-1', $purchaseOrderId);
+					return $po;
+				}
+			);
+
+		$response = $this->controller()->send('po-1');
+
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertSame($po, $response->getData());
+
+	}//end testSendReturns200WithUpdatedOrder()
+
+	/**
+	 * send() masks a cross-tenant administrationId as HTTP 404 rather than
+	 * advancing the order (REQ-001 negative direction).
+	 *
+	 * @return void
+	 */
+	public function testSendCrossTenantReturns404(): void {
+		$this->administrationContext = $this->createMock(AdministrationContextService::class);
+		$this->administrationContext->method('canAccess')->willReturn(false);
+		$this->withParams(['administrationId' => 'adm-other']);
+		$this->purchaseOrderService->expects($this->never())->method('blockSendUntilApproved');
+
+		$response = $this->controller()->send('po-1');
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testSendCrossTenantReturns404()
+
+	/**
+	 * send() rejects an anonymous caller with HTTP 401.
+	 *
+	 * @return void
+	 */
+	public function testSendAnonymousReturns401(): void {
+		$this->anonymous();
+		$this->withParams(['administrationId' => 'adm-1']);
+		$this->purchaseOrderService->expects($this->never())->method('blockSendUntilApproved');
+
+		$response = $this->controller()->send('po-1');
+
+		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+	}//end testSendAnonymousReturns401()
 
 	/**
 	 * previewApprovalChain() returns the server-determined chain for the

--- a/tests/Unit/Controller/ReconciliationResolutionControllerTest.php
+++ b/tests/Unit/Controller/ReconciliationResolutionControllerTest.php
@@ -27,6 +27,7 @@ use OCA\Shillinq\Service\ReconciliationResolutionService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -75,6 +76,13 @@ final class ReconciliationResolutionControllerTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 
 	/**
+	 * Mock IL10N.
+	 *
+	 * @var IL10N&MockObject
+	 */
+	private IL10N&MockObject $l10n;
+
+	/**
 	 * Set up shared fixtures — authenticated as `alice` by default.
 	 *
 	 * @return void
@@ -85,6 +93,8 @@ final class ReconciliationResolutionControllerTest extends TestCase {
 		$this->service = $this->createMock(ReconciliationResolutionService::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('alice');
@@ -119,6 +129,7 @@ final class ReconciliationResolutionControllerTest extends TestCase {
 			$this->service,
 			$this->userSession,
 			$this->logger,
+			$this->l10n,
 		);
 
 	}//end controller()

--- a/tests/Unit/Controller/ReportingControllerTest.php
+++ b/tests/Unit/Controller/ReportingControllerTest.php
@@ -185,6 +185,100 @@ final class ReportingControllerTest extends TestCase {
 	}//end testTypesRejectsAnonymousCaller()
 
 	/**
+	 * Generating a report succeeds for a member of the target administration
+	 * (positive direction — security-endpoint-guards re-verification, verdict
+	 * ALREADY-GUARDED: the controller already checked canAccess() before this
+	 * change).
+	 *
+	 * @return void
+	 */
+	public function testGenerateByMemberOfTargetAdministrationSucceeds(): void {
+		$this->withParams(
+			[
+				'reportType' => 'vat-return',
+				'period' => '2026-Q2',
+				'administrationId' => 'adm-1',
+				'format' => 'pdf',
+			]
+		);
+		$this->context->method('canAccess')->willReturn(true);
+		$this->service->expects($this->once())
+			->method('generate')
+			->with('vat-return', '2026-Q2', 'adm-1', 'pdf')
+			->willReturn(['id' => 'gen-1', 'administrationId' => 'adm-1', 'reportType' => 'vat-return']);
+
+		$response = $this->controller->generate();
+
+		self::assertSame(Http::STATUS_CREATED, $response->getStatus());
+		self::assertSame('gen-1', $response->getData()['id']);
+
+	}//end testGenerateByMemberOfTargetAdministrationSucceeds()
+
+	/**
+	 * NEGATIVE CONTROL: generating a report against an administration the
+	 * caller is not a member of is masked as 404, and the service is never
+	 * called (security-endpoint-guards, REQ-001).
+	 *
+	 * @return void
+	 */
+	public function testGenerateForForeignAdministrationIsForbidden(): void {
+		$this->withParams(
+			[
+				'reportType' => 'vat-return',
+				'period' => '2026-Q2',
+				'administrationId' => 'adm-other',
+				'format' => 'pdf',
+			]
+		);
+		$this->context->method('canAccess')->willReturn(false);
+		$this->service->expects($this->never())->method('generate');
+
+		$response = $this->controller->generate();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame(['error' => 'not-found'], $response->getData());
+
+	}//end testGenerateForForeignAdministrationIsForbidden()
+
+	/**
+	 * The generate endpoint refuses an anonymous caller with HTTP 401 before
+	 * any administration check runs.
+	 *
+	 * @return void
+	 */
+	public function testGenerateRejectsAnonymousCaller(): void {
+		$this->currentUser = null;
+		$this->service->expects($this->never())->method('generate');
+
+		$response = $this->controller->generate();
+
+		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+
+	}//end testGenerateRejectsAnonymousCaller()
+
+	/**
+	 * Generating with no administrationId at all is left to the service (a
+	 * caller-scoped report, e.g. stored under the caller's own Files home) —
+	 * it is not a bypass since no OTHER tenant's scope is ever named or
+	 * checked against.
+	 *
+	 * @return void
+	 */
+	public function testGenerateWithNoAdministrationIdSkipsTheGuardAndReachesTheService(): void {
+		$this->withParams(['reportType' => 'vat-return', 'period' => '2026-Q2', 'format' => 'pdf']);
+		$this->context->expects($this->never())->method('canAccess');
+		$this->service->expects($this->once())
+			->method('generate')
+			->with('vat-return', '2026-Q2', '', 'pdf')
+			->willReturn(['id' => 'gen-2']);
+
+		$response = $this->controller->generate();
+
+		self::assertSame(Http::STATUS_CREATED, $response->getStatus());
+
+	}//end testGenerateWithNoAdministrationIdSkipsTheGuardAndReachesTheService()
+
+	/**
 	 * Without an explicit administrationId the listing is scoped to the caller's
 	 * memberships — one service query per accessible administration, never a
 	 * whole-instance listing (ADR-005 / REQ-MA-001).

--- a/tests/Unit/Controller/RequisitionControllerTest.php
+++ b/tests/Unit/Controller/RequisitionControllerTest.php
@@ -28,6 +28,7 @@ use OCA\Shillinq\Service\RequisitionConversionService;
 use OCA\Shillinq\Service\RequisitionService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -91,6 +92,13 @@ final class RequisitionControllerTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 
 	/**
+	 * Mock IL10N (ADR-050 localized error messages).
+	 *
+	 * @var IL10N&MockObject
+	 */
+	private IL10N&MockObject $l10n;
+
+	/**
 	 * The user the session reports; null models an anonymous caller.
 	 *
 	 * @var IUser|null
@@ -117,6 +125,10 @@ final class RequisitionControllerTest extends TestCase {
 		$this->administrationContext = $this->createMock(AdministrationContextService::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnCallback(
+			static fn (string $text, $params = []): string => $text
+		);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('alice');
@@ -135,6 +147,7 @@ final class RequisitionControllerTest extends TestCase {
 			administrationContext: $this->administrationContext,
 			userSession: $this->userSession,
 			logger: $this->logger,
+			l10n: $this->l10n,
 		);
 
 	}//end setUp()
@@ -254,8 +267,10 @@ final class RequisitionControllerTest extends TestCase {
 	}//end testApproveForeignAdministrationReturns404()
 
 	/**
-	 * A budget refusal from BudgetBlocker surfaces as 409 Conflict with the
-	 * service's own message — the transition is denied server-side.
+	 * A budget refusal from BudgetBlocker surfaces as 409 Conflict. Per ADR-050 /
+	 * REQ-003 the service's own exception text is NEVER placed in the response
+	 * body — the client gets a stable slug + generic localized message, and the
+	 * real reason is only visible server-side via the logger.
 	 *
 	 * @return void
 	 */
@@ -268,7 +283,11 @@ final class RequisitionControllerTest extends TestCase {
 		$response = $this->controller->approve('req-7');
 
 		self::assertSame(Http::STATUS_CONFLICT, $response->getStatus());
-		self::assertSame(['error' => 'Budget exceeded for programme P1'], $response->getData());
+		self::assertSame('requisition-invalid-state', $response->getData()['error']);
+		self::assertStringNotContainsStringIgnoringCase(
+			'Budget exceeded for programme P1',
+			(string)json_encode($response->getData())
+		);
 
 	}//end testApproveBudgetRefusalReturns409()
 
@@ -402,6 +421,165 @@ final class RequisitionControllerTest extends TestCase {
 		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 
 	}//end testRejectRejectsMalformedIdWith400()
+
+	/**
+	 * Creating a requisition succeeds for a member of the target administration
+	 * (positive direction — security-endpoint-guards re-verification, verdict
+	 * ALREADY-GUARDED: the controller already checked canAccess() before this
+	 * change).
+	 *
+	 * @return void
+	 */
+	public function testCreateByMemberOfTargetAdministrationSucceeds(): void {
+		$this->withParams(
+			[
+				'administrationId' => 'adm-1',
+				'programme' => 'P1',
+				'financialYear' => 2026,
+				'neededByDate' => '2026-09-01',
+				'justification' => 'Replace laptops',
+				'kind' => 'goods',
+				'lines' => [
+					['description' => 'Laptop', 'quantity' => 1, 'unitPrice' => 1000, 'glAccountSuggestion' => '4000'],
+				],
+			]
+		);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+		$this->requisitionService->expects($this->once())
+			->method('createRequisition')
+			->with('adm-1', $this->anything())
+			->willReturn(['id' => 'req-1', 'administrationId' => 'adm-1', 'statusCode' => 'draft']);
+
+		$response = $this->controller->create();
+
+		self::assertSame(Http::STATUS_CREATED, $response->getStatus());
+		self::assertSame('req-1', $response->getData()['id']);
+
+	}//end testCreateByMemberOfTargetAdministrationSucceeds()
+
+	/**
+	 * NEGATIVE CONTROL: creating a requisition against an administration the
+	 * caller is not a member of is masked as 404, and the service is never
+	 * called (security-endpoint-guards, REQ-001).
+	 *
+	 * @return void
+	 */
+	public function testCreateForForeignAdministrationIsForbidden(): void {
+		$this->withParams(['administrationId' => 'adm-other']);
+		$this->administrationContext->method('canAccess')->willReturn(false);
+		$this->requisitionService->expects($this->never())->method('createRequisition');
+
+		$response = $this->controller->create();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testCreateForForeignAdministrationIsForbidden()
+
+	/**
+	 * A validation refusal from the service layer (missing/invalid field) never
+	 * places the exception's own text in the response body (ADR-050 / REQ-003).
+	 *
+	 * @return void
+	 */
+	public function testCreateValidationFailureDoesNotLeakExceptionText(): void {
+		$this->withParams(['administrationId' => 'adm-1']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+		$this->requisitionService->method('createRequisition')
+			->willThrowException(new \RuntimeException('programma is required'));
+
+		$response = $this->controller->create();
+
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		self::assertSame('requisition-create-invalid', $response->getData()['error']);
+		self::assertStringNotContainsStringIgnoringCase(
+			'programma is required',
+			(string)json_encode($response->getData())
+		);
+
+	}//end testCreateValidationFailureDoesNotLeakExceptionText()
+
+	/**
+	 * Submitting a draft requisition succeeds for a member of its administration
+	 * (positive direction — security-endpoint-guards re-verification).
+	 *
+	 * @return void
+	 */
+	public function testSubmitByOwnAdministrationMemberSucceeds(): void {
+		$this->withParams(['administrationId' => 'adm-1']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+		$this->requisitionService->expects($this->once())
+			->method('submitRequisition')
+			->with('adm-1', 'req-1')
+			->willReturn(['id' => 'req-1', 'statusCode' => 'submitted']);
+
+		$response = $this->controller->submit('req-1');
+
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertSame('submitted', $response->getData()['statusCode']);
+
+	}//end testSubmitByOwnAdministrationMemberSucceeds()
+
+	/**
+	 * NEGATIVE CONTROL: submitting inside another tenant's administration is
+	 * masked as 404 and never reaches the service (security-endpoint-guards).
+	 *
+	 * @return void
+	 */
+	public function testSubmitForForeignAdministrationIsForbidden(): void {
+		$this->withParams(['administrationId' => 'adm-other']);
+		$this->administrationContext->method('canAccess')->willReturn(false);
+		$this->requisitionService->expects($this->never())->method('submitRequisition');
+
+		$response = $this->controller->submit('req-1');
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testSubmitForForeignAdministrationIsForbidden()
+
+	/**
+	 * Converting an approved requisition succeeds for a member of its
+	 * administration (positive direction — security-endpoint-guards
+	 * re-verification).
+	 *
+	 * @return void
+	 */
+	public function testConvertByOwnAdministrationMemberSucceeds(): void {
+		$this->withParams(['administrationId' => 'adm-1']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+		$this->conversionService->expects($this->once())
+			->method('convertToPurchaseOrder')
+			->with('adm-1', 'req-1')
+			->willReturn(
+				[
+					'requisition' => ['id' => 'req-1', 'statusCode' => 'converted'],
+					'purchaseOrder' => ['id' => 'po-1'],
+				]
+			);
+
+		$response = $this->controller->convert('req-1');
+
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertSame('po-1', $response->getData()['purchaseOrder']['id']);
+
+	}//end testConvertByOwnAdministrationMemberSucceeds()
+
+	/**
+	 * NEGATIVE CONTROL: converting inside another tenant's administration is
+	 * masked as 404 and never reaches the conversion service
+	 * (security-endpoint-guards).
+	 *
+	 * @return void
+	 */
+	public function testConvertForForeignAdministrationIsForbidden(): void {
+		$this->withParams(['administrationId' => 'adm-other']);
+		$this->administrationContext->method('canAccess')->willReturn(false);
+		$this->conversionService->expects($this->never())->method('convertToPurchaseOrder');
+
+		$response = $this->controller->convert('req-1');
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testConvertForForeignAdministrationIsForbidden()
 
 	// phpcs:enable CustomSniffs.Functions.NamedParameters
 }//end class

--- a/tests/Unit/Controller/VATReturnControllerTest.php
+++ b/tests/Unit/Controller/VATReturnControllerTest.php
@@ -31,6 +31,7 @@ use OCA\Shillinq\Controller\VATReturnController;
 use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\VATReturnService;
 use OCP\AppFramework\Http;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -80,6 +81,13 @@ final class VATReturnControllerTest extends TestCase {
 	 * @var LoggerInterface&MockObject
 	 */
 	private LoggerInterface&MockObject $logger;
+
+	/**
+	 * Mock IL10N — client-facing error messages (ADR-050).
+	 *
+	 * @var IL10N&MockObject
+	 */
+	private IL10N&MockObject $l10n;
 
 	/**
 	 * Mock AdministrationContextService — the ADR-005 membership guard.
@@ -137,6 +145,8 @@ final class VATReturnControllerTest extends TestCase {
 		$this->container = $this->createMock(ContainerInterface::class);
 		$this->session = $this->createMock(IUserSession::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
 		$this->context = $this->createMock(AdministrationContextService::class);
 
 		$this->canAccess = true;
@@ -153,6 +163,7 @@ final class VATReturnControllerTest extends TestCase {
 			session: $this->session,
 			context: $this->context,
 			logger: $this->logger,
+			l10n: $this->l10n,
 		);
 
 		// Bind the session once to a mutable reference; tests can override the

--- a/tests/Unit/Controller/WbsoAccountApiControllerTest.php
+++ b/tests/Unit/Controller/WbsoAccountApiControllerTest.php
@@ -32,6 +32,7 @@ use OCA\Shillinq\Controller\WbsoAccountApiController;
 use OCA\Shillinq\Service\WbsoAccountService;
 use OCA\Shillinq\Service\WbsoRbacResolver;
 use OCP\AppFramework\Http;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -82,6 +83,13 @@ final class WbsoAccountApiControllerTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 
 	/**
+	 * Mock IL10N.
+	 *
+	 * @var IL10N&MockObject
+	 */
+	private IL10N&MockObject $l10n;
+
+	/**
 	 * Controller under test.
 	 *
 	 * @var WbsoAccountApiController
@@ -100,6 +108,8 @@ final class WbsoAccountApiControllerTest extends TestCase {
 		$this->rbac = $this->createMock(WbsoRbacResolver::class);
 		$this->session = $this->createMock(IUserSession::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('alice');
@@ -111,6 +121,7 @@ final class WbsoAccountApiControllerTest extends TestCase {
 			rbac: $this->rbac,
 			userSession: $this->session,
 			logger: $this->logger,
+			l10n: $this->l10n,
 		);
 	}//end setUp()
 
@@ -152,6 +163,7 @@ final class WbsoAccountApiControllerTest extends TestCase {
 			rbac: $this->rbac,
 			userSession: $session,
 			logger: $this->logger,
+			l10n: $this->l10n,
 		);
 
 		$response = $controller->index();

--- a/tests/Unit/Controller/WbsoAdministratieControllerTest.php
+++ b/tests/Unit/Controller/WbsoAdministratieControllerTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Tests\Unit\Controller;
 
 use OCA\Shillinq\Controller\WbsoAdministratieController;
+use OCA\Shillinq\Service\AdministrationContextService;
 use OCA\Shillinq\Service\WbsoAdministratieService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -63,6 +64,23 @@ final class WbsoAdministratieControllerTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 
 	/**
+	 * Mock AdministrationContextService — the ADR-005 membership guard.
+	 *
+	 * @var AdministrationContextService&MockObject
+	 */
+	private AdministrationContextService&MockObject $administrationContext;
+
+	/**
+	 * What canAccess() answers. Defaults to true (member of every
+	 * administration asked about) so the pre-existing tests, none of which
+	 * were written with the guard in mind, keep exercising the same
+	 * happy-path shape they always did.
+	 *
+	 * @var bool
+	 */
+	private bool $canAccess = true;
+
+	/**
 	 * The controller under test.
 	 *
 	 * @var WbsoAdministratieController
@@ -79,10 +97,14 @@ final class WbsoAdministratieControllerTest extends TestCase {
 		$this->request = $this->createMock(IRequest::class);
 		$this->service = $this->createMock(WbsoAdministratieService::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->administrationContext = $this->createMock(AdministrationContextService::class);
+		$this->canAccess = true;
+		$this->administrationContext->method('canAccess')->willReturnCallback(fn (): bool => $this->canAccess);
 		$this->controller = new WbsoAdministratieController(
 			request: $this->request,
 			service: $this->service,
 			logger: $this->logger,
+			administrationContext: $this->administrationContext,
 		);
 
 	}//end setUp()
@@ -126,6 +148,51 @@ final class WbsoAdministratieControllerTest extends TestCase {
 		self::assertSame($payload, $response->getData());
 
 	}//end testReturnsOkWithRealisatieSummary()
+
+	/**
+	 * ADR-005 Rule 3 / REQ-001 (security-endpoint-guards): a caller with no
+	 * AdministrationMembership for the requested administration_id is
+	 * refused with a masked 404 — proving the request never previously
+	 * enforced any membership check, any authenticated user could read
+	 * another organization's statutory WBSO realisatie by quoting its
+	 * administration_id.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 */
+	public function testNonMemberIsRefusedWithMasked404(): void {
+		$this->withAdmin('adm-not-mine');
+		$this->canAccess = false;
+		$this->service->expects(self::never())->method('realisatieSummary');
+
+		$response = $this->controller->realisatie();
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testNonMemberIsRefusedWithMasked404()
+
+	/**
+	 * A member of the requested administration still gets the realisatie
+	 * summary exactly as before (positive direction, REQ-004).
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+	 */
+	public function testMemberOfRequestedAdministrationSucceeds(): void {
+		$this->withAdmin('adm-a');
+		$this->canAccess = true;
+		$payload = ['data' => [['decisionNumber' => 'WBSO-1', 'exceeded' => false]], 'total' => 1];
+		$this->service->expects(self::once())
+			->method('realisatieSummary')
+			->with('adm-a')
+			->willReturn($payload);
+
+		$response = $this->controller->realisatie();
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertSame($payload, $response->getData());
+
+	}//end testMemberOfRequestedAdministrationSucceeds()
 
 	/**
 	 * A missing administration_id yields HTTP 400.

--- a/tests/Unit/Controller/WbsoDocumentApiControllerTest.php
+++ b/tests/Unit/Controller/WbsoDocumentApiControllerTest.php
@@ -29,6 +29,7 @@ use OCA\Shillinq\Controller\WbsoDocumentApiController;
 use OCA\Shillinq\Service\WbsoDocumentService;
 use OCA\Shillinq\Service\WbsoRbacResolver;
 use OCP\AppFramework\Http;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -80,6 +81,13 @@ final class WbsoDocumentApiControllerTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 
 	/**
+	 * Mock IL10N.
+	 *
+	 * @var IL10N&MockObject
+	 */
+	private IL10N&MockObject $l10n;
+
+	/**
 	 * Controller.
 	 *
 	 * @var WbsoDocumentApiController
@@ -98,6 +106,8 @@ final class WbsoDocumentApiControllerTest extends TestCase {
 		$this->rbac = $this->createMock(WbsoRbacResolver::class);
 		$this->session = $this->createMock(IUserSession::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('admin');
@@ -109,6 +119,7 @@ final class WbsoDocumentApiControllerTest extends TestCase {
 			rbac: $this->rbac,
 			userSession: $this->session,
 			logger: $this->logger,
+			l10n: $this->l10n,
 		);
 	}//end setUp()
 

--- a/tests/Unit/Controller/WbsoTransactionApiControllerTest.php
+++ b/tests/Unit/Controller/WbsoTransactionApiControllerTest.php
@@ -29,6 +29,7 @@ use OCA\Shillinq\Controller\WbsoTransactionApiController;
 use OCA\Shillinq\Service\WbsoRbacResolver;
 use OCA\Shillinq\Service\WbsoTransactionService;
 use OCP\AppFramework\Http;
+use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -80,6 +81,13 @@ final class WbsoTransactionApiControllerTest extends TestCase {
 	private LoggerInterface&MockObject $logger;
 
 	/**
+	 * Mock IL10N — client-facing error messages (ADR-050).
+	 *
+	 * @var IL10N&MockObject
+	 */
+	private IL10N&MockObject $l10n;
+
+	/**
 	 * Controller.
 	 *
 	 * @var WbsoTransactionApiController
@@ -98,6 +106,8 @@ final class WbsoTransactionApiControllerTest extends TestCase {
 		$this->rbac = $this->createMock(WbsoRbacResolver::class);
 		$this->session = $this->createMock(IUserSession::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('alice');
@@ -109,6 +119,7 @@ final class WbsoTransactionApiControllerTest extends TestCase {
 			rbac: $this->rbac,
 			userSession: $this->session,
 			logger: $this->logger,
+			l10n: $this->l10n,
 		);
 	}//end setUp()
 
@@ -170,6 +181,121 @@ final class WbsoTransactionApiControllerTest extends TestCase {
 		self::assertSame(Http::STATUS_CONFLICT, $response->getStatus());
 
 	}//end testReverseConflictReturns409()
+
+	/**
+	 * ADR-050 (REQ-003): a caught RuntimeException on reverse() must not leak
+	 * `$e->getMessage()` into the response body — the body carries a stable
+	 * slug + localized message, and the real exception text is logged only.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 */
+	public function testReverseConflictBodyDoesNotLeakExceptionText(): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null): mixed {
+				return match ($key) {
+					'administration_id' => 'adm-1',
+					'reason' => 'oops',
+					default => $default,
+				};
+			}
+		);
+		$this->rbac->method('hasAny')->willReturn(true);
+		$this->transactions->method('reverseTransaction')
+			->willThrowException(new RuntimeException('boom at /var/www/secret.php:99'));
+
+		$response = $this->controller->reverse(id: 'tx-1');
+		$body = $response->getData();
+
+		self::assertSame('wbso-transaction-conflict', $body['error']);
+		self::assertStringNotContainsString('secret.php', (string)($body['message'] ?? ''));
+		self::assertStringNotContainsString('boom', (string)($body['message'] ?? ''));
+
+	}//end testReverseConflictBodyDoesNotLeakExceptionText()
+
+	/**
+	 * ADR-050 (REQ-003): reverse() naming a missing transaction is masked as
+	 * 404 with a slug, not the raw InvalidArgumentException message.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 */
+	public function testReverseNotFoundReturnsSlugNotRawMessage(): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null): mixed {
+				return match ($key) {
+					'administration_id' => 'adm-1',
+					'reason' => 'oops',
+					default => $default,
+				};
+			}
+		);
+		$this->rbac->method('hasAny')->willReturn(true);
+		$this->transactions->method('reverseTransaction')
+			->willThrowException(new \InvalidArgumentException('Transaction not found'));
+
+		$response = $this->controller->reverse(id: 'tx-missing');
+		$body = $response->getData();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame('wbso-transaction-not-found', $body['error']);
+
+	}//end testReverseNotFoundReturnsSlugNotRawMessage()
+
+	/**
+	 * ADR-050 (REQ-003): post() naming a missing transaction is masked as 404
+	 * with a slug, not the raw InvalidArgumentException message.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 */
+	public function testPostNotFoundReturnsSlugNotRawMessage(): void {
+		$this->request->method('getParam')->willReturn('adm-1');
+		$this->rbac->method('hasAny')->willReturn(true);
+		$this->transactions->method('postTransaction')
+			->willThrowException(new \InvalidArgumentException('Transaction with id secret-internal-id not found'));
+
+		$response = $this->controller->post(id: 'tx-missing');
+		$body = $response->getData();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame('wbso-transaction-not-found', $body['error']);
+		self::assertStringNotContainsString('secret-internal-id', (string)($body['message'] ?? ''));
+
+	}//end testPostNotFoundReturnsSlugNotRawMessage()
+
+	/**
+	 * ADR-050 (REQ-003): create() with an invalid payload returns a slug, not
+	 * the raw InvalidArgumentException message.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-003
+	 */
+	public function testCreateInvalidInputReturnsSlugNotRawMessage(): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null): mixed {
+				return match ($key) {
+					'administration_id' => 'adm-1',
+					default => $default,
+				};
+			}
+		);
+		$this->rbac->method('hasAny')->willReturn(true);
+		$this->transactions->method('createTransaction')
+			->willThrowException(new \InvalidArgumentException('amount must be a positive decimal, got -100.5'));
+
+		$response = $this->controller->create();
+		$body = $response->getData();
+
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		self::assertSame('wbso-transaction-invalid-input', $body['error']);
+		self::assertStringNotContainsString('-100.5', (string)($body['message'] ?? ''));
+
+	}//end testCreateInvalidInputReturnsSlugNotRawMessage()
 
 	/**
 	 * Post happy path returns 200.

--- a/tests/Unit/Service/InvoiceGenerationServiceIdorTest.php
+++ b/tests/Unit/Service/InvoiceGenerationServiceIdorTest.php
@@ -1,0 +1,520 @@
+<?php
+
+/**
+ * Second-order IDOR guard on InvoiceGenerationService::draftInvoice().
+ *
+ * REQ-001 (security-endpoint-guards): draftInvoice() resolves every id the
+ * client supplies on the request (timeEntryIds/expenseIds/meterReadingIds/
+ * milestoneId, and the UsageRatePlan a MeterReading points at) through
+ * OpenRegister's ObjectService by id alone. Before the fix, none of those
+ * lookups checked that the resolved record's own administrationId matched
+ * the caller's server-resolved administration — a member of administration A
+ * could reference administration B's UrenRegistratie/ExpenseClaimEntry/
+ * MeterReading/Milestone ids and have B's data (hours, expense amounts,
+ * metered usage, milestone name/budget) folded straight into A's invoice.
+ *
+ * These tests seed TWO administrations (adm-attacker / adm-victim) and drive
+ * draftInvoice() as adm-attacker with a request that references both an
+ * adm-attacker-owned id and an adm-victim-owned id for each source type,
+ * proving both directions in one assertion block: the caller's own record is
+ * still resolved and billed (the fix does not regress the legitimate path),
+ * and the victim's record is silently excluded — never resolved, never
+ * billed, never leaked into a description or amount — exactly like an
+ * unknown/non-existent id, which is this file's pre-existing convention for
+ * an unresolvable reference.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Service
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Service;
+
+use OCA\Shillinq\Request\InvoiceGenerationRequest;
+use OCA\Shillinq\Service\BillingModelEngine;
+use OCA\Shillinq\Service\InvoiceDeduplicationService;
+use OCA\Shillinq\Service\InvoiceGenerationService;
+use OCA\Shillinq\Service\RateCardResolver;
+use OCA\Shillinq\Service\RetainerResolver;
+use OCA\Shillinq\Service\UsageRatingCalculator;
+use OCA\Shillinq\Service\VATCalculationService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
+use OCP\IAppConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Proves draftInvoice()'s referenced-record lookups are administration-scoped.
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+final class InvoiceGenerationServiceIdorTest extends TestCase {
+
+	private const ADMIN_ATTACKER = 'adm-attacker';
+
+	private const ADMIN_VICTIM = 'adm-victim';
+
+	/**
+	 * In-memory fake ObjectService supporting the fluent find/findAll/saveObject
+	 * shape InvoiceGenerationService consumes (same shape as
+	 * MeteredInvoiceGenerationTest's double).
+	 *
+	 * @var object
+	 */
+	private object $objectService;
+
+	/**
+	 * Subject under test.
+	 *
+	 * @var InvoiceGenerationService
+	 */
+	private InvoiceGenerationService $service;
+
+	/**
+	 * Seed both administrations' fixtures and wire the service under test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->objectService = new class {
+
+			/**
+			 * Records keyed by schema; also the store find/findAll read from.
+			 *
+			 * @var array<string,array<int,array<string,mixed>>>
+			 */
+			public array $store = [];
+
+			/**
+			 * Save log keyed by schema.
+			 *
+			 * @var array<string,array<int,array<string,mixed>>>
+			 */
+			public array $saved = [];
+
+			/**
+			 * Current schema.
+			 *
+			 * @var string
+			 */
+			private string $schema = '';
+
+			/**
+			 * Auto-increment id counter.
+			 *
+			 * @var integer
+			 */
+			private int $seq = 0;
+
+			/**
+			 * Fluent register selector.
+			 *
+			 * @param string $register Register slug.
+			 *
+			 * @return self
+			 */
+			public function setRegister(string $register): self {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * Fluent schema selector.
+			 *
+			 * @param string $schema Schema slug.
+			 *
+			 * @return self
+			 */
+			public function setSchema(string $schema): self {
+				$this->schema = $schema;
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * Find one record by id under the current schema (id-only — used by
+			 * fetchInvoice()/generateInvoiceNumber(), never by the scoped loaders
+			 * under test here).
+			 *
+			 * @param string $id Record id.
+			 *
+			 * @return array<string,mixed>|null
+			 */
+			public function find(string $id): ?array {
+				foreach (($this->store[$this->schema] ?? []) as $row) {
+					if ((string)($row['id'] ?? '') === $id) {
+						return $row;
+					}
+				}
+
+				return null;
+			}//end find()
+
+			/**
+			 * Return rows for the current schema, applying equality filters —
+			 * the compound id+administrationId filter InvoiceGenerationService's
+			 * findScoped() issues is honoured here exactly like the real
+			 * OpenRegister ObjectService::findAll() (AND across every filter key).
+			 *
+			 * @param array<string,mixed> $options Query options.
+			 *
+			 * @return array<int,array<string,mixed>>
+			 */
+			public function findAll(array $options): array {
+				$rows = $this->store[$this->schema] ?? [];
+				$filters = $options['filters'] ?? [];
+				if ($filters === []) {
+					return $rows;
+				}
+
+				return array_values(
+					array_filter(
+						$rows,
+						static function (array $row) use ($filters): bool {
+							foreach ($filters as $key => $value) {
+								if (($row[$key] ?? null) !== $value) {
+									return false;
+								}
+							}
+
+							return true;
+						}
+					)
+				);
+			}//end findAll()
+
+			/**
+			 * Persist a record (assigning an id when absent) under the current schema.
+			 *
+			 * @param array<string,mixed> $data Record payload.
+			 *
+			 * @return array<string,mixed>
+			 */
+			public function saveObject(array $data): array {
+				if (isset($data['id']) === false || (string)$data['id'] === '') {
+					$this->seq++;
+					$data['id'] = sprintf('%s-%d', strtolower($this->schema), $this->seq);
+				}
+
+				$this->store[$this->schema][] = $data;
+				$this->saved[$this->schema][] = $data;
+				return $data;
+			}//end saveObject()
+		};
+
+		$this->objectService->store = [
+			'UrenRegistratie' => [
+				[
+					'id' => 'ure-attacker-1',
+					'administrationId' => self::ADMIN_ATTACKER,
+					'resourceType' => 'consultant',
+					'hours' => 5.0,
+					'date' => '2026-03-10',
+					'hourlyRateOverride' => 100,
+				],
+				[
+					'id' => 'ure-victim-1',
+					'administrationId' => self::ADMIN_VICTIM,
+					'resourceType' => 'consultant',
+					'hours' => 8.0,
+					'date' => '2026-03-10',
+					'hourlyRateOverride' => 100,
+				],
+			],
+			'ExpenseClaimEntry' => [
+				[
+					'id' => 'exp-attacker-1',
+					'administrationId' => self::ADMIN_ATTACKER,
+					'description' => 'Attacker travel',
+					'amount' => 50.00,
+				],
+				[
+					'id' => 'exp-victim-1',
+					'administrationId' => self::ADMIN_VICTIM,
+					'description' => 'Victim confidential expense',
+					'amount' => 999.00,
+				],
+			],
+			'MeterReading' => [
+				[
+					'id' => 'mr-attacker-1',
+					'administrationId' => self::ADMIN_ATTACKER,
+					'meterId' => 'meter-attacker',
+					'resourceType' => 'api_calls',
+					'quantity' => 100,
+					'unit' => 'calls',
+					'ratePlanId' => 'urp-attacker',
+					'periodStart' => '2026-03-01',
+					'periodEnd' => '2026-03-31',
+				],
+				[
+					'id' => 'mr-victim-1',
+					'administrationId' => self::ADMIN_VICTIM,
+					'meterId' => 'meter-victim',
+					'resourceType' => 'api_calls',
+					'quantity' => 100,
+					'unit' => 'calls',
+					'ratePlanId' => 'urp-victim',
+					'periodStart' => '2026-03-01',
+					'periodEnd' => '2026-03-31',
+				],
+				[
+					// Attacker's OWN reading, but with a ratePlanId that resolves to
+					// the VICTIM's UsageRatePlan — proves the plan lookup is scoped
+					// too, not just the reading lookup.
+					'id' => 'mr-attacker-2',
+					'administrationId' => self::ADMIN_ATTACKER,
+					'meterId' => 'meter-attacker-2',
+					'resourceType' => 'api_calls',
+					'quantity' => 100,
+					'unit' => 'calls',
+					'ratePlanId' => 'urp-victim',
+					'periodStart' => '2026-03-01',
+					'periodEnd' => '2026-03-31',
+				],
+			],
+			'UsageRatePlan' => [
+				[
+					'id' => 'urp-attacker',
+					'administrationId' => self::ADMIN_ATTACKER,
+					'name' => 'Attacker plan',
+					'resourceType' => 'api_calls',
+					'unit' => 'calls',
+					'ratingMethod' => 'flat',
+					'unitPriceCents' => 5,
+					'vatRate' => 21,
+				],
+				[
+					'id' => 'urp-victim',
+					'administrationId' => self::ADMIN_VICTIM,
+					'name' => 'Victim confidential plan',
+					'resourceType' => 'api_calls',
+					'unit' => 'calls',
+					'ratingMethod' => 'flat',
+					'unitPriceCents' => 999,
+					'vatRate' => 21,
+				],
+			],
+			'Milestone' => [
+				[
+					'id' => 'ms-attacker-1',
+					'administrationId' => self::ADMIN_ATTACKER,
+					'name' => 'Attacker milestone',
+					'completedAt' => '2026-03-01',
+					'budgetAmount' => 500.00,
+				],
+				[
+					'id' => 'ms-victim-1',
+					'administrationId' => self::ADMIN_VICTIM,
+					'name' => 'Victim confidential milestone',
+					'completedAt' => '2026-03-01',
+					'budgetAmount' => 99999.00,
+				],
+			],
+			'BillableInvoice' => [],
+		];
+
+		$container = $this->createMock(ContainerInterface::class);
+		$container->method('get')->willReturn($this->objectService);
+
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturnCallback(
+			static fn (string $app, string $key, string $default): string => $default
+		);
+
+		$logger = new NullLogger();
+
+		$this->service = new InvoiceGenerationService(
+			$appConfig,
+			$logger,
+			new RateCardResolver($container, $appConfig, $logger),
+			new RetainerResolver($container, $appConfig, $logger),
+			new BillingModelEngine(),
+			new InvoiceDeduplicationService($container, $appConfig, $logger),
+			new VATCalculationService(),
+			new UsageRatingCalculator(),
+			objectService: new DuckObjectServiceAdapter($this->objectService),
+		);
+	}//end setUp()
+
+	/**
+	 * REQ-001: a cross-tenant timeEntryId is silently excluded from the
+	 * drafted invoice — only the attacker's own 5 billable hours land, not
+	 * the victim's 8 (13 combined would prove the exclusion failed).
+	 *
+	 * @return void
+	 */
+	public function testCrossTenantTimeEntryIdIsExcludedFromDraft(): void {
+		$request = new InvoiceGenerationRequest(
+			administrationId: self::ADMIN_ATTACKER,
+			billingModel: 't_and_m',
+			customerId: 'cust-1',
+			fromDate: '2026-03-01',
+			toDate: '2026-03-31',
+			timeEntryIds: ['ure-attacker-1', 'ure-victim-1'],
+			rateCardId: 'rc-none',
+		);
+
+		$invoice = $this->service->draftInvoice($request);
+
+		// Only the attacker's own 5 hours @ €100/hr (RateCardResolver's
+		// no-match fallback) = €500.00 net. If the victim's 8 hours had
+		// leaked in, this would be €1300.00 (13 hours combined).
+		self::assertSame(500.00, $invoice['netAmount']);
+
+		$lines = $this->objectService->saved['BillableInvoiceLine'] ?? [];
+		self::assertCount(1, $lines);
+		self::assertSame(5.0, $lines[0]['billableUnits']);
+	}//end testCrossTenantTimeEntryIdIsExcludedFromDraft()
+
+	/**
+	 * REQ-001: a cross-tenant expenseId is silently excluded — only the
+	 * attacker's own €50 expense line is persisted, never the victim's €999
+	 * confidential expense (which would also leak its description).
+	 *
+	 * @return void
+	 */
+	public function testCrossTenantExpenseIdIsExcludedFromDraft(): void {
+		$request = new InvoiceGenerationRequest(
+			administrationId: self::ADMIN_ATTACKER,
+			billingModel: 'fixed_fee',
+			customerId: 'cust-1',
+			fromDate: '2026-03-01',
+			toDate: '2026-03-31',
+			expenseIds: ['exp-attacker-1', 'exp-victim-1'],
+			fixedFeeCents: 100000,
+		);
+
+		$invoice = $this->service->draftInvoice($request);
+
+		// €1000.00 fixed fee + €50.00 attacker expense = €1050.00. The
+		// victim's €999.00 expense must not be added (would be €2049.00).
+		self::assertSame(1050.00, $invoice['netAmount']);
+
+		$lines = $this->objectService->saved['BillableInvoiceLine'] ?? [];
+		$expenseLines = array_values(array_filter($lines, static fn (array $l): bool => $l['sourceType'] === 'expense'));
+		self::assertCount(1, $expenseLines);
+		self::assertSame('exp-attacker-1', $expenseLines[0]['sourceId']);
+		self::assertSame('Attacker travel', $expenseLines[0]['description']);
+	}//end testCrossTenantExpenseIdIsExcludedFromDraft()
+
+	/**
+	 * REQ-001: a cross-tenant meterReadingId is silently excluded — only the
+	 * attacker's own metered reading rates onto the invoice.
+	 *
+	 * @return void
+	 */
+	public function testCrossTenantMeterReadingIdIsExcludedFromDraft(): void {
+		$request = new InvoiceGenerationRequest(
+			administrationId: self::ADMIN_ATTACKER,
+			billingModel: 'usage',
+			customerId: 'cust-1',
+			fromDate: '2026-03-01',
+			toDate: '2026-03-31',
+			meterReadingIds: ['mr-attacker-1', 'mr-victim-1'],
+			usageRatePlanId: 'urp-attacker',
+		);
+
+		$invoice = $this->service->draftInvoice($request);
+
+		$lines = $this->objectService->saved['BillableInvoiceLine'] ?? [];
+		self::assertCount(1, $lines);
+		self::assertSame('mr-attacker-1', $lines[0]['sourceId']);
+		// 100 calls @ €0.05/call (attacker plan) = €5.00; the victim's
+		// reading (which would rate at the victim's €9.99/call plan) is
+		// never resolved at all.
+		self::assertSame(5.00, $invoice['netAmount']);
+	}//end testCrossTenantMeterReadingIdIsExcludedFromDraft()
+
+	/**
+	 * REQ-001: a MeterReading that is the attacker's own record but whose
+	 * ratePlanId points at another tenant's UsageRatePlan must not rate
+	 * against that foreign plan — the reading is skipped (never billed at a
+	 * cross-tenant price), the same as any other unresolvable plan id.
+	 *
+	 * @return void
+	 */
+	public function testCrossTenantRatePlanReferenceIsExcludedFromDraft(): void {
+		$request = new InvoiceGenerationRequest(
+			administrationId: self::ADMIN_ATTACKER,
+			billingModel: 'usage',
+			customerId: 'cust-1',
+			fromDate: '2026-03-01',
+			toDate: '2026-03-31',
+			meterReadingIds: ['mr-attacker-2'],
+		);
+
+		$invoice = $this->service->draftInvoice($request);
+
+		// mr-attacker-2 references urp-victim; the plan lookup is scoped to
+		// adm-attacker so it never resolves, so the reading is skipped and
+		// nothing is billed — never the victim's €999.00/call rate.
+		self::assertSame(0.00, $invoice['netAmount']);
+		self::assertCount(0, $this->objectService->saved['BillableInvoiceLine'] ?? []);
+	}//end testCrossTenantRatePlanReferenceIsExcludedFromDraft()
+
+	/**
+	 * REQ-001: a cross-tenant milestoneId falls back to the same generic
+	 * stub as an unknown id — never the victim's real milestone name or
+	 * budget.
+	 *
+	 * @return void
+	 */
+	public function testCrossTenantMilestoneIdFallsBackToStub(): void {
+		$request = new InvoiceGenerationRequest(
+			administrationId: self::ADMIN_ATTACKER,
+			billingModel: 'milestone',
+			customerId: 'cust-1',
+			fromDate: '2026-03-01',
+			toDate: '2026-03-31',
+			milestoneId: 'ms-victim-1',
+		);
+
+		$invoice = $this->service->draftInvoice($request);
+
+		$lines = $this->objectService->saved['BillableInvoiceLine'] ?? [];
+		self::assertCount(1, $lines);
+		// Generic stub, not the victim's real name/budget.
+		self::assertSame('Milestone', $lines[0]['description']);
+		self::assertSame(0.00, $lines[0]['costAmount']);
+		self::assertSame(0.00, $invoice['netAmount']);
+	}//end testCrossTenantMilestoneIdFallsBackToStub()
+
+	/**
+	 * Own-tenant control: the attacker's own milestoneId resolves normally —
+	 * proves the fix does not regress the legitimate same-tenant path.
+	 *
+	 * @return void
+	 */
+	public function testOwnTenantMilestoneIdDraftsCorrectly(): void {
+		$request = new InvoiceGenerationRequest(
+			administrationId: self::ADMIN_ATTACKER,
+			billingModel: 'milestone',
+			customerId: 'cust-1',
+			fromDate: '2026-03-01',
+			toDate: '2026-03-31',
+			milestoneId: 'ms-attacker-1',
+		);
+
+		$invoice = $this->service->draftInvoice($request);
+
+		$lines = $this->objectService->saved['BillableInvoiceLine'] ?? [];
+		self::assertCount(1, $lines);
+		self::assertSame('Attacker milestone', $lines[0]['description']);
+		self::assertSame(500.00, $lines[0]['costAmount']);
+		self::assertSame(500.00, $invoice['netAmount']);
+	}//end testOwnTenantMilestoneIdDraftsCorrectly()
+}//end class

--- a/tests/Unit/Service/MeteredInvoiceGenerationTest.php
+++ b/tests/Unit/Service/MeteredInvoiceGenerationTest.php
@@ -191,6 +191,7 @@ final class MeteredInvoiceGenerationTest extends TestCase {
 			'UsageRatePlan' => [
 				[
 					'id' => 'urp-api-standard',
+					'administrationId' => 'adm-holding-nl',
 					'name' => 'API Calls — Standard',
 					'resourceType' => 'api_calls',
 					'unit' => 'calls',

--- a/tests/e2e/cbs-submissions.spec.ts
+++ b/tests/e2e/cbs-submissions.spec.ts
@@ -1,0 +1,254 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * CBS Submissions — Playwright UI coverage (security-endpoint-guards, Task 8).
+ *
+ * The CBS Submissions manifest-v2 page
+ * (`src/manifest.d/bookkeeping-cbs-bestanden-extended.json`, route
+ * `/bookkeeping/cbs-submissions`) is a pure declarative index+detail page with
+ * no custom Vue component and no dedicated router entry (ADR-024 / manifest-v2)
+ * — it is rendered generically by `@conduction/nextcloud-vue`'s `CnIndexPage`/
+ * `CnDetailPage`. This spec drives that generic shell through the real
+ * `data-testid`s it emits (`cn-index-page`, `cn-object-list-table`,
+ * `cn-object-row`, `cn-row-actions`, `cn-action-item-delete`,
+ * `cn-delete-dialog`), the same convention `waterschappen-bbv-variant.spec.ts`
+ * and `list-views-cndatatable.spec.ts` already establish for this fleet.
+ *
+ * ── What this spec covers, and what it deliberately does not ──────────────
+ * `CnIndexPage`'s self-fetch mode talks to OpenRegister's GENERIC object API
+ * (`useObjectStore()`'s default `baseUrl` is `/apps/openregister/api/objects`
+ * — see `node_modules/@conduction/nextcloud-vue/src/store/useObjectStore.js`),
+ * not to `lib/Controller/CBSSubmissionController.php`'s own
+ * `/apps/shillinq/api/cbs-submissions` REST surface. So the UI-driven delete
+ * flow below exercises OpenRegister's own register/schema-level RBAC, which
+ * is explicitly out of scope for security-endpoint-guards (see design.md's
+ * ADR-031 alignment section) — NOT the app-level per-administration guard
+ * this change added to `CBSSubmissionController::destroy()`.
+ *
+ * That guard is proven two other ways, both stronger than driving the UI
+ * could be: `tests/Unit/Controller/CBSSubmissionControllerTest.php` calls the
+ * controller directly (positive + negative direction, REQ-004), and the
+ * `request`-fixture test below calls the REAL `/apps/shillinq/api/
+ * cbs-submissions/{id}` route over HTTP as the Nextcloud admin account (which
+ * carries no `AdministrationMembership` of its own — tests/e2e/ci-seed.sh —
+ * so this also incidentally proves the admin-bypass added alongside the
+ * guard). That is the one place this file's assertions can actually fail on
+ * a regression to REQ-001, and it is named honestly as such rather than
+ * implied by the UI flow around it.
+ *
+ * @spec openspec/changes/security-endpoint-guards/specs/security-endpoint-guards/spec.md#req-001
+ * @e2e security-endpoint-guards/req-001/cbs-submissions-list-view-renders
+ * @e2e security-endpoint-guards/req-001/cbs-submissions-delete-own-draft
+ */
+
+import { test, expect, type Page, type APIRequestContext } from '@playwright/test'
+
+const APP = '/apps/shillinq'
+const LIST_ROUTE = '/bookkeeping/cbs-submissions'
+const OR_OBJECTS_BASE = '/index.php/apps/openregister/api/objects/shillinq/CBSSubmission'
+const SHILLINQ_API_BASE = '/index.php/apps/shillinq/api/cbs-submissions'
+
+async function dismissWizard(page: Page): Promise<void> {
+	const wizard = page.locator('#firstrunwizard')
+	if (await wizard.isVisible().catch(() => false)) {
+		await page.keyboard.press('Escape').catch(() => {})
+		await wizard.waitFor({ state: 'hidden', timeout: 4_000 }).catch(() => {})
+	}
+}
+
+/**
+ * A minimal, schema-valid draft CBSSubmission payload. `submissionNumber`
+ * must be unique per the register's own uniqueness expectations, so every
+ * caller gets a fresh one keyed on Date.now() + a random suffix.
+ */
+function draftPayload(administrationId = 'adm-e2e-cbs') {
+	const stamp = `${Date.now()}-${Math.floor(Math.random() * 10_000)}`
+	return {
+		submissionNumber: `CBS-E2E-${stamp}`,
+		status: 'draft',
+		reportingPeriodStartDate: '2026-01-01',
+		reportingPeriodEndDate: '2026-03-31',
+		organizationLegalName: 'Shillinq E2E Test BV',
+		kvkNumber: '12345678',
+		taxIdentificationNumber: 'NL123456789B01',
+		administrationId,
+		currency: 'EUR',
+	}
+}
+
+/**
+ * Seed one draft CBSSubmission through OpenRegister's generic object API —
+ * the same surface the manifest-v2 list page itself reads from.
+ */
+async function seedDraft(
+	request: APIRequestContext,
+	administrationId = 'adm-e2e-cbs',
+): Promise<{ id: string; submissionNumber: string }> {
+	const payload = draftPayload(administrationId)
+	const created = await request.post(OR_OBJECTS_BASE, {
+		headers: { 'OCS-APIRequest': 'true' },
+		data: payload,
+	})
+	expect(created.ok(), `seeding a draft CBSSubmission must succeed, got HTTP ${created.status()}`).toBeTruthy()
+	const body = await created.json()
+	const id = body?.id
+	expect(id, 'the seeded submission must come back with an id').toBeTruthy()
+	return { id, submissionNumber: payload.submissionNumber }
+}
+
+async function cleanupViaOpenRegister(request: APIRequestContext, id: string): Promise<void> {
+	const deleted = await request.delete(`${OR_OBJECTS_BASE}/${id}`, {
+		headers: { 'OCS-APIRequest': 'true' },
+	})
+	if (deleted.ok() === false && deleted.status() !== 404) {
+		// eslint-disable-next-line no-console
+		console.warn(`[cbs-submissions] failed to clean up seeded submission ${id}: HTTP ${deleted.status()}`)
+	}
+}
+
+test.describe('CBS Submissions — list view', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(APP + LIST_ROUTE)
+		await page.waitForLoadState('domcontentloaded')
+		await dismissWizard(page)
+	})
+
+	/**
+	 * @e2e security-endpoint-guards/req-001/cbs-submissions-list-view-renders
+	 */
+	test('the CBS Submissions index page mounts and stays on the shillinq route', async ({ page }) => {
+		expect(page.url()).toContain('/apps/shillinq')
+		await expect(page.getByTestId('cn-index-page')).toBeVisible({ timeout: 15_000 })
+	})
+
+	/**
+	 * With no seed data the table still renders (empty state); with seed
+	 * data present it renders a real row. Either way the generic
+	 * `CnDataTable` — not a bespoke table — must be the thing on screen.
+	 *
+	 * @e2e security-endpoint-guards/req-001/cbs-submissions-list-view-renders
+	 */
+	test('the submissions list renders through the generic CnDataTable', async ({ page }) => {
+		const table = page.getByTestId('cn-object-list-table')
+		const empty = page.getByTestId('cn-object-list-empty')
+		await expect(table.or(empty)).toBeVisible({ timeout: 15_000 })
+	})
+
+	/**
+	 * A seeded draft submission's own submission number is visible in the
+	 * rendered list — proves the table is bound to the real CBSSubmission
+	 * schema/register, not a static placeholder.
+	 *
+	 * @e2e security-endpoint-guards/req-001/cbs-submissions-list-view-renders
+	 */
+	test('a seeded draft submission appears in the list', async ({ page, request }) => {
+		const seeded = await seedDraft(request)
+		try {
+			await page.reload()
+			await page.waitForLoadState('domcontentloaded')
+			await dismissWizard(page)
+
+			const row = page.locator(`[data-testid="cn-object-row"][data-testid-row-id="${seeded.id}"]`)
+			await expect(row).toBeVisible({ timeout: 15_000 })
+			await expect(row).toContainText(seeded.submissionNumber)
+		} finally {
+			await cleanupViaOpenRegister(request, seeded.id)
+		}
+	})
+})
+
+test.describe('CBS Submissions — delete-own-draft flow', () => {
+	/**
+	 * Drives the UI's own delete affordance end to end: open the row's
+	 * action menu, click Delete, confirm in the dialog, and assert both the
+	 * network response and that the row disappears. This exercises
+	 * OpenRegister's generic delete path (see the file-level comment above
+	 * for why that is, and where the app-level guard is proven instead).
+	 *
+	 * @e2e security-endpoint-guards/req-001/cbs-submissions-delete-own-draft
+	 */
+	test('deleting a draft submission through the row-actions menu removes it', async ({ page, request }) => {
+		const seeded = await seedDraft(request)
+		let cleanedUp = false
+
+		try {
+			await page.goto(APP + LIST_ROUTE)
+			await page.waitForLoadState('domcontentloaded')
+			await dismissWizard(page)
+
+			const row = page.locator(`[data-testid="cn-object-row"][data-testid-row-id="${seeded.id}"]`)
+			await expect(row).toBeVisible({ timeout: 15_000 })
+
+			// Open the row's action menu (NcActions trigger wrapped by CnRowActions).
+			await row.getByTestId('cn-row-actions').click()
+			await page.getByTestId('cn-action-item-delete').click()
+
+			// Confirm in CnDeleteDialog's confirm phase.
+			const confirmDialog = page.locator(
+				'[data-testid-modal="cn-delete-dialog"][data-testid-phase="confirm"]',
+			)
+			await expect(confirmDialog).toBeVisible({ timeout: 10_000 })
+
+			const deleteRequest = page.waitForResponse(
+				(response) =>
+					response.url().includes(`/CBSSubmission/${seeded.id}`)
+					&& response.request().method() === 'DELETE',
+				{ timeout: 15_000 },
+			)
+			await confirmDialog.getByRole('button', { name: /delete/i }).click()
+			const deleteResponse = await deleteRequest
+			expect(
+				deleteResponse.status(),
+				`deleting one's own draft submission must succeed, got HTTP ${deleteResponse.status()}`,
+			).toBeLessThan(300)
+			cleanedUp = true
+
+			await expect(row).toBeHidden({ timeout: 10_000 })
+		} finally {
+			if (cleanedUp === false) {
+				await cleanupViaOpenRegister(request, seeded.id)
+			}
+		}
+	})
+})
+
+test.describe('CBS Submissions — app-level guard, exercised over real HTTP (REQ-001)', () => {
+	/**
+	 * This is the one assertion in this file that can actually fail on a
+	 * regression to the guard this change added. It calls
+	 * `CBSSubmissionController::destroy()` directly — the real
+	 * `/apps/shillinq/api/cbs-submissions/{id}` route, not the generic
+	 * OpenRegister object API the list page's own delete button uses (see
+	 * the file-level comment). The Nextcloud admin account this suite runs
+	 * as carries no `AdministrationMembership` of its own (ci-seed.sh), so
+	 * a 2xx here also proves the admin-bypass added alongside the guard.
+	 *
+	 * @e2e security-endpoint-guards/req-001/cbs-submissions-delete-own-draft
+	 */
+	test('DELETE /api/cbs-submissions/{id} deletes an admin-reachable draft submission', async ({ request }) => {
+		const seeded = await seedDraft(request)
+		let cleanedUp = false
+
+		try {
+			const response = await request.delete(`${SHILLINQ_API_BASE}/${seeded.id}`, {
+				headers: { 'OCS-APIRequest': 'true' },
+			})
+			expect(
+				response.status(),
+				`the app-level CBS submission delete endpoint must succeed for an admin caller, got HTTP ${response.status()}`,
+			).toBeLessThan(300)
+			cleanedUp = true
+
+			// A second delete of the same (now-gone) id must 404, not silently 200.
+			const second = await request.delete(`${SHILLINQ_API_BASE}/${seeded.id}`, {
+				headers: { 'OCS-APIRequest': 'true' },
+			})
+			expect(second.status()).toBe(404)
+		} finally {
+			if (cleanedUp === false) {
+				await cleanupViaOpenRegister(request, seeded.id)
+			}
+		}
+	})
+})

--- a/tests/e2e/cbs-submissions.spec.ts
+++ b/tests/e2e/cbs-submissions.spec.ts
@@ -46,7 +46,8 @@ import { test, expect, type Page, type APIRequestContext } from '@playwright/tes
 
 const APP = '/apps/shillinq'
 const LIST_ROUTE = '/bookkeeping/cbs-submissions'
-const OR_OBJECTS_BASE = '/index.php/apps/openregister/api/objects/shillinq/CBSSubmission'
+const OR_OBJECTS_BASE =
+	'/index.php/apps/openregister/api/objects/shillinq/CBSSubmission'
 const SHILLINQ_API_BASE = '/index.php/apps/shillinq/api/cbs-submissions'
 
 async function dismissWizard(page: Page): Promise<void> {
@@ -71,7 +72,11 @@ function draftPayload(administrationId = 'adm-e2e-cbs') {
 		reportingPeriodEndDate: '2026-03-31',
 		organizationLegalName: 'Shillinq E2E Test BV',
 		kvkNumber: '12345678',
-		taxIdentificationNumber: 'NL123456789B01',
+		// Schema pattern (lib/Settings/register.d/bookkeeping-cbs-bestanden-
+		// extended.json) is `^NL[0-9]{10}B[0-9]{2}$` — 10 digits, not the 9 a
+		// real Dutch BTW-nummer carries. Matching the DEPLOYED pattern here
+		// (not the real-world format) so seeding actually validates.
+		taxIdentificationNumber: 'NL1234567890B01',
 		administrationId,
 		currency: 'EUR',
 	}
@@ -90,20 +95,28 @@ async function seedDraft(
 		headers: { 'OCS-APIRequest': 'true' },
 		data: payload,
 	})
-	expect(created.ok(), `seeding a draft CBSSubmission must succeed, got HTTP ${created.status()}`).toBeTruthy()
+	expect(
+		created.ok(),
+		`seeding a draft CBSSubmission must succeed, got HTTP ${created.status()}`,
+	).toBeTruthy()
 	const body = await created.json()
 	const id = body?.id
 	expect(id, 'the seeded submission must come back with an id').toBeTruthy()
 	return { id, submissionNumber: payload.submissionNumber }
 }
 
-async function cleanupViaOpenRegister(request: APIRequestContext, id: string): Promise<void> {
+async function cleanupViaOpenRegister(
+	request: APIRequestContext,
+	id: string,
+): Promise<void> {
 	const deleted = await request.delete(`${OR_OBJECTS_BASE}/${id}`, {
 		headers: { 'OCS-APIRequest': 'true' },
 	})
 	if (deleted.ok() === false && deleted.status() !== 404) {
 		// eslint-disable-next-line no-console
-		console.warn(`[cbs-submissions] failed to clean up seeded submission ${id}: HTTP ${deleted.status()}`)
+		console.warn(
+			`[cbs-submissions] failed to clean up seeded submission ${id}: HTTP ${deleted.status()}`,
+		)
 	}
 }
 
@@ -117,9 +130,13 @@ test.describe('CBS Submissions — list view', () => {
 	/**
 	 * @e2e security-endpoint-guards/req-001/cbs-submissions-list-view-renders
 	 */
-	test('the CBS Submissions index page mounts and stays on the shillinq route', async ({ page }) => {
+	test('the CBS Submissions index page mounts and stays on the shillinq route', async ({
+		page,
+	}) => {
 		expect(page.url()).toContain('/apps/shillinq')
-		await expect(page.getByTestId('cn-index-page')).toBeVisible({ timeout: 15_000 })
+		await expect(page.getByTestId('cn-index-page')).toBeVisible({
+			timeout: 15_000,
+		})
 	})
 
 	/**
@@ -129,7 +146,9 @@ test.describe('CBS Submissions — list view', () => {
 	 *
 	 * @e2e security-endpoint-guards/req-001/cbs-submissions-list-view-renders
 	 */
-	test('the submissions list renders through the generic CnDataTable', async ({ page }) => {
+	test('the submissions list renders through the generic CnDataTable', async ({
+		page,
+	}) => {
 		const table = page.getByTestId('cn-object-list-table')
 		const empty = page.getByTestId('cn-object-list-empty')
 		await expect(table.or(empty)).toBeVisible({ timeout: 15_000 })
@@ -142,14 +161,19 @@ test.describe('CBS Submissions — list view', () => {
 	 *
 	 * @e2e security-endpoint-guards/req-001/cbs-submissions-list-view-renders
 	 */
-	test('a seeded draft submission appears in the list', async ({ page, request }) => {
+	test('a seeded draft submission appears in the list', async ({
+		page,
+		request,
+	}) => {
 		const seeded = await seedDraft(request)
 		try {
 			await page.reload()
 			await page.waitForLoadState('domcontentloaded')
 			await dismissWizard(page)
 
-			const row = page.locator(`[data-testid="cn-object-row"][data-testid-row-id="${seeded.id}"]`)
+			const row = page.locator(
+				`[data-testid="cn-object-row"][data-testid-row-id="${seeded.id}"]`,
+			)
 			await expect(row).toBeVisible({ timeout: 15_000 })
 			await expect(row).toContainText(seeded.submissionNumber)
 		} finally {
@@ -168,7 +192,10 @@ test.describe('CBS Submissions — delete-own-draft flow', () => {
 	 *
 	 * @e2e security-endpoint-guards/req-001/cbs-submissions-delete-own-draft
 	 */
-	test('deleting a draft submission through the row-actions menu removes it', async ({ page, request }) => {
+	test('deleting a draft submission through the row-actions menu removes it', async ({
+		page,
+		request,
+	}) => {
 		const seeded = await seedDraft(request)
 		let cleanedUp = false
 
@@ -177,7 +204,9 @@ test.describe('CBS Submissions — delete-own-draft flow', () => {
 			await page.waitForLoadState('domcontentloaded')
 			await dismissWizard(page)
 
-			const row = page.locator(`[data-testid="cn-object-row"][data-testid-row-id="${seeded.id}"]`)
+			const row = page.locator(
+				`[data-testid="cn-object-row"][data-testid-row-id="${seeded.id}"]`,
+			)
 			await expect(row).toBeVisible({ timeout: 15_000 })
 
 			// Open the row's action menu (NcActions trigger wrapped by CnRowActions).
@@ -226,14 +255,19 @@ test.describe('CBS Submissions — app-level guard, exercised over real HTTP (RE
 	 *
 	 * @e2e security-endpoint-guards/req-001/cbs-submissions-delete-own-draft
 	 */
-	test('DELETE /api/cbs-submissions/{id} deletes an admin-reachable draft submission', async ({ request }) => {
+	test('DELETE /api/cbs-submissions/{id} deletes an admin-reachable draft submission', async ({
+		request,
+	}) => {
 		const seeded = await seedDraft(request)
 		let cleanedUp = false
 
 		try {
-			const response = await request.delete(`${SHILLINQ_API_BASE}/${seeded.id}`, {
-				headers: { 'OCS-APIRequest': 'true' },
-			})
+			const response = await request.delete(
+				`${SHILLINQ_API_BASE}/${seeded.id}`,
+				{
+					headers: { 'OCS-APIRequest': 'true' },
+				},
+			)
 			expect(
 				response.status(),
 				`the app-level CBS submission delete endpoint must succeed for an admin caller, got HTTP ${response.status()}`,
@@ -241,9 +275,12 @@ test.describe('CBS Submissions — app-level guard, exercised over real HTTP (RE
 			cleanedUp = true
 
 			// A second delete of the same (now-gone) id must 404, not silently 200.
-			const second = await request.delete(`${SHILLINQ_API_BASE}/${seeded.id}`, {
-				headers: { 'OCS-APIRequest': 'true' },
-			})
+			const second = await request.delete(
+				`${SHILLINQ_API_BASE}/${seeded.id}`,
+				{
+					headers: { 'OCS-APIRequest': 'true' },
+				},
+			)
 			expect(second.status()).toBe(404)
 		} finally {
 			if (cleanedUp === false) {

--- a/tests/stubs/OpenRegister/Contract/ObjectEntityInterface.php
+++ b/tests/stubs/OpenRegister/Contract/ObjectEntityInterface.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Minimal ObjectEntityInterface stub for unit tests that mock/typehint
+ * OpenRegister's object entity contract without depending on the
+ * OpenRegister app being autoloaded. This is the read surface exercised by
+ * the app's own conversions (`jsonSerialize()`/`getObject()` and the
+ * ownership getters), sized to the INTERSECTION of the two pre-existing
+ * stub implementers already in this repo —
+ * `tests/stubs/OpenRegister/Db/ObjectEntity.php` (which additionally
+ * declares setters + getId()/setId(), not part of this contract) and
+ * `tests/Unit/Service/Support/ObjectEntityStub.php` (the narrower one,
+ * read-only, no id accessors) — so both remain valid implementers. Neither
+ * of those pre-existing files could actually compile until this interface
+ * was added: no `Contract/` directory previously existed under
+ * tests/stubs/OpenRegister/, so every test referencing this interface (and
+ * `OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter`, wired
+ * into 128 test classes per commit ef9c8fa5) fatal'd with "Interface ...
+ * not found" before this file was added. When run inside a deployed
+ * Nextcloud tree with OpenRegister installed, `lib/base.php` provides the
+ * real interface and this stub is simply shadowed (same convention as the
+ * sibling stubs registered in tests/bootstrap-unit.php).
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Contract;
+
+/**
+ * Stub for OCA\OpenRegister\Contract\ObjectEntityInterface used by shillinq tests.
+ */
+interface ObjectEntityInterface extends \JsonSerializable {
+
+	/**
+	 * Return the decoded object payload.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function getObject(): array;
+
+	/**
+	 * Return the schema slug.
+	 *
+	 * @return string|null
+	 */
+	public function getSchema(): ?string;
+
+	/**
+	 * Return the register slug.
+	 *
+	 * @return string|null
+	 */
+	public function getRegister(): ?string;
+
+	/**
+	 * Return the uuid.
+	 *
+	 * @return string|null
+	 */
+	public function getUuid(): ?string;
+
+	/**
+	 * Return the owning uid, when the entity carries one.
+	 *
+	 * @return string|null
+	 */
+	public function getOwner(): ?string;
+
+	/**
+	 * Return the organisation id, when the entity carries one.
+	 *
+	 * @return string|null
+	 */
+	public function getOrganisation(): ?string;
+
+}//end interface

--- a/tests/stubs/OpenRegister/Contract/ObjectServiceInterface.php
+++ b/tests/stubs/OpenRegister/Contract/ObjectServiceInterface.php
@@ -1,0 +1,470 @@
+<?php
+
+/**
+ * ObjectServiceInterface stub for unit tests that mock/typehint
+ * OpenRegister's object service contract (ADR-084) without depending on the
+ * OpenRegister app being autoloaded. Several controllers
+ * (CBSSubmissionController, InvoiceApiController, and others) already
+ * type-hint their constructor against this interface, and
+ * `OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter` — wired
+ * into 128 test classes per commit ef9c8fa5 ("wire the seeded OpenRegister
+ * store back into 128 test classes") — already `implements` it. No
+ * `Contract/` directory previously existed under tests/stubs/OpenRegister/,
+ * so every one of those (and every test directly mocking this interface,
+ * e.g. InvoiceApiControllerTest) fatal'd with "Interface ... not found"
+ * before this file was added. When run inside a deployed Nextcloud tree
+ * with OpenRegister installed, `lib/base.php` provides the real interface
+ * and this stub is simply shadowed (same convention as the sibling stubs
+ * registered in tests/bootstrap-unit.php).
+ *
+ * The full 25-method surface (and every parameter name/type) is reverse
+ * -derived from `DuckObjectServiceAdapter`'s own `implements
+ * ObjectServiceInterface` — that adapter's docblock explicitly documents it
+ * as "the published ADR-084 contract" and models every method the real
+ * interface declares, throwing for the handful production never calls. This
+ * stub's signatures are copied from that adapter verbatim so both it and
+ * every duck-typed double it wraps stay assignment-compatible.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Contract;
+
+use OCP\IUser;
+
+/**
+ * Stub for OCA\OpenRegister\Contract\ObjectServiceInterface used by shillinq tests.
+ *
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods) Mirrors the real 25-method contract.
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+interface ObjectServiceInterface {
+
+	/**
+	 * Scope subsequent calls to a register.
+	 *
+	 * @param string|int $register Register slug or id.
+	 *
+	 * @return static
+	 */
+	public function setRegister(string|int $register): static;
+
+	/**
+	 * Scope subsequent calls to a schema.
+	 *
+	 * @param string|int $schema Schema slug or id.
+	 *
+	 * @return static
+	 */
+	public function setSchema(string|int $schema): static;
+
+	/**
+	 * Drop the register/schema scope.
+	 *
+	 * @return void
+	 */
+	public function clearCurrents(): void;
+
+	/**
+	 * List objects matching a filter/paging config.
+	 *
+	 * @param array $config Filters, limit, offset, sort and search.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array
+	 */
+	public function findAll(array $config = [], bool $_rbac = true, bool $_multitenancy = true): array;
+
+	/**
+	 * Fetch a single object by id.
+	 *
+	 * @param int|string $id Object id, UUID or slug.
+	 * @param ?array $_extend Relations to expand.
+	 * @param bool $files Include file metadata.
+	 * @param string|int|null $register Register override.
+	 * @param string|int|null $schema Schema override.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 * @param bool $_render Render the entity.
+	 * @param bool $_audit Write an audit entry.
+	 *
+	 * @return ?ObjectEntityInterface
+	 */
+	public function find(
+		int|string $id,
+		?array $_extend = [],
+		bool $files = false,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $_render = true,
+		bool $_audit = true
+	): ?ObjectEntityInterface;
+
+	/**
+	 * Create or update an object.
+	 *
+	 * @param array $object Object payload.
+	 * @param ?array $extend Relations to expand.
+	 * @param string|int|null $register Register override.
+	 * @param string|int|null $schema Schema override.
+	 * @param ?string $uuid Explicit UUID.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 * @param bool $silent Suppress events.
+	 * @param bool $_validation Validate against the schema.
+	 * @param ?array $uploadedFiles Files uploaded alongside.
+	 * @param ?IUser $currentUser Explicit acting user.
+	 * @param bool $failIfExists Fail instead of updating.
+	 *
+	 * @return ObjectEntityInterface
+	 */
+	public function saveObject(
+		array $object,
+		?array $extend = [],
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		?string $uuid = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $silent = false,
+		bool $_validation = true,
+		?array $uploadedFiles = null,
+		?IUser $currentUser = null,
+		bool $failIfExists = false
+	): ObjectEntityInterface;
+
+	/**
+	 * Count rows the given query would return.
+	 *
+	 * @param array $config Filters, limit, offset, sort and search.
+	 *
+	 * @return int
+	 */
+	public function count(array $config = []): int;
+
+	/**
+	 * Scoped list query by register/schema slug.
+	 *
+	 * @param string $registerSlug The register slug.
+	 * @param string $schemaSlug The schema slug.
+	 * @param array $filters Equality filters.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array|int
+	 */
+	public function searchObjectsBySlug(
+		string $registerSlug,
+		string $schemaSlug,
+		array $filters = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): array|int;
+
+	/**
+	 * Apply a partial update to an object.
+	 *
+	 * @param string $objectId The object UUID or id.
+	 * @param array $data The fields to change.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 *
+	 * @return ObjectEntityInterface
+	 */
+	public function updateObject(
+		string $objectId,
+		array $data,
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): ObjectEntityInterface;
+
+	/**
+	 * Find without audit or read events.
+	 *
+	 * @param string $id Object id, UUID or slug.
+	 * @param ?array $_extend Relations to expand.
+	 * @param bool $files Include file metadata.
+	 * @param string|int|null $register Register override.
+	 * @param string|int|null $schema Schema override.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 *
+	 * @return ObjectEntityInterface
+	 */
+	public function findSilent(
+		string $id,
+		?array $_extend = [],
+		bool $files = false,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): ObjectEntityInterface;
+
+	/**
+	 * Run an operation with system privileges.
+	 *
+	 * No return type is declared — mirrors
+	 * `DuckObjectServiceAdapter::runAsSystem()`, the reference implementer,
+	 * which also declares none (an explicit `: mixed` here would be
+	 * incompatible with an implementation that omits the return type
+	 * entirely).
+	 *
+	 * @param callable $operation The operation to run.
+	 *
+	 * @return mixed
+	 */
+	public function runAsSystem(callable $operation);
+
+	/**
+	 * The currently-held context object, if any.
+	 *
+	 * @return ?ObjectEntityInterface
+	 */
+	public function getObject(): ?ObjectEntityInterface;
+
+	/**
+	 * Full-text/faceted object search.
+	 *
+	 * @param array $query The search query.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 * @param ?array $ids Restrict to these ids.
+	 * @param ?string $uses Restrict to objects used by this one.
+	 * @param ?array $views Restrict to these views.
+	 *
+	 * @return array|int
+	 */
+	public function searchObjects(
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		?array $ids = null,
+		?string $uses = null,
+		?array $views = null
+	): array|int;
+
+	/**
+	 * Delete an object by id.
+	 *
+	 * @param string $uuid The object UUID.
+	 * @param string|int|null $register Register id, UUID or slug.
+	 * @param string|int|null $schema Schema id, UUID or slug.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 * @param bool $_retentionSweep Run as part of a retention sweep.
+	 * @param ?IUser $currentUser Explicit acting user.
+	 * @param bool $permanent Delete permanently.
+	 *
+	 * @return bool
+	 */
+	public function deleteObject(
+		string $uuid,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $_retentionSweep = false,
+		?IUser $currentUser = null,
+		bool $permanent = false
+	): bool;
+
+	/**
+	 * Paginated full-text/faceted object search.
+	 *
+	 * @param array $query The search query.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 * @param bool $deleted Include soft-deleted objects.
+	 * @param ?array $ids Restrict to these ids.
+	 * @param ?string $uses Restrict to objects used by this one.
+	 * @param ?array $views Restrict to these views.
+	 *
+	 * @return array
+	 */
+	public function searchObjectsPaginated(
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $deleted = false,
+		?array $ids = null,
+		?string $uses = null,
+		?array $views = null
+	): array;
+
+	/**
+	 * Build a search query from raw request parameters.
+	 *
+	 * @param array $requestParams Raw request parameters.
+	 * @param int|string|array|null $register Register id, UUID or slug.
+	 * @param int|string|array|null $schema Schema id, UUID or slug.
+	 * @param ?array $ids Restrict to these ids.
+	 *
+	 * @return array
+	 */
+	public function buildSearchQuery(
+		array $requestParams,
+		int|string|array|null $register = null,
+		int|string|array|null $schema = null,
+		?array $ids = null
+	): array;
+
+	/**
+	 * Bulk-persist objects.
+	 *
+	 * @param array $objects The objects to store.
+	 * @param string|int|null $register Register id, UUID or slug.
+	 * @param string|int|null $schema Schema id, UUID or slug.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 * @param bool $validation Validate against the schema.
+	 * @param bool $events Emit events for each object.
+	 * @param bool $deduplicateIds Drop duplicate ids.
+	 * @param bool $enrich Enrich each object.
+	 * @param bool $_audit Write an audit-trail entry.
+	 *
+	 * @return array
+	 */
+	public function saveObjects(
+		array $objects,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		bool $validation = false,
+		bool $events = false,
+		bool $deduplicateIds = true,
+		bool $enrich = true,
+		bool $_audit = true
+	): array;
+
+	/**
+	 * Release an advisory lock.
+	 *
+	 * @param string|int $identifier The object id or UUID.
+	 * @param bool $advisory Take an advisory lock.
+	 *
+	 * @return bool
+	 */
+	public function unlockObject(string|int $identifier, bool $advisory = false): bool;
+
+	/**
+	 * Take an advisory lock.
+	 *
+	 * @param string $identifier The object id or UUID.
+	 * @param ?string $process A label for the holding process.
+	 * @param ?int $duration Lock duration in seconds.
+	 * @param bool $advisory Take an advisory lock.
+	 *
+	 * @return array
+	 */
+	public function lockObject(
+		string $identifier,
+		?string $process = null,
+		?int $duration = null,
+		bool $advisory = false
+	): array;
+
+	/**
+	 * Bulk-delete objects.
+	 *
+	 * @param array $uuids The object UUIDs.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array
+	 */
+	public function deleteObjects(array $uuids = [], bool $_rbac = true, bool $_multitenancy = true): array;
+
+	/**
+	 * Fetch an object's audit log.
+	 *
+	 * @param string $uuid The object UUID.
+	 * @param array $filters Equality filters.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array
+	 */
+	public function getLogs(string $uuid, array $filters = [], bool $_rbac = true, bool $_multitenancy = true): array;
+
+	/**
+	 * Objects the given object uses (outgoing relations).
+	 *
+	 * @param string $objectId The object UUID.
+	 * @param array $query The search query.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array
+	 */
+	public function getObjectUses(
+		string $objectId,
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): array;
+
+	/**
+	 * Objects that use the given object (incoming relations).
+	 *
+	 * @param string $objectId The object UUID.
+	 * @param array $query The search query.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 *
+	 * @return array
+	 */
+	public function getObjectUsedBy(
+		string $objectId,
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true
+	): array;
+
+	/**
+	 * Find objects by a relation term.
+	 *
+	 * @param string $search The term to match relations against.
+	 * @param bool $partialMatch Match relations partially.
+	 *
+	 * @return array
+	 */
+	public function findByRelations(string $search, bool $partialMatch = true): array;
+
+	/**
+	 * Count a search query's results without fetching them.
+	 *
+	 * @param array $query The search query.
+	 * @param bool $_rbac Apply register RBAC.
+	 * @param bool $_multitenancy Apply organisation scoping.
+	 * @param ?array $ids Restrict to these ids.
+	 * @param ?string $uses Restrict to objects used by this one.
+	 *
+	 * @return int
+	 */
+	public function countSearchObjects(
+		array $query = [],
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		?array $ids = null,
+		?string $uses = null
+	): int;
+
+}//end interface


### PR DESCRIPTION
## Summary
Full triage of every `#[NoAdminRequired]` endpoint (105 mechanical candidates + 5 audit-named findings):
- **Real fixes:** CBS submissions create/update/destroy/generate (+index/show) — any authenticated user could delete statutory filings; `DBAController::ensureAdministrationAccess()` was a documented no-op stub (now enforcing, 7 call sites); `CalendarController::createBooking`; cross-tenant IDORs in `BookingDepthController::createSeries` (foreign resource), `DunningController::resumePause` (foreign pause), `WbsoAdministratieController::realisatie` (unchecked query-string tenant), and `InvoiceGenerationService::draftInvoice` (client-supplied time-entry/expense/meter/milestone ids now scoped lookups, incl. nested UsageRatePlan).
- **ADR-050:** all 29 grep-matched `$e->getMessage()` leaks plus several equivalent-shape variants replaced with `{message, error:<kebab-slug>}` + server-side logging (leak grep now zero).
- **Verdict table** (design.md): 86/105 candidates were false positives — the gate regex doesn't recognize `->canAccess(`, this app's canonical guard (follow-up gate improvement filed); 14 JUSTIFY with inline rationale; every changed posture has both-direction PHPUnit coverage with red/green negative controls.
- **Infra fixed en route:** missing `tests/stubs/OpenRegister/Contract/{ObjectServiceInterface,ObjectEntityInterface}` stubs (whole unit suite fatal'd without a deployed NC tree); psalm allowlist gap.

Full suite: **4624 tests, 45357 assertions, 0 failures, 0 errors** (`phpunit-unit.xml`). Psalm clean on all changed lib files. New Playwright spec `tests/e2e/cbs-submissions.spec.ts` (runs at programme verify stage).

Documented remaining (design.md, tracked in programme ledger): RateCardResolver/RetainerResolver unscoped lookups (same shape, needs 2-service signature change), FinancialDashboard partial (blocked on GLLine schema), DunningRunService dead param, bulkResolve per-id message map.

OpenSpec change: `openspec/changes/security-endpoint-guards` (REQ-001..004).

🤖 Generated with [Claude Code](https://claude.com/claude-code)