### PR TITLE
chore(deps): take hydra-gates v1.8.1 — the contract v1.8.0 shipped broken

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -516,16 +516,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.8.0",
+            "version": "v1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "9fc64ab93f7a20b69f6b5912745ef9fc456c1cee"
+                "reference": "8e0e9857e54d6c680e157939e78a468e58d3751a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/9fc64ab93f7a20b69f6b5912745ef9fc456c1cee",
-                "reference": "9fc64ab93f7a20b69f6b5912745ef9fc456c1cee",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/8e0e9857e54d6c680e157939e78a468e58d3751a",
+                "reference": "8e0e9857e54d6c680e157939e78a468e58d3751a",
                 "shasum": ""
             },
             "require": {
@@ -569,9 +569,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.8.0"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.8.1"
             },
-            "time": "2026-08-15T06:24:48+00:00"
+            "time": "2026-08-20T05:07:22+00:00"
         },
         {
             "name": "consolidation/annotated-command",

--- a/tests/Unit/Service/Support/DuckObjectServiceAdapter.php
+++ b/tests/Unit/Service/Support/DuckObjectServiceAdapter.php
@@ -566,6 +566,67 @@ final class DuckObjectServiceAdapter implements ObjectServiceInterface {
 	}//end updateObject()
 
 	/**
+	 * Merge a partial update onto an object.
+	 *
+	 * Added to the published contract in hydra-gates v1.8.1; v1.8.0 declared the
+	 * interface without it, so this adapter satisfied the contract by accident
+	 * and taking v1.8.1 turns that into a load-time fatal.
+	 *
+	 * Same two arms as `updateObject()` above, for the same reason: a double
+	 * that models `patchObject()` directly must be asked for it, or the
+	 * synthesised find()+saveObject() path below would ask it for a
+	 * `saveObject()` it never declared and the adapter would refuse — which
+	 * reads as "the patch was never persisted" rather than as a missing double.
+	 *
+	 * @param string          $objectId      The object UUID or id.
+	 * @param array           $data          The fields to merge.
+	 * @param string|int|null $register      Register id, UUID or slug.
+	 * @param string|int|null $schema        Schema id, UUID or slug.
+	 * @param bool            $_rbac         Apply register RBAC (ignored).
+	 * @param bool            $_multitenancy Apply organisation scoping (ignored).
+	 * @param ?IUser          $currentUser   Acting user (ignored).
+	 *
+	 * @return ObjectEntityInterface
+	 */
+	public function patchObject(
+		string $objectId,
+		array $data,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		?IUser $currentUser = null
+	): ObjectEntityInterface {
+		if (method_exists($this->inner, 'patchObject') === true) {
+			return $this->entity(
+				value: $this->invokeInner(
+					method: 'patchObject',
+					primary: $objectId,
+					named: [
+						'data'          => $data,
+						'object'        => $data,
+						'register'      => ($register ?? $this->register),
+						'schema'        => ($schema ?? $this->schema),
+						'_rbac'         => $_rbac,
+						'_multitenancy' => $_multitenancy,
+					]
+				)
+			) ?? new ObjectEntityStub(payload: $data);
+		}
+
+		$existing = $this->find(id: $objectId);
+		$merged   = $data;
+		if ($existing !== null) {
+			$merged = array_merge($existing->getObject(), $data);
+		}
+
+		$merged['id'] = $objectId;
+
+		return $this->saveObject(object: $merged);
+
+	}//end patchObject()
+
+	/**
 	 * Find without audit or read events.
 	 *
 	 * @param string          $id            Object id, UUID or slug.

--- a/tests/Unit/Service/Support/InMemoryObjectServiceStub.php
+++ b/tests/Unit/Service/Support/InMemoryObjectServiceStub.php
@@ -569,6 +569,52 @@ final class InMemoryObjectServiceStub implements ObjectServiceInterface {
 	}//end updateObject()
 
 	/**
+	 * Merge a partial update onto a stored object.
+	 *
+	 * Added to the published contract in hydra-gates v1.8.1. v1.8.0 declared the
+	 * interface without it, so this stub satisfied the contract by accident;
+	 * taking v1.8.1 turns the omission into a load-time fatal that kills the
+	 * whole suite before a test runs.
+	 *
+	 * ⚠️ The REAL `updateObject()` REPLACES — the merge above is this stub's own
+	 * behaviour, not the service's, and a test that relies on it is asserting
+	 * something production does not do. Left as it is here deliberately: fixing
+	 * it is a behaviour change to existing tests and does not belong in a
+	 * dependency bump. `patchObject()` is the method that genuinely merges, so
+	 * it is modelled with the same read-merge-write this file already performs.
+	 *
+	 * @param string          $objectId      The object UUID or id.
+	 * @param array           $data          The fields to merge.
+	 * @param string|int|null $register      Register id, UUID or slug (ignored).
+	 * @param string|int|null $schema        Schema id, UUID or slug (ignored).
+	 * @param bool            $_rbac         Apply register RBAC (ignored).
+	 * @param bool            $_multitenancy Apply organisation scoping (ignored).
+	 * @param ?IUser          $currentUser   Acting user (ignored).
+	 *
+	 * @return ObjectEntityInterface
+	 */
+	public function patchObject(
+		string $objectId,
+		array $data,
+		string|int|null $register = null,
+		string|int|null $schema = null,
+		bool $_rbac = true,
+		bool $_multitenancy = true,
+		?IUser $currentUser = null
+	): ObjectEntityInterface {
+		$existing = $this->find(id: $objectId);
+		$merged   = $data;
+		if ($existing !== null) {
+			$merged = array_merge($existing->getObject(), $data);
+		}
+
+		$merged['id'] = $objectId;
+
+		return $this->saveObject(object: $merged);
+
+	}//end patchObject()
+
+	/**
 	 * Not modelled.
 	 *
 	 * @param string $objectId      The object UUID.


### PR DESCRIPTION
v1.8.0 shipped an `ObjectServiceInterface` **without `patchObject()`** and with `updateObject()` still summarised as "Apply a partial update to an existing object" — the exact wording that sent a consumer down the erasing path. The correction landed on `main` in `f8cad2f0`, two days after v1.8.0 was tagged; every app has been pinned to the broken copy ever since. v1.8.1 publishes it.

**Why every app and not just openregister.** `hydra-gates/composer.json` claims the app's own namespace:

```json
"psr-4": { "OCA\\OpenRegister\\Contract\\": "hydra-gates/contracts/" }
```

That is a *longer* prefix than openregister's own `OCA\OpenRegister\` → `lib/`, so the gate package wins. Nine repos vendor it, so under `OC_App::loadApps()` whichever app registers first defines the contract for the whole instance. Measured on a running instance:

```
WINNER: custom_apps/softwarecatalog/vendor/conduction/hydra-gates/.../ObjectServiceInterface.php
patchObject: NO
```

**softwarecatalog's** vendor directory was defining openregister's contract — and updating openregister alone did **not** change the winner. Verified empirically before opening these PRs.

v1.8.1 also carries everything else merged on `main` since v1.8.0 (63 commits), including gate-behaviour changes: phpcs errors fail the gate (#483), gate-8 judges how the caller consumes the null (#506), coverage-guard ignores deletions (#480), and the release step now bumps `openapi.json` alongside `appinfo/info.xml` (#515).

Lockfile only — the `^1.0` constraint already allowed this.