### PR TITLE
fix(e2e): locate the delete-confirm button by variant, not an English name

### DIFF
--- a/tests/e2e/cbs-submissions.spec.ts
+++ b/tests/e2e/cbs-submissions.spec.ts
@@ -244,13 +244,43 @@ test.describe('CBS Submissions — delete-own-draft flow', () => {
 			)
 			await expect(confirmDialog).toBeVisible({ timeout: 10_000 })
 
+			// The confirm button is NOT inside `confirmDialog`. CnDeleteDialog
+			// puts its Cancel/Delete buttons in NcDialog's `#actions` slot, and
+			// NcDialog renders that slot into `.dialog__actions` — a SIBLING of
+			// `.dialog__wrapper > .dialog__content`, which is where the
+			// `data-testid-phase` marker div lives. Scoping the button lookup to
+			// `confirmDialog` therefore matched ZERO buttons (that div holds only
+			// an NcNoteCard), so nothing was ever clicked, no DELETE went out, and
+			// the run died on `waitForResponse` 15s later rather than on the click.
+			// The old `{ name: /delete/i }` was a second, independent miss: this
+			// instance renders the dialog in Dutch — the buttons are "Annuleren"
+			// and "Verwijderen", so an English name regex matches nothing even
+			// when correctly scoped.
+			//
+			// Locate it instead by the destructive `variant="error"` NcButton that
+			// CnDeleteDialog gives the confirm action (`button-vue--error`) — the
+			// only error-variant button in the dialog, and language-independent.
+			// The `toHaveCount(1)` below is the guard that keeps this honest: if
+			// nc-vue ever restructures the dialog, this fails loudly instead of
+			// silently selecting Cancel or nothing.
+			const deleteDialog = page
+				.locator('.dialog')
+				.filter({ has: confirmDialog })
+			const confirmButton = deleteDialog.locator(
+				'.dialog__actions button.button-vue--error',
+			)
+			await expect(
+				confirmButton,
+				"CnDeleteDialog must expose exactly one destructive confirm button in the dialog's actions",
+			).toHaveCount(1)
+
 			const deleteRequest = page.waitForResponse(
 				(response) =>
 					response.url().includes(`/CBSSubmission/${seeded.id}`)
 					&& response.request().method() === 'DELETE',
 				{ timeout: 15_000 },
 			)
-			await confirmDialog.getByRole('button', { name: /delete/i }).click()
+			await confirmButton.click()
 			const deleteResponse = await deleteRequest
 			expect(
 				deleteResponse.status(),


### PR DESCRIPTION
## The symptom

`CBS Submissions — delete-own-draft flow` failed on **every** branch — the last pre-existing E2E failure on `development`:

```
TimeoutError: page.waitForResponse: Timeout 15000ms exceeded while waiting for event "response"
  245 |   await expect(confirmDialog).toBeVisible({ timeout: 10_000 })
```

The confirm dialog became visible, then the wait for `DELETE /CBSSubmission/{id}` timed out. That reads like a missing request. It was a missing **click**.

## Two independent defects in one locator, each fatal alone

**1. DOM scoping.** `confirmDialog` is the `[data-testid-phase="confirm"]` div, which `CnDeleteDialog` renders into `NcDialog`'s **default** slot. `NcDialog` puts the `#actions` slot in `.dialog__actions` — a **sibling** of `.dialog__wrapper > .dialog__content`. The buttons are therefore not descendants of `confirmDialog`. Captured live:

```
buttons inside phase div: 0 ; matching /delete/i: 0
.dialog__actions button count: 2
```

**2. Localization.** The instance renders Dutch, so `{ name: /delete/i }` matches nothing even when correctly scoped:

```json
[ { "text": "Annuleren", "cls": "button-vue--secondary" },
  { "text": "Verwijderen", "cls": "button-vue--error" } ]
```

Because zero elements matched, `.click()` never resolved — it waited for an element that would never appear — so the unawaited `waitForResponse` rejected first at 15s. Hence a *response* timeout for what was really a *click* that never happened.

## The app was never broken

The URL predicate was correct all along. Clicking the real button, live:

```
REQ DELETE http://localhost:8080/apps/openregister/api/objects/shillinq/CBSSubmission/207b32c8-...
RES 204
row count after delete: 0
```

Chain confirmed in source: `CnIndexPage` → `onSingleDeleteConfirm` → `selfModeActions.handleSingleDelete` → `useObjectStore.deleteObject` → `_buildUrl` = `/apps/openregister/api/objects/{register}/{schema}/{id}`.

## The fix

Target the destructive `NcButton` by its variant class (`button-vue--error`), which `CnDeleteDialog` sets on the confirm action alone and which does **not** change with locale — instead of an English name regex scoped into a div containing no buttons. Guarded with `toHaveCount(1)` so a future nc-vue restructure fails loudly rather than silently clicking Cancel or nothing.

**Nothing was loosened.** The test still waits for the real `DELETE`, still asserts status `< 300`, still asserts the row disappears. The count guard is a net tightening.

## Verification

```
5 passed (1.5m)
```

The target test passes rather than skips. One earlier run showed `1 flaky` on a *different* test (`a seeded draft submission appears in the list`) which hit the 30s timeout on a loaded box and passed on retry — a load-time flake unrelated to this fix, clean on both subsequent runs.

## Separate finding, deliberately not included here

`git status` in the worktree also shows `M src/manifest.d.shell.json` (+77 lines, a `Budgets` menu block), regenerated by `prebuild` when the e2e global-setup built the bundle. **The committed generated shell on `development` is stale** relative to `src/manifest.d/*`. That is real repo hygiene debt and is being tracked separately — it does not belong in this PR.
