### PR TITLE
fix(build): load the shared chunks #932 split out — the SPA does not boot on development

### DIFF
--- a/templates/index.php
+++ b/templates/index.php
@@ -3,6 +3,27 @@
 use OCP\Util;
 
 $appId = OCA\Shillinq\AppInfo\Application::APP_ID;
+// The webpack build (see webpack.config.js -> optimization.splitChunks, added
+// by #932) emits this entry point as THREE files, not one. Webpack's own build
+// output says so:
+//
+//     Entrypoint main = shillinq-shared-nc-vue.js
+//                       shillinq-shared-vendor.js
+//                       shillinq-main.js
+//
+// All three must be loaded, in dependency order — `shillinq-main.js` references
+// modules that now live in the shared chunks. An `initial` chunk is NOT fetched
+// by the webpack runtime; the page has to request it, and this app has no
+// HtmlWebpackPlugin to inject the tags.
+//
+// Loading only `-main` is what broke the SPA on `development`: the entry went
+// 12,468,786 -> 9,158,113 bytes, the framework never arrived, and ~190 e2e
+// tests failed with `locator('main, [role="main"]')` never appearing. Frontend
+// Build stayed green throughout — emitting a chunk nobody requests is not a
+// build error. pipelinq/templates/index.php carries the same three lines for
+// the same reason.
+Util::addScript($appId, $appId . '-shared-vendor');
+Util::addScript($appId, $appId . '-shared-nc-vue');
 Util::addScript($appId, $appId . '-main');
 ?>
 <div id="shillinq-app"></div>

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -3,6 +3,17 @@
 use OCP\Util;
 
 $appId = OCA\Shillinq\AppInfo\Application::APP_ID;
