### PR TITLE
fix(orders): OrderDetail rendered a bare widget grid instead of the detail page

### DIFF
--- a/src/manifest.d/order-workspace.json
+++ b/src/manifest.d/order-workspace.json
@@ -34,25 +34,26 @@
 			"route": "/orders/:id",
 			"type": "detail",
 			"_note": "OrderPrimitive is the unified transactional WORKSPACE primitive that replaces the scattered Subsidie / Purchase Order / Quote / Sales Order records — one record whose orderType/direction re-skins it. Body leads with the order header (counterparty, type, terms, total) plus a total-amount KPI; the Order lines are the primary child table (the auditable breakdown) with Payments beside them so the operator sees what was ordered and what has been paid. Documents (quote/PO/contract) and the audit trail sit in the sidebar. No email/calendar leaf on the record itself — a transaction workspace, not a comms surface.",
-			"widgets": [
-				{
-					"id": "order-total",
-					"widgetKey": "stats-block",
-					"slot": "body",
-					"gridX": 0,
-					"gridY": 0,
-					"gridWidth": 12,
-					"gridHeight": 1,
-					"props": {
-						"entries": [
-							{ "title": "Order total", "register": "shillinq", "schema": "OrderLine", "metric": "sum", "field": "lineAmount", "filter": { "orderId": "@objectId" } }
-						]
-					}
-				}
-			],
 			"config": {
 				"register": "shillinq",
 				"schema": "OrderPrimitive",
+				"_widgetsNote": "These live under config.widgets[] + config.layout[], NOT as a page-level widgets[] block. A page-level widgets[] on a type:\"detail\" page makes CnPageRenderer render a bare CnWidgetGrid INSTEAD of the typed detail component, so the page silently loses its header, max-width, padding, sidebar and grid discipline — and the sidebarProps/relatedCollections below would never render at all. The v2 schema calls page-level widgets[] 'preferred'; for a TYPED page it is the broken spelling. gate-69 page-type-discipline catches it.",
+				"widgets": [
+					{
+						"id": "order-total",
+						"type": "stats-block",
+						"title": "Order total",
+						"icon": "ChartBar",
+						"content": {
+							"entries": [
+								{ "title": "Order total", "register": "shillinq", "schema": "OrderLine", "metric": "sum", "field": "lineAmount", "filter": { "orderId": "@objectId" } }
+							]
+						}
+					}
+				],
+				"layout": [
+					{ "id": "1", "widgetId": "order-total", "gridX": 0, "gridY": 0, "gridWidth": 12, "gridHeight": 2 }
+				],
 				"relatedCollections": [
 					{ "title": "Order lines", "register": "shillinq", "schema": "OrderLine", "filter": { "orderId": "@objectId" }, "columns": [
 						{"key": "lineNumber", "label": "#"},


### PR DESCRIPTION
fix(orders): OrderDetail rendered a bare widget grid instead of the detail page

gate-69 page-type-discipline is RED on development, so it fails on every open
shillinq PR regardless of what that PR changed:

    src/manifest.d/order-workspace.json: page 'OrderDetail' — type:"detail" with
    1 page-level body widget(s), so CnPageRenderer renders a bare CnWidgetGrid
    INSTEAD of the typed page component

Same shape as the check:manifest breakage fixed in #1040: pushes to development
are concurrency-cancelled, so the red never surfaces there and lands on whoever
opens the next PR.

What was actually broken
------------------------
`OrderDetail` declared a page-level `widgets[]` block (one stats-block for the
order total). On a `type:"detail"` page that short-circuits the typed detail
component, so the page loses its header, max-width, padding, sidebar and grid
discipline — and, more concretely here, the `config` block underneath it stops
rendering. That config carries the Order lines table, the Payments table, and
the Documents + Audit Trail sidebar tabs. The page's own `_note` describes those
as the point of the screen.

So this is not a lint nit. The KPI widget was the only thing on the page.

The trap is that the v2 schema calls page-level `widgets[]` "preferred" — it is,
for an untyped page. For a typed one it is the broken spelling, and the failure
is silent: the page renders, it just renders the wrong thing.

The fix
-------
Moved into `config.widgets[]` + `config.layout[]`, matching the shape every other
shillinq detail page already uses (`type`/`content`, geometry split into
`layout[]`), verified against ResourceDetail rather than invented.

`gridHeight` goes 1 -> 2. Not cosmetic drift: no stats-block anywhere in this
repo's 22 layout entries uses height 1 (they run 2–6), and since this widget has
never once rendered, its height 1 was never seen on screen. 2 is the minimum any
stats-block here uses, and the full width 12 the author asked for is kept.

A `_widgetsNote` on the config records why the widgets live where they do, so
the next person does not "fix" them back to the spelling the schema recommends.

Verification
------------
gate-69 is not in the vendored `conduction/hydra-gates v1.8.2` this repo pins —
CI resolves a newer gate set from `.github@main` — so the checker was fetched
from there and run the way the runner invokes it (log path + every
`src/manifest.d/*.json`, 87 files in scope), not approximated.

  origin/development, unmodified:  1 finding   (must-fail control)
  this branch:                     0 findings

Also green, so the conversion did not break its neighbours:

  check:manifest (incl. dead-config-key + Cn* prop premise)   rc=0
  check:markers, check:registers, check:seeds                 rc=0
  check:fragment-required, check:manifest-budget              rc=0
  check:nav-reachability                                      rc=0

`src/manifest.json` and `src/manifest.d.shell.json` carry no OrderDetail page
(the fragments are loaded separately), so there is nothing generated to rebuild.
