### PR TITLE
fix(budget): promoting a second scenario 500s because findAll returns entities

### DIFF
--- a/lib/Service/BudgetScenarioDefaultPromoter.php
+++ b/lib/Service/BudgetScenarioDefaultPromoter.php
@@ -244,7 +244,10 @@ class BudgetScenarioDefaultPromoter {
 			$normalised[] = $row->getObject();
 		}
 
-		return array_values($normalised);
+		// No array_values(): appending to $normalised already produces a list.
+		// The original call was needed because findAll()'s own result may be
+		// keyed; this loop re-indexes it by construction.
+		return $normalised;
 
 	}//end findAllDefaults()
 

--- a/lib/Service/BudgetScenarioDefaultPromoter.php
+++ b/lib/Service/BudgetScenarioDefaultPromoter.php
@@ -215,8 +215,8 @@ class BudgetScenarioDefaultPromoter {
 			return [];
 		}
 
-		// findAll() returns ObjectEntity INSTANCES, not arrays: ObjectService
-		// hands its rows to RenderObject::renderEntities(), whose per-row
+		// ObjectService::findAll() returns ObjectEntity INSTANCES, not arrays:
+		// it hands its rows to RenderObject::renderEntities(), whose per-row
 		// renderEntity() is declared `): ObjectEntity`. find() above already
 		// accounts for this by returning `$entity->getObject()`; this path did
 		// not, and the docblock claiming `list<array<string,mixed>>` hid it.
@@ -228,16 +228,23 @@ class BudgetScenarioDefaultPromoter {
 		//   TypeError: findCurrentDefault(): Return value must be of type
 		//   ?array, ObjectEntity returned
 		//
-		// so PHP rejects it before promote() ever reaches array_merge(), and
+		// PHP rejects it before promote() ever reaches array_merge(), and
 		// BudgetScenarioController's `catch (Throwable)` turns it into an
 		// unexpected error. It never fired on the FIRST promotion in an
 		// administration, because there is nothing to demote then — exactly
 		// the pair the e2e trace showed: 200 with `demotedScenarioId: null`,
 		// then 500 on the next one.
-		return array_values(array_map(
-			static fn (mixed $row): array => is_array($row) ? $row : $row->getObject(),
-			$rows
-		));
+		$normalised = [];
+		foreach ($rows as $row) {
+			if (is_array($row) === true) {
+				$normalised[] = $row;
+				continue;
+			}
+
+			$normalised[] = $row->getObject();
+		}
+
+		return array_values($normalised);
 
 	}//end findAllDefaults()
 

--- a/lib/Service/BudgetScenarioDefaultPromoter.php
+++ b/lib/Service/BudgetScenarioDefaultPromoter.php
@@ -215,7 +215,29 @@ class BudgetScenarioDefaultPromoter {
 			return [];
 		}
 
-		return array_values($rows);
+		// findAll() returns ObjectEntity INSTANCES, not arrays: ObjectService
+		// hands its rows to RenderObject::renderEntities(), whose per-row
+		// renderEntity() is declared `): ObjectEntity`. find() above already
+		// accounts for this by returning `$entity->getObject()`; this path did
+		// not, and the docblock claiming `list<array<string,mixed>>` hid it.
+		//
+		// The consequence was a 500 on every promotion that had to DEMOTE a
+		// previous default. The throw point is findCurrentDefault()'s own
+		// return type:
+		//
+		//   TypeError: findCurrentDefault(): Return value must be of type
+		//   ?array, ObjectEntity returned
+		//
+		// so PHP rejects it before promote() ever reaches array_merge(), and
+		// BudgetScenarioController's `catch (Throwable)` turns it into an
+		// unexpected error. It never fired on the FIRST promotion in an
+		// administration, because there is nothing to demote then — exactly
+		// the pair the e2e trace showed: 200 with `demotedScenarioId: null`,
+		// then 500 on the next one.
+		return array_values(array_map(
+			static fn (mixed $row): array => is_array($row) ? $row : $row->getObject(),
+			$rows
+		));
 
 	}//end findAllDefaults()
 

--- a/tests/Unit/Service/BudgetScenarioDefaultPromoterTest.php
+++ b/tests/Unit/Service/BudgetScenarioDefaultPromoterTest.php
@@ -30,8 +30,10 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Tests\Unit\Service;
 
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\Service\BudgetScenarioDefaultPromoter;
 use OCA\Shillinq\Tests\Unit\Service\Support\InMemoryObjectServiceStub;
+use OCA\Shillinq\Tests\Unit\Service\Support\ObjectEntityStub;
 use OCA\Shillinq\Tests\Unit\Service\Support\RacingDefaultObjectServiceDecorator;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
@@ -277,4 +279,104 @@ final class BudgetScenarioDefaultPromoterTest extends TestCase {
 		$this->assertSame(2, $outcome['defaultCount']);
 
 	}//end testLogsVerificationMismatchOnConcurrentPromotionRace()
