### PR TITLE
test(three-way-match): close three guard-coverage gaps (both directions, controls proven)

### DIFF
--- a/tests/Unit/Controller/ThreeWayMatchAuditControllerTest.php
+++ b/tests/Unit/Controller/ThreeWayMatchAuditControllerTest.php
@@ -1,0 +1,553 @@
+<?php
+
+/**
+ * Unit tests for ThreeWayMatchAuditController.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/bookkeeping-purchase-order-3way-11-audit-trail-export/tasks.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\ThreeWayMatchAuditController;
+use OCA\Shillinq\Service\AdministrationContextService;
+use OCA\Shillinq\Service\AuditExportService;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests the two read-only audit-trail endpoints (ledger, export) for: the
+ * anonymous refusal, the required administration scope, the cross-tenant
+ * 404 mask (ADR-005) — with the downstream service proven unreached — the
+ * required invoiceId, the missing-invoice 404, the service-refusal mapping
+ * and the no-stack-trace 500.
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+final class ThreeWayMatchAuditControllerTest extends TestCase {
+
+	/**
+	 * Mock IRequest.
+	 *
+	 * @var IRequest&MockObject
+	 */
+	private IRequest&MockObject $request;
+
+	/**
+	 * Mock AuditExportService.
+	 *
+	 * @var AuditExportService&MockObject
+	 */
+	private AuditExportService&MockObject $auditExportService;
+
+	/**
+	 * Mock AdministrationContextService (IDOR + tenant scope).
+	 *
+	 * @var AdministrationContextService&MockObject
+	 */
+	private AdministrationContextService&MockObject $administrationContext;
+
+	/**
+	 * Mock IUserSession.
+	 *
+	 * @var IUserSession&MockObject
+	 */
+	private IUserSession&MockObject $userSession;
+
+	/**
+	 * Mock DI container (lazy OR ObjectService).
+	 *
+	 * @var ContainerInterface&MockObject
+	 */
+	private ContainerInterface&MockObject $container;
+
+	/**
+	 * Mock LoggerInterface.
+	 *
+	 * @var LoggerInterface&MockObject
+	 */
+	private LoggerInterface&MockObject $logger;
+
+	/**
+	 * The user the session reports; null models an anonymous caller.
+	 *
+	 * @var IUser|null
+	 */
+	private ?IUser $currentUser = null;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var ThreeWayMatchAuditController
+	 */
+	private ThreeWayMatchAuditController $controller;
+
+	/**
+	 * Set up test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->request = $this->createMock(IRequest::class);
+		$this->auditExportService = $this->createMock(AuditExportService::class);
+		$this->administrationContext = $this->createMock(AdministrationContextService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->container = $this->createMock(ContainerInterface::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->currentUser = $user;
+
+		$this->userSession->method('getUser')->willReturnCallback(
+			function (): ?IUser {
+				return $this->currentUser;
+			}
+		);
+
+		$this->controller = new ThreeWayMatchAuditController(
+			request: $this->request,
+			auditExportService: $this->auditExportService,
+			administrationContext: $this->administrationContext,
+			userSession: $this->userSession,
+			container: $this->container,
+			logger: $this->logger,
+		);
+
+	}//end setUp()
+
+	/**
+	 * Configure request params from a key => value map.
+	 *
+	 * @param array<string,mixed> $map Param map.
+	 *
+	 * @return void
+	 */
+	private function withParams(array $map): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($map): mixed {
+				return ($map[$key] ?? $default);
+			}
+		);
+
+	}//end withParams()
+
+	/**
+	 * A schema-aware fake OCA\OpenRegister\Service\ObjectService: findAll
+	 * returns the canned records for the last setSchema().
+	 *
+	 * @param array<string, array<int, array<string, mixed>>> $bySchema Records per schema.
+	 *
+	 * @return object
+	 */
+	private function makeObjectService(array $bySchema): object {
+		return new class($bySchema) {
+			/**
+			 * Canned records keyed by schema.
+			 *
+			 * @var array<string, array<int, array<string, mixed>>>
+			 */
+			public array $bySchema;
+
+			/**
+			 * Current schema selected by setSchema().
+			 *
+			 * @var string
+			 */
+			public string $schema = '';
+
+			/**
+			 * @param array<string, array<int, array<string, mixed>>> $bySchema Records per schema.
+			 */
+			public function __construct(array $bySchema) {
+				$this->bySchema = $bySchema;
+			}//end __construct()
+
+			/**
+			 * @param string $_register Ignored.
+			 *
+			 * @return self
+			 */
+			public function setRegister(string $_register): self {
+				return $this;
+			}//end setRegister()
+
+			/**
+			 * @param string $schema Selected schema.
+			 *
+			 * @return self
+			 */
+			public function setSchema(string $schema): self {
+				$this->schema = $schema;
+				return $this;
+			}//end setSchema()
+
+			/**
+			 * @param array<string, mixed> $_filters Ignored.
+			 *
+			 * @return array<int, array<string, mixed>>
+			 */
+			public function findAll(array $_filters = []): array {
+				return ($this->bySchema[$this->schema] ?? []);
+			}//end findAll()
+		};
+
+	}//end makeObjectService()
+
+	/**
+	 * A valid ledger read returns 200 with the built ledger payload.
+	 *
+	 * @return void
+	 */
+	public function testLedgerReturns200WithLedgerPayload(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'invoiceId' => 'inv-9']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+
+		$objectService = $this->makeObjectService(
+			[
+				'SupplierInvoice' => [['id' => 'inv-9', 'administrationId' => 'adm-1', 'invoiceNumber' => 'INV-9']],
+				'ThreeWayMatch' => [],
+			]
+		);
+		$this->container->method('get')->willReturn($objectService);
+
+		$this->auditExportService->expects($this->once())
+			->method('buildLedger')
+			->willReturnCallback(
+				static function (array $bundle): array {
+					return [
+						'events' => [],
+						'summary' => ['invoiceId' => (string)$bundle['invoice']['id']],
+					];
+				}
+			);
+
+		$response = $this->controller->ledger();
+
+		self::assertInstanceOf(JSONResponse::class, $response);
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertSame('inv-9', $response->getData()['summary']['invoiceId']);
+
+	}//end testLedgerReturns200WithLedgerPayload()
+
+	/**
+	 * An anonymous ledger read is refused with 401 and never reaches the
+	 * export service.
+	 *
+	 * @return void
+	 */
+	public function testLedgerRejectsAnonymousCaller(): void {
+		$this->currentUser = null;
+		$this->auditExportService->expects($this->never())->method('buildLedger');
+
+		$response = $this->controller->ledger();
+
+		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		self::assertSame(['error' => 'Not logged in'], $response->getData());
+
+	}//end testLedgerRejectsAnonymousCaller()
+
+	/**
+	 * A missing administrationId is a 400 — the read is never unscoped.
+	 *
+	 * @return void
+	 */
+	public function testLedgerRequiresAdministrationId(): void {
+		$this->withParams(['invoiceId' => 'inv-9']);
+		$this->auditExportService->expects($this->never())->method('buildLedger');
+
+		$response = $this->controller->ledger();
+
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		self::assertSame(['error' => 'administrationId is required'], $response->getData());
+
+	}//end testLedgerRequiresAdministrationId()
+
+	/**
+	 * Reading the ledger inside another tenant's administration is masked
+	 * as 404 (ADR-005) and the export service is never reached — proving
+	 * the guard short-circuits rather than merely matching the status code.
+	 *
+	 * @return void
+	 */
+	public function testLedgerForeignAdministrationReturns404(): void {
+		$this->withParams(['administrationId' => 'adm-other', 'invoiceId' => 'inv-9']);
+		$this->administrationContext->method('canAccess')->willReturn(false);
+
+		// The invoice DOES exist and IS otherwise loadable — isolates the
+		// assertion to the administration guard rather than a coincidental
+		// "invoice not found" from an unconfigured container/ObjectService.
+		$objectService = $this->makeObjectService(
+			[
+				'SupplierInvoice' => [['id' => 'inv-9', 'administrationId' => 'adm-other', 'invoiceNumber' => 'INV-9']],
+				'ThreeWayMatch' => [],
+			]
+		);
+		$this->container->method('get')->willReturn($objectService);
+		$this->auditExportService->expects($this->never())->method('buildLedger');
+
+		$response = $this->controller->ledger();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame(['error' => 'Supplier invoice not found'], $response->getData());
+
+	}//end testLedgerForeignAdministrationReturns404()
+
+	/**
+	 * A missing invoiceId is a 400.
+	 *
+	 * @return void
+	 */
+	public function testLedgerRequiresInvoiceId(): void {
+		$this->withParams(['administrationId' => 'adm-1']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+		$this->auditExportService->expects($this->never())->method('buildLedger');
+
+		$response = $this->controller->ledger();
+
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		self::assertSame(['error' => 'invoiceId is required'], $response->getData());
+
+	}//end testLedgerRequiresInvoiceId()
+
+	/**
+	 * A ledger read for an invoice that does not exist (in-scope but
+	 * absent) is masked as 404, matching the cross-tenant response so a
+	 * probe cannot distinguish "wrong tenant" from "no such invoice".
+	 *
+	 * @return void
+	 */
+	public function testLedgerUnknownInvoiceReturns404(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'invoiceId' => 'inv-missing']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+
+		$objectService = $this->makeObjectService(['SupplierInvoice' => []]);
+		$this->container->method('get')->willReturn($objectService);
+		$this->auditExportService->expects($this->never())->method('buildLedger');
+
+		$response = $this->controller->ledger();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame(['error' => 'Supplier invoice not found'], $response->getData());
+
+	}//end testLedgerUnknownInvoiceReturns404()
+
+	/**
+	 * An unexpected failure while building the ledger is logged and returns
+	 * a generic 500 with no trace.
+	 *
+	 * @return void
+	 */
+	public function testLedgerUnexpectedFailureReturns500WithoutStackTrace(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'invoiceId' => 'inv-9']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+
+		$objectService = $this->makeObjectService(
+			[
+				'SupplierInvoice' => [['id' => 'inv-9', 'administrationId' => 'adm-1']],
+				'ThreeWayMatch' => [],
+			]
+		);
+		$this->container->method('get')->willReturn($objectService);
+		$this->auditExportService->method('buildLedger')
+			->willThrowException(new \LogicException('SQLSTATE[42S02] shillinq_match missing'));
+		$this->logger->expects($this->once())->method('error');
+
+		$response = $this->controller->ledger();
+
+		self::assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		self::assertSame(['error' => 'Could not load audit trail'], $response->getData());
+		self::assertStringNotContainsStringIgnoringCase(
+			'SQLSTATE',
+			(string)json_encode($response->getData())
+		);
+
+	}//end testLedgerUnexpectedFailureReturns500WithoutStackTrace()
+
+	/**
+	 * A valid export returns 200 with the package envelope, and the
+	 * server-only zipPath is stripped from the response.
+	 *
+	 * @return void
+	 */
+	public function testExportReturns200WithEnvelopeStrippingZipPath(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'invoiceId' => 'inv-9']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+
+		$seen = [];
+		$this->auditExportService->expects($this->once())
+			->method('generateAuditPackage')
+			->willReturnCallback(
+				static function (string $administrationId, string $invoiceId) use (&$seen): array {
+					$seen = [$administrationId, $invoiceId];
+					return [
+						'packageId' => 'audit-INV-9-abc123',
+						'invoiceId' => $invoiceId,
+						'sha256' => 'deadbeef',
+						'zipPath' => '/tmp/audit-INV-9-abc123.zip',
+						'archived' => true,
+					];
+				}
+			);
+
+		$response = $this->controller->export();
+
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertSame(['adm-1', 'inv-9'], $seen);
+		$data = $response->getData();
+		self::assertSame('audit-INV-9-abc123', $data['packageId']);
+		self::assertArrayNotHasKey('zipPath', $data);
+
+	}//end testExportReturns200WithEnvelopeStrippingZipPath()
+
+	/**
+	 * An anonymous export is refused with 401 and never reaches the export
+	 * service.
+	 *
+	 * @return void
+	 */
+	public function testExportRejectsAnonymousCaller(): void {
+		$this->currentUser = null;
+		$this->auditExportService->expects($this->never())->method('generateAuditPackage');
+
+		$response = $this->controller->export();
+
+		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		self::assertSame(['error' => 'Not logged in'], $response->getData());
+
+	}//end testExportRejectsAnonymousCaller()
+
+	/**
+	 * A missing administrationId is a 400 — the export is never unscoped.
+	 *
+	 * @return void
+	 */
+	public function testExportRequiresAdministrationId(): void {
+		$this->withParams(['invoiceId' => 'inv-9']);
+		$this->auditExportService->expects($this->never())->method('generateAuditPackage');
+
+		$response = $this->controller->export();
+
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		self::assertSame(['error' => 'administrationId is required'], $response->getData());
+
+	}//end testExportRequiresAdministrationId()
+
+	/**
+	 * Exporting inside another tenant's administration is masked as 404
+	 * (ADR-005) and the export service is never reached — proving the
+	 * guard short-circuits rather than merely matching the status code.
+	 *
+	 * @return void
+	 */
+	public function testExportForeignAdministrationReturns404(): void {
+		$this->withParams(['administrationId' => 'adm-other', 'invoiceId' => 'inv-9']);
+		$this->administrationContext->method('canAccess')->willReturn(false);
+		$this->auditExportService->expects($this->never())->method('generateAuditPackage');
+
+		$response = $this->controller->export();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame(['error' => 'Supplier invoice not found'], $response->getData());
+
+	}//end testExportForeignAdministrationReturns404()
+
+	/**
+	 * A missing invoiceId is a 400.
+	 *
+	 * @return void
+	 */
+	public function testExportRequiresInvoiceId(): void {
+		$this->withParams(['administrationId' => 'adm-1']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+		$this->auditExportService->expects($this->never())->method('generateAuditPackage');
+
+		$response = $this->controller->export();
+
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		self::assertSame(['error' => 'invoiceId is required'], $response->getData());
+
+	}//end testExportRequiresInvoiceId()
+
+	/**
+	 * A "not found" refusal from the export service maps to 404, not 400.
+	 *
+	 * @return void
+	 */
+	public function testExportUnknownInvoiceReturns404(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'invoiceId' => 'inv-9']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+		$this->auditExportService->method('generateAuditPackage')
+			->willThrowException(new \RuntimeException('Supplier invoice not found'));
+
+		$response = $this->controller->export();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame(['error' => 'Supplier invoice not found'], $response->getData());
+
+	}//end testExportUnknownInvoiceReturns404()
+
+	/**
+	 * Any other export-service refusal maps to 400 (validation).
+	 *
+	 * @return void
+	 */
+	public function testExportServiceRefusalReturns400(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'invoiceId' => 'inv-9']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+		$this->auditExportService->method('generateAuditPackage')
+			->willThrowException(new \RuntimeException('ZIP write failed'));
+
+		$response = $this->controller->export();
+
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+
+	}//end testExportServiceRefusalReturns400()
+
+	/**
+	 * An unexpected failure on export is logged and returns a generic 500
+	 * with no trace.
+	 *
+	 * @return void
+	 */
+	public function testExportUnexpectedFailureReturns500WithoutStackTrace(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'invoiceId' => 'inv-9']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+		$this->auditExportService->method('generateAuditPackage')
+			->willThrowException(new \LogicException('SQLSTATE[42S02] shillinq_match missing'));
+		$this->logger->expects($this->once())->method('error');
+
+		$response = $this->controller->export();
+
+		self::assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		self::assertSame(['error' => 'Could not export audit package'], $response->getData());
+		self::assertStringNotContainsStringIgnoringCase(
+			'SQLSTATE',
+			(string)json_encode($response->getData())
+		);
+
+	}//end testExportUnexpectedFailureReturns500WithoutStackTrace()
+
+	// phpcs:enable CustomSniffs.Functions.NamedParameters
+}//end class

