### PR TITLE
test(e2e): cover Requisitions and ReportingComplianceOverview (gate-19 gap)

### DIFF
--- a/tests/e2e/purchase-requisitions.spec.ts
+++ b/tests/e2e/purchase-requisitions.spec.ts
@@ -1,0 +1,273 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Gate-19 Playwright UI coverage — the Requisitions surface.
+ *
+ * ## The gap this closes
+ *
+ * `openspec/changes/archive/2026-07-14-purchase-requisition/specs/
+ * purchase-requisition/spec.md` `@e2e exclude`s every one of its six
+ * requirements with the same reason: *"no dedicated Playwright suite exists
+ * yet for this manifest page type in this app"*. That was true — a
+ * `git grep -l Requisition -- tests/e2e/` returned nothing, so the entire
+ * `Requisitions` / `RequisitionDetail` USER-FACING surface shipped with zero
+ * browser coverage while the backend carried `RequisitionServiceTest`,
+ * `RequisitionConversionServiceTest` and `RequisitionControllerTest`.
+ *
+ * This file covers the half those excludes correctly identify as browser
+ * work and nothing more: that the two manifest pages RESOLVE, that they mount
+ * the GENERIC renderer's typed page (`cn-index-page` / `cn-detail-page` — both
+ * pages ship with no custom `component`, see `src/manifest.json`'s
+ * `Requisitions` / `RequisitionDetail` entries), that the index binds the
+ * columns the manifest declares, that the index is reachable by NAVIGATION and
+ * not only by URL, and that a row opens its detail page.
+ *
+ * The approve/reject/convert LIFECYCLE is deliberately NOT driven here. Those
+ * are server-authoritative custom endpoints gated by `BudgetBlocker::canCommit`
+ * (REQ-REQ-002/-003); driving them from a spec would mutate the shared
+ * administration's seeded requisitions irreversibly (`draft` -> `submitted` has
+ * no UI undo), and their fail-closed behaviour is already proven against a REAL
+ * unmodified `BudgetBlocker`/`PurchaseOrderService` in PHPUnit, which is what
+ * the spec's own `@e2e exclude` reasons say. What was missing, and is added
+ * here, is proof the pages a user actually opens exist and render.
+ *
+ * ## Fixtures
+ *
+ * `lib/Settings/register.d/purchase-requisition.json` DECLARES its own seed
+ * objects — `REQ-2026-adm-demo-000001` (`draft`) and `REQ-2026-adm-demo-000002`
+ * (`submitted`), the spec's own "seed data covers every lifecycle-reachable
+ * starting status" scenario. They are imported with the register itself (by the
+ * install repair step locally, and explicitly by `tests/e2e/ci-seed.sh` in CI),
+ * so they are a DECLARED fixture of this app rather than ambient state a
+ * previous spec happened to leave behind. The detail-page test asserts against
+ * `REQ-2026-adm-demo-000001` BY NUMBER for exactly that reason: a bare
+ * "click the first row" would silently pass on any unrelated object that
+ * happened to sort first.
+ *
+ * ## Locator discipline
+ *
+ * Every locator below is a `data-testid` or a manifest-declared column label.
+ * No nc-vue chrome is addressed by its accessible NAME: this instance renders
+ * Dutch (the collapse toggle's `aria-label` is `Menu openen`, not
+ * `Open menu`), so an English-name role locator either misses or — worse —
+ * matches some other feature's element and reports a false PASS.
+ *
+ * @e2e purchase-requisition::requisitions-index-resolves-and-renders-columns
+ * @e2e purchase-requisition::requisitions-reachable-through-navigation
+ * @e2e purchase-requisition::requisition-row-opens-its-detail-page
+ * @spec openspec/changes/archive/2026-07-14-purchase-requisition/specs/purchase-requisition/spec.md
+ */
+
+import type { Page } from '@playwright/test'
+
+import { expect, test } from '@playwright/test'
+
+const APP = '/apps/shillinq'
+const REQUISITIONS_ROUTE = '/inkoop/requisitions'
+
+/** The `draft` requisition declared by `register.d/purchase-requisition.json`. */
+const SEEDED_REQUISITION_NUMBER = 'REQ-2026-adm-demo-000001'
+
+async function dismissOverlays(page: Page): Promise<void> {
+	const wizard = page.locator('#firstrunwizard')
+	if (await wizard.isVisible().catch(() => false)) {
+		await page.keyboard.press('Escape').catch(() => {})
+		await wizard.waitFor({ state: 'hidden', timeout: 4_000 }).catch(() => {})
+	}
+}
+
+/** Strip `/index.php`, query and hash, and any trailing slash. */
+function normalisePath(urlOrPath: string): string {
+	const path = urlOrPath.startsWith('http')
+		? new URL(urlOrPath).pathname
+		: urlOrPath.split(/[?#]/)[0]
+	return path.replace('/index.php', '').replace(/\/+$/, '') || '/'
+}
+
+/**
+ * Deep-link to a manifest route and prove the SPA resolved it rather than
+ * falling through to the `/:pathMatch(.*)*` catch-all redirect to Dashboard
+ * (`src/main.js`) — the `budget-core-schema.spec.ts` / `budget-known-costs.spec.ts`
+ * `gotoRoute()` precedent.
+ */
+async function gotoRoute(page: Page, route: string): Promise<void> {
+	const target = APP + route
+	await page.goto(target, { waitUntil: 'domcontentloaded', timeout: 25_000 })
+	await page.waitForSelector('#content-vue', { timeout: 15_000 })
+	await dismissOverlays(page)
+	expect(
+		normalisePath(page.url()),
+		`route ${route} must be declared by the manifest and resolve to itself`,
+	).toBe(normalisePath(target))
+}
+
+test.describe('purchase-requisition — the Requisitions index (REQ-REQ-001)', () => {
+	test.beforeEach(async ({ page }) => {
+		page.setViewportSize({ width: 1600, height: 1200 })
+		// The root config allows 30s per test. The nav-reachability test loads
+		// the Dashboard, expands a cluster and then loads the index — MEASURED at
+		// 16s idle but 31s on a loaded box, i.e. right on the line. Raised for
+		// the block (the `budget-scenarios.spec.ts` `test.setTimeout()`
+		// precedent) so a slow instance reports a real failure rather than a bare
+		// "Test timeout" that names no cause.
+		test.setTimeout(120_000)
+	})
+
+	/**
+	 * @e2e purchase-requisition::requisitions-index-resolves-and-renders-columns
+	 *
+	 * `/inkoop/requisitions` resolves to the generic index renderer and binds
+	 * the `Requisition` column set the manifest declares — not merely "some
+	 * app content", which the catch-all redirect to Dashboard would also
+	 * satisfy.
+	 */
+	test('the Requisitions route resolves and the typed index page renders its declared columns', async ({
+		page,
+	}) => {
+		await gotoRoute(page, REQUISITIONS_ROUTE)
+
+		await expect(page.getByTestId('cn-index-page')).toBeVisible({
+			timeout: 15_000,
+		})
+		await expect(page.getByTestId('cn-page-title')).toContainText('Requisitions')
+
+		// The manifest's `config.columns` for the `Requisition` schema. A
+		// Dashboard fallback renders none of these, so the set is what
+		// distinguishes "the Requisitions page mounted" from "the SPA is up".
+		const table = page.getByTestId('cn-object-list-table')
+		await expect(table).toBeVisible({ timeout: 15_000 })
+		for (const header of [
+			'Requisition #',
+			'Requester',
+			'Cost Centre',
+			'Fiscal Year',
+			'Needed By',
+			'Amount (excl. VAT)',
+			'Status',
+		]) {
+			await expect(
+				table.locator('thead th').filter({ hasText: header }),
+				`manifest column "${header}" is rendered`,
+			).toHaveCount(1)
+		}
+	})
+
+	/**
+	 * @e2e purchase-requisition::requisitions-reachable-through-navigation
+	 *
+	 * A route that only a hand-typed URL reaches is not a shipped feature.
+	 * The `Requisitions` leaf lives under the `Purchasing` cluster, which
+	 * renders COLLAPSED: its children are in the DOM but hidden. Expanding it
+	 * means clicking the entry's own collapse toggle — `.icon-collapse`, a
+	 * structural class, because its `aria-label` is Dutch on this instance —
+	 * since the top-level link NAVIGATES (to `/purchasing/overview`) instead of
+	 * expanding.
+	 */
+	test('Requisitions is reachable by clicking through the Purchasing nav cluster', async ({
+		page,
+	}) => {
+		await page.goto(`${APP}/`, {
+			waitUntil: 'domcontentloaded',
+			timeout: 25_000,
+		})
+		await page.waitForSelector('#content-vue', { timeout: 15_000 })
+		await dismissOverlays(page)
+
+		const purchasing = page.getByTestId('cn-nav-entry-Purchasing')
+		await expect(
+			purchasing,
+			'the Purchasing cluster is a top-level nav entry',
+		).toBeVisible({ timeout: 15_000 })
+
+		const leaf = page.getByTestId('cn-nav-entry-Requisitions')
+		await expect(
+			leaf,
+			'Requisitions is declared as a child of Purchasing, so it is in the DOM before expansion',
+		).toHaveCount(1)
+		await expect(leaf, '…but hidden while the cluster is collapsed').toBeHidden()
+
+		// Assert the trigger exists BEFORE clicking it: a click that never
+		// lands would otherwise be blamed on the navigation that follows.
+		const toggle = purchasing.locator('button.icon-collapse').first()
+		await expect(
+			toggle,
+			'the Purchasing entry has a collapse toggle',
+		).toBeVisible({ timeout: 10_000 })
+		await toggle.click()
+
+		await expect(leaf, 'expanding Purchasing reveals Requisitions').toBeVisible({
+			timeout: 10_000,
+		})
+		await leaf.click()
+
+		await expect(page).toHaveURL(
+			new RegExp(`${REQUISITIONS_ROUTE.replace(/\//g, '\\/')}$`),
+			{ timeout: 15_000 },
+		)
+		await expect(page.getByTestId('cn-index-page')).toBeVisible({
+			timeout: 15_000,
+		})
+		await expect(page.getByTestId('cn-page-title')).toContainText('Requisitions')
+	})
+})
+
+test.describe('purchase-requisition — the RequisitionDetail page (REQ-REQ-001)', () => {
+	test.beforeEach(async ({ page }) => {
+		page.setViewportSize({ width: 1600, height: 1200 })
+		// The root config allows 30s per test. The nav-reachability test loads
+		// the Dashboard, expands a cluster and then loads the index — MEASURED at
+		// 16s idle but 31s on a loaded box, i.e. right on the line. Raised for
+		// the block (the `budget-scenarios.spec.ts` `test.setTimeout()`
+		// precedent) so a slow instance reports a real failure rather than a bare
+		// "Test timeout" that names no cause.
+		test.setTimeout(120_000)
+	})
+
+	/**
+	 * @e2e purchase-requisition::requisition-row-opens-its-detail-page
+	 *
+	 * The index's `config.detailRoute` points at `RequisitionDetail`
+	 * (`/inkoop/requisitions/:id`). Clicking the seeded `draft` requisition's
+	 * row must land on that page with the object's own id in the URL and the
+	 * requisition number on screen — the click-through the manifest's own
+	 * `_note` describes ("Click through to RequisitionDetail for lines,
+	 * approve/reject and convert-to-PO actions").
+	 */
+	test('clicking the seeded requisition row opens RequisitionDetail for that object', async ({
+		page,
+	}) => {
+		await gotoRoute(page, REQUISITIONS_ROUTE)
+		await expect(page.getByTestId('cn-index-page')).toBeVisible({
+			timeout: 15_000,
+		})
+
+		const row = page
+			.getByTestId('cn-object-row')
+			.filter({ hasText: SEEDED_REQUISITION_NUMBER })
+		await expect(
+			row,
+			`the register-declared seed requisition ${SEEDED_REQUISITION_NUMBER} is listed `
+				+ '(imported with lib/Settings/register.d/purchase-requisition.json)',
+		).toHaveCount(1)
+		await expect(row).toBeVisible({ timeout: 15_000 })
+
+		await row.click()
+
+		// `:id` is the object UUID, so match the shape rather than a literal.
+		await expect(page).toHaveURL(
+			/\/apps\/shillinq\/inkoop\/requisitions\/[0-9a-f-]{36}$/,
+			{ timeout: 15_000 },
+		)
+		await expect(page.getByTestId('cn-detail-page')).toBeVisible({
+			timeout: 15_000,
+		})
+		await expect(
+			page
+				.getByTestId('cn-detail-page')
+				.getByText(SEEDED_REQUISITION_NUMBER)
+				.first(),
+			'the detail page shows the requisition that was clicked, not some other object',
+		).toBeVisible({ timeout: 15_000 })
+	})
+})

--- a/tests/e2e/reporting-compliance-overview.spec.ts
+++ b/tests/e2e/reporting-compliance-overview.spec.ts
@@ -1,0 +1,367 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Gate-19 Playwright UI coverage — the ReportingComplianceOverview cluster
+ * landing page.
+ *
+ * ## The gap this closes
+ *
+ * `ReportingComplianceOverview` (`src/manifest.d/reporting-compliance.json`) is
+ * the landing page of one of the six top-level clusters, and per
+ * `src/manifest.d/nav-six-clusters-landing-pages.json`'s own `_meta` it is the
+ * ONE cluster whose landing page was NOT created by `nav-six-clusters`: the
+ * other five got a fresh `ClusterOverview.vue` wrapper, Reporting & Compliance
+ * "reuses the pre-existing ReportingComplianceOverview as-is". Reuse is exactly
+ * why it went uncovered.
+ *
+ * The only existing reference to it was `NavSixClusters.spec.js`, whose single
+ * Reporting test is guarded by
+ *
+ *     test.skip(!deployed, 'ReportingComplianceOverview not deployed on this build')
+ *
+ * and asserts nothing beyond the root element plus a title being present. A
+ * skip and a pass are indistinguishable in the summary line, so that test
+ * cannot report the page as broken — it reports it as absent. Nothing anywhere
+ * asserted that the page renders its CONTENT.
+ *
+ * ## What is covered
+ *
+ * The page is a card catalogue: `ReportingComplianceOverview.vue` fetches
+ * `/api/reporting/types`, merges the static `reportViews` catalogue, and groups
+ * the result into `reporting-group-<category>` sections of
+ * `reporting-card-<reportId>` cards. Note the failure shape that makes the
+ * assertions below non-negotiable: if the catalogue request throws, the
+ * component's `catch` renders `reporting-overview-error` and `reports` stays
+ * EMPTY — so `reporting-overview` and `reporting-overview-title` are BOTH still
+ * visible on a page that shows the user nothing. Asserting the root, or the
+ * title, or "some app content exists", cannot fail for the way this page
+ * actually breaks. The tests therefore assert the groups and cards.
+ *
+ * Covered:
+ *  - the route resolves and the page renders its category-grouped cards, with
+ *    the KPI count agreeing with the number of cards actually on screen;
+ *  - the page is reachable through NAVIGATION (the `ReportingCompliance`
+ *    top-level entry is a direct link to it — `reporting-compliance.json`'s
+ *    `_menu_note`), not only by typed URL;
+ *  - the cluster's links are LIVE: a `reporting-open-*` card link navigates to
+ *    that report's own page, and the `reporting-overview-generated-link`
+ *    reaches `GeneratedReportsIndex`;
+ *  - the category filter narrows the rendered groups (the surface's one piece
+ *    of local behaviour).
+ *
+ * Generating a report is NOT driven here: `reporting-generate-*` opens
+ * `GenerateReportDialog`, which POSTs `/api/reporting/generate` and writes a
+ * persisted `GeneratedReport` plus a Files-backed artefact into the shared
+ * administration on every run. That belongs to `reports-via-docudesk`'s own
+ * backend suite, not to a landing-page reachability spec.
+ *
+ * ## Locator discipline
+ *
+ * Card and group locators are `data-testid`s carrying MANIFEST/catalogue ids
+ * (`reporting-card-TrialBalance`), never labels. The catalogue contains a card
+ * literally labelled "Scenarios" (`reportViews.js`'s `CashflowScenarios`), and
+ * `getByRole('link', { name: 'Scenarios' })` has already matched
+ * cashflow-13wk's own nav leaf in this repo and reported a false PASS.
+ *
+ * @e2e reporting-compliance-consolidation::overview-route-renders-report-catalogue
+ * @e2e reporting-compliance-consolidation::overview-reachable-through-navigation
+ * @e2e reporting-compliance-consolidation::overview-cluster-links-navigate
+ * @e2e reporting-compliance-consolidation::overview-generated-reports-link-resolves
+ * @e2e reporting-compliance-consolidation::overview-category-filter-narrows-groups
+ */
+
+import type { Page } from '@playwright/test'
+
+import { expect, test } from '@playwright/test'
+
+const APP = '/apps/shillinq'
+const OVERVIEW_ROUTE = '/reporting-compliance'
+const GENERATED_ROUTE = '/reporting-compliance/generated'
+
+/**
+ * A `kind: "view"` catalogue entry (`src/components/reporting/reportViews.js`)
+ * whose target page is a plain manifest index — so clicking its card link is a
+ * pure navigation, with no generation side effect.
+ */
+const SAMPLE_VIEW_CARD = {
+	id: 'TrialBalance',
+	/** `TrialBalance`'s manifest route. */
+	route: '/financial-statements/trial-balance',
+}
+
+async function dismissOverlays(page: Page): Promise<void> {
+	const wizard = page.locator('#firstrunwizard')
+	if (await wizard.isVisible().catch(() => false)) {
+		await page.keyboard.press('Escape').catch(() => {})
+		await wizard.waitFor({ state: 'hidden', timeout: 4_000 }).catch(() => {})
+	}
+}
+
+/** Strip `/index.php`, query and hash, and any trailing slash. */
+function normalisePath(urlOrPath: string): string {
+	const path = urlOrPath.startsWith('http')
+		? new URL(urlOrPath).pathname
+		: urlOrPath.split(/[?#]/)[0]
+	return path.replace('/index.php', '').replace(/\/+$/, '') || '/'
+}
+
+/**
+ * Deep-link to a manifest route and prove the SPA resolved it rather than
+ * falling through to the `/:pathMatch(.*)*` catch-all redirect to Dashboard
+ * (`src/main.js`) — the `budget-core-schema.spec.ts` `gotoRoute()` precedent.
+ */
+async function gotoRoute(page: Page, route: string): Promise<void> {
+	const target = APP + route
+	await page.goto(target, { waitUntil: 'domcontentloaded', timeout: 25_000 })
+	await page.waitForSelector('#content-vue', { timeout: 15_000 })
+	await dismissOverlays(page)
+	expect(
+		normalisePath(page.url()),
+		`route ${route} must be declared by the manifest and resolve to itself`,
+	).toBe(normalisePath(target))
+}
+
+/**
+ * Wait for the catalogue fetch to settle, then fail LOUDLY (with the
+ * component's own message) if it rendered the error branch — rather than
+ * letting the caller's card assertion time out and blame the selector.
+ */
+async function awaitCatalogue(page: Page): Promise<void> {
+	await expect(page.getByTestId('reporting-overview')).toBeVisible({
+		timeout: 15_000,
+	})
+	// 40s, not 20s: `/api/reporting/types` builds a 96-entry catalogue and this
+	// wait was MEASURED timing out at 20s on a loaded dev box (a run whose every
+	// test took ~31s against ~18s on an idle one). The wait is on the
+	// component's own loading branch disappearing, so a generous ceiling costs
+	// nothing on a fast instance.
+	//
+	// ⚠️ A per-assertion timeout can only spend the TEST's remaining budget. The
+	// root `playwright.config.ts` sets `timeout: 30_000`, so this 40s ceiling is
+	// unreachable on a local run unless the test itself is given more — which is
+	// why the describe block below raises it. Without that, a slow catalogue
+	// surfaces as "Test timeout of 30000ms exceeded" and the assertion that was
+	// merely waiting gets the blame.
+	await expect(page.getByTestId('reporting-overview-loading')).toHaveCount(0, {
+		timeout: 40_000,
+	})
+
+	const error = page.getByTestId('reporting-overview-error')
+	if ((await error.count()) > 0) {
+		throw new Error(
+			`ReportingComplianceOverview rendered its error branch instead of the `
+				+ `catalogue: "${await error.innerText()}" — /api/reporting/types failed.`,
+		)
+	}
+}
+
+test.describe('reporting-compliance-consolidation — the ReportingComplianceOverview landing page', () => {
+	test.beforeEach(async ({ page }) => {
+		page.setViewportSize({ width: 1600, height: 1200 })
+		// The root config's 30s per-test budget is not enough here and was
+		// MEASURED failing: the navigation test loads the Dashboard, clicks
+		// through, and then waits on a 96-entry catalogue fetch, which came to
+		// >30s on a loaded box and reported as a bare "Test timeout". Raised for
+		// the whole block (the `budget-scenarios.spec.ts` /
+		// `setup-wizard-english.spec.ts` `test.setTimeout()` precedent) rather
+		// than trimming the assertions the coverage is actually for.
+		test.setTimeout(120_000)
+	})
+
+	/**
+	 * @e2e reporting-compliance-consolidation::overview-route-renders-report-catalogue
+	 *
+	 * The route resolves, the custom page mounts, and it renders the
+	 * category-grouped catalogue — not just its own shell. The KPI's
+	 * "Available reports" count is cross-checked against the cards actually in
+	 * the DOM, so a page that reports 96 reports while rendering none fails.
+	 */
+	test('the route resolves and the page renders its category-grouped report cards', async ({
+		page,
+	}) => {
+		await gotoRoute(page, OVERVIEW_ROUTE)
+		await awaitCatalogue(page)
+
+		await expect(page.getByTestId('reporting-overview-title')).toContainText(
+			'Reporting & Compliance',
+		)
+		await expect(page.getByTestId('reporting-overview-filters')).toBeVisible()
+
+		const groups = page.locator('[data-testid^="reporting-group-"]')
+		await expect(
+			groups.first(),
+			'at least one category group renders',
+		).toBeVisible({ timeout: 15_000 })
+		expect(
+			await groups.count(),
+			'the catalogue groups reports across several categories',
+		).toBeGreaterThan(1)
+
+		const cards = page.locator('[data-testid^="reporting-card-"]')
+		const cardCount = await cards.count()
+		expect(cardCount, 'report cards render').toBeGreaterThan(0)
+
+		// `reporting-overview-kpi` is a CnStatsBlock over `reports.length`. If
+		// the count and the rendered cards disagree, one of the two lies.
+		const kpiText = await page.getByTestId('reporting-overview-kpi').innerText()
+		const kpiCount = Number(
+			(kpiText.match(/\d[\d.,]*/)?.[0] ?? '').replace(/[.,]/g, ''),
+		)
+		expect(
+			kpiCount,
+			`the "Available reports" KPI (${kpiText.replace(/\n/g, ' ')}) must match the ${cardCount} cards on screen`,
+		).toBe(cardCount)
+	})
+
+	/**
+	 * @e2e reporting-compliance-consolidation::overview-reachable-through-navigation
+	 *
+	 * `reporting-compliance.json`'s `menu` fragment sets the top-level
+	 * `ReportingCompliance` group's `route` to this page, making the cluster
+	 * entry a DIRECT link (the `_menu_note` on that fragment). Prove a user can
+	 * get here by clicking, not only by typing the URL.
+	 *
+	 * The entry is addressed by its manifest id, not by the label "Reporting &
+	 * Compliance": `menu-layout.json` relocates nineteen leaves INTO this
+	 * cluster, so a label-shaped locator can match a descendant rather than the
+	 * cluster entry itself.
+	 */
+	test('the landing page is reachable by clicking the Reporting & Compliance cluster entry', async ({
+		page,
+	}) => {
+		await page.goto(`${APP}/`, {
+			waitUntil: 'domcontentloaded',
+			timeout: 25_000,
+		})
+		await page.waitForSelector('#content-vue', { timeout: 15_000 })
+		await dismissOverlays(page)
+
+		const entry = page.getByTestId('cn-nav-entry-ReportingCompliance')
+		await expect(
+			entry,
+			'ReportingCompliance is a top-level nav entry',
+		).toBeVisible({ timeout: 15_000 })
+
+		// The entry's own link, not a relocated child's — scope the click to
+		// the entry element and take its direct navigation anchor.
+		await entry.locator('a.app-navigation-entry-link').first().click()
+
+		await expect(page).toHaveURL(
+			new RegExp(`${OVERVIEW_ROUTE.replace(/\//g, '\\/')}$`),
+			{ timeout: 15_000 },
+		)
+		await awaitCatalogue(page)
+		await expect(
+			page.locator('[data-testid^="reporting-card-"]').first(),
+		).toBeVisible({ timeout: 15_000 })
+	})
+
+	/**
+	 * @e2e reporting-compliance-consolidation::overview-cluster-links-navigate
+	 *
+	 * The cluster's cards are `router-link`s to the report's own page. A card
+	 * that renders but does not navigate is a picture of a feature, so click
+	 * one and assert the destination route resolves and mounts.
+	 */
+	test('a report card link navigates to that report’s own page', async ({
+		page,
+	}) => {
+		await gotoRoute(page, OVERVIEW_ROUTE)
+		await awaitCatalogue(page)
+
+		const card = page.getByTestId(`reporting-card-${SAMPLE_VIEW_CARD.id}`)
+		await expect(
+			card,
+			`the catalogue offers the ${SAMPLE_VIEW_CARD.id} view card`,
+		).toBeVisible({ timeout: 15_000 })
+
+		const openLink = page.getByTestId(`reporting-open-${SAMPLE_VIEW_CARD.id}`)
+		await expect(openLink, 'the card carries an Open link').toBeVisible()
+		await openLink.click()
+
+		await expect(page).toHaveURL(
+			new RegExp(`${SAMPLE_VIEW_CARD.route.replace(/\//g, '\\/')}$`),
+			{ timeout: 15_000 },
+		)
+		await expect(page.getByTestId('cn-index-page')).toBeVisible({
+			timeout: 15_000,
+		})
+	})
+
+	/**
+	 * @e2e reporting-compliance-consolidation::overview-generated-reports-link-resolves
+	 *
+	 * The overview is the only entry point to `GeneratedReportsIndex` — the
+	 * fragment's `_menu_note` records that the former "Generated reports" menu
+	 * leaf was deleted because "the overview IS the reports page … and links to
+	 * the generated-reports index itself". If this link breaks, that page
+	 * becomes unreachable, with no menu leaf left to reach it by.
+	 */
+	test('the “View generated reports” link reaches GeneratedReportsIndex', async ({
+		page,
+	}) => {
+		await gotoRoute(page, OVERVIEW_ROUTE)
+		await awaitCatalogue(page)
+
+		const link = page.getByTestId('reporting-overview-generated-link')
+		await expect(link).toBeVisible({ timeout: 15_000 })
+		await link.click()
+
+		await expect(page).toHaveURL(
+			new RegExp(`${GENERATED_ROUTE.replace(/\//g, '\\/')}$`),
+			{ timeout: 15_000 },
+		)
+		await expect(page.getByTestId('generated-reports')).toBeVisible({
+			timeout: 15_000,
+		})
+		await expect(page.getByTestId('generated-reports-table')).toBeVisible({
+			timeout: 15_000,
+		})
+	})
+
+	/**
+	 * @e2e reporting-compliance-consolidation::overview-category-filter-narrows-groups
+	 *
+	 * The category `<select>` is a plain native select (not `NcSelect`), so it
+	 * is driven with `selectOption`. Choosing one category must leave exactly
+	 * that group rendered — the filter is the page's one piece of local
+	 * behaviour and the only thing that makes the catalogue navigable at 96
+	 * cards.
+	 */
+	test('choosing a category leaves only that category’s group rendered', async ({
+		page,
+	}) => {
+		await gotoRoute(page, OVERVIEW_ROUTE)
+		await awaitCatalogue(page)
+
+		const groups = page.locator('[data-testid^="reporting-group-"]')
+		await expect(groups.first()).toBeVisible({ timeout: 15_000 })
+		const groupsBefore = await groups.count()
+		expect(groupsBefore, 'more than one group before filtering').toBeGreaterThan(
+			1,
+		)
+
+		// Take the category from the select's own options rather than hardcoding
+		// one: `categoryOptions` is derived from the loaded catalogue, so a
+		// literal could name a category this instance does not offer.
+		const select = page.getByTestId('reporting-category-filter')
+		await expect(select).toBeVisible()
+		const value = await select.locator('option').nth(1).getAttribute('value')
+		expect(
+			value,
+			'the category filter offers at least one category',
+		).toBeTruthy()
+
+		await select.selectOption(value as string)
+
+		await expect(
+			page.getByTestId(`reporting-group-${value}`),
+			`the "${value}" group survives its own filter`,
+		).toBeVisible({ timeout: 10_000 })
+		await expect(
+			groups,
+			'every other category group is filtered out',
+		).toHaveCount(1, { timeout: 10_000 })
+	})
+})


### PR DESCRIPTION
## Closes a tracked gate-19 coverage gap

**Requisitions** and **ReportingComplianceOverview** had **zero** Playwright coverage. 8 tests across two files (every spec in `tests/e2e/` is single-surface, and these are unrelated surfaces).

## Deployed-bundle check first — nothing here is inferred

`docker exec grep` against the **container's own copy** (`/var/www/html/custom_apps/shillinq/js`, built 2026-08-21 00:44) found `inkoop/requisitions` in `shillinq-main.js` and `ReportingComplianceOverview` in main plus both fragment chunks.

> Fetching that JS over HTTP is useless here: `/apps/shillinq/js/*` returns a 65 KB **login page** with HTTP 200 for all three files.

```
8 passed (2.4m)   — 0 failed, 0 skipped, 0 flaky, --retries=0
control: chart-of-accounts.spec.ts -> 1 passed
```

## Every test proven able to fail — twice

Two full red runs of **8/8**, once breaking the route/nav dependency and once breaking the content assertion, and each test failed with its **own** message rather than a shared timeout:

| break | went red with |
|---|---|
| route → `/inkoop/requisitions-BREAKPROOF` | `route … must be declared by the manifest`, Received `"/apps/shillinq"` (catch-all) |
| nav testid → `cn-nav-entry-RequisitionsBREAKPROOF` | `toHaveCount` Received 0 |
| column `Requisition #` → renamed | `manifest column … is rendered` Expected 1, Received 0 |
| `selectOption(value)` → `selectOption('')` | `every other category group is filtered out` Expected 1, **Received 8** |

All breaks restored from byte-identical backups.

## Six known locator traps, all live here, all avoided

- `reportViews.js` ships a card literally labelled **"Scenarios"** — the exact false-positive that already bit budget-scenarios. Every locator targets a `data-testid` carrying a manifest/catalogue id, never a label.
- The instance renders **Dutch** (`lang="nl"`; the collapse control's `aria-label` is `Menu openen`), so the nav toggle is addressed by `button.icon-collapse`.
- `cn-nav-entry-Requisitions` is **present but hidden** while `Purchasing` is collapsed, and the `Purchasing` top-level link **navigates** rather than expands. The test asserts hidden → click toggle → visible, proving the expansion instead of assuming it.
- No `isVisible()` as a gate; no `waitForResponse`; the category filter is a native `<select>`, not `NcSelect`.

## A real config trap the proof runs exposed

The root `playwright.config.ts` sets `timeout: 30_000` per test, so a per-assertion `{ timeout: 40_000 }` **can never be reached** — the test dies first with a bare `Test timeout of 30000ms exceeded` and whichever assertion happened to be *waiting* takes the blame. Reproduced on a loaded box (~31s per test vs ~18s idle). Each describe now sets `test.setTimeout(120_000)` in `beforeEach`, per the `budget-scenarios` / `setup-wizard-english` precedent, with the reason in the code. CI's own config is 60s so this was local-only — but it would have been a mystery failure for the next reader.

## Deliberately not covered

- **Requisition lifecycle** (approve / reject / convert-to-PO): mutates seeded requisitions one-way with no UI undo, and REQ-REQ-002/-003's fail-closed behaviour is already proven against a real `BudgetBlocker`/`PurchaseOrderService` in PHPUnit.
- **Report generation**: `reporting-generate-*` POSTs `/api/reporting/generate` and persists a `GeneratedReport` plus a Files artefact on every run.

Reachability and rendering were the actual gap.

## Two caveats — please do not read these as success

1. **`reporting-compliance-consolidation` has no `spec.md` in this tree.** The capability name comes from the manifest fragment's own `_meta.change`, but that change directory does not exist — it survives only as a dangling reference in `openspec/changes/archive/2026-07-22-spec-anchor-repair/residual-dangling.md`. Those five `@e2e` tags therefore document intent; gate-19 has no in-tree scenario to match them against today. That capability should be reverse-specced or the tags retargeted.
2. **CI risk on one test.** `requisitions-index` asserts the register-declared seed `REQ-2026-adm-demo-000001` is listed. `tests/e2e/ci-seed.sh` contains no `requisition` reference — it imports the register wholesale, which *should* carry the `objects` array, but that was not verifiable end-to-end from here. If CI's configuration import drops seed objects, that test goes red — which would itself be a true finding about the seed path. It is the one test of the eight whose CI outcome is unmeasured.
