### PR TITLE
fix(reporting): statutory reports via docudesk — PhpWord vendor-dir reach removed (ADR-075)

### DIFF
--- a/lib/Controller/ReportingController.php
+++ b/lib/Controller/ReportingController.php
@@ -169,11 +169,13 @@ class ReportingController extends Controller {
 	 *
 	 * Reads `reportType`, `period`, `administrationId` and `format` from the request,
 	 * delegates to the service and returns the recorded GeneratedReport (incl. fileId
-	 * + downloadPath). A service-level `{ error: ... }` envelope is surfaced as 422.
+	 * + downloadPath). A service-level `{ error: 'docudesk-unavailable' }` envelope
+	 * (docudesk not installed/reachable — REQ-RVD-005, ADR-081 rule 7) is surfaced as
+	 * 503; any other `{ error: ... }` envelope is surfaced as 422.
 	 *
 	 * @return JSONResponse The GeneratedReport record, or an error envelope.
 	 *
-	 * @spec exclude No canonical requirement exists for the reporting capability — see #525.
+	 * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-005
 	 */
 	#[NoAdminRequired]
 	public function generate(): JSONResponse {
@@ -205,7 +207,11 @@ class ReportingController extends Controller {
 		);
 
 		if (isset($result['error']) === true) {
-			return new JSONResponse($result, Http::STATUS_UNPROCESSABLE_ENTITY);
+			$status = $result['error'] === 'docudesk-unavailable'
+				? Http::STATUS_SERVICE_UNAVAILABLE
+				: Http::STATUS_UNPROCESSABLE_ENTITY;
+
+			return new JSONResponse($result, $status);
 		}
 
 		return new JSONResponse($result, Http::STATUS_CREATED);

--- a/lib/Controller/ReportingController.php
+++ b/lib/Controller/ReportingController.php
@@ -207,9 +207,10 @@ class ReportingController extends Controller {
 		);
 
 		if (isset($result['error']) === true) {
-			$status = $result['error'] === 'docudesk-unavailable'
-				? Http::STATUS_SERVICE_UNAVAILABLE
-				: Http::STATUS_UNPROCESSABLE_ENTITY;
+			$status = Http::STATUS_UNPROCESSABLE_ENTITY;
+			if ($result['error'] === 'docudesk-unavailable') {
+				$status = Http::STATUS_SERVICE_UNAVAILABLE;
+			}
 
 			return new JSONResponse($result, $status);
 		}

--- a/lib/Reporting/DocudeskUnavailableException.php
+++ b/lib/Reporting/DocudeskUnavailableException.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Docudesk-unavailable exception
+ *
+ * Thrown by a document report generator when docudesk is not installed, or
+ * its rendering services cannot be resolved from the container
+ * (AbstractDocumentReportGenerator::docudeskAvailable()). Distinct from a
+ * generic rendering failure so ReportGenerationService can record a visible
+ * `status: 'unavailable'` GeneratedReport and return a distinguishable
+ * `docudesk-unavailable` error code — per ADR-081 rule 7 ("A source app MUST
+ * degrade gracefully when the receiver is absent — an unsent allocation is a
+ * visible pending state, never a silent drop") and mirroring hrmq's
+ * `skipped-no-docudesk` outcome.
+ *
+ * @category Reporting
+ * @package  OCA\Shillinq\Reporting
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-005
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Reporting;
+
+use RuntimeException;
+
+/**
+ * Signals that docudesk (the fleet's document-rendering owner, ADR-075) is
+ * not available to render a document report.
+ */
+final class DocudeskUnavailableException extends RuntimeException {
+
+}//end class

--- a/lib/Reporting/Generator/AbstractDocumentReportGenerator.php
+++ b/lib/Reporting/Generator/AbstractDocumentReportGenerator.php
@@ -65,6 +65,7 @@ use OCA\Shillinq\Reporting\GeneratedFile;
 use OCA\Shillinq\Reporting\ReportCatalogue;
 use OCA\Shillinq\Reporting\ReportGeneratorInterface;
 use OCA\Shillinq\Reporting\ReportSection;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -154,7 +155,7 @@ abstract class AbstractDocumentReportGenerator implements ReportGeneratorInterfa
 	 * @return GeneratedFile
 	 *
 	 * @throws DocudeskUnavailableException When docudesk is not installed or unreachable.
-	 * @throws \RuntimeException When template selection or docudesk rendering fails.
+	 * @throws RuntimeException When template selection or docudesk rendering fails.
 	 */
 	public function generate(array $context, string $format): GeneratedFile {
 		$useFormat = in_array($format, self::FORMATS, true) === true ? $format : self::FORMATS[0];
@@ -168,7 +169,7 @@ abstract class AbstractDocumentReportGenerator implements ReportGeneratorInterfa
 
 		$selected = $this->selectTemplate();
 		if ($selected['templateId'] === null) {
-			throw new \RuntimeException((string)$selected['error']);
+			throw new RuntimeException((string)$selected['error']);
 		}
 
 		$section = new ReportSection();
@@ -181,7 +182,7 @@ abstract class AbstractDocumentReportGenerator implements ReportGeneratorInterfa
 		];
 
 		$options = [
-			'format' => self::DOCUDESK_FORMATS[$useFormat] ?? 'pdf',
+			'format' => self::DOCUDESK_FORMATS[$useFormat],
 			'userId' => $this->str($context, 'userId') !== '' ? $this->str($context, 'userId') : 'system',
 			'adHocData' => [
 				'report' => $reportBody,
@@ -197,12 +198,12 @@ abstract class AbstractDocumentReportGenerator implements ReportGeneratorInterfa
 		try {
 			$rendered = $this->documentService()->generateDocument($selected['templateId'], [], $options);
 		} catch (Throwable $e) {
-			throw new \RuntimeException('Docudesk rendering failed: ' . $e->getMessage(), 0, $e);
+			throw new RuntimeException('Docudesk rendering failed: ' . $e->getMessage(), 0, $e);
 		}
 
 		$content = (string)($rendered['content'] ?? '');
 		if ($content === '') {
-			throw new \RuntimeException('Docudesk returned no document content for "' . static::reportType() . '".');
+			throw new RuntimeException('Docudesk returned no document content for "' . static::reportType() . '".');
 		}
 
 		return new GeneratedFile(
@@ -451,7 +452,8 @@ abstract class AbstractDocumentReportGenerator implements ReportGeneratorInterfa
 			return [
 				'templateId' => null,
 				'error' => sprintf(
-					'Multiple docudesk templates (%s) for "%s" in namespace "%s"; generation is refused (never guess between templates that produce official documents).',
+					'Multiple docudesk templates (%s) for "%s" in namespace "%s"; generation is refused '
+					. '(never guess between templates that produce official documents).',
 					implode(', ', $ids),
 					$reportType,
 					self::TEMPLATE_NAMESPACE

--- a/lib/Reporting/Generator/AbstractDocumentReportGenerator.php
+++ b/lib/Reporting/Generator/AbstractDocumentReportGenerator.php
@@ -5,25 +5,35 @@
  *
  * Shared machinery for the "document" flavour of the report catalogue — the
  * jaarrekening, balans, winst-en-verliesrekening, management letter and BBV
- * jaarstukken. A document generator builds a single PhpWord document from a
- * DEFAULT layout defined in code (so a fresh install renders without any
- * external template asset) and emits it through one of three writers:
+ * jaarstukken. A document generator loads and classifies real OpenRegister
+ * objects into a `ReportSection` block tree (the same content a human report
+ * carries — headings, key/value tables, amount tables, notes), then this
+ * base hands that tree to docudesk for rendering:
+ * `OCA\DocuDesk\Service\DocumentService::generateDocument($templateId, [],
+ * $options)`, resolved by string FQCN through `\OCP\Server::get()` — no
+ * compile-time `use` import of any `OCA\DocuDesk\*` class, no composer/
+ * info.xml dependency on docudesk. This mirrors hrmq's `HrDocumentService`
+ * (`hrmq-docudesk-documents` / `payslip-pdf-docudesk`): the leaf assembles
+ * data and classification, docudesk renders (ADR-081 rule 6).
  *
- *  - DOCX via \PhpOffice\PhpWord\IOFactory::createWriter($phpWord, 'Word2007')
- *  - ODT  via \PhpOffice\PhpWord\IOFactory::createWriter($phpWord, 'ODText')
- *  - PDF  by configuring \PhpOffice\PhpWord\Settings::setPdfRendererName(
- *         Settings::PDF_RENDERER_DOMPDF) + setPdfRendererPath(<dompdf dir>) and
- *         createWriter($phpWord, 'PDF') — dompdf renders the HTML projection.
+ * Availability is duck-typed (docudeskAvailable()): when docudesk is not
+ * installed, or its services cannot be resolved, generate() throws
+ * DocudeskUnavailableException BEFORE any object loading, so
+ * ReportGenerationService can record a visible `status: 'unavailable'`
+ * outcome rather than a silent drop (ADR-081 rule 7).
  *
- * All three writers — PhpWord, dompdf — come from the PHPOffice libraries
- * BUNDLED IN OPENREGISTER, a runtime dependency whose autoloader is always
- * active, so this class merely `use`s the classes and adds nothing to
- * shillinq's composer.json.
+ * Template selection is config-first, discovery-second, and fails closed:
+ * an admin-set `IAppConfig` UUID wins; otherwise exactly one docudesk
+ * template with `namespace: "shillinq"` and `category` equal to the
+ * ReportCatalogue entry's `templateId` is used — zero or multiple matches
+ * refuse to render rather than guess between templates that produce
+ * official financial/statutory documents (mirrors hrmq design.md D3).
  *
  * The concrete generators are instantiated with no constructor arguments by
  * ReportGenerationService (mirroring RuleEngine provider discovery), so this
- * base resolves OpenRegister's ObjectService and the register slug lazily from
- * the Nextcloud server container rather than via constructor injection.
+ * base resolves OpenRegister's ObjectService, docudesk's services and the
+ * register slug lazily from the Nextcloud server container rather than via
+ * constructor injection.
  *
  * @category Reporting
  * @package  OCA\Shillinq\Reporting\Generator
@@ -34,23 +44,14 @@
  *
  * @link https://conduction.nl
  *
- * @spec exclude The reporting capability has no canonical spec. This tag pointed at
- *       openspec/changes/reporting-compliance-consolidation (a change directory that
- *       exists neither under changes nor under changes/archive), and no canonical
- *       reporting capability exists under openspec/specs either. Tracked in #525.
- *       Deliberately NOT resolved by writing that spec — authoring the requirement
- *       a tag is checked against turns the gate green over an unspecified capability.
+ * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-001
+ * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-002
+ * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-003
+ * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-004
+ * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-005
  *
- * KNOWINGLY DANGLING — do not repoint this tag (gate-46, shillinq#499).
- * The change directory it names was never committed, and the `reporting`
- * capability has NO canonical spec. One was drafted during gate remediation
- * and withdrawn: a spec written to fit the code, by the process whose job is
- * to check the code against a spec, is not a specification anyone agreed to.
- * Authoring it is the capability owner's decision, not a gate fix. No existing
- * target is honest either — bookkeeping-iv3-reporting REQ-IV3-004 and
- * bookkeeping-vat-btw-filing REQ-VBTW-004 forbid the PHP renderers in this
- * directory, so pointing there would report conformance to a rule this code
- * breaks.
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * phpcs:disable CustomSniffs.Functions.NamedParameters, Squiz.Commenting.InlineComment, Squiz.PHP.DisallowInlineIf
  */
@@ -59,43 +60,73 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Reporting\Generator;
 
+use OCA\Shillinq\Reporting\DocudeskUnavailableException;
 use OCA\Shillinq\Reporting\GeneratedFile;
 use OCA\Shillinq\Reporting\ReportCatalogue;
 use OCA\Shillinq\Reporting\ReportGeneratorInterface;
-use PhpOffice\PhpWord\Element\Section;
-use PhpOffice\PhpWord\IOFactory;
-use PhpOffice\PhpWord\PhpWord;
-use PhpOffice\PhpWord\Settings as PhpWordSettings;
-use PhpOffice\PhpWord\Shared\Converter;
-use ReflectionClass;
+use OCA\Shillinq\Reporting\ReportSection;
 use Throwable;
 
 /**
- * Base class carrying the default layout + the three-writer PhpWord pipeline.
+ * Base class carrying the default block vocabulary + the docudesk hand-off.
  */
 abstract class AbstractDocumentReportGenerator implements ReportGeneratorInterface {
 
 	/**
-	 * Editable formats first, PDF last — the order ReportCatalogue offers.
+	 * Public-facing formats, editable first — the order ReportCatalogue offers.
+	 * `docx` is no longer offered: docudesk's DocumentService only supports
+	 * `pdf` / `odf` / `html` (see DOCUDESK_FORMATS for the mapping).
 	 */
-	private const FORMATS = ['docx', 'odt', 'pdf'];
+	private const FORMATS = ['odt', 'pdf'];
+
+	/**
+	 * Maps a public-facing format label to the format key docudesk's
+	 * `DocumentService::generateDocument()` `options.format` expects.
+	 */
+	private const DOCUDESK_FORMATS = [
+		'odt' => 'odf',
+		'pdf' => 'pdf',
+	];
 
 	/**
 	 * Per-format MIME types for the rendered file.
 	 */
 	private const MIME_TYPES = [
-		'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
 		'odt' => 'application/vnd.oasis.opendocument.text',
 		'pdf' => 'application/pdf',
 	];
 
 	/**
-	 * The default theme colour (Conduction cobalt) for headings/accents.
+	 * The app id docudesk registers under (IAppManager::isInstalled probe).
+	 */
+	private const DOCUDESK_APP_ID = 'docudesk';
+
+	/**
+	 * docudesk's rendering service, resolved by string FQCN only (no
+	 * compile-time import).
+	 */
+	private const DOCUMENT_SERVICE_FQCN = 'OCA\\DocuDesk\\Service\\DocumentService';
+
+	/**
+	 * docudesk's template lookup service, resolved by string FQCN only.
+	 */
+	private const TEMPLATE_SERVICE_FQCN = 'OCA\\DocuDesk\\Service\\TemplateService';
+
+	/**
+	 * The docudesk template namespace shillinq's own templates live under.
+	 */
+	private const TEMPLATE_NAMESPACE = 'shillinq';
+
+	/**
+	 * The default theme colour (Conduction cobalt) for headings/accents — a
+	 * style hint carried into `ReportTable` cell styles (e.g. header row
+	 * `bgColor`); a docudesk template may use it or apply its own huisstijl.
 	 */
 	protected const ACCENT_COLOUR = '1A2A6C';
 
 	/**
-	 * Muted colour for sub-labels and footers.
+	 * Muted colour for sub-labels and footers — same style-hint role as
+	 * ACCENT_COLOUR.
 	 */
 	protected const MUTED_COLOUR = '6B7280';
 
@@ -109,43 +140,90 @@ abstract class AbstractDocumentReportGenerator implements ReportGeneratorInterfa
 	}//end supportedFormats()
 
 	/**
-	 * Render the report: the subclass builds the PhpWord document from real
-	 * objects, this base serialises it through the requested writer.
+	 * Render the report: the subclass builds the ReportSection block tree
+	 * from real objects, this base hands it to docudesk for rendering.
+	 *
+	 * Order matters: availability is checked BEFORE any object loading
+	 * (`build()` runs after the docudesk/template checks) so a docudesk
+	 * outage never costs an unnecessary OpenRegister scan and always fails
+	 * fast with a visible, distinguishable outcome (REQ-RVD-005).
 	 *
 	 * @param array<string, mixed> $context `{ reportType, period, administrationId, ... }`.
 	 * @param string $format One of supportedFormats().
 	 *
 	 * @return GeneratedFile
+	 *
+	 * @throws DocudeskUnavailableException When docudesk is not installed or unreachable.
+	 * @throws \RuntimeException When template selection or docudesk rendering fails.
 	 */
 	public function generate(array $context, string $format): GeneratedFile {
-		$useFormat = in_array($format, self::FORMATS, true) === true ? $format : 'docx';
+		$useFormat = in_array($format, self::FORMATS, true) === true ? $format : self::FORMATS[0];
 
-		$phpWord = $this->newDocument();
-		$this->build($phpWord, $context);
+		if ($this->docudeskAvailable() === false) {
+			throw new DocudeskUnavailableException(sprintf(
+				'Docudesk is not installed or its renderer could not be resolved; "%s" cannot be rendered.',
+				static::reportType()
+			));
+		}
 
-		$bytes = $this->render($phpWord, $useFormat);
-		$fileName = $this->fileName($context, $useFormat);
+		$selected = $this->selectTemplate();
+		if ($selected['templateId'] === null) {
+			throw new \RuntimeException((string)$selected['error']);
+		}
+
+		$section = new ReportSection();
+		$this->build($section, $context);
+
+		$reportBody = [
+			'title' => $this->documentTitle(),
+			'subtitle' => $this->catalogueLabel(),
+			'blocks' => $section->toArray(),
+		];
+
+		$options = [
+			'format' => self::DOCUDESK_FORMATS[$useFormat] ?? 'pdf',
+			'userId' => $this->str($context, 'userId') !== '' ? $this->str($context, 'userId') : 'system',
+			'adHocData' => [
+				'report' => $reportBody,
+				'meta' => [
+					'reportType' => static::reportType(),
+					'period' => $this->str($context, 'period'),
+					'administrationId' => $this->str($context, 'administrationId'),
+					'generatedAt' => gmdate('Y-m-d\TH:i:s\Z'),
+				],
+			],
+		];
+
+		try {
+			$rendered = $this->documentService()->generateDocument($selected['templateId'], [], $options);
+		} catch (Throwable $e) {
+			throw new \RuntimeException('Docudesk rendering failed: ' . $e->getMessage(), 0, $e);
+		}
+
+		$content = (string)($rendered['content'] ?? '');
+		if ($content === '') {
+			throw new \RuntimeException('Docudesk returned no document content for "' . static::reportType() . '".');
+		}
 
 		return new GeneratedFile(
-			fileName: $fileName,
+			fileName: $this->fileName($context, $useFormat),
 			mimeType: self::MIME_TYPES[$useFormat],
 			format: $useFormat,
-			content: $bytes,
+			content: $content,
 		);
 
 	}//end generate()
 
 	/**
-	 * Build the report body into the prepared PhpWord document. The subclass
-	 * loads its real objects and lays out the sections; the default cover/styles
-	 * are already applied by newDocument().
+	 * Build the report body into the prepared ReportSection. The subclass
+	 * loads its real objects and lays out the sections.
 	 *
-	 * @param PhpWord $phpWord The styled, ready-to-fill document.
+	 * @param ReportSection $section The block accumulator to fill.
 	 * @param array<string, mixed> $context `{ reportType, period, administrationId }`.
 	 *
 	 * @return void
 	 */
-	abstract protected function build(PhpWord $phpWord, array $context): void;
+	abstract protected function build(ReportSection $section, array $context): void;
 
 	/**
 	 * A human title for the report's cover block (e.g. 'Jaarrekening').
@@ -155,112 +233,48 @@ abstract class AbstractDocumentReportGenerator implements ReportGeneratorInterfa
 	abstract protected function documentTitle(): string;
 
 	// -----------------------------------------------------------------------
-	// Default layout / PhpWord build helper.
+	// Default block-vocabulary helpers (mirror the former PhpWord helpers).
 	// -----------------------------------------------------------------------
 
 	/**
-	 * Create a PhpWord document pre-loaded with the DEFAULT shillinq layout:
-	 * document metadata, a base font, named paragraph/heading/table styles and
-	 * an A4 portrait section geometry. This is the in-code template — no
-	 * external template file is required for a fresh install to render.
+	 * Add a styled cover block: a big title, an optional subtitle, and the
+	 * period/administration meta line.
 	 *
-	 * @return PhpWord
-	 */
-	protected function newDocument(): PhpWord {
-		$phpWord = new PhpWord();
-
-		$properties = $phpWord->getDocInfo();
-		$properties->setCreator('Shillinq');
-		$properties->setCompany('Conduction B.V.');
-		$properties->setTitle($this->documentTitle());
-		$properties->setCategory('Reporting & Compliance');
-		$properties->setDescription('Generated by Shillinq Reporting & Compliance.');
-
-		$phpWord->setDefaultFontName('DejaVu Sans');
-		$phpWord->setDefaultFontSize(10);
-
-		$phpWord->addTitleStyle(
-			1,
-			['name' => 'DejaVu Sans', 'size' => 16, 'bold' => true, 'color' => self::ACCENT_COLOUR],
-			['spaceBefore' => Converter::pointToTwip(14), 'spaceAfter' => Converter::pointToTwip(6)]
-		);
-		$phpWord->addTitleStyle(
-			2,
-			['name' => 'DejaVu Sans', 'size' => 12, 'bold' => true, 'color' => self::ACCENT_COLOUR],
-			['spaceBefore' => Converter::pointToTwip(10), 'spaceAfter' => Converter::pointToTwip(4)]
-		);
-
-		$phpWord->addFontStyle('coverTitle', ['name' => 'DejaVu Sans', 'size' => 26, 'bold' => true, 'color' => self::ACCENT_COLOUR]);
-		$phpWord->addFontStyle('coverSubtitle', ['name' => 'DejaVu Sans', 'size' => 13, 'color' => self::MUTED_COLOUR]);
-		$phpWord->addFontStyle('coverMeta', ['name' => 'DejaVu Sans', 'size' => 10, 'color' => self::MUTED_COLOUR]);
-		$phpWord->addFontStyle('label', ['name' => 'DejaVu Sans', 'size' => 10, 'color' => self::MUTED_COLOUR]);
-		$phpWord->addFontStyle('value', ['name' => 'DejaVu Sans', 'size' => 10]);
-		$phpWord->addFontStyle('amount', ['name' => 'DejaVu Sans', 'size' => 10]);
-		$phpWord->addFontStyle('amountBold', ['name' => 'DejaVu Sans', 'size' => 10, 'bold' => true]);
-		$phpWord->addFontStyle('note', ['name' => 'DejaVu Sans', 'size' => 9, 'color' => self::MUTED_COLOUR]);
-
-		$phpWord->addParagraphStyle('default', ['spaceAfter' => Converter::pointToTwip(6), 'lineHeight' => 1.15]);
-		$phpWord->addParagraphStyle('tight', ['spaceAfter' => Converter::pointToTwip(2)]);
-
-		$phpWord->addTableStyle(
-			'reportTable',
-			[
-				'borderColor' => 'D1D5DB',
-				'borderSize' => 6,
-				'cellMargin' => 60,
-			],
-			[
-				'bgColor' => 'EEF2FF',
-			]
-		);
-
-		return $phpWord;
-	}//end newDocument()
-
-	/**
-	 * Add a styled cover/heading block to a section: a big title, an optional
-	 * subtitle, the period/administration meta line and a divider.
-	 *
-	 * @param Section $section The section to write into.
+	 * @param ReportSection $section The section to write into.
 	 * @param string $title The cover title.
 	 * @param string $subtitle Subtitle / report type label.
 	 * @param array<string, mixed> $context Generation context for the meta line.
 	 *
 	 * @return void
 	 */
-	protected function addCover(Section $section, string $title, string $subtitle, array $context): void {
-		$section->addText($title, 'coverTitle', ['spaceAfter' => Converter::pointToTwip(2)]);
-		if ($subtitle !== '') {
-			$section->addText($subtitle, 'coverSubtitle', ['spaceAfter' => Converter::pointToTwip(8)]);
-		}
+	protected function addCover(ReportSection $section, string $title, string $subtitle, array $context): void {
+		$period = $this->str($context, 'period');
+		$administrationId = $this->str($context, 'administrationId');
 
-		$period = (string)($context['period'] ?? '');
-		$administrationId = (string)($context['administrationId'] ?? '');
-		$metaParts = [];
+		$meta = [];
 		if ($period !== '') {
-			$metaParts[] = 'Periode: ' . $period;
+			$meta[] = 'Periode: ' . $period;
 		}
 
 		if ($administrationId !== '') {
-			$metaParts[] = 'Administratie: ' . $administrationId;
+			$meta[] = 'Administratie: ' . $administrationId;
 		}
 
-		$metaParts[] = 'Gegenereerd: ' . gmdate('Y-m-d H:i') . ' UTC';
-		$section->addText(implode('   ·   ', $metaParts), 'coverMeta', ['spaceAfter' => Converter::pointToTwip(10)]);
+		$meta[] = 'Gegenereerd: ' . gmdate('Y-m-d H:i') . ' UTC';
 
-		$section->addTextBreak(1);
+		$section->addCover($title, $subtitle, $meta);
 
 	}//end addCover()
 
 	/**
 	 * Add a level-2 section heading.
 	 *
-	 * @param Section $section The section to write into.
+	 * @param ReportSection $section The section to write into.
 	 * @param string $heading The heading text.
 	 *
 	 * @return void
 	 */
-	protected function addHeading(Section $section, string $heading): void {
+	protected function addHeading(ReportSection $section, string $heading): void {
 		$section->addTitle($heading, 2);
 
 	}//end addHeading()
@@ -269,34 +283,27 @@ abstract class AbstractDocumentReportGenerator implements ReportGeneratorInterfa
 	 * Add a key/value details table (two columns) from an associative array.
 	 * Empty values are skipped so the default layout stays clean on sparse data.
 	 *
-	 * @param Section $section The section to write into.
+	 * @param ReportSection $section The section to write into.
 	 * @param array<string, string> $rows Label => value pairs (insertion order kept).
 	 *
 	 * @return void
 	 */
-	protected function addDetailsTable(Section $section, array $rows): void {
+	protected function addDetailsTable(ReportSection $section, array $rows): void {
 		$rows = array_filter($rows, static fn ($value): bool => trim((string)$value) !== '');
 		if ($rows === []) {
-			$section->addText('Geen gegevens beschikbaar.', 'note');
+			$section->addNote('Geen gegevens beschikbaar.');
 			return;
 		}
 
-		$table = $section->addTable('reportTable');
-		foreach ($rows as $label => $value) {
-			$table->addRow();
-			$labelCell = $table->addCell(Converter::cmToTwip(6));
-			$labelCell->addText((string)$label, 'label');
-			$valueCell = $table->addCell(Converter::cmToTwip(10));
-			$valueCell->addText((string)$value, 'value');
-		}
+		$section->addDetailsTable($rows);
 
 	}//end addDetailsTable()
 
 	/**
 	 * Add a financial amount table: a header row, then label/amount lines, then
-	 * an optional bold total row. Amounts are right-aligned and formatted.
+	 * an optional bold total row.
 	 *
-	 * @param Section $section The section to write into.
+	 * @param ReportSection $section The section to write into.
 	 * @param string $labelHead Header for the label column.
 	 * @param string $amountHead Header for the amount column.
 	 * @param array<int, array{label: string, amount: float|int|null, bold?: bool}> $lines The body lines.
@@ -306,7 +313,7 @@ abstract class AbstractDocumentReportGenerator implements ReportGeneratorInterfa
 	 * @return void
 	 */
 	protected function addAmountTable(
-		Section $section,
+		ReportSection $section,
 		string $labelHead,
 		string $amountHead,
 		array $lines,
@@ -314,64 +321,23 @@ abstract class AbstractDocumentReportGenerator implements ReportGeneratorInterfa
 		string $currency = 'EUR',
 	): void {
 		if ($lines === [] && $total === null) {
-			$section->addText('Geen posten in deze periode.', 'note');
+			$section->addNote('Geen posten in deze periode.');
 			return;
 		}
 
-		$table = $section->addTable('reportTable');
-
-		$table->addRow();
-		$table->addCell(Converter::cmToTwip(11), ['bgColor' => self::ACCENT_COLOUR])
-			->addText($labelHead, ['name' => 'DejaVu Sans', 'size' => 10, 'bold' => true, 'color' => 'FFFFFF']);
-		$table->addCell(Converter::cmToTwip(5), ['bgColor' => self::ACCENT_COLOUR])
-			->addText($amountHead, ['name' => 'DejaVu Sans', 'size' => 10, 'bold' => true, 'color' => 'FFFFFF'], ['alignment' => 'end']);
-
-		foreach ($lines as $line) {
-			$bold = (bool)($line['bold'] ?? false);
-			$style = $bold === true ? 'amountBold' : 'amount';
-			$table->addRow();
-			$table->addCell(Converter::cmToTwip(11))->addText((string)($line['label'] ?? ''), $style);
-			$table->addCell(Converter::cmToTwip(5))
-				->addText($this->amountCell($line['amount'] ?? null, $currency), $style, ['alignment' => 'end']);
-		}
-
-		if ($total !== null) {
-			$table->addRow();
-			$table->addCell(Converter::cmToTwip(11), ['bgColor' => 'EEF2FF'])->addText((string)($total['label'] ?? 'Totaal'), 'amountBold');
-			$table->addCell(Converter::cmToTwip(5), ['bgColor' => 'EEF2FF'])
-				->addText($this->amountCell($total['amount'] ?? 0, $currency), 'amountBold', ['alignment' => 'end']);
-		}
+		$section->addAmountTable($labelHead, $amountHead, $lines, $total, $currency);
 
 	}//end addAmountTable()
 
 	/**
-	 * Format an amount-table cell: a money string when a currency is given, or a
-	 * plain integer count when the currency is the empty string (used for the
-	 * count/severity tables that are not monetary).
-	 *
-	 * @param float|int|string|null $amount The cell value.
-	 * @param string $currency The currency code, or '' for counts.
-	 *
-	 * @return string
-	 */
-	private function amountCell(float|int|string|null $amount, string $currency): string {
-		if (trim($currency) === '') {
-			$value = is_numeric($amount) === true ? (float)$amount : 0.0;
-			return number_format($value, 0, ',', '.');
-		}
-
-		return $this->money($amount, $currency);
-	}//end amountCell()
-
-	/**
 	 * Add a paragraph of body text (toelichting / notes).
 	 *
-	 * @param Section $section The section to write into.
+	 * @param ReportSection $section The section to write into.
 	 * @param string $text The paragraph text.
 	 *
 	 * @return void
 	 */
-	protected function addParagraph(Section $section, string $text): void {
+	protected function addParagraph(ReportSection $section, string $text): void {
 		$section->addText($text, 'value', 'default');
 
 	}//end addParagraph()
@@ -379,138 +345,144 @@ abstract class AbstractDocumentReportGenerator implements ReportGeneratorInterfa
 	/**
 	 * Add a small grey footnote / note line.
 	 *
-	 * @param Section $section The section to write into.
+	 * @param ReportSection $section The section to write into.
 	 * @param string $text The note text.
 	 *
 	 * @return void
 	 */
-	protected function addNote(Section $section, string $text): void {
-		$section->addText($text, 'note', 'tight');
+	protected function addNote(ReportSection $section, string $text): void {
+		$section->addNote($text);
 
 	}//end addNote()
 
-	/**
-	 * Add a default A4 portrait section with comfortable margins.
-	 *
-	 * @param PhpWord $phpWord The document.
-	 *
-	 * @return Section
-	 */
-	protected function addSection(PhpWord $phpWord): Section {
-		return $phpWord->addSection(
-			[
-				'orientation' => 'portrait',
-				'marginTop' => Converter::cmToTwip(2.2),
-				'marginBottom' => Converter::cmToTwip(2.0),
-				'marginLeft' => Converter::cmToTwip(2.2),
-				'marginRight' => Converter::cmToTwip(2.2),
-			]
-		);
-
-	}//end addSection()
-
 	// -----------------------------------------------------------------------
-	// Three-writer rendering pipeline.
+	// Docudesk resolution + template selection.
 	// -----------------------------------------------------------------------
 
 	/**
-	 * Serialise the PhpWord document through the requested writer and return the
-	 * raw bytes. DOCX uses the Word2007 writer, ODT the ODText writer, PDF the
-	 * dompdf-backed PDF writer (Settings::PDF_RENDERER_DOMPDF + the bundled
-	 * dompdf path). All writers are bundled in OpenRegister.
+	 * Duck-typed docudesk availability probe: docudesk must be installed AND
+	 * both service FQCNs must resolve from the container. Mirrors hrmq's
+	 * HrDocumentService::docudeskAvailable() (design.md D5).
 	 *
-	 * @param PhpWord $phpWord The built document.
-	 * @param string $format docx | odt | pdf.
-	 *
-	 * @return string The rendered file bytes.
-	 *
-	 * @SuppressWarnings(PHPMD.ErrorControlOperator) `@unlink()` is
-	 *     best-effort temp-file cleanup in a `finally` block; a failure to
-	 *     remove it (already gone, permissions) must not mask the
-	 *     underlying render outcome.
+	 * @return bool
 	 */
-	protected function render(PhpWord $phpWord, string $format): string {
-		$writerName = match ($format) {
-			'odt' => 'ODText',
-			'pdf' => 'PDF',
-			default => 'Word2007',
-		};
-
-		if ($format === 'pdf') {
-			$this->configurePdfRenderer();
-		}
-
-		$tmp = tempnam(sys_get_temp_dir(), 'shillinq-report-');
-		if ($tmp === false) {
-			$tmp = sys_get_temp_dir() . '/shillinq-report-' . bin2hex(random_bytes(8));
-		}
-
+	protected function docudeskAvailable(): bool {
 		try {
-			$writer = IOFactory::createWriter($phpWord, $writerName);
-			$writer->save($tmp);
-			$bytes = (string)file_get_contents($tmp);
-		} finally {
-			if (is_file($tmp) === true) {
-				@unlink($tmp);
-			}
-		}
-
-		return $bytes;
-	}//end render()
-
-	/**
-	 * Point PhpWord's PDF writer at dompdf. The renderer NAME selects the dompdf
-	 * writer; the renderer PATH is set to the dompdf library directory bundled in
-	 * OpenRegister (resolved at runtime from the autoloaded \Dompdf\Dompdf class
-	 * file location, so it works wherever OpenRegister is installed). PhpWord
-	 * validates that the path exists, then loads the autoloaded Dompdf class.
-	 *
-	 * @return void
-	 */
-	protected function configurePdfRenderer(): void {
-		PhpWordSettings::setPdfRendererName(PhpWordSettings::PDF_RENDERER_DOMPDF);
-
-		$rendererPath = $this->dompdfLibraryPath();
-		if ($rendererPath !== null) {
-			PhpWordSettings::setPdfRendererPath($rendererPath);
-		}
-
-		// dompdf needs a writable temp/font dir; default to the system temp dir.
-		PhpWordSettings::setTempDir(sys_get_temp_dir());
-
-	}//end configurePdfRenderer()
-
-	/**
-	 * Resolve the directory of the bundled dompdf library from the autoloaded
-	 * \Dompdf\Dompdf class, so setPdfRendererPath() can validate a real path
-	 * without hard-coding OpenRegister's vendor location.
-	 *
-	 * @return string|null The dompdf library base dir, or null when unresolvable.
-	 */
-	private function dompdfLibraryPath(): ?string {
-		try {
-			if (class_exists('\\Dompdf\\Dompdf') === false) {
-				return null;
+			$appManager = \OCP\Server::get(\OCP\App\IAppManager::class);
+			if ($appManager->isInstalled(self::DOCUDESK_APP_ID) === false) {
+				return false;
 			}
 
-			$domPdfClass = '\\Dompdf\\Dompdf';
-			$reflection = new ReflectionClass($domPdfClass);
-			$file = $reflection->getFileName();
-			if ($file === false) {
-				return null;
-			}
-
-			// .../dompdf/dompdf/src/Dompdf.php -> .../dompdf/dompdf .
-			$dir = dirname($file, 2);
-			if (is_dir($dir) === true && is_readable($dir) === true) {
-				return $dir;
-			}
+			$this->documentService();
+			$this->templateService();
 		} catch (Throwable $e) {
-			return null;
-		}//end try
+			return false;
+		}
 
-		return null;
-	}//end dompdfLibraryPath()
+		return true;
+	}//end docudeskAvailable()
+
+	/**
+	 * docudesk's DocumentService, resolved by string FQCN only.
+	 *
+	 * @return object
+	 */
+	protected function documentService(): object {
+		return \OCP\Server::get(self::DOCUMENT_SERVICE_FQCN);
+	}//end documentService()
+
+	/**
+	 * docudesk's TemplateService, resolved by string FQCN only.
+	 *
+	 * @return object
+	 */
+	protected function templateService(): object {
+		return \OCP\Server::get(self::TEMPLATE_SERVICE_FQCN);
+	}//end templateService()
+
+	/**
+	 * Template selection: config-UUID first, then namespace/category
+	 * discovery against the ReportCatalogue entry's `templateId`, fail
+	 * closed on zero/multiple matches (REQ-RVD-004).
+	 *
+	 * @return array{templateId: string|null, error: string|null}
+	 */
+	protected function selectTemplate(): array {
+		$reportType = static::reportType();
+		$catalogue = ReportCatalogue::byId($reportType);
+		$category = (string)($catalogue['templateId'] ?? $reportType);
+
+		$configured = trim($this->configuredTemplateId($reportType));
+		if ($configured !== '') {
+			return ['templateId' => $configured, 'error' => null];
+		}
+
+		try {
+			$templates = $this->templateService()->getTemplatesByNamespace(self::TEMPLATE_NAMESPACE);
+		} catch (Throwable $e) {
+			return ['templateId' => null, 'error' => 'Could not look up docudesk templates: ' . $e->getMessage()];
+		}
+
+		$matches = [];
+		foreach ($this->normaliseRows($templates) as $template) {
+			if ((string)($template['category'] ?? '') === $category) {
+				$matches[] = $template;
+			}
+		}
+
+		if (count($matches) === 0) {
+			return [
+				'templateId' => null,
+				'error' => sprintf(
+					'No docudesk template found for "%s" in namespace "%s" (category "%s"); generation is refused.',
+					$reportType,
+					self::TEMPLATE_NAMESPACE,
+					$category
+				),
+			];
+		}
+
+		if (count($matches) > 1) {
+			$ids = array_map(
+				static fn (array $t): string => (string)($t['id'] ?? ($t['@self']['id'] ?? '?')),
+				$matches
+			);
+
+			return [
+				'templateId' => null,
+				'error' => sprintf(
+					'Multiple docudesk templates (%s) for "%s" in namespace "%s"; generation is refused (never guess between templates that produce official documents).',
+					implode(', ', $ids),
+					$reportType,
+					self::TEMPLATE_NAMESPACE
+				),
+			];
+		}
+
+		$id = (string)($matches[0]['id'] ?? $matches[0]['@self']['id'] ?? '');
+		if ($id === '') {
+			return ['templateId' => null, 'error' => 'The matched docudesk template has no id.'];
+		}
+
+		return ['templateId' => $id, 'error' => null];
+	}//end selectTemplate()
+
+	/**
+	 * An admin-configured docudesk template UUID override for this report type.
+	 *
+	 * @param string $reportType The ReportCatalogue report-type id.
+	 *
+	 * @return string The configured UUID, or '' when unset/unavailable.
+	 */
+	protected function configuredTemplateId(string $reportType): string {
+		try {
+			$appConfig = \OCP\Server::get(\OCP\IAppConfig::class);
+			return $appConfig->getValueString('shillinq', 'documents_template_' . $reportType, '');
+		} catch (Throwable $e) {
+			return '';
+		}
+
+	}//end configuredTemplateId()
 
 	// -----------------------------------------------------------------------
 	// Shared data access (self-resolved — generators take no constructor args).

--- a/lib/Reporting/Generator/AnnualAccountsReportGenerator.php
+++ b/lib/Reporting/Generator/AnnualAccountsReportGenerator.php
@@ -44,7 +44,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Reporting\Generator;
 
-use PhpOffice\PhpWord\PhpWord;
+use OCA\Shillinq\Reporting\ReportSection;
 
 /**
  * Renders the statutory annual accounts from a FinancialStatement object.
@@ -71,19 +71,18 @@ final class AnnualAccountsReportGenerator extends AbstractDocumentReportGenerato
 	/**
 	 * Build the jaarrekening body: cover, kerngegevens, balans, W&V, toelichting.
 	 *
-	 * @param PhpWord $phpWord The styled document.
+	 * @param ReportSection $section The block accumulator to fill.
 	 * @param array<string, mixed> $context `{ reportType, period, administrationId }`.
 	 *
 	 * @return void
 	 */
-	protected function build(PhpWord $phpWord, array $context): void {
+	protected function build(ReportSection $section, array $context): void {
 		$statement = $this->resolveStatement($context);
 		$currency = $this->str($statement, 'currency');
 		if ($currency === '') {
 			$currency = 'EUR';
 		}
 
-		$section = $this->addSection($phpWord);
 		$this->addCover($section, 'Jaarrekening', 'Titel 9 BW2 — jaarrekening', $context);
 
 		// --- Kerngegevens (key facts) ---
@@ -125,13 +124,13 @@ final class AnnualAccountsReportGenerator extends AbstractDocumentReportGenerato
 	 * Lay out the balance sheet: assets on one side, equity/provisions/
 	 * liabilities on the other, from FinancialStatement.balanceSheet.
 	 *
-	 * @param \PhpOffice\PhpWord\Element\Section $section The section.
+	 * @param ReportSection $section The block accumulator.
 	 * @param array<string, mixed> $statement The statement object.
 	 * @param string $currency The presentation currency.
 	 *
 	 * @return void
 	 */
-	private function buildBalanceSheet(\PhpOffice\PhpWord\Element\Section $section, array $statement, string $currency): void {
+	private function buildBalanceSheet(ReportSection $section, array $statement, string $currency): void {
 		$balance = $statement['balanceSheet'] ?? [];
 		if (is_array($balance) === false) {
 			$balance = [];
@@ -187,13 +186,13 @@ final class AnnualAccountsReportGenerator extends AbstractDocumentReportGenerato
 	/**
 	 * Lay out the profit-and-loss account from FinancialStatement.profitAndLoss.
 	 *
-	 * @param \PhpOffice\PhpWord\Element\Section $section The section.
+	 * @param ReportSection $section The block accumulator.
 	 * @param array<string, mixed> $statement The statement object.
 	 * @param string $currency The presentation currency.
 	 *
 	 * @return void
 	 */
-	private function buildProfitAndLoss(\PhpOffice\PhpWord\Element\Section $section, array $statement, string $currency): void {
+	private function buildProfitAndLoss(ReportSection $section, array $statement, string $currency): void {
 		$pnl = $statement['profitAndLoss'] ?? [];
 		if (is_array($pnl) === false) {
 			$pnl = [];
@@ -234,7 +233,7 @@ final class AnnualAccountsReportGenerator extends AbstractDocumentReportGenerato
 	/**
 	 * Build the toelichting (notes): general principles, audit and filing.
 	 *
-	 * @param \PhpOffice\PhpWord\Element\Section $section The section.
+	 * @param ReportSection $section The block accumulator.
 	 * @param array<string, mixed> $statement The statement object.
 	 * @param string $currency The presentation currency.
 	 *
@@ -245,7 +244,7 @@ final class AnnualAccountsReportGenerator extends AbstractDocumentReportGenerato
 	 *     buildProfitAndLoss() phases the orchestrator calls uniformly;
 	 *     this phase does not itself render a currency-denominated figure.
 	 */
-	private function buildNotes(\PhpOffice\PhpWord\Element\Section $section, array $statement, string $currency): void {
+	private function buildNotes(ReportSection $section, array $statement, string $currency): void {
 		$sizeClass = $this->str($statement, 'sizeClass');
 		$intro = 'Deze jaarrekening is opgesteld op grond van Titel 9 Boek 2 BW';
 		if ($this->str($statement, 'jurisdiction') !== '' && strtoupper($this->str($statement, 'jurisdiction')) !== 'NL') {

--- a/lib/Reporting/Generator/BalanceSheetReportGenerator.php
+++ b/lib/Reporting/Generator/BalanceSheetReportGenerator.php
@@ -45,7 +45,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Reporting\Generator;
 
-use PhpOffice\PhpWord\PhpWord;
+use OCA\Shillinq\Reporting\ReportSection;
 
 /**
  * Renders a balance sheet from Account balances (assets / liabilities / equity).
@@ -72,12 +72,12 @@ final class BalanceSheetReportGenerator extends AbstractDocumentReportGenerator 
 	/**
 	 * Build the balans body: assets vs. equity/liabilities from Account balances.
 	 *
-	 * @param PhpWord $phpWord The styled document.
+	 * @param ReportSection $section The block accumulator to fill.
 	 * @param array<string, mixed> $context `{ reportType, period, administrationId }`.
 	 *
 	 * @return void
 	 */
-	protected function build(PhpWord $phpWord, array $context): void {
+	protected function build(ReportSection $section, array $context): void {
 		$administrationId = $this->str($context, 'administrationId');
 		$accounts = $this->loadAccounts($administrationId);
 
@@ -92,7 +92,6 @@ final class BalanceSheetReportGenerator extends AbstractDocumentReportGenerator 
 
 		$grouped = $this->groupByType($accounts, $administrationId);
 
-		$section = $this->addSection($phpWord);
 		$this->addCover($section, 'Balans', 'Balans per peildatum', $context);
 
 		// --- Activa ---

--- a/lib/Reporting/Generator/BbvJaarstukkenReportGenerator.php
+++ b/lib/Reporting/Generator/BbvJaarstukkenReportGenerator.php
@@ -45,8 +45,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Reporting\Generator;
 
-use PhpOffice\PhpWord\Element\Section;
-use PhpOffice\PhpWord\PhpWord;
+use OCA\Shillinq\Reporting\ReportSection;
 
 /**
  * Renders BBV jaarstukken / programmaverantwoording from a BbvStatement object.
@@ -77,19 +76,18 @@ final class BbvJaarstukkenReportGenerator extends AbstractDocumentReportGenerato
 	/**
 	 * Build the BBV jaarstukken body from the BbvStatement object.
 	 *
-	 * @param PhpWord $phpWord The styled document.
+	 * @param ReportSection $section The block accumulator to fill.
 	 * @param array<string, mixed> $context `{ reportType, period, administrationId }`.
 	 *
 	 * @return void
 	 */
-	protected function build(PhpWord $phpWord, array $context): void {
+	protected function build(ReportSection $section, array $context): void {
 		$statement = $this->resolveStatement($context);
 		$currency = $this->str($statement, 'currency');
 		if ($currency === '') {
 			$currency = 'EUR';
 		}
 
-		$section = $this->addSection($phpWord);
 		$this->addCover(
 			$section,
 			'BBV-jaarstukken',
@@ -138,13 +136,13 @@ final class BbvJaarstukkenReportGenerator extends AbstractDocumentReportGenerato
 	 * Build the programmaplan section: the programmes plus the general cover
 	 * funds, overhead, VPB charge and onvoorzien.
 	 *
-	 * @param Section $section The section.
+	 * @param ReportSection $section The block accumulator.
 	 * @param array<string, mixed> $statement The BbvStatement object.
 	 * @param string $currency The presentation currency.
 	 *
 	 * @return void
 	 */
-	private function buildProgrammaplan(Section $section, array $statement, string $currency): void {
+	private function buildProgrammaplan(ReportSection $section, array $statement, string $currency): void {
 		$this->addHeading($section, 'Programmaplan (art. 8 BBV)');
 
 		$plan = $statement['programmePlan'] ?? [];
@@ -156,10 +154,10 @@ final class BbvJaarstukkenReportGenerator extends AbstractDocumentReportGenerato
 		if (is_array($programmes) === true && $programmes !== []) {
 			$table = $section->addTable('reportTable');
 			$table->addRow();
-			$table->addCell(\PhpOffice\PhpWord\Shared\Converter::cmToTwip(4), ['bgColor' => self::ACCENT_COLOUR])
-				->addText('Code', ['name' => 'DejaVu Sans', 'size' => 10, 'bold' => true, 'color' => 'FFFFFF']);
-			$table->addCell(\PhpOffice\PhpWord\Shared\Converter::cmToTwip(12), ['bgColor' => self::ACCENT_COLOUR])
-				->addText('Programma', ['name' => 'DejaVu Sans', 'size' => 10, 'bold' => true, 'color' => 'FFFFFF']);
+			$table->addCell(4, ['bgColor' => self::ACCENT_COLOUR])
+				->addText('Code', 'tableHeader');
+			$table->addCell(12, ['bgColor' => self::ACCENT_COLOUR])
+				->addText('Programma', 'tableHeader');
 
 			foreach ($programmes as $programme) {
 				if (is_array($programme) === false) {
@@ -167,8 +165,8 @@ final class BbvJaarstukkenReportGenerator extends AbstractDocumentReportGenerato
 				}
 
 				$table->addRow();
-				$table->addCell(\PhpOffice\PhpWord\Shared\Converter::cmToTwip(4))->addText($this->str($programme, 'code'), 'value');
-				$table->addCell(\PhpOffice\PhpWord\Shared\Converter::cmToTwip(12))->addText($this->str($programme, 'name'), 'value');
+				$table->addCell(4)->addText($this->str($programme, 'code'), 'value');
+				$table->addCell(12)->addText($this->str($programme, 'name'), 'value');
 			}
 		} else {
 			$this->addNote($section, 'Geen programma\'s opgenomen in het programmaplan.');
@@ -195,12 +193,12 @@ final class BbvJaarstukkenReportGenerator extends AbstractDocumentReportGenerato
 	 * List the mandatory BBV paragraphs (art. 9), flagging which of the seven
 	 * required paragraphs are present.
 	 *
-	 * @param Section $section The section.
+	 * @param ReportSection $section The block accumulator.
 	 * @param array<string, mixed> $statement The BbvStatement object.
 	 *
 	 * @return void
 	 */
-	private function buildParagraphs(Section $section, array $statement): void {
+	private function buildParagraphs(ReportSection $section, array $statement): void {
 		$required = [
 			'lokaleHeffingen' => 'Lokale heffingen',
 			'weerstandsvermogen' => 'Weerstandsvermogen en risicobeheersing',
@@ -229,13 +227,13 @@ final class BbvJaarstukkenReportGenerator extends AbstractDocumentReportGenerato
 	/**
 	 * Build the taakvelden overview: estimated revenue and expense per taakveld.
 	 *
-	 * @param Section $section The section.
+	 * @param ReportSection $section The block accumulator.
 	 * @param array<string, mixed> $statement The BbvStatement object.
 	 * @param string $currency The presentation currency.
 	 *
 	 * @return void
 	 */
-	private function buildTaskFields(Section $section, array $statement, string $currency): void {
+	private function buildTaskFields(ReportSection $section, array $statement, string $currency): void {
 		$this->addHeading($section, 'Overzicht taakvelden');
 
 		$taskFields = $statement['taskFields'] ?? [];
@@ -247,8 +245,8 @@ final class BbvJaarstukkenReportGenerator extends AbstractDocumentReportGenerato
 		$table = $section->addTable('reportTable');
 		$table->addRow();
 		foreach (['Code', 'Taakveld', 'Baten', 'Lasten'] as $head) {
-			$table->addCell(\PhpOffice\PhpWord\Shared\Converter::cmToTwip(4), ['bgColor' => self::ACCENT_COLOUR])
-				->addText($head, ['name' => 'DejaVu Sans', 'size' => 10, 'bold' => true, 'color' => 'FFFFFF']);
+			$table->addCell(4, ['bgColor' => self::ACCENT_COLOUR])
+				->addText($head, 'tableHeader');
 		}
 
 		$totalRevenue = 0.0;
@@ -264,28 +262,28 @@ final class BbvJaarstukkenReportGenerator extends AbstractDocumentReportGenerato
 			$totalExpense += $expense;
 
 			$table->addRow();
-			$table->addCell(\PhpOffice\PhpWord\Shared\Converter::cmToTwip(4))->addText($this->str($taskField, 'code'), 'value');
-			$table->addCell(\PhpOffice\PhpWord\Shared\Converter::cmToTwip(4))->addText($this->str($taskField, 'name'), 'value');
-			$table->addCell(\PhpOffice\PhpWord\Shared\Converter::cmToTwip(4))->addText($this->money($revenue, $currency), 'amount', ['alignment' => 'end']);
-			$table->addCell(\PhpOffice\PhpWord\Shared\Converter::cmToTwip(4))->addText($this->money($expense, $currency), 'amount', ['alignment' => 'end']);
+			$table->addCell(4)->addText($this->str($taskField, 'code'), 'value');
+			$table->addCell(4)->addText($this->str($taskField, 'name'), 'value');
+			$table->addCell(4)->addText($this->money($revenue, $currency), 'amount', ['alignment' => 'end']);
+			$table->addCell(4)->addText($this->money($expense, $currency), 'amount', ['alignment' => 'end']);
 		}
 
 		$table->addRow();
-		$table->addCell(\PhpOffice\PhpWord\Shared\Converter::cmToTwip(8), ['bgColor' => 'EEF2FF', 'gridSpan' => 2])->addText('Totaal', 'amountBold');
-		$table->addCell(\PhpOffice\PhpWord\Shared\Converter::cmToTwip(4), ['bgColor' => 'EEF2FF'])->addText($this->money($totalRevenue, $currency), 'amountBold', ['alignment' => 'end']);
-		$table->addCell(\PhpOffice\PhpWord\Shared\Converter::cmToTwip(4), ['bgColor' => 'EEF2FF'])->addText($this->money($totalExpense, $currency), 'amountBold', ['alignment' => 'end']);
+		$table->addCell(8, ['bgColor' => 'EEF2FF', 'gridSpan' => 2])->addText('Totaal', 'amountBold');
+		$table->addCell(4, ['bgColor' => 'EEF2FF'])->addText($this->money($totalRevenue, $currency), 'amountBold', ['alignment' => 'end']);
+		$table->addCell(4, ['bgColor' => 'EEF2FF'])->addText($this->money($totalExpense, $currency), 'amountBold', ['alignment' => 'end']);
 
 	}//end buildTaakvelden()
 
 	/**
 	 * Build the jaarrekening composition (art. 24): which components are present.
 	 *
-	 * @param Section $section The section.
+	 * @param ReportSection $section The block accumulator.
 	 * @param array<string, mixed> $statement The BbvStatement object.
 	 *
 	 * @return void
 	 */
-	private function buildAnnualAccounts(Section $section, array $statement): void {
+	private function buildAnnualAccounts(ReportSection $section, array $statement): void {
 		$this->addHeading($section, 'Jaarrekening (art. 24 BBV)');
 
 		$annualAccounts = $statement['annualAccounts'] ?? [];
@@ -308,13 +306,13 @@ final class BbvJaarstukkenReportGenerator extends AbstractDocumentReportGenerato
 	/**
 	 * Build the fixed-assets overview (arts. 59/62): capitalisation + valuation.
 	 *
-	 * @param Section $section The section.
+	 * @param ReportSection $section The block accumulator.
 	 * @param array<string, mixed> $statement The BbvStatement object.
 	 * @param string $currency The presentation currency.
 	 *
 	 * @return void
 	 */
-	private function buildFixedAssets(Section $section, array $statement, string $currency): void {
+	private function buildFixedAssets(ReportSection $section, array $statement, string $currency): void {
 		$this->addHeading($section, 'Vaste activa (art. 59/62 BBV)');
 
 		$assets = $statement['fixedAssets'] ?? [];

--- a/lib/Reporting/Generator/ManagementLetterReportGenerator.php
+++ b/lib/Reporting/Generator/ManagementLetterReportGenerator.php
@@ -45,8 +45,8 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Reporting\Generator;
 
+use OCA\Shillinq\Reporting\ReportSection;
 use OCA\Shillinq\Service\RuleAuditService;
-use PhpOffice\PhpWord\PhpWord;
 use Throwable;
 
 /**
@@ -78,15 +78,14 @@ final class ManagementLetterReportGenerator extends AbstractDocumentReportGenera
 	/**
 	 * Build the management-letter body: summary, severity breakdown, findings.
 	 *
-	 * @param PhpWord $phpWord The styled document.
+	 * @param ReportSection $section The block accumulator to fill.
 	 * @param array<string, mixed> $context `{ reportType, period, administrationId }`.
 	 *
 	 * @return void
 	 */
-	protected function build(PhpWord $phpWord, array $context): void {
+	protected function build(ReportSection $section, array $context): void {
 		$audit = $this->runAudit($context);
 
-		$section = $this->addSection($phpWord);
 		$this->addCover($section, 'Management letter', 'Bevindingenrapport — compliance & interne beheersing', $context);
 
 		// --- Aanhef (salutation / introduction) ---

--- a/lib/Reporting/Generator/ProfitLossReportGenerator.php
+++ b/lib/Reporting/Generator/ProfitLossReportGenerator.php
@@ -45,7 +45,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Reporting\Generator;
 
-use PhpOffice\PhpWord\PhpWord;
+use OCA\Shillinq\Reporting\ReportSection;
 
 /**
  * Renders a profit-and-loss account from revenue/expense account totals.
@@ -110,12 +110,12 @@ final class ProfitLossReportGenerator extends AbstractDocumentReportGenerator {
 	/**
 	 * Build the W&V body: revenue, expenses, result, from account totals.
 	 *
-	 * @param PhpWord $phpWord The styled document.
+	 * @param ReportSection $section The block accumulator to fill.
 	 * @param array<string, mixed> $context `{ reportType, period, administrationId }`.
 	 *
 	 * @return void
 	 */
-	protected function build(PhpWord $phpWord, array $context): void {
+	protected function build(ReportSection $section, array $context): void {
 		$administrationId = $this->str($context, 'administrationId');
 		$accounts = $this->loadAccounts($administrationId);
 
@@ -134,7 +134,6 @@ final class ProfitLossReportGenerator extends AbstractDocumentReportGenerator {
 		$totalExpense = $this->total($expenseLines);
 		$result = ($totalRevenue - $totalExpense);
 
-		$section = $this->addSection($phpWord);
 		$this->addCover($section, 'Winst- en verliesrekening', 'Resultatenrekening over de periode', $context);
 
 		// --- Opbrengsten ---

--- a/lib/Reporting/ReportCatalogue.php
+++ b/lib/Reporting/ReportCatalogue.php
@@ -10,10 +10,13 @@
  * IA — the consolidation target that replaces the reports scattered across the
  * Belastingen / Bookkeeping / PublicSector / Purchasing menus.
  *
- * `kind` is 'data' (rendered natively as XML/CSV/XBRL) or 'document' (rendered via
- * the PHPOffice libraries bundled in OpenRegister — PhpWord/PhpSpreadsheet + dompdf
- * — into editable DOCX/ODT + PDF from a default template; users who want to
- * customise the templates do so in docudesk).
+ * `kind` is 'data' (rendered natively as XML/CSV/XBRL) or 'document' (assembled by
+ * shillinq as structured content and rendered by docudesk into editable ODT
+ * ('odf' in docudesk's own vocabulary) + PDF from a `namespace: "shillinq"`
+ * template — see openspec/changes/reports-via-docudesk. `ib-aangifte` and
+ * `vpb-aangifte` are declared 'document' but currently have no implementing
+ * generator (`ReportGenerationService::generate()` returns `no-generator` for
+ * them) — out of this catalogue entry's control, tracked separately).
  *
  * @category Reporting
  * @package  OCA\Shillinq\Reporting
@@ -83,9 +86,9 @@ final class ReportCatalogue {
 			['id' => 'vpb-aangifte', 'label' => 'Vpb-aangifte', 'category' => 'tax', 'kind' => 'document', 'formats' => ['docx', 'odt', 'pdf'], 'templateId' => 'shillinq-vpb-aangifte', 'description' => 'Vennootschapsbelasting aangifte met fiscale balans.'],
 
 			// --- Statutory statements ---
-			['id' => 'annual-accounts', 'label' => 'Jaarrekening', 'category' => 'statements', 'kind' => 'document', 'formats' => ['docx', 'odt', 'pdf'], 'templateId' => 'shillinq-jaarrekening', 'description' => 'Titel 9 BW2 jaarrekening (balans, W&V, toelichting).'],
-			['id' => 'balance-sheet', 'label' => 'Balans', 'category' => 'statements', 'kind' => 'document', 'formats' => ['docx', 'odt', 'pdf'], 'templateId' => 'shillinq-balans', 'description' => 'Balans per peildatum.'],
-			['id' => 'profit-loss', 'label' => 'Winst- en verliesrekening', 'category' => 'statements', 'kind' => 'document', 'formats' => ['docx', 'odt', 'pdf'], 'templateId' => 'shillinq-winst-verlies', 'description' => 'Resultatenrekening over de periode.'],
+			['id' => 'annual-accounts', 'label' => 'Jaarrekening', 'category' => 'statements', 'kind' => 'document', 'formats' => ['odt', 'pdf'], 'templateId' => 'shillinq-jaarrekening', 'description' => 'Titel 9 BW2 jaarrekening (balans, W&V, toelichting).'],
+			['id' => 'balance-sheet', 'label' => 'Balans', 'category' => 'statements', 'kind' => 'document', 'formats' => ['odt', 'pdf'], 'templateId' => 'shillinq-balans', 'description' => 'Balans per peildatum.'],
+			['id' => 'profit-loss', 'label' => 'Winst- en verliesrekening', 'category' => 'statements', 'kind' => 'document', 'formats' => ['odt', 'pdf'], 'templateId' => 'shillinq-winst-verlies', 'description' => 'Resultatenrekening over de periode.'],
 			['id' => 'sbr-xbrl', 'label' => 'SBR/XBRL-deponering', 'category' => 'statements', 'kind' => 'data', 'formats' => ['xbrl'], 'templateId' => null, 'description' => 'SBR-jaarrekening in XBRL (KvK/Belastingdienst).'],
 
 			// --- Ledger / balances ---
@@ -98,12 +101,12 @@ final class ReportCatalogue {
 
 			// --- Public sector ---
 			['id' => 'iv3', 'label' => 'IV3-rapportage', 'category' => 'public-sector', 'kind' => 'data', 'formats' => ['xml', 'csv'], 'templateId' => null, 'description' => 'Informatie voor derden (CBS).'],
-			['id' => 'bbv-jaarstukken', 'label' => 'BBV-jaarstukken', 'category' => 'public-sector', 'kind' => 'document', 'formats' => ['docx', 'odt', 'pdf'], 'templateId' => 'shillinq-bbv-jaarstukken', 'description' => 'BBV programmaverantwoording & jaarstukken.'],
+			['id' => 'bbv-jaarstukken', 'label' => 'BBV-jaarstukken', 'category' => 'public-sector', 'kind' => 'document', 'formats' => ['odt', 'pdf'], 'templateId' => 'shillinq-bbv-jaarstukken', 'description' => 'BBV programmaverantwoording & jaarstukken.'],
 
 			// --- Compliance / audit trail ---
 			['id' => 'rule-audit', 'label' => 'Compliance-auditrapport', 'category' => 'compliance', 'kind' => 'data', 'formats' => ['csv', 'pdf'], 'templateId' => null, 'description' => 'Resultaat van de regelmotor (shillinq:rules:audit): afdwingbare regels, overtredingen, dekking.'],
 			['id' => 'audit-trail', 'label' => 'Audit trail', 'category' => 'compliance', 'kind' => 'data', 'formats' => ['csv'], 'templateId' => null, 'description' => 'Onveranderlijke mutatie-audittrail over de periode.'],
-			['id' => 'management-letter', 'label' => 'Management letter', 'category' => 'compliance', 'kind' => 'document', 'formats' => ['docx', 'odt', 'pdf'], 'templateId' => 'shillinq-management-letter', 'description' => 'Management letter / bevindingenrapport.'],
+			['id' => 'management-letter', 'label' => 'Management letter', 'category' => 'compliance', 'kind' => 'document', 'formats' => ['odt', 'pdf'], 'templateId' => 'shillinq-management-letter', 'description' => 'Management letter / bevindingenrapport.'],
 		];
 
 	}//end all()

--- a/lib/Reporting/ReportGenerationService.php
+++ b/lib/Reporting/ReportGenerationService.php
@@ -14,10 +14,17 @@
  * it. Listing reads those GeneratedReport records back through OpenRegister.
  *
  * Persistence of GeneratedReport records goes through OpenRegister's ObjectService
- * (resolved from the container). Office rendering (PhpWord/PhpSpreadsheet/dompdf) and
- * native data rendering (XMLWriter/fputcsv) live inside the individual generators —
- * this service only moves the rendered bytes to Files and records metadata, so it
- * never `use`s an office/PDF class itself and adds nothing to shillinq's composer.
+ * (resolved from the container). DOCUMENT-kind generators hand off rendering to
+ * docudesk (`OCA\DocuDesk\Service\DocumentService`, resolved by string FQCN inside
+ * the generator — ADR-075); DATA-kind generators render bytes natively (XMLWriter/
+ * fputcsv). Either way this service only moves the rendered bytes to Files and
+ * records metadata — it never `use`s an office/PDF/docudesk class itself and adds
+ * nothing to shillinq's composer.
+ *
+ * A DocudeskUnavailableException from a DOCUMENT generator is handled distinctly
+ * from any other generator failure (REQ-RVD-005, ADR-081 rule 7): the attempt is
+ * still recorded — `status: 'unavailable'` — so a docudesk outage is a visible,
+ * findable state rather than a silent drop.
  *
  * Every external call (container, Files, tags, object persistence) is fail-soft:
  * failures are logged as warnings and degrade gracefully rather than crash the
@@ -138,6 +145,8 @@ class ReportGenerationService {
 	 *
 	 * @return array<string, mixed> The recorded GeneratedReport (incl. fileId + downloadPath),
 	 *                              or an `{ error: ... }` envelope when generation cannot proceed.
+	 *
+	 * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-005
 	 */
 	public function generate(string $reportType, string $period, string $administrationId, string $format): array {
 		$catalogue = ReportCatalogue::byId($reportType);
@@ -168,6 +177,37 @@ class ReportGenerationService {
 
 		try {
 			$rendered = $generator->generate($context, $useFormat);
+		} catch (DocudeskUnavailableException $e) {
+			// ADR-081 rule 7: a source app MUST degrade gracefully when the
+			// receiver is absent -- an unsent allocation is a visible pending
+			// state, never a silent drop. Record the attempt (status:
+			// 'unavailable') before returning, so it is findable via
+			// listGenerated() rather than disappearing with the HTTP response.
+			$this->logger->warning(
+				'ReportGenerationService: docudesk unavailable, report generation deferred',
+				['reportType' => $reportType, 'exception' => $e->getMessage()]
+			);
+
+			$record = $this->saveRecord(
+				[
+					'reportType' => $reportType,
+					'reportLabel' => (string)($catalogue['label'] ?? $reportType),
+					'category' => (string)($catalogue['category'] ?? ''),
+					'period' => $period,
+					'administrationId' => $administrationId,
+					'format' => $useFormat,
+					'status' => 'unavailable',
+					'generatedAt' => gmdate('Y-m-d\TH:i:s\Z'),
+					'generatedBy' => ($this->userSession->getUser()?->getUID() ?? ''),
+				]
+			);
+
+			return [
+				'error' => 'docudesk-unavailable',
+				'reportType' => $reportType,
+				'message' => $e->getMessage(),
+				'record' => $record,
+			];
 		} catch (\Throwable $e) {
 			$this->logger->warning(
 				'ReportGenerationService: generator failed',

--- a/lib/Reporting/ReportGeneratorInterface.php
+++ b/lib/Reporting/ReportGeneratorInterface.php
@@ -12,13 +12,15 @@
  * Two flavours of generator:
  *  - DATA reports (SAF-T XML, ledger CSV, SBR/XBRL) render bytes natively in
  *    shillinq.
- *  - DOCUMENT reports (annual accounts, management letters, statements) render
- *    editable DOCX/ODT and PDF via the PHPOffice libraries bundled in OpenRegister
- *    — PhpOffice\PhpWord (DOCX/ODT), PhpOffice\PhpSpreadsheet (XLSX/CSV) and dompdf
- *    (PDF). OpenRegister is a runtime dependency whose autoloader is always active,
- *    so these classes resolve without adding any office/PDF dependency to shillinq.
- *    Generation uses the DEFAULT templates shipped in lib/Reporting/templates/; if a
- *    user wants to customise those templates they do so in docudesk.
+ *  - DOCUMENT reports (annual accounts, management letters, statements) assemble
+ *    a structured report body (data loading + business classification, unchanged
+ *    from before) and hand it to docudesk's `DocumentService::generateDocument()`
+ *    for rendering into editable ODT ('odf' in docudesk's own vocabulary) or PDF
+ *    — shillinq holds no PhpWord/PhpSpreadsheet/dompdf and adds no office/PDF
+ *    dependency of its own (ADR-075: docudesk owns document/PDF generation for
+ *    the fleet). Template content lives in docudesk under
+ *    `namespace: "shillinq"`; this interface's implementations do not author it
+ *    (see openspec/changes/reports-via-docudesk).
  *
  * @category Reporting
  * @package  OCA\Shillinq\Reporting
@@ -66,8 +68,9 @@ interface ReportGeneratorInterface {
 
 	/**
 	 * The formats this generator can emit, in preference order. DATA reports return
-	 * e.g. ['xml'] or ['csv']; DOCUMENT reports return ['docx', 'odt', 'pdf'] (the
-	 * editable formats first, since docudesk renders them from one template).
+	 * e.g. ['xml'] or ['csv']; DOCUMENT reports return ['odt', 'pdf'] (the editable
+	 * format first, mapped internally to docudesk's 'odf'/'pdf' `options.format`
+	 * values — docudesk's DocumentService supports no `docx` output).
 	 *
 	 * @return array<int, string>
 	 */

--- a/lib/Reporting/ReportSection.php
+++ b/lib/Reporting/ReportSection.php
@@ -184,7 +184,12 @@ final class ReportSection {
 	public function toArray(): array {
 		$out = [];
 		foreach ($this->blocks as $block) {
-			$out[] = $block instanceof ReportTable ? $block->toArray() : $block;
+			$item = $block;
+			if ($block instanceof ReportTable) {
+				$item = $block->toArray();
+			}
+
+			$out[] = $item;
 		}
 
 		return $out;

--- a/lib/Reporting/ReportSection.php
+++ b/lib/Reporting/ReportSection.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * Report section block accumulator
+ *
+ * A docudesk-agnostic, in-memory stand-in for PhpWord's `Element\Section`,
+ * kept API-shaped identically (`addText()`, `addTextBreak()`, `addTitle()`,
+ * `addTable()`) so the five document report generators' `build()` bodies
+ * port with a mechanical find/replace of their type hints rather than a
+ * rewrite of their layout calls. Instead of mutating a Word document, each
+ * call appends one plain-array "block" to an ordered list; `toArray()`
+ * returns that list for serialisation into docudesk's `adHocData.report`
+ * (AbstractDocumentReportGenerator::generate(), REQ-RVD-002).
+ *
+ * @category Reporting
+ * @package  OCA\Shillinq\Reporting
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-002
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Reporting;
+
+/**
+ * Accumulates an ordered list of report content blocks.
+ */
+final class ReportSection {
+
+	/**
+	 * Accumulated blocks, in insertion order.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $blocks = [];
+
+	/**
+	 * Append a paragraph of text.
+	 *
+	 * @param string $text The text.
+	 * @param string $style A style key (e.g. 'value', 'note', 'amountBold', 'coverTitle').
+	 * @param array<string, mixed>|string $paragraphStyle A paragraph style key or option array (e.g. 'default', 'tight').
+	 *
+	 * @return self
+	 */
+	public function addText(string $text, string $style = 'value', array|string $paragraphStyle = 'default'): self {
+		$this->blocks[] = [
+			'type' => 'text',
+			'text' => $text,
+			'style' => $style,
+			'paragraphStyle' => $paragraphStyle,
+		];
+
+		return $this;
+	}//end addText()
+
+	/**
+	 * Append a vertical spacer.
+	 *
+	 * @param int $count Number of line breaks.
+	 *
+	 * @return self
+	 */
+	public function addTextBreak(int $count = 1): self {
+		$this->blocks[] = ['type' => 'textBreak', 'count' => $count];
+		return $this;
+	}//end addTextBreak()
+
+	/**
+	 * Append a heading.
+	 *
+	 * @param string $text The heading text.
+	 * @param int $depth Heading depth/level (1 = top-level title, 2 = section heading).
+	 *
+	 * @return self
+	 */
+	public function addTitle(string $text, int $depth = 2): self {
+		$this->blocks[] = ['type' => 'heading', 'text' => $text, 'depth' => $depth];
+		return $this;
+	}//end addTitle()
+
+	/**
+	 * Append a cover block (title + optional subtitle + meta line).
+	 *
+	 * @param string $title The cover title.
+	 * @param string $subtitle The cover subtitle (empty to omit).
+	 * @param array<int, string> $meta Meta line parts (already formatted, joined by the renderer).
+	 *
+	 * @return self
+	 */
+	public function addCover(string $title, string $subtitle, array $meta): self {
+		$this->blocks[] = [
+			'type' => 'cover',
+			'title' => $title,
+			'subtitle' => $subtitle,
+			'meta' => $meta,
+		];
+
+		return $this;
+	}//end addCover()
+
+	/**
+	 * Append a note (empty-state or footnote — matches the semantic "note"
+	 * style previously rendered in muted, smaller text).
+	 *
+	 * @param string $text The note text.
+	 *
+	 * @return self
+	 */
+	public function addNote(string $text): self {
+		$this->blocks[] = ['type' => 'note', 'text' => $text];
+		return $this;
+	}//end addNote()
+
+	/**
+	 * Append a key/value details table.
+	 *
+	 * @param array<string, string> $rows Label => value pairs, insertion order kept.
+	 *
+	 * @return self
+	 */
+	public function addDetailsTable(array $rows): self {
+		$this->blocks[] = ['type' => 'detailsTable', 'rows' => $rows];
+		return $this;
+	}//end addDetailsTable()
+
+	/**
+	 * Append a financial amount table.
+	 *
+	 * @param string $labelHead Header for the label column.
+	 * @param string $amountHead Header for the amount column.
+	 * @param array<int, array{label: string, amount: float|int|null, bold?: bool}> $lines The body lines.
+	 * @param array{label: string, amount: float|int}|null $total Optional total row.
+	 * @param string $currency ISO-4217 currency for formatting, or '' for a plain count column.
+	 *
+	 * @return self
+	 */
+	public function addAmountTable(
+		string $labelHead,
+		string $amountHead,
+		array $lines,
+		?array $total,
+		string $currency,
+	): self {
+		$this->blocks[] = [
+			'type' => 'amountTable',
+			'labelHead' => $labelHead,
+			'amountHead' => $amountHead,
+			'lines' => $lines,
+			'total' => $total,
+			'currency' => $currency,
+		];
+
+		return $this;
+	}//end addAmountTable()
+
+	/**
+	 * Start a new generic table block and return its builder.
+	 *
+	 * @param string $styleKey A named style key (informational).
+	 *
+	 * @return ReportTable
+	 */
+	public function addTable(string $styleKey = 'reportTable'): ReportTable {
+		$table = new ReportTable($styleKey);
+		$this->blocks[] = $table;
+		return $table;
+	}//end addTable()
+
+	/**
+	 * Serialise every accumulated block to a plain array.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function toArray(): array {
+		$out = [];
+		foreach ($this->blocks as $block) {
+			$out[] = $block instanceof ReportTable ? $block->toArray() : $block;
+		}
+
+		return $out;
+	}//end toArray()
+}//end class

--- a/lib/Reporting/ReportTable.php
+++ b/lib/Reporting/ReportTable.php
@@ -107,7 +107,13 @@ final class ReportTable {
 
 		$this->rows[$rowIndex][$cellIndex]['text'] = $text;
 		$this->rows[$rowIndex][$cellIndex]['textStyle'] = $style;
-		$this->rows[$rowIndex][$cellIndex]['textOptions'] = is_array($options) === true ? $options : ['style' => $options];
+
+		$textOptions = ['style' => $options];
+		if (is_array($options) === true) {
+			$textOptions = $options;
+		}
+
+		$this->rows[$rowIndex][$cellIndex]['textOptions'] = $textOptions;
 
 	}//end fillCell()
 

--- a/lib/Reporting/ReportTable.php
+++ b/lib/Reporting/ReportTable.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Report table block builder
+ *
+ * A minimal, docudesk-agnostic stand-in for PhpWord's `Element\Table` /
+ * `Element\Cell` API, kept API-shaped identically (`addRow()`, `addCell()`
+ * returning a chainable cell that supports `addText()`) so the two
+ * hand-rolled tables in BbvJaarstukkenReportGenerator port with a mechanical
+ * find/replace rather than a rewrite. Widths are relative hints (plain
+ * numbers, formerly twips from `Converter::cmToTwip()`) a docudesk template
+ * may use or ignore — there is no physical page to lay out against once
+ * nothing renders to an actual Word document.
+ *
+ * @category Reporting
+ * @package  OCA\Shillinq\Reporting
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-002
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Reporting;
+
+/**
+ * Accumulates rows/cells for one generic table block.
+ */
+final class ReportTable {
+
+	/**
+	 * Accumulated rows; each is a list of cell arrays.
+	 *
+	 * @var array<int, array<int, array<string, mixed>>>
+	 */
+	private array $rows = [];
+
+	/**
+	 * @param string $styleKey The named style this table was created with (informational).
+	 */
+	public function __construct(
+		private readonly string $styleKey = 'reportTable',
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Start a new (initially empty) row. Cells are appended to the most
+	 * recently started row by addCell().
+	 *
+	 * @return self
+	 */
+	public function addRow(): self {
+		$this->rows[] = [];
+		return $this;
+	}//end addRow()
+
+	/**
+	 * Append a cell to the current row and return a builder for its content.
+	 *
+	 * @param float|int $widthCm A relative width hint (plain number, formerly cm-to-twip).
+	 * @param array<string, mixed> $cellStyle Cell style hints (e.g. `bgColor`, `gridSpan`).
+	 *
+	 * @return ReportTableCell
+	 */
+	public function addCell(float|int $widthCm = 0, array $cellStyle = []): ReportTableCell {
+		if ($this->rows === []) {
+			$this->addRow();
+		}
+
+		$lastIndex = array_key_last($this->rows);
+		$cellIndex = count($this->rows[$lastIndex]);
+		$this->rows[$lastIndex][$cellIndex] = [
+			'widthCm' => $widthCm,
+			'cellStyle' => $cellStyle,
+			'text' => '',
+			'textStyle' => 'value',
+			'textOptions' => [],
+		];
+
+		return new ReportTableCell($this, $lastIndex, $cellIndex);
+	}//end addCell()
+
+	/**
+	 * Called by ReportTableCell::addText() to fill in the cell it was handed.
+	 *
+	 * @param int $rowIndex The row index.
+	 * @param int $cellIndex The cell index within the row.
+	 * @param string $text The cell text.
+	 * @param string $style The text style key.
+	 * @param array<string, mixed>|string $options Paragraph/text options (e.g. `['alignment' => 'end']`).
+	 *
+	 * @return void
+	 */
+	public function fillCell(int $rowIndex, int $cellIndex, string $text, string $style, array|string $options): void {
+		if (isset($this->rows[$rowIndex][$cellIndex]) === false) {
+			return;
+		}
+
+		$this->rows[$rowIndex][$cellIndex]['text'] = $text;
+		$this->rows[$rowIndex][$cellIndex]['textStyle'] = $style;
+		$this->rows[$rowIndex][$cellIndex]['textOptions'] = is_array($options) === true ? $options : ['style' => $options];
+
+	}//end fillCell()
+
+	/**
+	 * Serialise this table to a plain-array block.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function toArray(): array {
+		return [
+			'type' => 'table',
+			'styleKey' => $this->styleKey,
+			'rows' => $this->rows,
+		];
+	}//end toArray()
+}//end class

--- a/lib/Reporting/ReportTableCell.php
+++ b/lib/Reporting/ReportTableCell.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Report table cell handle
+ *
+ * Returned by `ReportTable::addCell()`. Mirrors PhpWord's `Element\Cell::
+ * addText()` chaining shape (`$table->addCell($w)->addText($text, $style)`)
+ * without holding any PhpWord/document state itself — it writes back into
+ * its owning `ReportTable` by (row, cell) coordinate.
+ *
+ * @category Reporting
+ * @package  OCA\Shillinq\Reporting
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-002
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Reporting;
+
+/**
+ * A handle onto one cell of a ReportTable.
+ */
+final class ReportTableCell {
+
+	/**
+	 * @param ReportTable $table The owning table.
+	 * @param int $rowIndex The row index this cell lives in.
+	 * @param int $cellIndex The cell index within the row.
+	 */
+	public function __construct(
+		private readonly ReportTable $table,
+		private readonly int $rowIndex,
+		private readonly int $cellIndex,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Set this cell's text content and style.
+	 *
+	 * @param string $text The cell text.
+	 * @param string $style The text style key (e.g. 'value', 'amount', 'amountBold').
+	 * @param array<string, mixed>|string $options Paragraph/text options (e.g. `['alignment' => 'end']`).
+	 *
+	 * @return self
+	 */
+	public function addText(string $text, string $style = 'value', array|string $options = []): self {
+		$this->table->fillCell($this->rowIndex, $this->cellIndex, $text, $style, $options);
+		return $this;
+	}//end addText()
+}//end class

--- a/lib/Settings/docudesk-templates.json
+++ b/lib/Settings/docudesk-templates.json
@@ -759,6 +759,79 @@
           ]
         }
       ]
+    },
+    {
+      "templateId": "shillinq-balans",
+      "title": "Balans",
+      "description": "Balance sheet per peildatum (openspec/changes/reports-via-docudesk REQ-RVD-006). NOT yet a live docudesk Template object -- BalanceSheetReportGenerator::selectTemplate() looks up `namespace: \"shillinq\", category: \"shillinq-balans\"` in docudesk's own `template` register and fails closed with a diagnostic until that Template's Twig/HTML content is authored (hrmq `hrmq-docudesk-documents` precedent: template content authoring is a docudesk-side follow-up, not part of the consumption leaf). This entry documents the ReportSection block tree BalanceSheetReportGenerator hands to `DocumentService::generateDocument()` via `options.adHocData.report`, so a template author knows what to render.",
+      "register": "shillinq",
+      "reportCatalogueId": "balance-sheet",
+      "blockVocabulary": {
+        "cover": "title 'Balans', subtitle, meta line (Periode/Administratie/Gegenereerd)",
+        "heading": "'Activa', 'Passiva', 'Balanscontrole'",
+        "amountTable": "Activa lines+total, Eigen vermogen lines+total, Schulden lines+total, Recapitulatie passiva lines+total -- each {labelHead, amountHead, lines: [{label, amount, bold?}], total: {label, amount}|null, currency}",
+        "text": "'Eigen vermogen' / 'Schulden' subheadings (style: amountBold)",
+        "detailsTable": "Balanscontrole key/value rows (Aantal grootboekrekeningen, Totaal activa, Totaal passiva, Verschil, Balans sluit aan)",
+        "note": "empty-state ('Er zijn geen grootboekrekeningen gevonden...') when no accounts"
+      }
+    },
+    {
+      "templateId": "shillinq-winst-verlies",
+      "title": "Winst- en verliesrekening",
+      "description": "Profit-and-loss account over the period (openspec/changes/reports-via-docudesk REQ-RVD-006). NOT yet a live docudesk Template object -- ProfitLossReportGenerator::selectTemplate() looks up `namespace: \"shillinq\", category: \"shillinq-winst-verlies\"`; see shillinq-balans's description for the fail-closed/follow-up rationale.",
+      "register": "shillinq",
+      "reportCatalogueId": "profit-loss",
+      "blockVocabulary": {
+        "cover": "title 'Winst- en verliesrekening', subtitle, meta line",
+        "heading": "'Opbrengsten', 'Kosten', 'Resultaat'",
+        "amountTable": "Opbrengsten lines+total, Kosten lines+total, Resultaatbepaling (opbrengsten/kosten/resultaat)",
+        "note": "methodology note + empty-state when no revenue/expense accounts"
+      }
+    },
+    {
+      "templateId": "shillinq-jaarrekening",
+      "title": "Jaarrekening",
+      "description": "Titel 9 BW2 jaarrekening -- kerngegevens, balans, W&V, toelichting (openspec/changes/reports-via-docudesk REQ-RVD-006). NOT yet a live docudesk Template object -- AnnualAccountsReportGenerator::selectTemplate() looks up `namespace: \"shillinq\", category: \"shillinq-jaarrekening\"`; see shillinq-balans's description for the fail-closed/follow-up rationale.",
+      "register": "shillinq",
+      "reportCatalogueId": "annual-accounts",
+      "blockVocabulary": {
+        "cover": "title 'Jaarrekening', subtitle 'Titel 9 BW2 -- jaarrekening', meta line",
+        "heading": "'Kerngegevens', 'Balans per <date>', 'Winst- en verliesrekening', 'Toelichting', 'Controle en deponering'",
+        "detailsTable": "Kerngegevens (soort/jurisdictie/stelsel/boekjaar/taal/valuta/grootteklasse/balanstotaal/omzet/personeel), Controle en deponering (gecontroleerd/kwalificatie/data)",
+        "amountTable": "Activa/Passiva (fixed+current assets, equity+provisions+liabilities), Resultatenrekening (omzet/lasten/financieel/resultaat)",
+        "text": "toelichting intro + comparatives/netting/components paragraphs",
+        "note": "balans-sluit-niet-aan warning when activa != passiva"
+      }
+    },
+    {
+      "templateId": "shillinq-management-letter",
+      "title": "Management letter",
+      "description": "Bevindingenrapport from RuleAuditService's compliance audit (openspec/changes/reports-via-docudesk REQ-RVD-006). NOT yet a live docudesk Template object -- ManagementLetterReportGenerator::selectTemplate() looks up `namespace: \"shillinq\", category: \"shillinq-management-letter\"`; see shillinq-balans's description for the fail-closed/follow-up rationale.",
+      "register": "shillinq",
+      "reportCatalogueId": "management-letter",
+      "blockVocabulary": {
+        "cover": "title 'Management letter', subtitle, meta line",
+        "text": "aanhef/introductie paragraphs, closing recommendation",
+        "heading": "'Samenvatting', 'Bevindingen naar ernst', 'Bevindingen per object-type' (conditional), 'Belangrijkste bevindingen' (conditional), 'Aanbeveling'",
+        "detailsTable": "Samenvatting key/value rows (normenkader, dekkingsgraad, objecten gecontroleerd/compliant, compliancegraad)",
+        "amountTable": "Bevindingen naar ernst (mandatory/conditional/recommended counts, currency ''), per object-type counts (conditional), top violated rules (conditional)",
+        "note": "closing note on the audit engine/coverage"
+      }
+    },
+    {
+      "templateId": "shillinq-bbv-jaarstukken",
+      "title": "BBV-jaarstukken",
+      "description": "NL public-sector BBV jaarstukken / programmaverantwoording (openspec/changes/reports-via-docudesk REQ-RVD-006). NOT yet a live docudesk Template object -- BbvJaarstukkenReportGenerator::selectTemplate() looks up `namespace: \"shillinq\", category: \"shillinq-bbv-jaarstukken\"`; see shillinq-balans's description for the fail-closed/follow-up rationale.",
+      "register": "shillinq",
+      "reportCatalogueId": "bbv-jaarstukken",
+      "blockVocabulary": {
+        "cover": "title 'BBV-jaarstukken', documentType+subtitle, meta line",
+        "heading": "'Kerngegevens', 'Programmaplan (art. 8 BBV)', 'Verplichte paragrafen (art. 9 BBV)', 'Overzicht taakvelden', 'Jaarrekening (art. 24 BBV)', 'Vaste activa (art. 59/62 BBV)'",
+        "detailsTable": "Kerngegevens, art. 9 paragraph presence (Aanwezig/Ontbreekt), Jaarrekening component presence (Ja/Nee)",
+        "amountTable": "Programmaplan algemene posten, Vaste activa lines+total",
+        "table": "Programmaplan programme list (code/naam), Taakvelden overview (code/naam/baten/lasten + totaalrij) -- generic {styleKey, rows: [{cells: [{widthCm, cellStyle, text, textStyle, textOptions}]}]} blocks, not amountTable/detailsTable",
+        "note": "empty-state notes for programmes/taakvelden/vaste activa when absent"
+      }
     }
   ]
 }

--- a/lib/Settings/register.d/reporting-generated-report.json
+++ b/lib/Settings/register.d/reporting-generated-report.json
@@ -3,7 +3,7 @@
   "components": {
     "schemas": {
       "GeneratedReport": {
-        "version": "0.1.0",
+        "version": "0.1.1",
         "slug": "GeneratedReport",
         "title": "Generated Report",
         "type": "object",
@@ -44,7 +44,7 @@
           },
           "format": {
             "type": "string",
-            "description": "File format: pdf | docx | odt | xlsx | csv | xml | xbrl | json.",
+            "description": "File format: pdf | odt | xlsx | csv | xml | xbrl | json (document-kind reports render as pdf/odt via docudesk; docx is not produced).",
             "title": "Format"
           },
           "fileName": {
@@ -89,9 +89,10 @@
             "enum": [
               "generating",
               "ready",
-              "failed"
+              "failed",
+              "unavailable"
             ],
-            "description": "Generation status.",
+            "description": "Generation status. 'unavailable' means the render step could not run because its renderer (docudesk, for document-kind reports) was not installed/reachable -- a visible, retryable outcome, distinct from 'failed' (REQ-RVD-005, ADR-081 rule 7).",
             "title": "Status"
           },
           "tags": {

--- a/openspec/changes/reports-via-docudesk/.openspec.yaml
+++ b/openspec/changes/reports-via-docudesk/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: conduction
+created: 2026-08-20

--- a/openspec/changes/reports-via-docudesk/design.md
+++ b/openspec/changes/reports-via-docudesk/design.md
@@ -1,0 +1,160 @@
+# Design: reports-via-docudesk
+
+## Context
+
+`AbstractDocumentReportGenerator` currently does two jobs in one class: (1)
+load + aggregate/classify OpenRegister objects into report content (per
+generator — balance grouping, revenue/expense classification, rule-audit
+summarisation, BBV programme/taakveld tables), and (2) lay that content out
+into a `PhpOffice\PhpWord\PhpWord` document via a shared vocabulary of
+protected helpers (`addCover`, `addHeading`, `addDetailsTable`,
+`addAmountTable`, `addParagraph`, `addNote`, `addSection`) plus a few direct
+`Section`/`Table`/`Cell` calls in `BbvJaarstukkenReportGenerator` and
+`AnnualAccountsReportGenerator`'s private helpers, then serialises through
+PhpWord's DOCX/ODT writers or a dompdf-backed PDF writer.
+
+Job (1) is legitimate shillinq business logic (ADR-081 rule 6: "the domain
+app supplies context and classification"). Job (2) is exactly the capability
+ADR-075 assigns to docudesk. The fix separates them: job (1) stays, almost
+byte-for-byte; job (2) is replaced by a hand-off to docudesk's
+`DocumentService::generateDocument(templateId, dataRefs, options)`.
+
+## Decisions
+
+### D1 — Keep the same helper vocabulary, change what it writes into
+
+Rewriting every `build()`/private-helper method in five files to talk to a
+brand-new API would touch ~1500 lines and re-risk every generator's
+classification logic for no reason — that logic never touched PhpWord. Instead,
+`AbstractDocumentReportGenerator` gains a small in-house `ReportSection` /
+`ReportTable` pair (`lib/Reporting/ReportSection.php`,
+`lib/Reporting/ReportTable.php`) that mimics the *shape* of the PhpWord calls
+already in use (`addText`, `addTextBreak`, `addTitle`, `addTable`→`addRow`→
+`addCell`→`addText`) but accumulates an ordered list of plain-array "blocks"
+instead of mutating a Word document. The five generators' `build()` signature
+changes from `build(PhpWord $phpWord, array $context)` to
+`build(ReportSection $section, array $context)`, their one-line
+`$section = $this->addSection($phpWord);` is deleted (the base now constructs
+the top-level `ReportSection` itself), and their PhpWord-specific imports are
+removed. `BbvJaarstukkenReportGenerator`'s two hand-rolled tables (programme
+list, taakveld list) keep using `$section->addTable(...)` / `$table->addRow()`
+/ `$table->addCell($widthCm, $style)->addText(...)` against `ReportTable`
+instead of PhpWord's `Element\Table`/`Element\Cell` — the twip-converting
+`\PhpOffice\PhpWord\Shared\Converter::cmToTwip(N)` calls become plain `N` (a
+relative width hint a docudesk template may use or ignore; twips were never
+meaningful once nothing renders to an actual Word document).
+
+The resulting `ReportSection::toArray()` is a plain, JSON-serialisable tree:
+`{type: heading|text|textBreak|note|amountTable|detailsTable|table, ...}` per
+block — semantically the same content the old PhpWord document carried, just
+undressed of layout/typography concerns docudesk now owns.
+
+### D2 — The hand-off: dataRefs empty, computed body in `adHocData`
+
+Unlike hrmq's documents (one Employee + one Contract/Payslip — docudesk
+re-resolves them itself via `dataRefs`), these five reports are aggregates
+over many `Account`/`GLLine`/other rows with classification logic
+(account-type bucketing, GL-movement derivation, rule-audit summarisation)
+that has no docudesk-side equivalent to recompute from raw refs. Per ADR-081
+rule 6, shillinq supplies "context and classification"; docudesk supplies
+rendering. So `dataRefs = []` and the entire computed `ReportSection::toArray()`
+tree travels as `options.adHocData.report` (`{title, subtitle, blocks}`),
+alongside `options.adHocData.meta` (`reportType`, `period`, `administrationId`,
+`generatedAt`). `options.format` maps the caller's requested format to
+docudesk's vocabulary (`odt` → docudesk's `odf`; `pdf` → `pdf`) —
+`VALID_FORMATS` in `docudesk/lib/Service/DocumentService.php` is
+`['pdf', 'odf', 'html']`, which has no `docx`, so `docx` output support is
+dropped, not reimplemented. `ReportCatalogue`'s five document-kind entries'
+`formats` arrays change from `['docx', 'odt', 'pdf']` to `['odt', 'pdf']`.
+
+### D3 — Template discovery reuses the catalogue's existing (previously dead) `templateId` field
+
+`ReportCatalogue::REPORTS` already carries a per-entry `templateId` (e.g.
+`shillinq-balans`, `shillinq-winst-verlies`, `shillinq-jaarrekening`,
+`shillinq-management-letter`, `shillinq-bbv-jaarstukken`) that no code read —
+grep confirms zero references outside the catalogue definition itself. Rather
+than invent a second key, template discovery in
+`AbstractDocumentReportGenerator::selectTemplate()` now uses that value as the
+docudesk template `category`, mirroring hrmq's `category === documentType`
+convention but through the catalogue's own naming: config override first
+(`IAppConfig` key `documents_template_{reportType}`, an admin-set docudesk
+template UUID), else exactly one `namespace: "shillinq"` docudesk template
+whose `category` equals the catalogue's `templateId` — zero or multiple
+matches fail closed with a diagnostic (never guess between templates that
+produce statutory/financial documents), exactly hrmq's D3.
+
+### D4 — Docudesk absence is a distinguishable, visible outcome — not a silent drop
+
+Per ADR-081 rule 7 ("A source app MUST degrade gracefully when the receiver
+is absent — an unsent allocation is a visible pending state, never a silent
+drop") and hrmq's `skipped-no-docudesk` precedent:
+
+- `AbstractDocumentReportGenerator::docudeskAvailable()` duck-type probes
+  `IAppManager::isInstalled('docudesk')` plus resolvability of
+  `OCA\DocuDesk\Service\{DocumentService,TemplateService}` via
+  `\OCP\Server::get()` (string FQCN only — no compile-time import, no
+  composer/info.xml dependency on docudesk), exactly hrmq's probe.
+- `generate()` checks this FIRST, before any object loading, and throws a new
+  `OCA\Shillinq\Reporting\DocudeskUnavailableException` when false — a
+  distinct type from a generic rendering failure.
+- `ReportGenerationService::generate()` now catches
+  `DocudeskUnavailableException` *before* its existing catch-all `\Throwable`
+  branch. Previously, ANY generator exception — including a docudesk-absent
+  probe failure, a template-lookup miss, or a genuine bug — collapsed into
+  the same undiagnostic `{error: 'generation-failed'}` response with **no**
+  `GeneratedReport` record written at all (the record-then-render order only
+  wrote a record on success). The new branch writes a `GeneratedReport` with
+  `status: 'unavailable'` (new enum value, `lib/Settings/register.d/
+  reporting-generated-report.json`) BEFORE returning, so a docudesk-absent
+  attempt is visible in the generated-reports index — not merely a JSON
+  error that disappears the moment the HTTP response is discarded. The
+  controller (`ReportingController::generate()`) maps
+  `error: 'docudesk-unavailable'` to `503 Service Unavailable` (previously
+  every `{error}` envelope, including this one, mapped to a blanket 422).
+- This is a **structural** improvement independent of any one bug: because
+  `docudeskAvailable()` is checked lazily inside `generate()` rather than at
+  class-load/instantiation time, `ReportGenerationService::generators()`'s
+  glob-and-instantiate discovery can no longer silently drop a generator from
+  the catalogue the way it could when a missing PhpWord class threw a fatal
+  `\Error` at container-resolution time — the generator always exists; only
+  the render step can be unavailable, and that step now says so explicitly.
+
+### D5 — Template content authoring is handed back to docudesk (scoped, not half-done)
+
+`lib/Settings/docudesk-templates.json` already declares 15 report/letter
+templates in a shillinq-authored, sections/columns/aggregation-shaped JSON
+format for other capabilities (innovatiebox, R&D subsidies, dunning, VPB).
+Investigation confirms **this file is not mechanically imported by
+docudesk or shillinq at runtime** — neither app's `lib/` greps for
+`docudesk-templates.json`, and its shape (top-level `sections`/`columns`/
+`aggregation`/`totals` keys) does not match docudesk's own `template` OR
+schema (`docudesk_register.json` → `template`: requires `name`, `content`
+(Twig/HTML string), `namespace`; optional `category`). It is a **design-intent
+declaration**, not a live integration surface — exactly the role hrmq's own
+reference change assigns the same problem: hrmq's `hrmq-docudesk-documents`
+design.md lists "seeding starter templates into docudesk" as an explicit
+**Non-Goal**, "follow-up — cross-app write", because template *content*
+(the actual Twig markup) is authored in docudesk by a human/admin, not
+generated by the consuming leaf app.
+
+This change follows that precedent exactly: it (a) extends
+`docudesk-templates.json` with five new entries (`shillinq-balans`,
+`shillinq-winst-verlies`, `shillinq-jaarrekening`,
+`shillinq-management-letter`, `shillinq-bbv-jaarstukken`) documenting the
+`ReportSection::toArray()` block vocabulary each template must render
+(heading/text/textBreak/note/amountTable/detailsTable/table — the same shape
+every existing declared template in the file already documents structurally),
+and (b) does **not** claim those five docudesk `namespace: "shillinq"`
+Template objects exist yet. `selectTemplate()`'s zero-match branch fails
+closed with a diagnostic naming exactly which `(namespace, category)` pair
+was not found — which is also today's honest state for hrmq's own four
+letter-document types (design.md: "Non-Goals: seeding starter templates").
+Creating those five Template objects in docudesk (admin UI or a future
+docudesk-side seed) is explicitly **handed back** as follow-up work, not
+absorbed into this change.
+
+## Non-Goals (see proposal.md)
+
+Restated for locality: no docudesk-side template content authoring, no
+ADR-075 fleet-wide published-contract package, no changes to the six
+"data"-kind report generators.

--- a/openspec/changes/reports-via-docudesk/proposal.md
+++ b/openspec/changes/reports-via-docudesk/proposal.md
@@ -1,0 +1,74 @@
+---
+kind: code
+depends_on: []
+---
+
+# Proposal: reports-via-docudesk
+
+## Summary
+
+`lib/Reporting/Generator/AbstractDocumentReportGenerator.php` and its five
+concrete subclasses (`BalanceSheetReportGenerator`, `ProfitLossReportGenerator`,
+`AnnualAccountsReportGenerator`, `ManagementLetterReportGenerator`,
+`BbvJaarstukkenReportGenerator`) `use PhpOffice\PhpWord\{Element\Section,
+IOFactory, PhpWord}` and construct `new PhpWord()` to build DOCX/ODT/PDF
+documents in-process, using dompdf for the PDF path. `phpoffice/phpword` is in
+neither shillinq's `composer.json` require NOR its `vendor/` — the code only
+resolves today because OpenRegister's and docudesk's vendor directories happen
+to be autoloaded on the same PHP instance. ADR-075 D3 bans "loading another
+app's vendor directory" by name and already lists shillinq's `Reporting/`
+stack as a known violation; ADR-087 extends the same one-channel principle to
+office-suite interaction generally. This change removes PhpWord from `lib/`
+entirely and re-implements the five document generators as docudesk
+consumers: each one assembles a structured report body (the data-aggregation
+logic is unchanged) and hands it to docudesk's `DocumentService::
+generateDocument()` for rendering, mirroring the hrmq `payslip-pdf-docudesk`
+consumption pattern ("hrmq assembles data, docudesk renders — no Dompdf/Twig
+in hrmq").
+
+## Motivation
+
+1. **Fragile by accident, not by contract.** The current code has no
+   composer/vendor relationship to PhpWord or dompdf at all — it works only
+   because two unrelated apps' vendor trees happen to be co-loaded. Neither
+   `composer audit` nor ADR-093's dependency cooldown can see this surface,
+   because from shillinq's own dependency graph it does not exist. A version
+   bump, an uninstall, or a reorder of either app breaks report generation
+   with no warning to anyone who reads shillinq's own manifest.
+2. **The failure mode was silent.** `ReportGenerationService::generators()`
+   discovers generators by glob-and-instantiate and catches `\Throwable` at
+   instantiation time, logging a warning and simply omitting the generator
+   from the discovered set. If the cross-app vendor reach ever stops
+   resolving, the five reports do not error loudly — they vanish from the
+   catalogue and the caller gets a generic `no-generator` 422 with no
+   indication that docudesk (the fleet's actual document-generation owner)
+   was never consulted.
+3. **The correct pattern is already proven in the fleet.** hrmq's
+   `HrDocumentService` (spec `hrmq-docudesk-documents` / `payslip-pdf-
+   docudesk`) is the reference consumer: duck-typed, same-instance resolution
+   of `OCA\DocuDesk\Service\{DocumentService,TemplateService}` by string FQCN,
+   config-first/discovery-second/fail-closed template selection, and an
+   explicit `skipped-no-docudesk` outcome when docudesk is absent — never a
+   silent drop. This change ports that pattern into shillinq's reporting
+   subsystem.
+
+## Non-Goals
+
+- Authoring the five docudesk-side Twig/HTML `namespace: "shillinq"` Template
+  objects themselves. hrmq's own reference change explicitly treats "seeding
+  starter templates into docudesk" as a follow-up cross-app write, not part
+  of the consumption leaf — this change follows the same precedent. It ships
+  the consumption leaf (generators + fail-closed discovery + visible
+  degradation) and the `lib/Settings/docudesk-templates.json` declaration
+  docudesk template authoring is scoped against; template content authoring
+  is handed back explicitly (see design.md).
+- Building ADR-075's fleet-wide "published PHP contract" (interface package /
+  capability registry). ADR-075 is `Proposed`, not `Accepted`, and no such
+  contract exists in docudesk today — hrmq's own shipped implementation
+  duck-types by FQCN, same as this change. Removing the OR-vendor-dir-reach
+  violation (the specific thing ADR-075 D3 bans by name) is in scope;
+  publishing a versioned contract for the whole fleet is not.
+- Changing the six OTHER report generators in `lib/Reporting/Generator/`
+  (SAF-T, XAF, trial balance, general ledger, IV3, VAT return, rule audit) —
+  they are "data" kind (native XML/CSV/XBRL), never touched PhpWord, and are
+  out of this defect's blast radius.

--- a/openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md
+++ b/openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md
@@ -1,0 +1,239 @@
+# reports-via-docudesk Specification
+
+**Status**: in-progress
+**Scope**: shillinq
+**OpenSpec changes**:
+- reports-via-docudesk
+
+## Purpose
+
+Removes `phpoffice/phpword` (resolved today only via cross-app vendor-dir
+reach into OpenRegister/docudesk's own vendor trees — banned by ADR-075 D3)
+from shillinq's `lib/Reporting/Generator/` document report stack, and
+re-implements the five document report generators (balance sheet, profit and
+loss, annual accounts, management letter, BBV jaarstukken) as docudesk
+consumers per the hrmq `payslip-pdf-docudesk` reference pattern: shillinq
+assembles the report's structured content, docudesk renders it. Docudesk's
+absence degrades to a visible, distinguishable outcome, never a silent drop
+(ADR-081 rule 7).
+
+## ADDED Requirements
+
+@e2e exclude backend-only defect fix (generator internals + service error
+handling); no new UI surface — the existing Reporting & Compliance overview
+page and generate/download flow are unchanged black-box, and shillinq has no
+Playwright coverage of the reporting-generate endpoint today (tracked
+separately, not introduced or removed by this change)
+
+### Requirement: REQ-RVD-001: The five document report generators SHALL carry no PhpOffice reference anywhere in `lib/`
+
+`AbstractDocumentReportGenerator` and its five subclasses
+(`BalanceSheetReportGenerator`, `ProfitLossReportGenerator`,
+`AnnualAccountsReportGenerator`, `ManagementLetterReportGenerator`,
+`BbvJaarstukkenReportGenerator`) MUST NOT `use` any `PhpOffice\PhpWord\*`
+class, construct `new PhpWord()`, call `IOFactory::createWriter()`, or resolve
+`\Dompdf\Dompdf` by any means (reflection, `class_exists`, or otherwise).
+`composer.json` MUST NOT declare `phpoffice/phpword` (per the binding
+ruling: "if we use docudesk as a leaf then we won't need PHPWord as a
+dependency" — PhpWord disappears, it is not re-declared).
+
+#### Scenario: Zero PhpOffice references in lib/
+
+- **GIVEN** the shillinq `lib/` tree after this change
+- **WHEN** `grep -rn "PhpOffice" lib/` is run
+- **THEN** it returns zero matches
+
+#### Scenario: composer.json carries no PhpWord dependency
+
+- **GIVEN** `composer.json`
+- **WHEN** its `require` and `require-dev` sections are inspected
+- **THEN** neither contains `phpoffice/phpword`
+
+### Requirement: REQ-RVD-002: A document generator SHALL assemble a structured report body and hand it to docudesk's `DocumentService::generateDocument()`; it MUST NOT render bytes itself
+
+A document report generator SHALL assemble its content as a `ReportSection`
+block tree and MUST NOT construct, serialise, or write any document/PDF
+bytes itself — rendering is docudesk's exclusive responsibility (ADR-075).
+
+Each of the five generators' `build(ReportSection $section, array $context)`
+method retains its existing OpenRegister object loading and business
+classification logic (account-type bucketing, GL-movement derivation,
+rule-audit summarisation, BBV programme/taakveld aggregation) unchanged, but
+writes into a `ReportSection` (an in-memory block accumulator) instead of a
+`PhpOffice\PhpWord\PhpWord` document. `AbstractDocumentReportGenerator::
+generate()` serialises the resulting block tree into
+`options.adHocData.report`, resolves the docudesk template id per REQ-RVD-004,
+and calls `OCA\DocuDesk\Service\DocumentService::generateDocument($templateId,
+[], $options)` (empty `dataRefs` — the computed body, not raw object refs,
+travels in `adHocData`, per ADR-081 rule 6: shillinq supplies context and
+classification, docudesk renders) resolved by string FQCN through
+`\OCP\Server::get()` — no compile-time `use` import of any `OCA\DocuDesk\*`
+class, no composer/info.xml dependency on docudesk.
+
+#### Scenario: A generator's build() output reaches docudesk's adHocData
+
+- **GIVEN** a `BalanceSheetReportGenerator` and a fake `DocumentService` whose
+  `generateDocument()` records the `$options` it was called with
+- **WHEN** `generate(['administrationId' => 'admin-1'], 'pdf')` is invoked
+  against fixture `Account` rows
+- **THEN** `$options['adHocData']['report']['blocks']` contains the
+  balance-sheet's activa/passiva amount-table blocks with the same figures
+  the OpenRegister fixture rows imply, and `$options['dataRefs']` is not
+  referenced by the call (the method signature's third positional argument
+  carries no raw `Account` refs)
+
+#### Scenario: The rendered file's bytes come from docudesk's response
+
+- **GIVEN** a fake `DocumentService::generateDocument()` returning
+  `['content' => 'FAKE-PDF-BYTES']`
+- **WHEN** a document generator's `generate()` is called with `format: 'pdf'`
+- **THEN** the returned `GeneratedFile->content` equals `'FAKE-PDF-BYTES'`
+  verbatim — the generator does not transform, wrap, or re-encode it
+
+### Requirement: REQ-RVD-003: Requested formats SHALL map to docudesk's supported vocabulary; `docx` output is no longer offered
+
+A document generator SHALL only offer formats docudesk's `DocumentService`
+actually supports (`pdf`, `odf`, mapped from the public `odt` label) and MUST
+NOT offer `docx`.
+
+`AbstractDocumentReportGenerator::supportedFormats()` returns `['odt', 'pdf']`
+(previously `['docx', 'odt', 'pdf']`). A requested format of `odt` maps to
+docudesk's `format: 'odf'` option value; `pdf` maps to `pdf` directly.
+`ReportCatalogue`'s five document-kind entries' `formats` arrays are updated
+to `['odt', 'pdf']`.
+
+#### Scenario: odt request maps to docudesk's odf format key
+
+- **GIVEN** a fake `DocumentService::generateDocument()` that records the
+  `$options['format']` it received
+- **WHEN** a document generator's `generate($context, 'odt')` is called
+- **THEN** the recorded `$options['format']` equals `'odf'`, and the returned
+  `GeneratedFile->format` equals `'odt'` (the public-facing label is
+  unchanged so existing download links/extensions keep working)
+
+#### Scenario: An unsupported format falls back to the first supported one
+
+- **GIVEN** a document generator
+- **WHEN** `generate($context, 'docx')` is called (no longer supported)
+- **THEN** the generator falls back to `'odt'` (the first entry of
+  `supportedFormats()`), matching the pre-existing fallback behaviour for any
+  unsupported format
+
+### Requirement: REQ-RVD-004: Template selection SHALL be config-first, namespace/category discovery second, and fail closed on zero or multiple matches
+
+For a given `reportType`, `selectTemplate()` first checks the `IAppConfig`
+key `documents_template_{reportType}` (an admin-set docudesk template UUID);
+when empty, it calls `TemplateService::getTemplatesByNamespace('shillinq')`
+and filters for `category === ReportCatalogue::byId($reportType)['templateId']`
+(e.g. `shillinq-balans` for `balance-sheet`). Exactly one match is used; zero
+or multiple matches MUST fail the generation attempt with a diagnostic naming
+the `(namespace, category)` pair searched — the generator MUST NOT guess
+between templates that produce official financial/statutory documents.
+
+#### Scenario: Configured template UUID wins over discovery
+
+- **GIVEN** `IAppConfig` holds `documents_template_balance-sheet =
+  "11111111-1111-1111-1111-111111111111"` and docudesk also has a discoverable
+  `namespace: shillinq, category: shillinq-balans` template with a different id
+- **WHEN** `selectTemplate()` runs for `balance-sheet`
+- **THEN** the configured UUID is used, and `TemplateService::
+  getTemplatesByNamespace()` is not consulted
+
+#### Scenario: Zero matching templates fails closed with a diagnostic
+
+- **GIVEN** no `IAppConfig` override and no docudesk template with
+  `namespace: shillinq, category: shillinq-balans`
+- **WHEN** `balance-sheet` generation is attempted
+- **THEN** the attempt fails with a message naming `shillinq` and
+  `shillinq-balans`, and `DocumentService::generateDocument()` is never called
+
+#### Scenario: Multiple matching templates fails closed rather than guessing
+
+- **GIVEN** two docudesk templates both with `namespace: shillinq, category:
+  shillinq-balans`
+- **WHEN** `balance-sheet` generation is attempted
+- **THEN** the attempt fails with a diagnostic naming both candidate ids, and
+  neither is rendered
+
+### Requirement: REQ-RVD-005: Docudesk's absence SHALL be a visible, distinguishable outcome — never a silent drop
+
+A document generator SHALL detect docudesk's absence before attempting to
+render, and the system MUST record and surface that outcome visibly and
+distinguishably from a generic failure — never as a silent drop (ADR-081
+rule 7).
+
+`AbstractDocumentReportGenerator::docudeskAvailable()` duck-type probes
+`IAppManager::isInstalled('docudesk')` plus resolvability of
+`OCA\DocuDesk\Service\{DocumentService,TemplateService}`. When false,
+`generate()` throws `OCA\Shillinq\Reporting\DocudeskUnavailableException`
+before any object loading or template lookup. `ReportGenerationService::
+generate()` catches this exception ahead of its generic `\Throwable` handler,
+writes a `GeneratedReport` record with `status: 'unavailable'` (added to the
+schema's `status` enum alongside `generating`/`ready`/`failed`), and returns
+`{error: 'docudesk-unavailable', reportType, message, record}`.
+`ReportingController::generate()` maps `error: 'docudesk-unavailable'` to
+`503 Service Unavailable` (other `{error}` envelopes keep the existing `422`).
+
+#### Scenario: Docudesk absent yields a visible unavailable record, not silence
+
+- **GIVEN** `docudeskAvailable()` returns `false` (docudesk not installed)
+- **WHEN** `POST /api/reporting/generate` is called for `balance-sheet`
+- **THEN** the response is `503` with `{error: 'docudesk-unavailable', ...}`,
+  AND a `GeneratedReport` object exists (findable via `listGenerated()`) with
+  `reportType: 'balance-sheet'` and `status: 'unavailable'` — the attempt is
+  recorded, not dropped
+
+#### Scenario: Docudesk absence is distinguishable from a generic generation failure
+
+- **GIVEN** two failure causes: (a) docudesk not installed, (b) a template
+  lookup throwing an unrelated exception
+- **WHEN** each is triggered via `generate()`
+- **THEN** (a) returns `error: 'docudesk-unavailable'` / HTTP 503 and writes a
+  `status: 'unavailable'` record, while (b) returns `error:
+  'generation-failed'` / HTTP 422 as before — the two causes are never
+  reported identically
+
+#### Scenario: Generator discovery no longer silently drops a generator
+
+- **GIVEN** `ReportGenerationService::generators()`'s glob-and-instantiate
+  discovery
+- **WHEN** every file under `lib/Reporting/Generator/*.php` is instantiated
+- **THEN** all five document generators are always present in the discovered
+  index regardless of docudesk's install state — docudesk availability is
+  checked lazily inside `generate()`, never at instantiation, so a docudesk
+  outage cannot make a report type vanish from `GET /api/reporting/types`
+
+### Requirement: REQ-RVD-006: Template content authoring is declared, not fabricated by the leaf
+
+This change SHALL declare the block vocabulary each of the five docudesk
+templates must render, and MUST NOT fabricate the docudesk-side Twig/HTML
+`content` itself — that is out of scope, handed back explicitly.
+
+`lib/Settings/docudesk-templates.json` gains five entries (`shillinq-balans`,
+`shillinq-winst-verlies`, `shillinq-jaarrekening`,
+`shillinq-management-letter`, `shillinq-bbv-jaarstukken`) documenting the
+`ReportSection` block vocabulary (`heading`/`text`/`textBreak`/`note`/
+`amountTable`/`detailsTable`/`table`) each corresponding docudesk
+`namespace: "shillinq"` Template object must be able to render. This change
+does NOT create those five docudesk Template objects (Twig/HTML `content`) —
+per hrmq's own `hrmq-docudesk-documents` precedent ("seeding starter
+templates into docudesk" is an explicit Non-Goal, "follow-up — cross-app
+write"), template content authoring is handed back as follow-up work.
+
+#### Scenario: Five new declarations exist and document the block vocabulary
+
+- **GIVEN** `lib/Settings/docudesk-templates.json`
+- **WHEN** parsed as JSON
+- **THEN** it contains one entry per `templateId` in
+  `['shillinq-balans', 'shillinq-winst-verlies', 'shillinq-jaarrekening',
+  'shillinq-management-letter', 'shillinq-bbv-jaarstukken']`, each describing
+  which `ReportSection` block types the corresponding report emits
+
+#### Scenario: No fabricated docudesk Template objects are claimed to exist
+
+- **GIVEN** this change's task list
+- **WHEN** inspected for a task claiming to create docudesk `template`-schema
+  OpenRegister objects
+- **THEN** no such task exists — REQ-RVD-004's zero-match fail-closed path is
+  the honest, current behaviour until a docudesk-side follow-up seeds the
+  five templates

--- a/openspec/changes/reports-via-docudesk/tasks.md
+++ b/openspec/changes/reports-via-docudesk/tasks.md
@@ -1,0 +1,148 @@
+# Tasks: reports-via-docudesk
+
+## Implementation Tasks
+
+### Task 1: Build the `ReportSection`/`ReportTable` block accumulators and `DocudeskUnavailableException`
+- **spec_ref**: `openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-002`
+- **files**: `lib/Reporting/ReportSection.php` (new), `lib/Reporting/ReportTable.php` (new),
+  `lib/Reporting/DocudeskUnavailableException.php` (new)
+- **acceptance_criteria**:
+  - GIVEN a `ReportSection` WHEN `addText()`, `addTextBreak()`, `addTitle()`,
+    `addTable()->addRow()->addCell()->addText()` are called in the same
+    sequence the PhpWord `Section`/`Table`/`Cell` API was previously called
+    THEN `toArray()` returns an ordered, JSON-serialisable block list
+    preserving that sequence and every text/style/width argument passed
+  - GIVEN `DocudeskUnavailableException` WHEN thrown and caught as
+    `\Throwable` THEN it carries a human-readable message and is
+    distinguishable via `instanceof` from any other exception type
+- [x] Implement
+- [x] Test
+
+### Task 2: Rewrite `AbstractDocumentReportGenerator` — remove PhpWord, add docudesk hand-off
+- **spec_ref**: `openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-001`, `#req-rvd-002`, `#req-rvd-003`, `#req-rvd-004`, `#req-rvd-005`
+- **files**: `lib/Reporting/Generator/AbstractDocumentReportGenerator.php`
+- **acceptance_criteria**:
+  - GIVEN the rewritten file WHEN `grep -n "PhpOffice" AbstractDocumentReportGenerator.php`
+    runs THEN it returns zero matches
+  - GIVEN `generate($context, $format)` WHEN docudesk is available and a
+    template resolves THEN it returns a `GeneratedFile` whose `content`
+    equals the fake `DocumentService::generateDocument()`'s `['content']`
+    verbatim, `format` maps `odt`→`odf`/`pdf`→`pdf` in the outgoing options,
+    and `dataRefs` passed is `[]` while `adHocData.report` carries the built
+    `ReportSection` tree
+  - GIVEN `docudeskAvailable()` is false WHEN `generate()` is called THEN it
+    throws `DocudeskUnavailableException` before any `loadObjects()` call
+    (proven by a spy/counting fake ObjectService recording zero invocations)
+  - GIVEN zero or multiple matching docudesk templates WHEN `generate()` is
+    called THEN it throws with a message naming the searched namespace/category
+    and `DocumentService::generateDocument()` is never invoked
+  - GIVEN `addHeading`/`addDetailsTable`/`addAmountTable`/`addParagraph`/
+    `addNote`/`addCover` WHEN called on a `ReportSection` THEN each produces
+    the block shape REQ-RVD-002/REQ-RVD-006 document (same semantic content
+    as their prior PhpWord-writing versions, e.g. an empty `addDetailsTable`
+    row set still yields the "Geen gegevens beschikbaar." note)
+- [x] Implement
+- [x] Test
+
+### Task 3: Port the five concrete generators onto `ReportSection`
+- **spec_ref**: `openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-001`, `#req-rvd-002`
+- **files**: `lib/Reporting/Generator/BalanceSheetReportGenerator.php`,
+  `lib/Reporting/Generator/ProfitLossReportGenerator.php`,
+  `lib/Reporting/Generator/AnnualAccountsReportGenerator.php`,
+  `lib/Reporting/Generator/ManagementLetterReportGenerator.php`,
+  `lib/Reporting/Generator/BbvJaarstukkenReportGenerator.php`
+- **acceptance_criteria**:
+  - GIVEN each file WHEN `grep -n "PhpOffice" <file>` runs THEN it returns
+    zero matches, and `build()`'s first parameter is typed `ReportSection`
+    (no `PhpWord`/`Section` import remains)
+  - GIVEN `BbvJaarstukkenReportGenerator`'s two hand-rolled tables (programme
+    list, taakveld list) WHEN rendered through the new `ReportTable` THEN
+    they carry the same rows/columns/values as before, with
+    `\PhpOffice\PhpWord\Shared\Converter::cmToTwip(N)` calls replaced by
+    plain numeric width hints
+  - GIVEN each generator's existing OpenRegister loading/classification
+    logic (account bucketing, GL-movement derivation, rule-audit
+    summarisation, BBV programme/taakveld/fixed-asset aggregation) WHEN
+    exercised against the same fixture rows as before THEN it produces
+    numerically identical figures — this task changes rendering, not
+    business logic
+- [x] Implement
+- [x] Test
+
+### Task 4: Wire format mapping and the catalogue's `templateId` into discovery; drop `docx`
+- **spec_ref**: `openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-003`, `#req-rvd-004`
+- **files**: `lib/Reporting/ReportCatalogue.php`, `lib/Reporting/ReportGeneratorInterface.php`
+- **acceptance_criteria**:
+  - GIVEN `ReportCatalogue::REPORTS` WHEN inspected THEN the five
+    document-kind entries' `formats` arrays are `['odt', 'pdf']`
+    (previously `['docx', 'odt', 'pdf']`), and each entry's existing
+    `templateId` value is unchanged (now consumed by `selectTemplate()`)
+  - GIVEN `ReportGeneratorInterface`'s docblock WHEN read THEN it describes
+    the docudesk hand-off, not "PHPOffice libraries bundled in OpenRegister"
+- [x] Implement
+- [x] Test
+
+### Task 5: `ReportGenerationService` — visible, distinguishable docudesk-unavailable outcome
+- **spec_ref**: `openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-005`
+- **files**: `lib/Reporting/ReportGenerationService.php`,
+  `lib/Settings/register.d/reporting-generated-report.json`
+- **acceptance_criteria**:
+  - GIVEN `generate()`'s try/catch around `$generator->generate()` WHEN a
+    `DocudeskUnavailableException` is thrown THEN a `GeneratedReport` record
+    is saved with `status: 'unavailable'` BEFORE the method returns, and the
+    returned array is `{error: 'docudesk-unavailable', reportType, message,
+    record}` — distinct from the generic `{error: 'generation-failed'}` path
+    for any other `\Throwable`
+  - GIVEN `reporting-generated-report.json`'s `GeneratedReport.status` enum
+    WHEN inspected THEN it is `['generating', 'ready', 'failed',
+    'unavailable']` and the schema `version` is bumped
+  - GIVEN a second, unrelated exception type thrown from a generator WHEN
+    `generate()` is called THEN the existing `{error: 'generation-failed'}` /
+    no-record behaviour is unchanged (regression check)
+- [x] Implement
+- [x] Test
+
+### Task 6: `ReportingController` — map `docudesk-unavailable` to 503
+- **spec_ref**: `openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-005`
+- **files**: `lib/Controller/ReportingController.php`
+- **acceptance_criteria**:
+  - GIVEN `generate()`'s existing `if (isset($result['error'])) { return new
+    JSONResponse($result, Http::STATUS_UNPROCESSABLE_ENTITY); }` WHEN
+    `$result['error'] === 'docudesk-unavailable'` THEN the status code is
+    `Http::STATUS_SERVICE_UNAVAILABLE` (503) instead; every other `{error}`
+    envelope keeps `422`
+- [x] Implement
+- [x] Test
+
+### Task 7: Declare the five report templates in `docudesk-templates.json`; hand back content authoring
+- **spec_ref**: `openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-006`
+- **files**: `lib/Settings/docudesk-templates.json`
+- **acceptance_criteria**:
+  - GIVEN the file WHEN parsed as JSON THEN it contains the five new
+    `templateId` entries listed in REQ-RVD-006, each documenting the block
+    vocabulary its docudesk Template must render
+  - GIVEN this tasks.md WHEN read THEN no task claims to create the docudesk
+    `template`-schema OpenRegister objects themselves — that is explicitly
+    out of scope (design.md D5)
+- [x] Implement
+- [x] Test
+
+### Task 8: Verification sweep
+- **spec_ref**: `openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-001`
+- **files**: (verification only, no source changes)
+- **acceptance_criteria**:
+  - GIVEN the finished change WHEN `grep -rn "PhpOffice" lib/` runs THEN it
+    returns zero matches
+  - GIVEN every changed `.php` file WHEN `php -l` runs against each THEN
+    every file reports "No syntax errors detected"
+  - GIVEN the reporting namespace's PHPUnit suite WHEN
+    `vendor/bin/phpunit -c phpunit-unit.xml --filter Report` runs THEN the
+    full tally (not a truncated subset) is read and reported, including the
+    new docudesk-absent visible-outcome test
+  - GIVEN the hydra gate runner WHEN invoked with
+    `HYDRA_GATE_BASE_REF=origin/development` against this branch THEN its
+    output is captured and reported (pass/fail per gate, not summarised away)
+  - GIVEN `openspec validate reports-via-docudesk --strict` WHEN run THEN it
+    passes
+- [x] Implement
+- [x] Test

--- a/tests/Unit/Reporting/AbstractDocumentReportGeneratorTest.php
+++ b/tests/Unit/Reporting/AbstractDocumentReportGeneratorTest.php
@@ -1,0 +1,310 @@
+<?php
+
+/**
+ * Unit tests for AbstractDocumentReportGenerator's docudesk hand-off.
+ *
+ * Proves reports-via-docudesk REQ-RVD-002 (the built ReportSection tree
+ * reaches docudesk's adHocData, and the returned bytes come from docudesk
+ * verbatim), REQ-RVD-003 (odt/pdf format mapping to docudesk's odf/pdf
+ * vocabulary), REQ-RVD-004 (config-first/discovery-second/fail-closed
+ * template selection) and REQ-RVD-005 (docudesk's absence throws
+ * DocudeskUnavailableException BEFORE any object loading -- a visible,
+ * distinguishable outcome, never a silent drop). Exercised through a minimal
+ * anonymous subclass rather than one of the five concrete generators, since
+ * they are `final` and this suite targets the shared base's own hand-off
+ * logic, decoupled from any one report's business classification.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Reporting
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-002
+ * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-003
+ * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-004
+ * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-005
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters, PEAR.Commenting.FunctionComment, Squiz.PHP.DisallowInlineIf
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Reporting;
+
+use OCA\Shillinq\Reporting\DocudeskUnavailableException;
+use OCA\Shillinq\Reporting\Generator\AbstractDocumentReportGenerator;
+use OCA\Shillinq\Reporting\ReportSection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A fake docudesk DocumentService recording the call it received.
+ */
+final class FakeAdrgDocumentService {
+
+	/**
+	 * @var array{templateId: string, dataRefs: array<mixed>, options: array<string, mixed>}|null
+	 */
+	public ?array $lastCall = null;
+
+	/**
+	 * @param array<string, mixed> $response The response generateDocument() returns.
+	 */
+	public function __construct(
+		private readonly array $response = ['content' => 'FAKE-PDF-BYTES'],
+	) {
+
+	}//end __construct()
+
+	/**
+	 * @param string $templateId The template id.
+	 * @param array<mixed> $dataRefs The data refs.
+	 * @param array<string, mixed> $options The options.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function generateDocument(string $templateId, array $dataRefs, array $options = []): array {
+		$this->lastCall = ['templateId' => $templateId, 'dataRefs' => $dataRefs, 'options' => $options];
+		return $this->response;
+	}//end generateDocument()
+}//end class
+
+/**
+ * A fake docudesk TemplateService returning a configured template list.
+ */
+final class FakeAdrgTemplateService {
+
+	/**
+	 * @param array<int, array<string, mixed>> $templates The templates getTemplatesByNamespace() returns.
+	 */
+	public function __construct(
+		private readonly array $templates = [],
+	) {
+
+	}//end __construct()
+
+	/**
+	 * @param string $namespace The namespace.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function getTemplatesByNamespace(string $namespace): array {
+		return $this->templates;
+	}//end getTemplatesByNamespace()
+}//end class
+
+/**
+ * A minimal concrete generator exercising the base's default block vocabulary.
+ */
+final class FixtureDocumentReportGenerator extends AbstractDocumentReportGenerator {
+
+	/**
+	 * Counts loadObjects() invocations -- proves the availability check runs
+	 * BEFORE any object loading (REQ-RVD-005).
+	 *
+	 * @var int
+	 */
+	public int $loadObjectsCalls = 0;
+
+	private bool $docudeskUp;
+	private ?FakeAdrgDocumentService $fakeDocumentService;
+	private ?FakeAdrgTemplateService $fakeTemplateService;
+	private string $configuredId;
+
+	public function __construct(
+		bool $docudeskUp = true,
+		?FakeAdrgDocumentService $fakeDocumentService = null,
+		?FakeAdrgTemplateService $fakeTemplateService = null,
+		string $configuredId = '',
+	) {
+		$this->docudeskUp = $docudeskUp;
+		$this->fakeDocumentService = $fakeDocumentService ?? new FakeAdrgDocumentService();
+		$this->fakeTemplateService = $fakeTemplateService ?? new FakeAdrgTemplateService([
+			['id' => 'tpl-1', 'category' => 'shillinq-balans'],
+		]);
+		$this->configuredId = $configuredId;
+
+	}//end __construct()
+
+	public static function reportType(): string {
+		return 'balance-sheet';
+	}//end reportType()
+
+	protected function documentTitle(): string {
+		return 'Balans';
+	}//end documentTitle()
+
+	protected function build(ReportSection $section, array $context): void {
+		$this->addCover($section, 'Balans', 'Balans per peildatum', $context);
+		$this->addHeading($section, 'Activa');
+		$this->addAmountTable(
+			$section,
+			'Rekening',
+			'Saldo',
+			[['label' => '1300 Debiteuren', 'amount' => 1000.0]],
+			['label' => 'Totaal activa', 'amount' => 1000.0],
+			'EUR'
+		);
+
+	}//end build()
+
+	protected function docudeskAvailable(): bool {
+		return $this->docudeskUp;
+	}//end docudeskAvailable()
+
+	protected function documentService(): object {
+		return $this->fakeDocumentService;
+	}//end documentService()
+
+	protected function templateService(): object {
+		return $this->fakeTemplateService;
+	}//end templateService()
+
+	protected function configuredTemplateId(string $reportType): string {
+		return $this->configuredId;
+	}//end configuredTemplateId()
+
+	protected function loadObjects(string $schema, array $filters = [], int $limit = 10000): array {
+		$this->loadObjectsCalls++;
+		return [];
+	}//end loadObjects()
+}//end class
+
+/**
+ * Tests AbstractDocumentReportGenerator's docudesk hand-off.
+ */
+final class AbstractDocumentReportGeneratorTest extends TestCase {
+
+	/**
+	 * REQ-RVD-002: the built ReportSection tree reaches adHocData, and the
+	 * returned GeneratedFile content is docudesk's response verbatim.
+	 */
+	public function testBuiltSectionReachesAdHocDataAndBytesAreVerbatim(): void {
+		$documentService = new FakeAdrgDocumentService(['content' => 'FAKE-PDF-BYTES']);
+		$generator = new FixtureDocumentReportGenerator(true, $documentService);
+
+		$file = $generator->generate(['administrationId' => 'admin-1', 'period' => '2026'], 'pdf');
+
+		$this->assertSame('FAKE-PDF-BYTES', $file->content);
+		$this->assertNotNull($documentService->lastCall);
+		$this->assertSame([], $documentService->lastCall['dataRefs']);
+
+		$blocks = $documentService->lastCall['options']['adHocData']['report']['blocks'];
+		$amountTableBlocks = array_values(array_filter($blocks, static fn (array $b): bool => $b['type'] === 'amountTable'));
+		$this->assertNotEmpty($amountTableBlocks);
+		$this->assertSame('1300 Debiteuren', $amountTableBlocks[0]['lines'][0]['label']);
+		$this->assertSame(1000.0, $amountTableBlocks[0]['lines'][0]['amount']);
+	}//end testBuiltSectionReachesAdHocDataAndBytesAreVerbatim()
+
+	/**
+	 * REQ-RVD-003: 'odt' maps to docudesk's 'odf' format key; the returned
+	 * GeneratedFile keeps the public-facing 'odt' label.
+	 */
+	public function testOdtMapsToDocudeskOdfFormat(): void {
+		$documentService = new FakeAdrgDocumentService();
+		$generator = new FixtureDocumentReportGenerator(true, $documentService);
+
+		$file = $generator->generate([], 'odt');
+
+		$this->assertSame('odf', $documentService->lastCall['options']['format']);
+		$this->assertSame('odt', $file->format);
+	}//end testOdtMapsToDocudeskOdfFormat()
+
+	/**
+	 * REQ-RVD-003: an unsupported format ('docx', no longer offered) falls
+	 * back to the first supported format.
+	 */
+	public function testUnsupportedFormatFallsBackToFirstSupported(): void {
+		$generator = new FixtureDocumentReportGenerator(true);
+
+		$file = $generator->generate([], 'docx');
+
+		$this->assertSame(AbstractDocumentReportGenerator::supportedFormats()[0], $file->format);
+	}//end testUnsupportedFormatFallsBackToFirstSupported()
+
+	/**
+	 * REQ-RVD-005: docudesk absent throws DocudeskUnavailableException BEFORE
+	 * any object loading -- a visible, distinguishable outcome, not silence.
+	 */
+	public function testDocudeskAbsentThrowsBeforeAnyObjectLoading(): void {
+		$generator = new FixtureDocumentReportGenerator(false);
+
+		$this->expectException(DocudeskUnavailableException::class);
+
+		try {
+			$generator->generate([], 'pdf');
+		} finally {
+			$this->assertSame(0, $generator->loadObjectsCalls, 'build() must not run when docudesk is unavailable');
+		}
+	}//end testDocudeskAbsentThrowsBeforeAnyObjectLoading()
+
+	/**
+	 * REQ-RVD-004: zero matching templates fails closed with a diagnostic
+	 * naming the searched namespace/category; DocumentService is never called.
+	 */
+	public function testZeroMatchingTemplatesFailsClosed(): void {
+		$documentService = new FakeAdrgDocumentService();
+		$templateService = new FakeAdrgTemplateService([]);
+		$generator = new FixtureDocumentReportGenerator(true, $documentService, $templateService);
+
+		try {
+			$generator->generate([], 'pdf');
+			$this->fail('Expected a RuntimeException for zero matching templates.');
+		} catch (\RuntimeException $e) {
+			$this->assertStringContainsString('shillinq', $e->getMessage());
+			$this->assertStringContainsString('shillinq-balans', $e->getMessage());
+		}
+
+		$this->assertNull($documentService->lastCall, 'generateDocument() must not be called when no template matches.');
+	}//end testZeroMatchingTemplatesFailsClosed()
+
+	/**
+	 * REQ-RVD-004: multiple matching templates fails closed rather than
+	 * guessing between templates that produce official documents.
+	 */
+	public function testMultipleMatchingTemplatesFailsClosed(): void {
+		$documentService = new FakeAdrgDocumentService();
+		$templateService = new FakeAdrgTemplateService([
+			['id' => 'tpl-1', 'category' => 'shillinq-balans'],
+			['id' => 'tpl-2', 'category' => 'shillinq-balans'],
+		]);
+		$generator = new FixtureDocumentReportGenerator(true, $documentService, $templateService);
+
+		try {
+			$generator->generate([], 'pdf');
+			$this->fail('Expected a RuntimeException for multiple matching templates.');
+		} catch (\RuntimeException $e) {
+			$this->assertStringContainsString('tpl-1', $e->getMessage());
+			$this->assertStringContainsString('tpl-2', $e->getMessage());
+		}
+
+		$this->assertNull($documentService->lastCall);
+	}//end testMultipleMatchingTemplatesFailsClosed()
+
+	/**
+	 * REQ-RVD-004: a configured template UUID wins over namespace/category
+	 * discovery -- TemplateService is never consulted.
+	 */
+	public function testConfiguredTemplateIdWinsOverDiscovery(): void {
+		$documentService = new FakeAdrgDocumentService();
+		$templateService = new FakeAdrgTemplateService([
+			['id' => 'discovered-id', 'category' => 'shillinq-balans'],
+		]);
+		$generator = new FixtureDocumentReportGenerator(
+			true,
+			$documentService,
+			$templateService,
+			'11111111-1111-1111-1111-111111111111'
+		);
+
+		$generator->generate([], 'pdf');
+
+		$this->assertSame('11111111-1111-1111-1111-111111111111', $documentService->lastCall['templateId']);
+	}//end testConfiguredTemplateIdWinsOverDiscovery()
+}//end class

--- a/tests/Unit/Reporting/ReportGenerationServiceTest.php
+++ b/tests/Unit/Reporting/ReportGenerationServiceTest.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * Unit tests for ReportGenerationService's docudesk-unavailable handling.
+ *
+ * Proves reports-via-docudesk REQ-RVD-005 (ADR-081 rule 7): when a document
+ * generator throws DocudeskUnavailableException, ReportGenerationService::
+ * generate() records a GeneratedReport with `status: 'unavailable'` BEFORE
+ * returning, and the returned envelope carries the distinguishable
+ * `error: 'docudesk-unavailable'` code -- distinct from the generic
+ * `error: 'generation-failed'` / no-record path any OTHER exception type
+ * still takes (regression check). Before this change, EVERY generator
+ * exception -- including a docudesk-absent probe failure -- collapsed into
+ * the undiagnostic generic path with no record written at all.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Reporting
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/reports-via-docudesk/specs/reports-via-docudesk/spec.md#req-rvd-005
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters, PEAR.Commenting.FunctionComment, Squiz.PHP.DisallowInlineIf
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Reporting;
+
+use OCA\Shillinq\Reporting\DocudeskUnavailableException;
+use OCA\Shillinq\Reporting\GeneratedFile;
+use OCA\Shillinq\Reporting\ReportGenerationService;
+use OCA\Shillinq\Reporting\ReportGeneratorInterface;
+use OCP\Files\IRootFolder;
+use OCP\IUser;
+use OCP\IUserSession;
+use OCP\SystemTag\ISystemTagManager;
+use OCP\SystemTag\ISystemTagObjectMapper;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\NullLogger;
+use ReflectionClass;
+
+/**
+ * A fake OpenRegister ObjectService capturing every saveObject() call.
+ */
+final class FakeRgsObjectService {
+
+	/**
+	 * @var array<int, array{object: array<string, mixed>, register: string, schema: string}>
+	 */
+	public array $saved = [];
+
+	/**
+	 * @param array<string, mixed> $object The record.
+	 * @param string $register The register slug.
+	 * @param string $schema The schema slug.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function saveObject(array $object, string $register, string $schema): array {
+		$this->saved[] = ['object' => $object, 'register' => $register, 'schema' => $schema];
+		return array_merge($object, ['id' => 'saved-' . count($this->saved)]);
+	}//end saveObject()
+}//end class
+
+/**
+ * A minimal PSR container resolving only the OpenRegister ObjectService.
+ */
+final class FakeRgsContainer implements ContainerInterface {
+
+	/**
+	 * @param FakeRgsObjectService $objectService The fake ObjectService.
+	 */
+	public function __construct(
+		private FakeRgsObjectService $objectService,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * @param string $id Service id.
+	 *
+	 * @return mixed
+	 */
+	public function get(string $id): mixed {
+		if ($id === 'OCA\\OpenRegister\\Service\\ObjectService') {
+			return $this->objectService;
+		}
+
+		throw new \RuntimeException('Unknown service: ' . $id);
+	}//end get()
+
+	/**
+	 * @param string $id Service id.
+	 *
+	 * @return bool
+	 */
+	public function has(string $id): bool {
+		return $id === 'OCA\\OpenRegister\\Service\\ObjectService';
+	}//end has()
+}//end class
+
+/**
+ * A generator stub that always throws the given exception.
+ */
+final class ThrowingGenerator implements ReportGeneratorInterface {
+
+	/**
+	 * @param \Throwable $exception The exception generate() throws.
+	 */
+	public function __construct(
+		private readonly \Throwable $exception,
+	) {
+
+	}//end __construct()
+
+	public static function reportType(): string {
+		return 'balance-sheet';
+	}//end reportType()
+
+	public static function supportedFormats(): array {
+		return ['odt', 'pdf'];
+	}//end supportedFormats()
+
+	public function generate(array $context, string $format): GeneratedFile {
+		throw $this->exception;
+	}//end generate()
+}//end class
+
+/**
+ * Tests ReportGenerationService's docudesk-unavailable outcome.
+ */
+final class ReportGenerationServiceTest extends TestCase {
+
+	/**
+	 * Build a service wired to a fake container/objectService, with the
+	 * generator index pre-seeded via reflection (bypassing glob discovery,
+	 * which only scans real files under lib/Reporting/Generator/).
+	 *
+	 * @param ReportGeneratorInterface $generator The single generator to seed under its reportType().
+	 * @param FakeRgsObjectService $objectService The fake ObjectService (for assertions).
+	 *
+	 * @return ReportGenerationService
+	 */
+	private function service(ReportGeneratorInterface $generator, FakeRgsObjectService $objectService): ReportGenerationService {
+		$userSession = $this->createMock(IUserSession::class);
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$userSession->method('getUser')->willReturn($user);
+
+		$service = new ReportGenerationService(
+			new FakeRgsContainer($objectService),
+			$this->createMock(IRootFolder::class),
+			$this->createMock(ISystemTagManager::class),
+			$this->createMock(ISystemTagObjectMapper::class),
+			$userSession,
+			new NullLogger(),
+		);
+
+		$reflection = new ReflectionClass($service);
+		$property = $reflection->getProperty('generators');
+		$property->setAccessible(true);
+		$property->setValue($service, [$generator::reportType() => $generator]);
+
+		return $service;
+	}//end service()
+
+	/**
+	 * REQ-RVD-005: docudesk-unavailable is a visible, distinguishable outcome.
+	 */
+	public function testDocudeskUnavailableRecordsVisibleStatusAndDistinctError(): void {
+		$objectService = new FakeRgsObjectService();
+		$generator = new ThrowingGenerator(new DocudeskUnavailableException('docudesk not installed'));
+		$service = $this->service($generator, $objectService);
+
+		$result = $service->generate('balance-sheet', '2026', 'admin-1', 'pdf');
+
+		$this->assertSame('docudesk-unavailable', $result['error']);
+		$this->assertArrayHasKey('record', $result);
+
+		$this->assertCount(1, $objectService->saved, 'A GeneratedReport record must be saved for a docudesk-unavailable attempt.');
+		$this->assertSame('unavailable', $objectService->saved[0]['object']['status']);
+		$this->assertSame('balance-sheet', $objectService->saved[0]['object']['reportType']);
+		$this->assertSame('GeneratedReport', $objectService->saved[0]['schema']);
+	}//end testDocudeskUnavailableRecordsVisibleStatusAndDistinctError()
+
+	/**
+	 * Regression: any OTHER exception type keeps the pre-existing generic
+	 * behaviour -- no record written, `error: 'generation-failed'`.
+	 */
+	public function testOtherExceptionKeepsGenericBehaviourAndWritesNoRecord(): void {
+		$objectService = new FakeRgsObjectService();
+		$generator = new ThrowingGenerator(new \RuntimeException('template lookup exploded'));
+		$service = $this->service($generator, $objectService);
+
+		$result = $service->generate('balance-sheet', '2026', 'admin-1', 'pdf');
+
+		$this->assertSame('generation-failed', $result['error']);
+		$this->assertCount(0, $objectService->saved, 'A generic generation failure must not write a GeneratedReport record.');
+	}//end testOtherExceptionKeepsGenericBehaviourAndWritesNoRecord()
+}//end class


### PR DESCRIPTION
## The defect
`AbstractDocumentReportGenerator` did `use PhpOffice\PhpWord\...` and `new PhpWord()` — but **`phpoffice/phpword` was in neither shillinq's composer.json nor its vendor/**. It resolved only because `openregister/vendor/` and `docudesk/vendor/` happen to be autoloaded on the same instance. ADR-075 D3 bans this by name ("loading another app's vendor directory") and already listed "shillinq (OR vendor-dir reach)" as a known violation. Blast radius: `POST /api/reporting/generate` → Balance Sheet, P&L, Annual Accounts, Management Letter, BBV Jaarstukken. Worse, `ReportGenerationService` caught the resulting `\Error` and logged it, so the failure mode was **a report that silently never appears**, invisible to `composer audit` and to ADR-093's cooldown.

## The fix
- PhpWord replaced by `ReportSection`/`ReportTable`/`ReportTableCell` block accumulators with the same call shape, so the 5 concrete generators' business logic ported with import/type-hint edits only — no logic changes. **`grep -rn "PhpOffice" lib/` → zero matches**, and `phpoffice/phpword` is *not* re-added to composer.json (per the user's ruling: with docudesk as the channel the dependency disappears rather than being declared).
- Hand-off follows hrmq's proven `payslip-pdf-docudesk` pattern (duck-typed FQCN, config-first/discovery-second/fail-closed template selection): `DocumentService::generateDocument(templateId, dataRefs, options)`, formats `pdf|odf|html` (docudesk has no `docx`, so `docx` output is dropped from `ReportCatalogue`).
- **Silent failure → visible state** (ADR-081 rule 7, quoted in the spec): docudesk absence throws before any object loading; the service records a `GeneratedReport` with `status: 'unavailable'` and returns a distinguishable `docudesk-unavailable`; the controller maps it to **503** instead of a blanket 422. Tests assert the throw happens before object load, that the record is visible and distinguishable, and a regression test keeps other exceptions on the old generic path.

## Deliberately not done
The 5 docudesk Template objects (Twig content) were **not fabricated here**. Investigation found `docudesk-templates.json` is a design-intent declaration that nothing mechanically imports, and its shape doesn't match docudesk's real `template` schema; hrmq's own design lists template seeding as an explicit non-goal. Declared the 5 entries documenting each report's block vocabulary and handed template authoring back to docudesk. Until it lands, `selectTemplate()`'s zero-match path fails closed with a diagnostic — visible, not silent.

Verification: `grep PhpOffice lib/` zero · PHPUnit `--filter Report` **184 tests / 636 assertions / 0 failures** · `php -l` clean on 16 files · hydra gates **62/62 applicable green** · `openspec validate --strict` valid.

Known gap (pre-existing, stated not hidden): no per-generator numeric regression fixtures for the 5 report types — none existed before either; the port was verified as mechanical by diff review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)