--- a/tests/Unit/Controller/ThreeWayMatchControllerTest.php
+++ b/tests/Unit/Controller/ThreeWayMatchControllerTest.php
@@ -1,0 +1,319 @@
+<?php
+
+/**
+ * Unit tests for ThreeWayMatchController.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/bookkeeping-purchase-order-3way-06-matching-engine/tasks.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\ThreeWayMatchController;
+use OCA\Shillinq\Service\AdministrationContextService;
+use OCA\Shillinq\Service\ThreeWayMatchingEngine;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Tests the single trigger endpoint (evaluate) for: the anonymous refusal,
+ * the required administration scope, the cross-tenant 404 mask (ADR-005) —
+ * with the matching engine proven unreached — the required invoiceId, the
+ * service-refusal mapping and the no-stack-trace 500.
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+final class ThreeWayMatchControllerTest extends TestCase {
+
+	/**
+	 * Mock IRequest.
+	 *
+	 * @var IRequest&MockObject
+	 */
+	private IRequest&MockObject $request;
+
+	/**
+	 * Mock ThreeWayMatchingEngine (server-authoritative).
+	 *
+	 * @var ThreeWayMatchingEngine&MockObject
+	 */
+	private ThreeWayMatchingEngine&MockObject $matchingEngine;
+
+	/**
+	 * Mock AdministrationContextService (IDOR + tenant scope).
+	 *
+	 * @var AdministrationContextService&MockObject
+	 */
+	private AdministrationContextService&MockObject $administrationContext;
+
+	/**
+	 * Mock IUserSession.
+	 *
+	 * @var IUserSession&MockObject
+	 */
+	private IUserSession&MockObject $userSession;
+
+	/**
+	 * Mock LoggerInterface.
+	 *
+	 * @var LoggerInterface&MockObject
+	 */
+	private LoggerInterface&MockObject $logger;
+
+	/**
+	 * The user the session reports; null models an anonymous caller.
+	 *
+	 * @var IUser|null
+	 */
+	private ?IUser $currentUser = null;
+
+	/**
+	 * The controller under test.
+	 *
+	 * @var ThreeWayMatchController
+	 */
+	private ThreeWayMatchController $controller;
+
+	/**
+	 * Set up test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->request = $this->createMock(IRequest::class);
+		$this->matchingEngine = $this->createMock(ThreeWayMatchingEngine::class);
+		$this->administrationContext = $this->createMock(AdministrationContextService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->currentUser = $user;
+
+		$this->userSession->method('getUser')->willReturnCallback(
+			function (): ?IUser {
+				return $this->currentUser;
+			}
+		);
+
+		$this->controller = new ThreeWayMatchController(
+			request: $this->request,
+			matchingEngine: $this->matchingEngine,
+			administrationContext: $this->administrationContext,
+			userSession: $this->userSession,
+			logger: $this->logger,
+		);
+
+	}//end setUp()
+
+	/**
+	 * Configure request params from a key => value map.
+	 *
+	 * @param array<string,mixed> $map Param map.
+	 *
+	 * @return void
+	 */
+	private function withParams(array $map): void {
+		$this->request->method('getParam')->willReturnCallback(
+			static function (string $key, mixed $default = null) use ($map): mixed {
+				return ($map[$key] ?? $default);
+			}
+		);
+
+	}//end withParams()
+
+	/**
+	 * A valid trigger returns 200 with the persisted match and forwards the
+	 * scope + invoice id to the engine.
+	 *
+	 * @return void
+	 */
+	public function testEvaluateReturns200WithPersistedMatch(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'invoiceId' => 'inv-9']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+
+		$seen = [];
+		$this->matchingEngine->expects($this->once())
+			->method('evaluateMatch')
+			->willReturnCallback(
+				static function (string $administrationId, string $invoiceId) use (&$seen): array {
+					$seen = [$administrationId, $invoiceId];
+					return ['id' => 'twm-1', 'invoiceId' => $invoiceId, 'status' => 'matched'];
+				}
+			);
+
+		$response = $this->controller->evaluate();
+
+		self::assertInstanceOf(JSONResponse::class, $response);
+		self::assertSame(Http::STATUS_OK, $response->getStatus());
+		self::assertSame(['adm-1', 'inv-9'], $seen);
+		self::assertSame('matched', $response->getData()['status']);
+
+	}//end testEvaluateReturns200WithPersistedMatch()
+
+	/**
+	 * An anonymous evaluate is refused with 401 and never reaches the engine.
+	 *
+	 * @return void
+	 */
+	public function testEvaluateRejectsAnonymousCaller(): void {
+		$this->currentUser = null;
+		$this->matchingEngine->expects($this->never())->method('evaluateMatch');
+
+		$response = $this->controller->evaluate();
+
+		self::assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+		self::assertSame(['error' => 'Not logged in'], $response->getData());
+
+	}//end testEvaluateRejectsAnonymousCaller()
+
+	/**
+	 * A missing administrationId is a 400 — the trigger is never unscoped.
+	 *
+	 * @return void
+	 */
+	public function testEvaluateRequiresAdministrationId(): void {
+		$this->withParams(['invoiceId' => 'inv-9']);
+		$this->matchingEngine->expects($this->never())->method('evaluateMatch');
+
+		$response = $this->controller->evaluate();
+
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		self::assertSame(['error' => 'administrationId is required'], $response->getData());
+
+	}//end testEvaluateRequiresAdministrationId()
+
+	/**
+	 * Triggering inside another tenant's administration is masked as 404
+	 * (ADR-005) and the matching engine is never reached — proving the
+	 * guard short-circuits rather than merely matching the status code.
+	 *
+	 * @return void
+	 */
+	public function testEvaluateForeignAdministrationReturns404(): void {
+		$this->withParams(['administrationId' => 'adm-other', 'invoiceId' => 'inv-9']);
+		$this->administrationContext->method('canAccess')->willReturn(false);
+		$this->matchingEngine->expects($this->never())->method('evaluateMatch');
+
+		$response = $this->controller->evaluate();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame(['error' => 'Supplier invoice not found'], $response->getData());
+
+	}//end testEvaluateForeignAdministrationReturns404()
+
+	/**
+	 * A missing invoiceId is a 400 (a blank id would otherwise reach the engine).
+	 *
+	 * @return void
+	 */
+	public function testEvaluateRequiresInvoiceId(): void {
+		$this->withParams(['administrationId' => 'adm-1']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+		$this->matchingEngine->expects($this->never())->method('evaluateMatch');
+
+		$response = $this->controller->evaluate();
+
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		self::assertSame(['error' => 'invoiceId is required'], $response->getData());
+
+	}//end testEvaluateRequiresInvoiceId()
+
+	/**
+	 * A malformed invoiceId never reaches the engine — the slug pattern
+	 * rejects it as a missing id.
+	 *
+	 * @return void
+	 */
+	public function testEvaluateRejectsMalformedInvoiceId(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'invoiceId' => '../../inv']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+		$this->matchingEngine->expects($this->never())->method('evaluateMatch');
+
+		$response = $this->controller->evaluate();
+
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+		self::assertSame(['error' => 'invoiceId is required'], $response->getData());
+
+	}//end testEvaluateRejectsMalformedInvoiceId()
+
+	/**
+	 * A "not found" refusal from the engine maps to 404, not 400.
+	 *
+	 * @return void
+	 */
+	public function testEvaluateUnknownInvoiceReturns404(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'invoiceId' => 'inv-9']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+		$this->matchingEngine->method('evaluateMatch')
+			->willThrowException(new \RuntimeException('SupplierInvoice not found'));
+
+		$response = $this->controller->evaluate();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame(['error' => 'SupplierInvoice not found'], $response->getData());
+
+	}//end testEvaluateUnknownInvoiceReturns404()
+
+	/**
+	 * Any other engine refusal maps to 400 (validation).
+	 *
+	 * @return void
+	 */
+	public function testEvaluateServiceRefusalReturns400(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'invoiceId' => 'inv-9']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+		$this->matchingEngine->method('evaluateMatch')
+			->willThrowException(new \RuntimeException('SupplierInvoice has no PO reference'));
+
+		$response = $this->controller->evaluate();
+
+		self::assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+
+	}//end testEvaluateServiceRefusalReturns400()
+
+	/**
+	 * An unexpected failure is logged and returns a generic 500 with no trace.
+	 *
+	 * @return void
+	 */
+	public function testEvaluateUnexpectedFailureReturns500WithoutStackTrace(): void {
+		$this->withParams(['administrationId' => 'adm-1', 'invoiceId' => 'inv-9']);
+		$this->administrationContext->method('canAccess')->willReturn(true);
+		$this->matchingEngine->method('evaluateMatch')
+			->willThrowException(new \LogicException('SQLSTATE[42S02] shillinq_match missing'));
+		$this->logger->expects($this->once())->method('error');
+
+		$response = $this->controller->evaluate();
+
+		self::assertSame(Http::STATUS_INTERNAL_SERVER_ERROR, $response->getStatus());
+		self::assertSame(['error' => 'Could not evaluate three-way match'], $response->getData());
+		self::assertStringNotContainsStringIgnoringCase(
+			'SQLSTATE',
+			(string)json_encode($response->getData())
+		);
+
+	}//end testEvaluateUnexpectedFailureReturns500WithoutStackTrace()
+
+	// phpcs:enable CustomSniffs.Functions.NamedParameters
+}//end class

