### PR TITLE
fix(begroting): render the BudgetScenarioDetail modifiers list, retire a spent exemption

### DIFF
--- a/src/manifest.d/budget-scenarios.json
+++ b/src/manifest.d/budget-scenarios.json
@@ -69,13 +69,13 @@
 					{"key": "status", "label": "Status", "type": "string"},
 					{"key": "administrationId", "label": "Administration", "type": "string"}
 				],
-				"relatedLists": [
-					{"id": "modifiers", "title": "Modifiers", "schema": "BudgetScenarioModifier", "foreignKey": "scenarioId", "join": "scenarioId", "columns": [
+				"relatedCollections": [
+					{"title": "Modifiers", "register": "shillinq", "schema": "BudgetScenarioModifier", "filter": {"scenarioId": "@objectId"}, "columns": [
 						{"key": "modifierType", "label": "Type"},
 						{"key": "effectiveDate", "label": "Effective date"},
 						{"key": "targetRecurId", "label": "Target recurring cost"},
 						{"key": "targetLedgerGroupId", "label": "Target ledger group"}
-					], "detailRoute": "BudgetScenarioModifierDetail"}
+					], "rowRoute": "BudgetScenarioModifierDetail"}
 				],
 				"indexRoute": "BudgetScenarios",
 				"sidebarProps": {

--- a/tests/validate-manifest.js
+++ b/tests/validate-manifest.js
@@ -283,10 +283,7 @@ const DEAD_CONFIG_KEYS = {
  *
  * @type {Object<string,string>}
  */
-const PENDING_FRAGMENTS = {
-	'budget-core-schema.json':
-		'converted by PR #1011 (fix/ledgergroup-children), which owns this file; remove this entry when that PR merges',
-}
+const PENDING_FRAGMENTS = {}
 
 /**
  * Re-derive the `Cn*` prop names from the installed component sources and


### PR DESCRIPTION
fix(begroting): render the BudgetScenarioDetail modifiers list, retire a spent exemption

`check:manifest` is RED on development, and has been since the budget-scenarios
work landed. Because pushes to development are concurrency-cancelled, the red
never showed up there -- it shows up on whichever PR happens to run next, which
is how a stylelint bump (#943) came to be carrying a begroting bug.

Two findings, both from the dead-config-key gate, neither related to any open
PR's own diff.

1. The modifiers list rendered nothing
--------------------------------------
budget-scenarios.json, pages[id=BudgetScenarioDetail].config declared
`relatedLists`. No Cn* page component accepts that prop -- it lands in $attrs
and renders NOTHING. The scenario detail page has therefore been shipping a
Modifiers section that is silently empty, which is the exact failure already
proven and fixed on LedgerGroupDetail (the gate's deny-list cites it).

Converted to `relatedCollections` with the documented shape:

    {"title": "Modifiers", "register": "shillinq",
     "schema": "BudgetScenarioModifier",
     "filter": {"scenarioId": "@objectId"},
     "columns": [...], "rowRoute": "BudgetScenarioModifierDetail"}

The filter token is the part worth checking rather than copying, since the gate
message warns that `@object.<field>` cannot reach `@self.slug`. Verified against
the schema rather than assumed: BudgetScenarioModifier.scenarioId is declared
`type: string, format: uuid, $ref: BudgetScenario` in
lib/Settings/register.d/budget-scenarios.json and is on the `required` list, so
the child stores the parent's UUID as a flat field -- which is precisely what
`@objectId` resolves to.

`rowRoute` was likewise checked, not carried over: BudgetScenarioModifierDetail
is a real page in this same fragment (/begroting/scenario-modifiers/:id), not
just a name the old `detailRoute` happened to hold.

Dropped `id`, `foreignKey` and `join`: they belong to the dead key's vocabulary
and have no counterpart in the replacement's shape.

2. A self-retiring exemption that had retired
---------------------------------------------
PENDING_FRAGMENTS exempted budget-core-schema.json pending PR #1011
(fix/ledgergroup-children). #1011 is merged and the key is gone, so the gate did
what it was built to do and failed demanding its own exemption be deleted.
Deleted; the map is now empty.

That mechanism is worth keeping in mind: the exemption could not quietly widen
the gate after the reason for it expired, so this cost one line instead of
becoming a permanent hole.

Verification
------------
The gate FAILED on unmodified origin/development (f31c8475) with exactly these
two messages, and PASSES on this branch -- so both the must-fail and must-pass
controls are on the same checker, not on my reading of it.

  node tests/validate-manifest.js   FAIL -> PASS (0 issues)
    with node_modules present, so the Cn* prop premise actually ran:
    "checked 1 dead key(s) against 894 prop names from 251 Cn* components"
    -- i.e. relatedCollections is confirmed a real prop and relatedLists is
    confirmed not one, rather than the deny-list being trusted on faith.
  328 page configs across 86 fragments inspected (the gate also fails if it
    inspects zero, so that count is evidence it reached its subject)

  check:markers, check:registers, check:seeds, check:fragment-required,
  check:manifest-budget          all rc=0
  check:nav-reachability         rc=0 (571 pages, 51 menu entries, 0 new orphans)
  npm run format                 rc=0
  npm run lint                   rc=0, 0 errors / 100 pre-existing warnings

Note the JSON fragment does not satisfy Prettier -- but it does not on
development either, and `format` globs only {js,ts,vue,css,scss}, so this
deliberately leaves the file's existing style alone rather than reformatting
1,000 lines inside a bug fix.