+// Same three-file entry point as templates/index.php — webpack's build output:
+//
+//     Entrypoint adminSettings = shillinq-shared-nc-vue.js
+//                                shillinq-shared-vendor.js
+//                                shillinq-settings.js
+//
+// `adminSettings` shares the framework chunks with `main` (that is what
+// `minChunks: 2` selects for), so this template has to load them too. See the
+// longer note in templates/index.php.
+Util::addScript($appId, $appId . '-shared-vendor');
+Util::addScript($appId, $appId . '-shared-nc-vue');
 Util::addScript($appId, $appId . '-settings');
 ?>
 <div id="shillinq-settings"></div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -212,35 +212,80 @@ webpackConfig.output = {
 webpackConfig.optimization = {
 	...(webpackConfig.optimization || {}),
 	minimizer: [new TerserPlugin({ parallel: 2 })],
-	// ⚠️ NO `splitChunks` HERE — AND THAT IS LOAD-BEARING, NOT AN OMISSION.
-	//
-	// #932 (frontend-bundle-hygiene REQ-FBH-002 / ADR-061) added an `ncVue` /
-	// `vendor` cacheGroup split with `chunks: 'initial'`, pulling Vue,
-	// @nextcloud/vue, @conduction/nextcloud-vue and Pinia out of `main` into
-	// `shillinq-shared-nc-vue.js` and `shillinq-shared-vendor.js`.
-	//
-	// Nothing loads those files. An `initial` chunk is not fetched by the
-	// webpack runtime — the PAGE has to request it, and this app has no
-	// HtmlWebpackPlugin. Its two templates name exactly one script each:
-	//
-	//     templates/index.php           Util::addScript($appId, $appId . '-main')
-	//     templates/settings/admin.php  Util::addScript($appId, $appId . '-settings')
-	//
-	// So the framework left `main` and never arrived: `shillinq-main.js` went
-	// 12,468,786 -> 9,158,113 bytes and the SPA stopped booting. Measured on
-	// run 32358287419 — ~190 e2e failures, nearly the whole suite, all the
-	// same shape: `locator('main, [role="main"]')` never appears. The build
-	// itself stayed green, because emitting a chunk nobody requests is not a
-	// build error.
-	//
-	// Reverted to restore a working app. The optimisation is still worth
-	// having, but it needs the templates to load the shared chunks (in order,
-	// before the entry) and an e2e run to prove the app still mounts — and
-	// note `minChunks: 2` means a chunk can legitimately come out EMPTY and
-	// not be emitted at all, so a template cannot addScript it blindly.
-	//
-	// The `devtool: false` half of #932 is kept (line 16): it took ~41 MB of
-	// .map files out of js/ and cannot affect what the page loads.
+	// frontend-bundle-hygiene REQ-FBH-002 / ADR-061: the base
+	// `@nextcloud/webpack-vue-config` only sets
+	// `splitChunks.automaticNameDelimiter` — webpack 5's own default
+	// `splitChunks.chunks: 'async'` means NONE of this app's three *initial*
+	// entries (`main`, `adminSettings`, `widget`) share code today; each
+	// independently bundles its own full copy of Vue, @nextcloud/vue,
+	// @conduction/nextcloud-vue and Pinia. Pull the shared framework code
+	// used by `main`/`adminSettings` into two cached chunks, following
+	// pipelinq's `ncVue`/`vendor` cacheGroup split
+	// (pipelinq/webpack.config.js:259-295).
+	splitChunks: {
+		...(webpackConfig.optimization?.splitChunks || {}),
+		// `widget` (src/components/widget/WidgetEmbed.js, REQ-WSW-004) is a
+		// UMD bundle partner sites embed via ONE `<script src=".../widget.js">`
+		// tag. It MUST stay fully self-contained — splitting its framework
+		// code into a second chunk would require a third-party page to load a
+		// script tag it was never told about. Excluded by name, mirroring
+		// openregister's `integrationGlobal` exclusion for the identical
+		// reason (openregister/webpack.config.js:60).
+		chunks: (chunk) => chunk.name !== 'widget',
+		cacheGroups: {
+			default: false,
+			defaultVendors: false,
+			ncVue: {
+				name: appId + '-shared-nc-vue',
+				// 'initial' ONLY — not 'all'. The outer `chunks` filter above
+				// still lets webpack consider async (dynamically-imported)
+				// modules for this cacheGroup if it were 'all', which would
+				// hoist nc-vue's OWN lazily-loaded chunks (the RVO icon set,
+				// the @mdi/js icon-browser bundle behind
+				// CnIconBrowserPanel.vue's `import(/* webpackChunkName:
+				// "cn-icons-mdi" */ '@mdi/js')`) into this eager chunk,
+				// loaded on every page instead of only when their feature is
+				// opened — exactly the regression pipelinq's own comment
+				// documents hitting with the RVO set and fixing the same way.
+				chunks: 'initial',
+				// Matches both the npm dist AND the monorepo-dev alias
+				// (`../nextcloud-vue/src/...`, resolved outside node_modules
+				// when USE_LOCAL_LIB=true aliases @conduction/nextcloud-vue
+				// to the sibling source tree above).
+				test: /[\\/]node_modules[\\/](@nextcloud[\\/]vue|@conduction[\\/]nextcloud-vue)[\\/]|[\\/]nextcloud-vue[\\/]src[\\/]/,
+				priority: 30,
+				// minChunks: 2 (NOT the cacheGroup default of 1) — measured, not
+				// assumed. `main` (595 pages, most of the nc-vue barrel) and
+				// `adminSettings` (a handful of settings screens, a small slice
+				// of the barrel) use very different-sized subsets of nc-vue. At
+				// minChunks:1 (the first version of this change), the cacheGroup
+				// extracted the UNION of both entries' nc-vue usage into one
+				// chunk — 6.28 MB — that BOTH entries then had to load in full.
+				// Measured effect: adminSettings's own entrypoint total went
+				// from 3.34 MiB to 8.44 MiB, a regression, not a win — the exact
+				// "moving bytes into a second chunk the same page also loads"
+				// trap. minChunks:2 restricts extraction to modules actually
+				// reachable from BOTH entries, leaving each entry's own
+				// exclusively-used modules where they were. See design.md §6/
+				// tasks.md Validation for the corrected before/after numbers.
+				minChunks: 2,
+				reuseExistingChunk: true,
+				enforce: true,
+				filename: appId + '-shared-nc-vue.js',
+			},
+			vendor: {
+				name: appId + '-shared-vendor',
+				chunks: 'initial',
+				test: /[\\/]node_modules[\\/](vue|vue-router|pinia|vue-material-design-icons|@vueuse)[\\/]/,
+				priority: 20,
+				// Same minChunks:2 correction as the ncVue group above.
+				minChunks: 2,
+				reuseExistingChunk: true,
+				enforce: true,
+				filename: appId + '-shared-vendor.js',
+			},
+		},
+	},
 }
 
 module.exports = webpackConfig

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -212,80 +212,35 @@ webpackConfig.output = {
 webpackConfig.optimization = {
 	...(webpackConfig.optimization || {}),
 	minimizer: [new TerserPlugin({ parallel: 2 })],
-	// frontend-bundle-hygiene REQ-FBH-002 / ADR-061: the base
-	// `@nextcloud/webpack-vue-config` only sets
-	// `splitChunks.automaticNameDelimiter` — webpack 5's own default
-	// `splitChunks.chunks: 'async'` means NONE of this app's three *initial*
-	// entries (`main`, `adminSettings`, `widget`) share code today; each
-	// independently bundles its own full copy of Vue, @nextcloud/vue,
-	// @conduction/nextcloud-vue and Pinia. Pull the shared framework code
-	// used by `main`/`adminSettings` into two cached chunks, following
-	// pipelinq's `ncVue`/`vendor` cacheGroup split
-	// (pipelinq/webpack.config.js:259-295).
-	splitChunks: {
-		...(webpackConfig.optimization?.splitChunks || {}),
-		// `widget` (src/components/widget/WidgetEmbed.js, REQ-WSW-004) is a
-		// UMD bundle partner sites embed via ONE `<script src=".../widget.js">`
-		// tag. It MUST stay fully self-contained — splitting its framework
-		// code into a second chunk would require a third-party page to load a
-		// script tag it was never told about. Excluded by name, mirroring
-		// openregister's `integrationGlobal` exclusion for the identical
-		// reason (openregister/webpack.config.js:60).
-		chunks: (chunk) => chunk.name !== 'widget',
-		cacheGroups: {
-			default: false,
-			defaultVendors: false,
-			ncVue: {
-				name: appId + '-shared-nc-vue',
-				// 'initial' ONLY — not 'all'. The outer `chunks` filter above
-				// still lets webpack consider async (dynamically-imported)
-				// modules for this cacheGroup if it were 'all', which would
-				// hoist nc-vue's OWN lazily-loaded chunks (the RVO icon set,
-				// the @mdi/js icon-browser bundle behind
-				// CnIconBrowserPanel.vue's `import(/* webpackChunkName:
-				// "cn-icons-mdi" */ '@mdi/js')`) into this eager chunk,
-				// loaded on every page instead of only when their feature is
-				// opened — exactly the regression pipelinq's own comment
-				// documents hitting with the RVO set and fixing the same way.
-				chunks: 'initial',
-				// Matches both the npm dist AND the monorepo-dev alias
-				// (`../nextcloud-vue/src/...`, resolved outside node_modules
-				// when USE_LOCAL_LIB=true aliases @conduction/nextcloud-vue
-				// to the sibling source tree above).
-				test: /[\\/]node_modules[\\/](@nextcloud[\\/]vue|@conduction[\\/]nextcloud-vue)[\\/]|[\\/]nextcloud-vue[\\/]src[\\/]/,
-				priority: 30,
-				// minChunks: 2 (NOT the cacheGroup default of 1) — measured, not
-				// assumed. `main` (595 pages, most of the nc-vue barrel) and
-				// `adminSettings` (a handful of settings screens, a small slice
-				// of the barrel) use very different-sized subsets of nc-vue. At
-				// minChunks:1 (the first version of this change), the cacheGroup
-				// extracted the UNION of both entries' nc-vue usage into one
-				// chunk — 6.28 MB — that BOTH entries then had to load in full.
-				// Measured effect: adminSettings's own entrypoint total went
-				// from 3.34 MiB to 8.44 MiB, a regression, not a win — the exact
-				// "moving bytes into a second chunk the same page also loads"
-				// trap. minChunks:2 restricts extraction to modules actually
-				// reachable from BOTH entries, leaving each entry's own
-				// exclusively-used modules where they were. See design.md §6/
-				// tasks.md Validation for the corrected before/after numbers.
-				minChunks: 2,
-				reuseExistingChunk: true,
-				enforce: true,
-				filename: appId + '-shared-nc-vue.js',
-			},
-			vendor: {
-				name: appId + '-shared-vendor',
-				chunks: 'initial',
-				test: /[\\/]node_modules[\\/](vue|vue-router|pinia|vue-material-design-icons|@vueuse)[\\/]/,
-				priority: 20,
-				// Same minChunks:2 correction as the ncVue group above.
-				minChunks: 2,
-				reuseExistingChunk: true,
-				enforce: true,
-				filename: appId + '-shared-vendor.js',
-			},
-		},
-	},
+	// ⚠️ NO `splitChunks` HERE — AND THAT IS LOAD-BEARING, NOT AN OMISSION.
+	//
+	// #932 (frontend-bundle-hygiene REQ-FBH-002 / ADR-061) added an `ncVue` /
+	// `vendor` cacheGroup split with `chunks: 'initial'`, pulling Vue,
+	// @nextcloud/vue, @conduction/nextcloud-vue and Pinia out of `main` into
+	// `shillinq-shared-nc-vue.js` and `shillinq-shared-vendor.js`.
+	//
+	// Nothing loads those files. An `initial` chunk is not fetched by the
+	// webpack runtime — the PAGE has to request it, and this app has no
+	// HtmlWebpackPlugin. Its two templates name exactly one script each:
+	//
+	//     templates/index.php           Util::addScript($appId, $appId . '-main')
+	//     templates/settings/admin.php  Util::addScript($appId, $appId . '-settings')
+	//
+	// So the framework left `main` and never arrived: `shillinq-main.js` went
+	// 12,468,786 -> 9,158,113 bytes and the SPA stopped booting. Measured on
+	// run 32358287419 — ~190 e2e failures, nearly the whole suite, all the
+	// same shape: `locator('main, [role="main"]')` never appears. The build
+	// itself stayed green, because emitting a chunk nobody requests is not a
+	// build error.
+	//
+	// Reverted to restore a working app. The optimisation is still worth
+	// having, but it needs the templates to load the shared chunks (in order,
+	// before the entry) and an e2e run to prove the app still mounts — and
+	// note `minChunks: 2` means a chunk can legitimately come out EMPTY and
+	// not be emitted at all, so a template cannot addScript it blindly.
+	//
+	// The `devtool: false` half of #932 is kept (line 16): it took ~41 MB of
+	// .map files out of js/ and cannot affect what the page loads.
 }
 
 module.exports = webpackConfig


### PR DESCRIPTION
**The shillinq SPA does not boot on `development`.** ~190 e2e tests — nearly the whole suite — fail with one shape:

```
Error: expect(locator).toBeVisible() failed
Locator: locator('main, [role="main"]')
Error: element(s) not found
```

## Cause

#932 (`frontend-bundle-hygiene`, ADR-061) split Vue, `@nextcloud/vue`, `@conduction/nextcloud-vue` and Pinia out of the entries into shared chunks with **`chunks: 'initial'`** — but left the templates naming one script each.

An **initial** chunk is not fetched by the webpack runtime. The page must request it, and this app has no `HtmlWebpackPlugin` to inject the tags. Webpack's own build output states the entry points are three files:

```
Entrypoint main          = shillinq-shared-nc-vue.js  shillinq-shared-vendor.js  shillinq-main.js
Entrypoint adminSettings = shillinq-shared-nc-vue.js  shillinq-shared-vendor.js  shillinq-settings.js
```

Both chunks **are** emitted — 973 KiB and 51.1 KiB (run `32358287419`). Only one of the three was ever loaded, so the framework never arrived:

| | before #932 | after |
|---|---|---|
| `shillinq-main.js` | 12,468,786 B | **9,158,113 B** |
| e2e failures | 5 | **~190** |

**Frontend Build stayed green the whole time.** Emitting a chunk nobody requests is not a build error — only e2e could see this, and #932 was merged with its E2E job already red.

## The fix

The **missing half of #932**, not a revert. The optimisation is kept; the templates now load the three files in dependency order:

```php
Util::addScript($appId, $appId . '-shared-vendor');
Util::addScript($appId, $appId . '-shared-nc-vue');
Util::addScript($appId, $appId . '-main');       // and '-settings' in the admin template
```

This is exactly what `pipelinq/templates/index.php` already does — and #932 cited that file as its model, but copied only the webpack half.

`widget` needs nothing: `webpack.config.js` excludes it from splitting (`chunks: (chunk) => chunk.name !== 'widget'`) so the UMD embed bundle stays self-contained for third-party pages.

## Verification

- Both shared chunks confirmed **emitted** in the CI build output, with webpack naming all three files per entrypoint.
- `php -l` clean on both templates.
- The real proof is e2e on this PR: if the shared chunks now load, `main` mounts and the ~190 failures collapse back to the 5 pre-existing ones (a separate cause, addressed in #955).

## Note on the first commit

This branch opens with a revert of the splitChunks block. That was my first fix, before I checked whether the chunks were emitted and how pipelinq handles it. The second commit reverts that and does it properly — the history is left intact rather than rewritten.

## Fleet check

hermiq and portaliq also declare `shared-nc-vue` / `shared-vendor` chunks and already carry 4 `addScript` lines, so they are not affected. openregister, openbuild, decidesk and scholiq have no initial-chunk split at all.