--- a/tests/Unit/Controller/ThreeWayMatchExceptionControllerTest.php
+++ b/tests/Unit/Controller/ThreeWayMatchExceptionControllerTest.php
@@ -373,6 +373,26 @@ final class ThreeWayMatchExceptionControllerTest extends TestCase {
 	}//end testDisputeRequiresReason()
 
 	/**
+	 * Disputing inside another tenant's administration is masked as 404
+	 * (ADR-005) and the exception-resolution service is never reached —
+	 * proving the guard short-circuits rather than merely matching the
+	 * status code.
+	 *
+	 * @return void
+	 */
+	public function testDisputeForeignAdministrationReturns404(): void {
+		$this->withParams(['administrationId' => 'adm-other', 'matchId' => 'match-3', 'disputeReason' => 'short']);
+		$this->administrationContext->method('canAccess')->willReturn(false);
+		$this->exceptions->expects($this->never())->method('fileDispute');
+
+		$response = $this->controller->dispute();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertSame(['error' => 'Administration not found'], $response->getData());
+
+	}//end testDisputeForeignAdministrationReturns404()
+
+	/**
 	 * A "not found" refusal from the service maps to 404, not 400.
 	 *
 	 * @return void


### PR DESCRIPTION
## Summary
Pre-existing coverage debt surfaced during the full `#[NoAdminRequired]` security triage. These controllers are already correctly guarded via `AdministrationContextService::canAccess()` — this is missing *evidence*, not a live vulnerability.

- `ThreeWayMatchController` — had **no test file at all**; now 9 tests.
- `ThreeWayMatchAuditController` — had **no test file at all**; now 15 tests (`ledger()` and `export()`).
- `ThreeWayMatchExceptionController::dispute()` — had positive-direction coverage only; added the foreign-administration rejection, matching `accept()`/`reject()`'s existing shape.

Every `#[NoAdminRequired]` method now has **both** directions, and each negative test asserts the downstream service is `expects(never())` — proving the guard short-circuits rather than merely that a status code matched.

## A vacuous test, caught in the act
Disabling all three guards at once should have turned three tests red. **Only two did.** `testLedgerForeignAdministrationReturns404` passed *with the guard disabled*, because its unconfigured container mock produced a coincidental 404 through `loadBundle()` swallowing a container error — a different code path entirely. Fixed the test to configure a container that actually returns the invoice, so bypassing the guard genuinely lets the request through. Re-run with guards still disabled: **3/3 red** (400/500 vs expected 404). Guards restored: **3/3 green**. Final `grep -rn "TEMP-NEGATIVE-CONTROL"` → no matches; `git diff --stat -- lib/` → empty, confirming the temporary edits left no trace in production code.

That test would have sat in the suite looking like protection while proving nothing.

## Suite tallies (full `phpunit-unit.xml`)
- Before: `Tests: 4624, Assertions: 45359, Failures: 0, Errors: 0`
- After: `Tests: 4649, Assertions: 45436, Failures: 0, Errors: 0`
- Delta +25 / +77 — exactly 9 + 15 + 1, zero regressions.

Out of scope, stated: `AuditExportService` and `ThreeWayMatchingEngine` internals remain mocked units; this targets controller-level guard coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)