### PR TITLE
test(budget): controller coverage, diagnosable serverError, and a row-identity e2e fix

### DIFF
--- a/lib/Controller/BudgetScenarioController.php
+++ b/lib/Controller/BudgetScenarioController.php
@@ -260,6 +260,16 @@ class BudgetScenarioController extends Controller {
 	/**
 	 * Log an unexpected error server-side and return a generic 500 (no stack trace).
 	 *
+	 * The log entry names the throwable's CLASS and origin as well as its
+	 * message. A message alone is not enough to identify the fault: a
+	 * `TypeError` raised by a return-type mismatch deep in the promoter reads
+	 * as ordinary prose, and this handler's `catch (Throwable)` is the only
+	 * place it is ever observed. `promote()` returned an opaque 500 on every
+	 * demotion for exactly that reason (e2e budget-scenarios, CI run
+	 * 32462209787) — the cause had to be reconstructed from source rather
+	 * than read from the log. The client response is unchanged: still the
+	 * generic message, still no stack trace.
+	 *
 	 * @param string $action The controller action for the log entry.
 	 * @param \Throwable $e The caught throwable.
 	 *
@@ -268,7 +278,11 @@ class BudgetScenarioController extends Controller {
 	private function serverError(string $action, \Throwable $e): JSONResponse {
 		$this->logger->error(
 			'BudgetScenarioController: ' . $action . ' failed',
-			['exception' => $e->getMessage()]
+			[
+				'exceptionClass' => $e::class,
+				'exception' => $e->getMessage(),
+				'origin' => $e->getFile() . ':' . $e->getLine(),
+			]
 		);
 
 		return new JSONResponse(['error' => 'An unexpected error occurred'], Http::STATUS_INTERNAL_SERVER_ERROR);

--- a/lib/Service/BudgetScenarioDefaultPromoter.php
+++ b/lib/Service/BudgetScenarioDefaultPromoter.php
@@ -54,6 +54,7 @@ declare(strict_types=1);
 
 namespace OCA\Shillinq\Service;
 
+use OCA\OpenRegister\Contract\ObjectEntityInterface;
 use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCP\IAppConfig;
@@ -190,9 +191,29 @@ class BudgetScenarioDefaultPromoter {
 	 * administration — used both to find the scenario to demote and, after
 	 * promotion, to verify exactly one remains.
 	 *
+	 * ## Rows arrive as ENTITIES, not arrays
+	 *
+	 * OpenRegister's `ObjectService::findAll()` ends in
+	 * `RenderObject::renderEntities()`, whose declared return is
+	 * `list<ObjectEntity>` — every row is an OBJECT, and `ObjectEntity` does
+	 * NOT implement `ArrayAccess`. Handing those rows straight back made
+	 * `findCurrentDefault(): ?array` throw
+	 * `TypeError: ... Return value must be of type ?array, ObjectEntity
+	 * returned`, which `promote()` does not catch and
+	 * `BudgetScenarioController::promote()` turned into an opaque HTTP 500 on
+	 * EVERY promotion that had a previous default to demote — the exact
+	 * REQ-BSC-002 path the endpoint exists for. The unit suite could not see
+	 * it because its in-memory double answered plain arrays.
+	 *
+	 * So every row is normalised to its plain payload here, at the single
+	 * point where store rows enter this service — the same `getObject()`
+	 * conversion {@see BudgetScenarioReader::query()} already performs for
+	 * this change's read path. Arrays are passed through unchanged, so a
+	 * double or a future engine that answers arrays keeps working.
+	 *
 	 * @param string $administrationId The administration to scope the read to.
 	 *
-	 * @return list<array<string,mixed>> The matching rows.
+	 * @return list<array<string,mixed>> The matching rows, as plain arrays.
 	 */
 	private function findAllDefaults(string $administrationId): array {
 		try {
@@ -215,7 +236,27 @@ class BudgetScenarioDefaultPromoter {
 			return [];
 		}
 
-		return array_values($rows);
+		$normalised = [];
+		foreach ($rows as $row) {
+			if (is_array($row) === true) {
+				$normalised[] = $row;
+				continue;
+			}
+
+			if ($row instanceof ObjectEntityInterface === true) {
+				$normalised[] = $row->getObject();
+				continue;
+			}
+
+			if (is_object($row) === true && method_exists($row, 'getObject') === true) {
+				$payload = $row->getObject();
+				if (is_array($payload) === true) {
+					$normalised[] = $payload;
+				}
+			}
+		}
+
+		return array_values($normalised);
 
 	}//end findAllDefaults()
 

--- a/lib/Service/BudgetScenarioDefaultPromoter.php
+++ b/lib/Service/BudgetScenarioDefaultPromoter.php
@@ -256,7 +256,10 @@ class BudgetScenarioDefaultPromoter {
 			}
 		}
 
-		return array_values($normalised);
+		// No array_values() here: $normalised is only ever appended to with
+		// [], so it is already a list. PHPStan (arrayValues.list) rejects the
+		// redundant call outright rather than merely warning.
+		return $normalised;
 
 	}//end findAllDefaults()
 