+
+	/**
+	 * REGRESSION: findAll() hands back ObjectEntity INSTANCES, not arrays.
+	 *
+	 * Every other test here passes an InMemoryObjectServiceStub whose
+	 * findAll() returns plain arrays — which is why this defect shipped green.
+	 * The real ObjectService routes its rows through
+	 * RenderObject::renderEntities(), whose per-row renderEntity() is declared
+	 * `): ObjectEntity`, so production hands the promoter objects where the
+	 * stub hands it arrays. findCurrentDefault() is declared `: ?array`, so
+	 * PHP throws on the return itself —
+	 *
+	 *   TypeError: findCurrentDefault(): Return value must be of type ?array,
+	 *   ObjectEntity returned
+	 *
+	 * — and BudgetScenarioController's `catch (Throwable)` turns that into a
+	 * 500.
+	 *
+	 * It only ever fired on a promotion that had to DEMOTE a previous default:
+	 * the first promotion in an administration has nothing to demote. The e2e
+	 * trace showed exactly that pair — 200 with `demotedScenarioId: null`,
+	 * then 500 on the next promotion.
+	 *
+	 * This test drives findAll() through the ENTITY shape production actually
+	 * produces. It fails with the TypeError before the fix.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/budget-scenarios/specs/budget-scenarios/spec.md#req-bsc-002
+	 */
+	public function testDemotesAPreviousDefaultWhenFindAllReturnsEntities(): void {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturn('shillinq');
+
+		$rows = [
+			['id' => 'scn-a', 'administrationId' => 'ADM-001', 'name' => 'A', 'isDefault' => true, 'status' => 'active'],
+			['id' => 'scn-b', 'administrationId' => 'ADM-001', 'name' => 'B', 'isDefault' => false, 'status' => 'draft'],
+		];
+
+		$entity = static fn (array $row): ObjectEntityStub => new ObjectEntityStub(
+			payload: $row,
+			register: 'shillinq',
+			schema: 'BudgetScenario',
+		);
+
+		$saved = [];
+		$store = $this->createMock(ObjectServiceInterface::class);
+		$store->method('setRegister')->willReturnSelf();
+		$store->method('setSchema')->willReturnSelf();
+		$store->method('find')->willReturnCallback(
+			static function (int|string $id) use ($rows, $entity): ?ObjectEntityStub {
+				foreach ($rows as $row) {
+					if ($row['id'] === (string)$id) {
+						return $entity($row);
+					}
+				}
+
+				return null;
+			}
+		);
+		// THE POINT OF THIS TEST: entities, exactly as ObjectService returns.
+		$store->method('findAll')->willReturnCallback(
+			static function () use (&$saved, $rows, $entity): array {
+				$defaults = [];
+				foreach ($rows as $row) {
+					$current = ($saved[$row['id']] ?? $row);
+					if (($current['isDefault'] ?? false) === true) {
+						$defaults[] = $entity($current);
+					}
+				}
+
+				return $defaults;
+			}
+		);
+		$store->method('saveObject')->willReturnCallback(
+			static function (array $object) use (&$saved, $entity): ObjectEntityStub {
+				$saved[(string)($object['id'] ?? '')] = $object;
+
+				return $entity($object);
+			}
+		);
+
+		$promoter = new BudgetScenarioDefaultPromoter(
+			appConfig: $appConfig,
+			logger: new NullLogger(),
+			objectService: $store,
+		);
+
+		$outcome = $promoter->promote(scenarioId: 'scn-b');
+
+		$this->assertSame('scn-b', $outcome['scenarioId']);
+		$this->assertSame(
+			'scn-a',
+			$outcome['demotedScenarioId'],
+			'the previous default must be demoted even when findAll returns entities',
+		);
+		$this->assertTrue($outcome['verified']);
+		$this->assertSame(1, $outcome['defaultCount']);
+
+	}//end testDemotesAPreviousDefaultWhenFindAllReturnsEntities()
 }//end class


### PR DESCRIPTION
`development` is red on one e2e test: promoting scenario B to default — which must demote scenario A — returns **500** from `BudgetScenarioController::promote`.

## What is actually wrong

`ObjectService::findAll()` returns **ObjectEntity instances, not arrays**. It routes its rows through `RenderObject::renderEntities()`, whose per-row `renderEntity()` is declared `): ObjectEntity`.

`find()` in this class already accounts for that — it returns `$entity->getObject()`. `findAllDefaults()` did not, and its docblock claiming `list<array<string,mixed>>` hid the mismatch.

`findCurrentDefault()` is declared `: ?array`, so PHP throws on the return itself:

```
TypeError: findCurrentDefault(): Return value must be of type ?array, ObjectEntity returned
```

That happens *before* `promote()` reaches `array_merge()`, and the controller's `catch (Throwable)` turns it into an unexpected error.

## Why it looked intermittent

It only fires on a promotion that has to **demote** a previous default. The first promotion in an administration has nothing to demote and succeeds. The e2e trace shows the pair exactly:

```
POST .../6946ec7c.../promote -> 200  {"demotedScenarioId": null, "verified": true}
POST .../bda97e8b.../promote -> 500  {"error":"An unexpected error occurred"}
```

## Why no unit test caught it

Every existing test here drives `InMemoryObjectServiceStub`, whose `findAll()` returns plain **arrays** while its `find()` correctly returns `?ObjectEntityInterface`. The double models one method against reality and the other against convenience, so production and the suite were checking different interfaces.

The regression test added here drives `findAll()` through the entity shape production actually produces.

## Verification

- Reverting the fix makes the new test fail with the `TypeError` above.
- With the fix: **4889 tests, 46073 assertions, 0 failures.**

## Follow-up, deliberately not folded in

The stub's own divergence is the deeper enabler. Fixing it is a test-support change with blast radius across the whole suite (other tests index `findAll()` rows as arrays), which does not belong in a fix for a red branch. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)