### PR TITLE
fix(security): scope resumePause to its administration — the parameter was dead

### DIFF
--- a/lib/Service/DunningRunService.php
+++ b/lib/Service/DunningRunService.php
@@ -520,6 +520,31 @@ class DunningRunService {
 			throw new RuntimeException(sprintf('DunningPauseDispute %s not found.', $pauseId));
 		}
 
+		// Defence in depth: $administrationId was accepted and then IGNORED.
+		//
+		// fetchById() resolves by id ALONE, so before this check the parameter
+		// appeared exactly once in the whole method — its own declaration. A
+		// dead tenant parameter is what enabled the resumePause IDOR in the
+		// first place: it reads as scoped at every call site while scoping
+		// nothing. The controller layer closes the live hole; this closes it
+		// again at the service, so the guarantee does not depend on one caller
+		// remembering.
+		//
+		// The message is deliberately IDENTICAL to the not-found case above:
+		// a distinct "wrong administration" error would confirm the object
+		// exists, turning the guard into an existence oracle — the same
+		// masking rule AdministrationContextService::canAccess() follows when
+		// it answers 404 rather than 403.
+		//
+		// administrationId is `required` on DunningPauseDispute, so a stored
+		// row always carries one; an empty argument is treated as "no scope
+		// asserted" and left to the caller's own guard rather than silently
+		// matching everything.
+		$pauseAdministrationId = (string)($pause['administrationId'] ?? '');
+		if ($administrationId !== '' && $pauseAdministrationId !== $administrationId) {
+			throw new RuntimeException(sprintf('DunningPauseDispute %s not found.', $pauseId));
+		}
+
 		$pause['pauseEnd'] = (new DateTimeImmutable())->format(DATE_ATOM);
 		if ($resolution === 'expire') {
 			$pause['lifecycleState'] = 'hardDeadlineExpired';

--- a/tests/Unit/Service/DunningRunServiceTest.php
+++ b/tests/Unit/Service/DunningRunServiceTest.php
@@ -276,6 +276,53 @@ final class DunningRunServiceTest extends TestCase {
 	}//end testResumePauseFlipsLifecycleState()
 
 	/**
+	 * resumePause() must refuse a pause belonging to another administration.
+	 *
+	 * The $administrationId parameter was accepted and then IGNORED —
+	 * fetchById() resolves by id alone, so before the guard the parameter
+	 * appeared exactly once in the method, its own declaration. A dead tenant
+	 * parameter reads as scoped at every call site while scoping nothing, and
+	 * that is precisely what enabled the resumePause IDOR.
+	 *
+	 * The refusal message is deliberately identical to the not-found case, so
+	 * the guard cannot be used as an existence oracle.
+	 *
+	 * @return void
+	 */
+	public function testResumePauseRefusesAnotherAdministrationsPause(): void {
+		$os = new OpenRegisterFaithfulObjectService();
+		$os->seed(schema: 'DunningPauseDispute', rows: [
+			['id' => 'pause-b', 'administrationId' => 'adm-B', 'lifecycleState' => 'active'],
+		]);
+		$service = $this->makeService(os: $os);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('DunningPauseDispute pause-b not found.');
+		$service->resumePause(administrationId: 'adm-A', pauseId: 'pause-b', resolution: 'resolve');
+
+	}//end testResumePauseRefusesAnotherAdministrationsPause()
+
+	/**
+	 * The paired must-PASS control: the OWNING administration still resolves.
+	 *
+	 * Without this, a guard that refused everything would look identical to a
+	 * guard that refuses correctly.
+	 *
+	 * @return void
+	 */
+	public function testResumePauseStillResolvesForTheOwningAdministration(): void {
+		$os = new OpenRegisterFaithfulObjectService();
+		$os->seed(schema: 'DunningPauseDispute', rows: [
+			['id' => 'pause-own', 'administrationId' => 'adm-A', 'lifecycleState' => 'active'],
+		]);
+		$service = $this->makeService(os: $os);
+
+		$resolved = $service->resumePause(administrationId: 'adm-A', pauseId: 'pause-own', resolution: 'resolve');
+		self::assertSame('resolved', $resolved['lifecycleState']);
+
+	}//end testResumePauseStillResolvesForTheOwningAdministration()
+
+	/**
 	 * REQ-CCD-010: writeOff materialises the OninbaarAfschrijving record.
 	 *
 	 * @return void


### PR DESCRIPTION
## The `$administrationId` parameter was accepted and then ignored

`DunningRunService::resumePause()` takes `string $administrationId` — and `fetchById()` resolves by **id alone**. Before this change the parameter appeared exactly **once** in the whole method: its own declaration.

**A dead tenant parameter is worse than none.** It reads as scoped at every call site while scoping nothing, and that is precisely what enabled the `resumePause` IDOR. The controller layer closes the live hole; this closes it again at the service, so the guarantee no longer depends on one caller remembering.

## Two deliberate details

**The refusal message is identical to the not-found case.** A distinct "wrong administration" error would confirm the object exists, turning the guard into an existence oracle — the same masking rule `AdministrationContextService::canAccess()` follows when it answers 404 rather than 403.

**An empty argument means "no scope asserted"**, left to the caller's own guard, rather than silently matching everything. `administrationId` is `required` on `DunningPauseDispute`, so a stored row always carries one.

`fetchById()` itself is untouched — it has **7 callers**, and changing its signature would ripple through all of them for one method's fix.

## Two tests, and the pair is the point

| test | proves |
|---|---|
| `testResumePauseRefusesAnotherAdministrationsPause` | adm-A cannot resume adm-B's pause, and gets the not-found message |
| `testResumePauseStillResolvesForTheOwningAdministration` | the **paired must-PASS control** |

Without the second, a guard that refused *everything* would look identical to one that refuses correctly.

## Proven able to fail

Replacing the condition with `if (false)` turns **exactly one** test red:

```
1) testResumePauseRefusesAnotherAdministrationsPause
   Failed asserting that exception of type "RuntimeException" is thrown.
Tests: 27, Assertions: 72, Failures: 1.
```

The control stays green throughout. Restored: `OK (27 tests, 73 assertions)`.