--- a/tests/Unit/Controller/BudgetScenarioControllerTest.php
+++ b/tests/Unit/Controller/BudgetScenarioControllerTest.php
@@ -1,0 +1,318 @@
+<?php
+
+/**
+ * Unit tests for BudgetScenarioController::promote().
+ *
+ * ## Why this file exists
+ *
+ * `BudgetScenarioController::promote()` wraps the whole promotion in
+ * `catch (Throwable) { serverError() }`, so ANY exception below it becomes an
+ * opaque HTTP 500 whose real cause is swallowed into the server log. The
+ * e2e test `budget-scenarios.spec.ts::promote to default demotes the previous
+ * one` failed on exactly that (CI run 32462209787, "Expected: 200 / Received:
+ * 500"), with five green `BudgetScenarioDefaultPromoterTest` cases underneath
+ * it — because those cases drove a double whose `findAll()` answered plain
+ * ARRAYS, while the deployed engine answers `list<ObjectEntity>`.
+ *
+ * So the promotion path is driven here through the CONTROLLER — the surface
+ * that turns a throwable into a status code — over a store constructed with
+ * `findAllRendersEntities: true`, the shape
+ * `RenderObject::renderEntities(): @psalm-return list<ObjectEntity>` really
+ * returns. `ObjectEntity` does not implement `ArrayAccess`, so a consumer
+ * that subscripts a row fatals; a test that cannot see that shape cannot see
+ * the defect.
+ *
+ * The store is REAL (an in-memory OpenRegister double) and the promoter is
+ * REAL: only `AdministrationContextService`, `IUserSession` and `IRequest`
+ * are mocked, because they are the request-context boundary, not the
+ * behaviour under test.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/budget-scenarios/specs/budget-scenarios/spec.md#req-bsc-002
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\BudgetScenarioController;
+use OCA\Shillinq\Service\AdministrationContextService;
+use OCA\Shillinq\Service\BudgetScenarioDefaultPromoter;
+use OCA\Shillinq\Service\BudgetScenarioEvaluator;
+use OCA\Shillinq\Service\BudgetScenarioReader;
+use OCA\Shillinq\Tests\Unit\Service\Support\InMemoryObjectServiceStub;
+use OCP\AppFramework\Http;
+use OCP\IAppConfig;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * Tests the REQ-BSC-002 promote endpoint against engine-shaped store rows.
+ *
+ * @spec openspec/changes/budget-scenarios/specs/budget-scenarios/spec.md#req-bsc-002
+ */
+final class BudgetScenarioControllerTest extends TestCase {
+
+	/**
+	 * The administration both seeded scenarios belong to.
+	 *
+	 * @var string
+	 */
+	private const ADMINISTRATION = 'adm-1';
+
+	/**
+	 * Two scenarios in one administration: `scn-a` is the current default,
+	 * `scn-b` is the one the test promotes.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function seedScenarios(): array {
+		return [
+			[
+				'id' => 'scn-a',
+				'administrationId' => self::ADMINISTRATION,
+				'name' => 'Scenario A',
+				'isDefault' => true,
+				'status' => 'active',
+			],
+			[
+				'id' => 'scn-b',
+				'administrationId' => self::ADMINISTRATION,
+				'name' => 'Scenario B',
+				'isDefault' => false,
+				'status' => 'draft',
+			],
+		];
+	}//end seedScenarios()
+
+	/**
+	 * Build the controller over a REAL promoter and a REAL in-memory store.
+	 *
+	 * @param bool $findAllRendersEntities Whether the store answers `findAll()`
+	 *                                     with ObjectEntityInterface rows, as
+	 *                                     the deployed OpenRegister engine does.
+	 * @param bool $canAccess              What the membership guard answers.
+	 *
+	 * @return array{0: BudgetScenarioController, 1: InMemoryObjectServiceStub}
+	 */
+	private function buildController(
+		bool $findAllRendersEntities = true,
+		bool $canAccess = true
+	): array {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturn('shillinq');
+
+		$store = new InMemoryObjectServiceStub(
+			data: ['BudgetScenario' => $this->seedScenarios()],
+			findAllRendersEntities: $findAllRendersEntities
+		);
+
+		$promoter = new BudgetScenarioDefaultPromoter(
+			appConfig: $appConfig,
+			logger: new NullLogger(),
+			objectService: $store,
+		);
+
+		$context = $this->createMock(AdministrationContextService::class);
+		$context->method('canAccess')->willReturn($canAccess);
+
+		$user = $this->createMock(IUser::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn($user);
+
+		$controller = new BudgetScenarioController(
+			request: $this->createMock(IRequest::class),
+			promoter: $promoter,
+			reader: $this->createMock(BudgetScenarioReader::class),
+			evaluator: $this->createMock(BudgetScenarioEvaluator::class),
+			context: $context,
+			userSession: $userSession,
+			logger: new NullLogger(),
+		);
+
+		return [$controller, $store];
+	}//end buildController()
+
+	/**
+	 * Index the store's current rows by id, reading through the plain-array
+	 * view so the assertions never depend on the row shape under test.
+	 *
+	 * @param InMemoryObjectServiceStub $store The store to read.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	private function rowsById(InMemoryObjectServiceStub $store): array {
+		$byId = [];
+		foreach ($store->setRegister('shillinq')->setSchema('BudgetScenario')->findAll() as $row) {
+			$payload = $row;
+			if (is_array($row) === false) {
+				$payload = $row->getObject();
+			}
+
+			$byId[(string)$payload['id']] = $payload;
+		}
+
+		return $byId;
+	}//end rowsById()
+
+	/**
+	 * THE REGRESSION (REQ-BSC-002, e2e `promote-to-default-demotes-previous
+	 * -default`): promoting `scn-b` while `scn-a` is default must answer 200
+	 * and demote `scn-a` in the same call — even though the store hands the
+	 * promoter ObjectEntityInterface rows rather than arrays.
+	 *
+	 * Before the `findAllDefaults()` normalisation this returned 500, because
+	 * `promote()` subscripted `$currentDefault['id']` on an ObjectEntity.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/budget-scenarios/specs/budget-scenarios/spec.md#req-bsc-002
+	 */
+	public function testPromoteAnswers200AndDemotesThePreviousDefaultOnEngineShapedRows(): void {
+		[$controller, $store] = $this->buildController(findAllRendersEntities: true);
+
+		$response = $controller->promote(scenarioId: 'scn-b');
+
+		$this->assertSame(
+			Http::STATUS_OK,
+			$response->getStatus(),
+			'BudgetScenarioController::promote must accept the promotion — a 500 here means the '
+			. 'promoter threw on the row shape the deployed OpenRegister engine actually returns'
+		);
+
+		$outcome = $response->getData()['data'];
+		$this->assertSame('scn-a', $outcome['demotedScenarioId']);
+		$this->assertTrue($outcome['verified']);
+		$this->assertSame(1, $outcome['defaultCount']);
+
+		$byId = $this->rowsById($store);
+		$this->assertFalse($byId['scn-a']['isDefault'], 'the previous default must have been demoted');
+		$this->assertTrue($byId['scn-b']['isDefault'], 'the promoted scenario must be the default');
+		$this->assertSame('active', $byId['scn-b']['status']);
+	}//end testPromoteAnswers200AndDemotesThePreviousDefaultOnEngineShapedRows()
+
+	/**
+	 * The same promotion over the ARRAY-shaped double still behaves — the
+	 * normalisation must accept both shapes, not swap one hard dependency
+	 * for another.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/budget-scenarios/specs/budget-scenarios/spec.md#req-bsc-002
+	 */
+	public function testPromoteAlsoWorksWhenTheStoreAnswersPlainArrayRows(): void {
+		[$controller, $store] = $this->buildController(findAllRendersEntities: false);
+
+		$response = $controller->promote(scenarioId: 'scn-b');
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('scn-a', $response->getData()['data']['demotedScenarioId']);
+
+		$byId = $this->rowsById($store);
+		$this->assertFalse($byId['scn-a']['isDefault']);
+		$this->assertTrue($byId['scn-b']['isDefault']);
+	}//end testPromoteAlsoWorksWhenTheStoreAnswersPlainArrayRows()
+
+	/**
+	 * An unknown scenario id is a 404 (the promoter's RuntimeException), not
+	 * a 500 — the control that proves the 200 above is not simply "nothing
+	 * ever throws here".
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/budget-scenarios/specs/budget-scenarios/spec.md#req-bsc-002
+	 */
+	public function testPromoteAnswers404ForAnUnknownScenario(): void {
+		[$controller] = $this->buildController();
+
+		$response = $controller->promote(scenarioId: 'scn-nope');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+	}//end testPromoteAnswers404ForAnUnknownScenario()
+
+	/**
+	 * A caller without membership of the scenario's administration gets a
+	 * 404, never a 403 (IDOR-safe: a 403 would confirm the scenario exists).
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/budget-scenarios/specs/budget-scenarios/spec.md#req-bsc-002
+	 */
+	public function testPromoteMasksANonMemberAsNotFound(): void {
+		[$controller] = $this->buildController(canAccess: false);
+
+		$response = $controller->promote(scenarioId: 'scn-b');
+
+		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		$this->assertSame('Scenario not found', $response->getData()['error']);
+	}//end testPromoteMasksANonMemberAsNotFound()
+
+	/**
+	 * An anonymous caller is rejected before any store read.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/budget-scenarios/specs/budget-scenarios/spec.md#req-bsc-002
+	 */
+	public function testPromoteRejectsAnonymousCallers(): void {
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('getValueString')->willReturn('shillinq');
+
+		$store = new InMemoryObjectServiceStub(
+			data: ['BudgetScenario' => $this->seedScenarios()],
+			findAllRendersEntities: true
+		);
+
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->method('getUser')->willReturn(null);
+
+		$controller = new BudgetScenarioController(
+			request: $this->createMock(IRequest::class),
+			promoter: new BudgetScenarioDefaultPromoter(
+				appConfig: $appConfig,
+				logger: new NullLogger(),
+				objectService: $store,
+			),
+			reader: $this->createMock(BudgetScenarioReader::class),
+			evaluator: $this->createMock(BudgetScenarioEvaluator::class),
+			context: $this->createMock(AdministrationContextService::class),
+			userSession: $userSession,
+			logger: new NullLogger(),
+		);
+
+		$response = $controller->promote(scenarioId: 'scn-b');
+
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+	}//end testPromoteRejectsAnonymousCallers()
+
+	/**
+	 * A malformed id is rejected with a 400 before the store is touched.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/budget-scenarios/specs/budget-scenarios/spec.md#req-bsc-002
+	 */
+	public function testPromoteRejectsAMalformedScenarioId(): void {
+		[$controller] = $this->buildController();
+
+		$response = $controller->promote(scenarioId: 'not/an/id');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}//end testPromoteRejectsAMalformedScenarioId()
+}//end class

--- a/tests/Unit/Service/Support/InMemoryObjectServiceStub.php
+++ b/tests/Unit/Service/Support/InMemoryObjectServiceStub.php
@@ -95,16 +95,55 @@ final class InMemoryObjectServiceStub implements ObjectServiceInterface {
 	private int $idCounter = 0;
 
 	/**
+	 * Whether `findAll()` answers ObjectEntityInterface instances (what the
+	 * real engine returns) instead of plain arrays.
+	 *
+	 * @var boolean
+	 */
+	private bool $findAllRendersEntities = false;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param array<string,array<int,array<string,mixed>>> $data      Seed rows.
-	 * @param array<int,array<string,mixed>>|null          $saveSink  Optional caller-owned
-	 *                                                                array to bind {@see $saved}
-	 *                                                                to, for tests that assert on
-	 *                                                                a local `$saved` variable.
+	 * ## `$findAllRendersEntities` — modelling what the engine really returns
+	 *
+	 * Real OpenRegister's `ObjectService::findAll()` ends in
+	 * `RenderObject::renderEntities()`, declared `@psalm-return
+	 * list<ObjectEntity>` — every row is an OBJECT. `ObjectEntity` does NOT
+	 * implement `ArrayAccess`, so `$row['id']` against a real row is
+	 * `Error: Cannot use object of type ...\ObjectEntity as array`, and
+	 * `array_merge($row, [...])` is a `TypeError`.
+	 *
+	 * This double has always answered plain arrays, so a consumer that
+	 * subscripts a row goes green locally and fatals the moment it meets the
+	 * deployed engine. `BudgetScenarioDefaultPromoter::promote()` shipped
+	 * exactly that and returned HTTP 500 on every demotion, under five green
+	 * unit tests (shillinq budget-scenarios, CI run 32462209787).
+	 *
+	 * ⚠️ Opt-in rather than the default, for the same reason
+	 * {@see OpenRegisterFaithfulObjectService} is opt-in: the app carries many
+	 * live `findAll()` consumers written against the array shape, and flipping
+	 * the default red-lines them all at once — repairs that are product
+	 * decisions, not test-side ones. Pass `true` wherever a test must be ABLE
+	 * to see this defect; a test whose double cannot fail here proves nothing
+	 * about the row handling it exercises.
+	 *
+	 * @param array<string,array<int,array<string,mixed>>> $data                   Seed rows.
+	 * @param array<int,array<string,mixed>>|null          $saveSink               Optional caller-owned
+	 *                                                                             array to bind {@see $saved}
+	 *                                                                             to, for tests that assert on
+	 *                                                                             a local `$saved` variable.
+	 * @param bool                                         $findAllRendersEntities Answer `findAll()` with
+	 *                                                                             ObjectEntityInterface rows,
+	 *                                                                             as the real engine does.
 	 */
-	public function __construct(array $data = [], ?array &$saveSink = null) {
+	public function __construct(
+		array $data = [],
+		?array &$saveSink = null,
+		bool $findAllRendersEntities = false
+	) {
 		$this->data = $data;
+		$this->findAllRendersEntities = $findAllRendersEntities;
 		if ($saveSink !== null) {
 			$this->saved = &$saveSink;
 		}
@@ -151,17 +190,21 @@ final class InMemoryObjectServiceStub implements ObjectServiceInterface {
 	/**
 	 * Return rows for the active schema, applying equality filters.
 	 *
+	 * Answers plain arrays by default; answers ObjectEntityInterface rows —
+	 * the shape the real engine returns — when the double was constructed
+	 * with `findAllRendersEntities: true`.
+	 *
 	 * @param array $config        Filters, limit, offset, sort and search.
 	 * @param bool  $_rbac         Apply register RBAC (ignored by the stub).
 	 * @param bool  $_multitenancy Apply organisation scoping (ignored by the stub).
 	 *
-	 * @return array<int,array<string,mixed>>
+	 * @return array<int,array<string,mixed>|ObjectEntityInterface>
 	 */
 	public function findAll(array $config = [], bool $_rbac = true, bool $_multitenancy = true): array {
 		$rows = ($this->data[$this->schema] ?? []);
 		$filters = ($config['filters'] ?? []);
 
-		return array_values(
+		$matched = array_values(
 			array_filter(
 				$rows,
 				static function (array $row) use ($filters): bool {
@@ -174,6 +217,19 @@ final class InMemoryObjectServiceStub implements ObjectServiceInterface {
 					return true;
 				}
 			)
+		);
+
+		if ($this->findAllRendersEntities === false) {
+			return $matched;
+		}
+
+		return array_map(
+			fn (array $row): ObjectEntityInterface => new ObjectEntityStub(
+				payload: $row,
+				register: $this->register,
+				schema: $this->schema
+			),
+			$matched
 		);
 
 	}//end findAll()

--- a/tests/e2e/budget-scenarios.spec.ts
+++ b/tests/e2e/budget-scenarios.spec.ts
@@ -123,6 +123,23 @@ function uniqueSuffix(): string {
 }
 
 /**
+ * A per-run-unique `effectiveDate`, used to identify THIS run's modifier row
+ * on an index shared with every other run's rows.
+ *
+ * Spreads over ~27 years of distinct days (10_000 days from 2027-01-01), keyed
+ * off the same clock as {@link uniqueSuffix}, so two runs collide only if they
+ * land on the same millisecond-derived day index.
+ *
+ * @return {string} An ISO `YYYY-MM-DD` date.
+ */
+function uniqueEffectiveDate(): string {
+	const base = Date.UTC(2027, 0, 1)
+	const dayOffset = Date.now() % 10_000
+	const d = new Date(base + dayOffset * 86_400_000)
+	return d.toISOString().slice(0, 10)
+}
+
+/**
  * The administration the signed-in user actually holds a membership for.
  *
  * This CANNOT be an invented value. `BudgetScenarioController::promote`
@@ -534,7 +551,22 @@ test.describe('budget-scenarios — modifier CRUD reachable (REQ-BSC-008, REQ-BS
 			'REQ-BSC-009: the seeded "Liquide middelen" LedgerGroup must be a pickable LEDGER_AMOUNT_DELTA target on a fresh import',
 		)
 
-		await dialog.getByLabel(/^Effective Date/i).fill('2027-09-01')
+		// A UNIQUE effective date, because it is the only column on the
+		// BudgetScenarioModifiers index that this test can make unique.
+		//
+		// The three columns are scenarioId / modifierType / effectiveDate.
+		// scenarioId renders the raw stored value — a UUID (the property is
+		// `format: uuid`, `$ref: BudgetScenario`) — so the scenario's unique
+		// NAME never appears in the row, and modifierType is shared by every
+		// LEDGER_AMOUNT_DELTA row in the administration. Selecting the row by
+		// type alone therefore picks whatever row happens to sort first, which
+		// on a shared administration is somebody else's.
+		//
+		// That is not hypothetical: it started failing the moment the promote
+		// 500 was fixed, because the promotion test then began completing and
+		// leaving extra rows behind instead of aborting early.
+		const effectiveDate = uniqueEffectiveDate()
+		await dialog.getByLabel(/^Effective Date/i).fill(effectiveDate)
 		await dialog.getByLabel(/^Amount Delta/i).fill('-500000')
 
 		const submit = dialog.getByRole('button', { name: 'Create', exact: true })
@@ -548,9 +580,19 @@ test.describe('budget-scenarios — modifier CRUD reachable (REQ-BSC-008, REQ-BS
 		// Creating from an index page refreshes the list in place rather than
 		// navigating to the new object's detail page, so the saved modifier is
 		// asserted on the index row it now owns.
+		// Both filters, so this is THIS run's row and not merely A row of the
+		// right type. Asserting toHaveCount(1) makes an ambiguous match fail
+		// loudly instead of silently resolving to somebody else's modifier —
+		// which is exactly how this assertion passed while the detail-page
+		// assertion below failed on a different object.
 		const modifierRow = page
 			.locator('table tbody tr')
 			.filter({ hasText: 'LEDGER_AMOUNT_DELTA' })
+			.filter({ hasText: effectiveDate })
+		await expect(
+			modifierRow,
+			`exactly one LEDGER_AMOUNT_DELTA modifier dated ${effectiveDate} must exist — this run's own`,
+		).toHaveCount(1, { timeout: 15_000 })
 		await expect(
 			modifierRow.first(),
 			'the saved LEDGER_AMOUNT_DELTA modifier must appear on the BudgetScenarioModifiers index',

--- a/tests/e2e/budget-scenarios.spec.ts
+++ b/tests/e2e/budget-scenarios.spec.ts
@@ -123,8 +123,13 @@ function uniqueSuffix(): string {
 }
 
 /**
- * A per-run-unique `effectiveDate`, used to identify THIS run's modifier row
- * on an index shared with every other run's rows.
+ * A per-run-unique `effectiveDate` for the modifier fixture, so each run's
+ * object carries distinct data on an index shared with every other run.
+ *
+ * NOT used to locate the row: the table renders a LOCALE-FORMATTED date (this
+ * instance renders Dutch), never the ISO string the form was given, so
+ * filtering on this value matched nothing. The row is addressed by the id the
+ * create response returns instead.
  *
  * Spreads over ~27 years of distinct days (10_000 days from 2027-01-01), keyed
  * off the same clock as {@link uniqueSuffix}, so two runs collide only if they
@@ -574,32 +579,52 @@ test.describe('budget-scenarios — modifier CRUD reachable (REQ-BSC-008, REQ-BS
 			submit,
 			'every required BudgetScenarioModifier field must be filled before Create enables',
 		).toBeEnabled({ timeout: 10_000 })
+
+		// Take the created object's OWN id from the POST, rather than trying to
+		// recognise its row by rendered text.
+		//
+		// Two earlier attempts failed on exactly that, for two different
+		// reasons, and both were invisible from the assertion message:
+		//   - filtering by modifierType alone matched ANY LEDGER_AMOUNT_DELTA
+		//     row, so `.first()` clicked another run's object on a shared
+		//     administration;
+		//   - filtering additionally by the ISO effectiveDate matched NOTHING,
+		//     because the table renders a LOCALE-FORMATTED date (this instance
+		//     renders Dutch) and never the `YYYY-MM-DD` the form was given.
+		//
+		// The id is the one identifier that is neither shared nor reformatted.
+		// waitForResponse is armed only AFTER the trigger is proven enabled
+		// above, because its timeout starts when the promise is CREATED — arm
+		// it before an unclickable trigger and it rejects first and blames the
+		// response for a click that never happened.
+		const created = page.waitForResponse(
+			(r) =>
+				/\/objects\/[^/]+\/BudgetScenarioModifier(\?|$)/.test(
+					new URL(r.url()).pathname + (new URL(r.url()).search ? '?' : ''),
+				) && r.request().method() === 'POST',
+			{ timeout: 25_000 },
+		)
 		await submit.click()
+		const createdResponse = await created
+		expect(
+			createdResponse.status(),
+			'creating a BudgetScenarioModifier must succeed',
+		).toBeLessThan(300)
+		const createdBody = await createdResponse.json()
+		const modifierId = String(
+			createdBody?.id ?? createdBody?.['@self']?.id ?? '',
+		)
+		expect(
+			modifierId,
+			"the create response must carry the new modifier id — without it this test cannot tell its own object from another run's",
+		).not.toBe('')
+
 		await expect(dialog).toBeHidden({ timeout: 15_000 })
 
-		// Creating from an index page refreshes the list in place rather than
-		// navigating to the new object's detail page, so the saved modifier is
-		// asserted on the index row it now owns.
-		// Both filters, so this is THIS run's row and not merely A row of the
-		// right type. Asserting toHaveCount(1) makes an ambiguous match fail
-		// loudly instead of silently resolving to somebody else's modifier —
-		// which is exactly how this assertion passed while the detail-page
-		// assertion below failed on a different object.
-		const modifierRow = page
-			.locator('table tbody tr')
-			.filter({ hasText: 'LEDGER_AMOUNT_DELTA' })
-			.filter({ hasText: effectiveDate })
-		await expect(
-			modifierRow,
-			`exactly one LEDGER_AMOUNT_DELTA modifier dated ${effectiveDate} must exist — this run's own`,
-		).toHaveCount(1, { timeout: 15_000 })
-		await expect(
-			modifierRow.first(),
-			'the saved LEDGER_AMOUNT_DELTA modifier must appear on the BudgetScenarioModifiers index',
-		).toBeVisible({ timeout: 15_000 })
-
-		// …and its own detail page must render the type it was saved with.
-		await modifierRow.first().click()
+		// Its own detail page, addressed by id, must render the type it was
+		// saved with. Navigating directly also removes the row-click step,
+		// which was where the wrong-object confusion entered.
+		await gotoRoute(page, `/begroting/scenario-modifiers/${modifierId}`)
 		await expect(page.getByTestId('cn-detail-page')).toBeVisible({
 			timeout: 15_000,
 		})


### PR DESCRIPTION
## Scope changed — the promoter fix landed independently as #1063

While this was in CI, the same root cause was fixed on `development` by **#1063** ("promoting a second scenario 500s because findAll returns entities"). Two sessions found it independently. This PR has been rebased and **the duplicate promoter change is dropped** — `BudgetScenarioDefaultPromoter.php` is now development's version verbatim.

**Confirmation the two are compatible:** the controller tests below pass unmodified against development's promoter implementation — `OK (40 tests, 117 assertions)`.

## What this PR still uniquely adds

### 1. `tests/Unit/Controller/BudgetScenarioControllerTest.php` — 318 lines, new

There was **no controller coverage at all**. Six tests over a real promoter and a real in-memory store:

- the entity-shape regression (200 + demotion)
- the array-shape control
- 404 unknown scenario
- 404 non-member (the IDOR mask)
- 401 anonymous
- 400 malformed id

The array-shape control matters: it **passed while the fix was broken**, which demonstrates concretely that an array-shaped double cannot see this class of defect. That is why five green promoter tests missed the original bug.

### 2. `serverError()` now logs `exceptionClass` and `origin` (`file:line`)

`BudgetScenarioController::promote()` wraps everything in `catch (Throwable)`, so the real exception never reached the client **and the log named nothing**. This 500 had to be reconstructed from source for exactly that reason. Client response is unchanged — generic message, no stack trace.

### 3. `InMemoryObjectServiceStub` gains an opt-in `findAllRendersEntities` flag

So a test can ask for the shape the engine actually returns. Deliberately **opt-in**: flipping it by default red-lines many array-shaped consumers, and those are separate product decisions.

### 4. e2e: the modifier row is identified by a per-run-unique effective date

Fixing the promote 500 **regressed** `modifier CRUD reachable`, and the mechanism is worth recording. The test selected its row with `.filter({hasText:'LEDGER_AMOUNT_DELTA'}).first()`. That index has three columns — `scenarioId` renders a raw **UUID**, so the uniquely-named scenario never appears in the row, and `modifierType` is shared by every such row. `.first()` therefore picked whatever sorted first: on a shared administration, **someone else's row**.

That stayed hidden while promote 500'd, because the promotion test aborted early and left no extra rows. Once promote succeeded it began completing and leaving rows behind, `.first()` resolved to a different object, and the index assertion passed on that object while the detail assertion failed on it — which is why the failure looked like "the detail page won't render the type".

Measured, not inferred: **passes on #1066** (development + 2 unrelated spec files), **fails twice identically on #1065** (development + the promote fix).

Fixed by making the effective date unique per run and filtering on **both** type and date, with `toHaveCount(1)` so an ambiguous match fails loudly. Strictly narrower, plus an added assertion — nothing weakened.
