### PR TITLE
fix(e2e): scope the CBS delete button to the dialog, not the phase marker

### DIFF
--- a/tests/e2e/cbs-submissions.spec.ts
+++ b/tests/e2e/cbs-submissions.spec.ts
@@ -238,11 +238,25 @@ test.describe('CBS Submissions — delete-own-draft flow', () => {
 			await row.getByTestId('cn-row-actions').click()
 			await page.getByTestId('cn-action-item-delete').click()
 
-			// Confirm in CnDeleteDialog's confirm phase.
-			const confirmDialog = page.locator(
+			// Wait for CnDeleteDialog to reach its confirm phase...
+			const confirmPhase = page.locator(
 				'[data-testid-modal="cn-delete-dialog"][data-testid-phase="confirm"]',
 			)
-			await expect(confirmDialog).toBeVisible({ timeout: 10_000 })
+			await expect(confirmPhase).toBeVisible({ timeout: 10_000 })
+
+			// ...but take the button from the DIALOG, not from that marker.
+			//
+			// `data-testid-phase="confirm"` sits on the div holding the warning
+			// NcNoteCard; the Cancel/Delete buttons live in NcDialog's `#actions`
+			// slot, which is a SIBLING of it (see CnDeleteDialog.vue in
+			// @conduction/nextcloud-vue). Scoping the button lookup to the phase
+			// marker searches a subtree that contains no buttons at all, so the
+			// click hangs — and because `waitForResponse` below starts its 15s
+			// timer before the click is awaited, IT rejects first. The failure
+			// therefore pointed at the response wait and read as "the app never
+			// issued a DELETE", when nothing had been clicked. The trace shows it:
+			// 78 GETs, one unrelated user_status PUT, and no DELETE.
+			const confirmDialog = page.getByRole('dialog').filter({ has: confirmPhase })
 
 			const deleteRequest = page.waitForResponse(
 				(response) =>
@@ -250,7 +264,7 @@ test.describe('CBS Submissions — delete-own-draft flow', () => {
 					&& response.request().method() === 'DELETE',
 				{ timeout: 15_000 },
 			)
-			await confirmDialog.getByRole('button', { name: /delete/i }).click()
+			await confirmDialog.getByRole('button', { name: /^delete$/i }).click()
 			const deleteResponse = await deleteRequest
 			expect(
 				deleteResponse.status(),

--- a/tests/e2e/cbs-submissions.spec.ts
+++ b/tests/e2e/cbs-submissions.spec.ts
@@ -256,7 +256,9 @@ test.describe('CBS Submissions — delete-own-draft flow', () => {
 			// therefore pointed at the response wait and read as "the app never
 			// issued a DELETE", when nothing had been clicked. The trace shows it:
 			// 78 GETs, one unrelated user_status PUT, and no DELETE.
-			const confirmDialog = page.getByRole('dialog').filter({ has: confirmPhase })
+			const confirmDialog = page
+				.getByRole('dialog')
+				.filter({ has: confirmPhase })
 
 			const deleteRequest = page.waitForResponse(
 				(response) =>


### PR DESCRIPTION
This one spec has been failing on **every** shillinq PR — #967, #1002 and #943 all hit it — and it is the last thing standing between them and green.

```
TimeoutError: page.waitForResponse: Timeout 15000ms exceeded
```

which reads as *the UI never issued a DELETE*. It is not that.

## What the trace actually shows

- **78 GETs, one unrelated `user_status` heartbeat PUT, zero DELETEs**
- **no JS error** on click
- the page snapshot at failure still shows the dialog **open, with Cancel focused**

Nothing had been clicked.

## Why

`CnDeleteDialog.vue` in `@conduction/nextcloud-vue`:

```html
<div v-else data-testid-modal="cn-delete-dialog" data-testid-phase="confirm">
    <NcNoteCard type="warning">{{ resolvedWarningText }}</NcNoteCard>
</div>
<template #actions>
    … <NcButton>{{ confirmLabel }}</NcButton>
</template>
```

The `confirm` marker is on the div holding the **warning text**. The Cancel/Delete buttons live in `NcDialog`'s `#actions` slot — a **sibling**. Scoping the button lookup to the marker searched a subtree containing no buttons, so the click hung.

And `waitForResponse()` starts its 15s timer when it is **created**, a few lines before the click is awaited — so the response wait rejected first and the error pointed at the response instead of at the click that never landed. That misdirection is why this read as an application bug for so long.

The accessibility snapshot confirms the right scope — `role=dialog` wraps both the note and the actions:

```
- dialog:
  - heading "Delete item"
  - note: Are you sure you want to permanently delete "…"?
  - button "Cancel"
  - button "Delete"
```

## Fix

Wait on the phase marker for readiness, then take the button from the **dialog**. The name match is tightened to `/^delete$/i` so it cannot drift onto the "Delete item" heading if that ever becomes a button.

## Verification

I could not run this locally — it needs the seeded Nextcloud instance — so the evidence is the trace plus the component source, not a local repro. CI is the check.