### PR TITLE
fix(begroting): make the LedgerGroup parent/child drill-down actually render

### DIFF
--- a/lib/Service/BudgetVsActualsReader.php
+++ b/lib/Service/BudgetVsActualsReader.php
@@ -45,15 +45,24 @@
  * This is the same batched shape `budget-projection-engine design.md` §7b
  * independently arrived at for its own GL-based reader.
  *
- * ## Dual-keyed LedgerGroup lookups
+ * ## Triple-keyed LedgerGroup lookups
  *
  * `LedgerGroup.parentLedgerGroupId` and `BudgetLine.ledgerGroupId` may each
- * reference a `LedgerGroup` by either its OpenRegister object id or its
- * `@self.slug` (seed data uses the slug, since a real id is not known at
- * authoring time — mirrors `GLLine.transactionId`'s own dual convention).
- * Every internal `LedgerGroup` lookup index here is keyed by BOTH values
- * pointing at the same entry, so a caller or seed using either convention
- * resolves correctly.
+ * reference a `LedgerGroup` by its OpenRegister object id, its `@self.slug`, or
+ * its `code` (mirrors `GLLine.transactionId`'s own multi-key convention). Every
+ * internal `LedgerGroup` lookup index here is keyed by ALL THREE values pointing
+ * at the same entry, so a caller or seed using any convention resolves
+ * correctly.
+ *
+ * The shipped seed stores the `code`, and the id/slug branches are deliberately
+ * KEPT rather than dead: dropping either would silently reroot any hand-authored
+ * row that still uses one. `code` is not merely a convenience — it is the only
+ * parent identity the manifest's declarative filter engine can produce, because
+ * `@object.<field>` reads a FLAT payload field and cannot reach `@self.slug`,
+ * while `@objectId` yields a UUID no seed can know at authoring time. That is
+ * what makes the LedgerGroupDetail `children` relatedCollection resolve in the
+ * UI; slug-shaped stored values matched nothing and the page rendered
+ * "No relations yet".
  *
  * @category Service
  * @package  OCA\Shillinq\Service
@@ -285,6 +294,7 @@ class BudgetVsActualsReader {
 		foreach ($rows as $row) {
 			$id = (string)($row['@self']['id'] ?? $row['id'] ?? '');
 			$slug = (string)($row['@self']['slug'] ?? $row['slug'] ?? '');
+			$code = (string)($row['code'] ?? '');
 			$index = count($entries);
 
 			$parentRef = null;
@@ -305,6 +315,16 @@ class BudgetVsActualsReader {
 
 			if ($slug !== '' && $slug !== $id) {
 				$keyToIndex[$slug] = $index;
+			}
+
+			// `code` is the THIRD accepted parent key, and the one the shipped
+			// seed actually stores (see the register fragment's
+			// parentLedgerGroupId description). `code` is unique within an
+			// administration, which is exactly the scope $rows covers —
+			// LedgerGroup rows are loaded per administrationId. First writer
+			// wins so an id/slug key is never shadowed by a colliding code.
+			if ($code !== '' && isset($keyToIndex[$code]) === false) {
+				$keyToIndex[$code] = $index;
 			}
 		}
 

--- a/lib/Settings/register.d/budget-core-schema.json
+++ b/lib/Settings/register.d/budget-core-schema.json
@@ -48,10 +48,9 @@
           "parentLedgerGroupId": {
             "type": "string",
             "nullable": true,
-            "description": "Self-FK (the parent LedgerGroup's @self.slug), enabling nesting — mirrors Account.parentAccountNumber. Null for a root group. A parent with children uses its OWN BudgetLine if one exists; otherwise its value is the recursive sum of its children's resolved values (design.md §3d) — no double counting when both exist.",
+            "description": "Self-FK holding the parent LedgerGroup's `code` — a flat business key, exactly as the description says it mirrors: Account.parentAccountNumber references an accountNumber, not an object id. Null for a root group. WHY A BUSINESS KEY AND NOT AN ID: a real object id is not known at seed-authoring time, and OpenRegister's `@ref:` seed-token mechanism (which would mint one) is unusable here — it only walks `components.objects`, a bucket shillinq's fragment merge currently corrupts (see _objects_placement_note). A `code` is the only parent identity BOTH the PHP rollup and the manifest's declarative filter engine can resolve: the LedgerGroupDetail `children` relatedCollection filters `parentLedgerGroupId == @object.code`, and `@object.<field>` reads a FLAT payload field only — it cannot reach `@self.slug`. `code` is unique within an administration, which is the scope BudgetVsActualsReader loads. BudgetVsActualsReader keeps its id|slug|code lookup so hand-authored id or slug references still resolve. A parent with children uses its OWN BudgetLine if one exists; otherwise its value is the recursive sum of its children's resolved values (design.md §3d) — no double counting when both exist.",
             "example": null,
-            "title": "Parent Ledger Group ID",
-            "$ref": "LedgerGroup"
+            "title": "Parent Ledger Group Code"
           },
           "accountRanges": {
             "type": "array",
@@ -454,6 +453,7 @@
       }
     }
   },
+  "_objects_placement_note": "These seed objects sit at the TOP-LEVEL `objects` key, NOT under `components.objects`. Both buckets are imported by OpenRegister's ImportHandler, but SettingsService::deepMergeConfig() currently mis-merges the `components.objects` bucket across fragments: measured on this tree it keeps only 98 of the ~483 objects the fragments declare, later fragments overwriting earlier ones index-by-index. Moving these 19 rows there loses 11 of them AND clobbers 19 rows belonging to other fragments. Do not move them until that merge bug is fixed (tracked separately). CONSEQUENCE: `@ref:<schema>:<slug>` seed-reference tokens — which the importer rewrites into the target object's UUID — are NOT usable here, because resolveSeedReferenceTokens() only walks `components.objects`. That is why parentLedgerGroupId below carries the parent's `code` (a flat business key, exactly like Account.parentAccountNumber) rather than an object id: it is the only parent identity that both the PHP rollup and the manifest's `@object.code` filter token can resolve. SECOND TRAP: the import loop only re-saves an ALREADY-IMPORTED object when the incoming `@self.version` compares HIGHER than the stored one (both default to '1.0.0'), so on any instance that already seeded these rows an edit here is a silent no-op — the old values stay in the database and nothing is logged at warning level. The eight child rows therefore carry `@self.version: \"1.0.1\"`; bump it again on any future change to their payload.",
   "objects": [
     {
       "@self": {
@@ -476,13 +476,14 @@
         "register": "shillinq",
         "schema": "LedgerGroup",
         "slug": "ledger-group-neto",
+        "version": "1.0.1",
         "seedExemption": "anchor"
       },
       "administrationId": "template",
       "code": "NETO",
       "name": "Netto-omzet",
       "order": 10,
-      "parentLedgerGroupId": "ledger-group-omzet",
+      "parentLedgerGroupId": "OMZET",
       "accountRanges": [
         {
           "from": "8000",
@@ -497,13 +498,14 @@
         "register": "shillinq",
         "schema": "LedgerGroup",
         "slug": "ledger-group-wvpv",
+        "version": "1.0.1",
         "seedExemption": "anchor"
       },
       "administrationId": "template",
       "code": "WVPV",
       "name": "Wijziging voorraden gereed product en onderhanden werk",
       "order": 20,
-      "parentLedgerGroupId": "ledger-group-omzet",
+      "parentLedgerGroupId": "OMZET",
       "accountRanges": [
         {
           "from": "8100",
@@ -518,13 +520,14 @@
         "register": "shillinq",
         "schema": "LedgerGroup",
         "slug": "ledger-group-geac",
+        "version": "1.0.1",
         "seedExemption": "anchor"
       },
       "administrationId": "template",
       "code": "GEAC",
       "name": "Geactiveerde productie eigen bedrijf",
       "order": 30,
-      "parentLedgerGroupId": "ledger-group-omzet",
+      "parentLedgerGroupId": "OMZET",
       "accountRanges": [
         {
           "from": "8200",
@@ -539,13 +542,14 @@
         "register": "shillinq",
         "schema": "LedgerGroup",
         "slug": "ledger-group-ovop",
+        "version": "1.0.1",
         "seedExemption": "anchor"
       },
       "administrationId": "template",
       "code": "OVOP",
       "name": "Overige bedrijfsopbrengsten",
       "order": 40,
-      "parentLedgerGroupId": "ledger-group-omzet",
+      "parentLedgerGroupId": "OMZET",
       "accountRanges": [
         {
           "from": "8300",
@@ -576,13 +580,14 @@
         "register": "shillinq",
         "schema": "LedgerGroup",
         "slug": "ledger-group-kpvo",
+        "version": "1.0.1",
         "seedExemption": "anchor"
       },
       "administrationId": "template",
       "code": "KPVO",
       "name": "Kostprijs van de omzet",
       "order": 10,
-      "parentLedgerGroupId": "ledger-group-kostprijs-van-de-omzet",
+      "parentLedgerGroupId": "KPOMZET",
       "accountRanges": [
         {
           "from": "7000",
@@ -597,13 +602,14 @@
         "register": "shillinq",
         "schema": "LedgerGroup",
         "slug": "ledger-group-inkw",
+        "version": "1.0.1",
         "seedExemption": "anchor"
       },
       "administrationId": "template",
       "code": "INKW",
       "name": "Inkoopwaarde van de omzet",
       "order": 20,
-      "parentLedgerGroupId": "ledger-group-kostprijs-van-de-omzet",
+      "parentLedgerGroupId": "KPOMZET",
       "accountRanges": [
         {
           "from": "7100",
@@ -634,13 +640,14 @@
         "register": "shillinq",
         "schema": "LedgerGroup",
         "slug": "ledger-group-lone",
+        "version": "1.0.1",
         "seedExemption": "anchor"
       },
       "administrationId": "template",
       "code": "LONE",
       "name": "Lonen en salarissen",
       "order": 10,
-      "parentLedgerGroupId": "ledger-group-personeel",
+      "parentLedgerGroupId": "PERSONEEL",
       "accountRanges": [
         {
           "from": "4000",
@@ -655,13 +662,14 @@
         "register": "shillinq",
         "schema": "LedgerGroup",
         "slug": "ledger-group-socl",
+        "version": "1.0.1",
         "seedExemption": "anchor"
       },
       "administrationId": "template",
       "code": "SOCL",
       "name": "Sociale lasten en pensioenlasten",
       "order": 20,
-      "parentLedgerGroupId": "ledger-group-personeel",
+      "parentLedgerGroupId": "PERSONEEL",
       "accountRanges": [
         {
           "from": "4100",

--- a/src/manifest.d/budget-core-schema.json
+++ b/src/manifest.d/budget-core-schema.json
@@ -38,7 +38,7 @@
 			"type": "detail",
 			"title": "Annual Budget",
 			"config": {
-				"_note": "REQ-BCS-006/009. The fiscal-year begroting container. State chip drives the draft/active/closed lifecycle (activate is gated by AnnualBudgetDefaultGuard's one-default invariant); the budgetLines related list is this budget's phased BudgetLine rows.",
+				"_note": "REQ-BCS-006/009. The fiscal-year begroting container. State chip drives the draft/active/closed lifecycle (activate is gated by AnnualBudgetDefaultGuard's one-default invariant); the budgetLines relatedCollection is this budget's phased BudgetLine rows (key MUST be `relatedCollections` — see the LedgerGroupDetail note below).",
 				"register": "shillinq",
 				"schema": "AnnualBudget",
 				"auditTrail": true,
@@ -49,12 +49,12 @@
 					{"key": "state", "label": "State", "type": "string"},
 					{"key": "administrationId", "label": "Administration", "type": "string"}
 				],
-				"relatedLists": [
-					{"id": "budgetLines", "title": "Budget lines", "schema": "BudgetLine", "foreignKey": "annualBudgetId", "join": "annualBudgetId", "columns": [
+				"relatedCollections": [
+					{"title": "Budget lines", "register": "shillinq", "schema": "BudgetLine", "filter": {"annualBudgetId": "@objectId"}, "columns": [
 						{"key": "ledgerGroupId", "label": "Ledger group"},
 						{"key": "source", "label": "Source"},
 						{"key": "month01Amount", "label": "Jan"}
-					], "detailRoute": "BudgetLineDetail"}
+					], "rowRoute": "BudgetLineDetail"}
 				],
 				"indexRoute": "AnnualBudgets",
 				"sidebarProps": {
@@ -90,7 +90,7 @@
 			"type": "detail",
 			"title": "Ledger Group",
 			"config": {
-				"_note": "REQ-BCS-004/005/009. A verzamelpost: an ordered, nestable GL-account grouping resolved from accountRanges + explicit include/exclude (design.md §3a) — membership is computed in PHP (BudgetVsActualsReader), not shown as a live query here. The children related list surfaces nested LedgerGroups via parentLedgerGroupId (design.md §3d's parent-rollup rule).",
+				"_note": "REQ-BCS-004/005/009. A verzamelpost: an ordered, nestable GL-account grouping resolved from accountRanges + explicit include/exclude (design.md §3a) — membership is computed in PHP (BudgetVsActualsReader), not shown as a live query here. The children relatedCollection surfaces nested LedgerGroups via parentLedgerGroupId (design.md §3d's parent-rollup rule). NOTE THE KEY: CnDetailPage's prop is `relatedCollections` with a token-resolved `filter` — a `relatedLists` block (the spelling 22 other shillinq fragments still use) is not a prop on any Cn page component, so it lands in $attrs, renders nothing, and the page shows only the generic 'No relations yet' widget while every gate stays green. THE FILTER TOKEN IS `@object.code`, NOT `@objectId`: `@objectId` resolves to the row's UUID, but parentLedgerGroupId stores the parent's `code` (a flat business key — see the register fragment's note on why an id is not available at seed time), so an `@objectId` filter matched zero rows and the page fell back to 'No relations yet'. `@object.<field>` reads a FLAT payload field only — it cannot reach `@self.slug`, which is why the seed cannot reference the parent by slug either.",
 				"register": "shillinq",
 				"schema": "LedgerGroup",
 				"auditTrail": true,
@@ -106,12 +106,12 @@
 					{"key": "effectiveTo", "label": "Effective to", "type": "string"},
 					{"key": "administrationId", "label": "Administration", "type": "string"}
 				],
-				"relatedLists": [
-					{"id": "children", "title": "Child ledger groups", "schema": "LedgerGroup", "foreignKey": "parentLedgerGroupId", "join": "parentLedgerGroupId", "columns": [
+				"relatedCollections": [
+					{"title": "Child ledger groups", "register": "shillinq", "schema": "LedgerGroup", "filter": {"parentLedgerGroupId": "@object.code"}, "columns": [
 						{"key": "code", "label": "Code"},
 						{"key": "name", "label": "Name"},
 						{"key": "order", "label": "Order"}
-					], "detailRoute": "LedgerGroupDetail"}
+					], "rowRoute": "LedgerGroupDetail"}
 				],
 				"indexRoute": "LedgerGroups",
 				"sidebarProps": {

--- a/tests/e2e/budget-core-schema.spec.ts
+++ b/tests/e2e/budget-core-schema.spec.ts
@@ -253,7 +253,10 @@ test.describe('budget-core-schema — LedgerGroup seeded data (REQ-BCS-005)', ()
 	 * REQ-BCS-004 scenario: a nested LedgerGroup is reachable from its
 	 * parent's detail page — `Personeel` (parent) lists `Lonen en
 	 * salarissen`/`Sociale lasten en pensioenlasten` (children) via the
-	 * `children` relatedList (`parentLedgerGroupId`).
+	 * `children` relatedCollection (`parentLedgerGroupId`). The manifest key
+	 * is `relatedCollections` — `relatedLists` is not a prop on any Cn page
+	 * component, so it lands in `$attrs` and renders nothing while every
+	 * gate stays green.
 	 */
 	test("Personeel's detail page lists its two seeded children", async ({
 		page,
@@ -265,6 +268,17 @@ test.describe('budget-core-schema — LedgerGroup seeded data (REQ-BCS-005)', ()
 
 		const body = page.locator('#app-content-vue, main').first()
 		const personeelRow = body.getByText('Personeel', { exact: true }).first()
+		// `isVisible()` is a POINT-IN-TIME probe with no auto-wait, and
+		// `cn-index-page` mounts BEFORE its rows arrive. Probing straight
+		// after the mount therefore races the row load, and the defensive
+		// skip below fires on a page that would have rendered the row a
+		// moment later — observed self-skipping 3 of 4 runs. A skip and a
+		// pass are indistinguishable in the summary line, so this raced
+		// itself into looking green. Wait for the row explicitly first; the
+		// skip then means what it says (genuinely absent seed data).
+		await personeelRow
+			.waitFor({ state: 'visible', timeout: 15_000 })
+			.catch(() => {})
 		const found = await personeelRow.isVisible().catch(() => false)
 		test.skip(
 			!found,


### PR DESCRIPTION
## The verzamelpost → grootboek drill-down never worked

`Personeel`'s detail page rendered the generic **"No relations yet"** widget instead of its two seeded children. Every gate stayed green throughout.

Three independent causes, each sufficient on its own.

### 1. The manifest key is dead

The fragment declared the children list under **`relatedLists`**. `CnDetailPage`'s prop is **`relatedCollections`**. `CnPageRenderer` spreads `config` onto props, so `relatedLists` lands in `$attrs` and renders nothing. Nothing errors — the feature is simply absent.

> ⚠️ **22 other shillinq fragments use the same dead spelling.** Every one of those related lists is rendering nothing today. Tracked separately; far outside this fix.

### 2. The parent reference never resolved

Children stored `parentLedgerGroupId: 'ledger-group-personeel'` — a synthetic slug — while the parent's identity is a UUID. Measured live:

```
PERSONEEL  @self.id = f7c9ee89-381e-4f1e-adb5-ff1b173e3aa0
LONE       parentLedgerGroupId = 'ledger-group-personeel'   <- the slug
?parentLedgerGroupId=<uuid>  ->  total 0
```

The supported `@ref:<schema>:<slug>` seed token **cannot** be used here: `resolveSeedReferenceTokens()` only walks `components.objects`, and `deepMergeConfig()` corrupts that bucket (see below). Children now store the parent's `code`, matching the `Account.parentAccountNumber` precedent the schema description already cites.

### 3. The filter token was wrong

`@objectId` resolves to the row's UUID; `@object.code` reads the flat payload field the children actually store. `@object.<field>` reads a flat field only — it cannot reach `@self.slug`.

## A silent no-op that nearly hid the fix

The corrected rows carry `@self.version: "1.0.1"`. This is **required**: the importer only re-saves an existing object when the incoming version compares *higher*. Without the bump, the corrected parent links are a silent no-op, logged only at debug level.

## The test was racing itself into looking green

Its defensive `test.skip` used `isVisible()` — a point-in-time probe with no auto-wait — immediately after `cn-index-page` mounts but *before* rows load. It **self-skipped 3 of 4 runs**. A skip and a pass are indistinguishable in the summary line, so the race read as success. An explicit `waitFor` now precedes the probe, so the skip means what it claims: genuinely absent seed data.

No assertion weakened, no skip added, no expected name changed.

## Verification

Rebuilt, re-imported, confirmed stored values flip (`LONE -> PERSONEEL`), the widget's own query returns 2 rows, and DOM-level proof that `cn-related-collections` renders `LONE Lonen en salarissen` + `SOCL Sociale lasten en pensioenlasten` with zero "No relations yet".

```
5 passed (1.7m)      target test 5/5 under --repeat-each=5
```
PHPUnit 17/17 · PHPCS clean · prettier/eslint clean · all six repo validators pass.

## Handed back, not fixed here

1. **`components.objects` is a corrupted bucket app-wide.** `deepMergeConfig()` keeps ~98 of the ~483 objects fragments declare, later fragments overwriting earlier index-by-index — so **~385 seed objects across ~40 fragments have never imported**. Fixing it un-drops all of them at once.
2. **`relatedLists` is dead in 22 other fragments.**
