### PR TITLE
fix(ci): give dispatched runs their own concurrency lane

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -67,7 +67,30 @@ on:
 # Proven in openconnector#1158: its first-ever completed `development` push run
 # (31048998594) executed Coverage Baseline Check, SBOM and Features Extract.
 concurrency:
-  group: quality-${{ github.head_ref || github.ref_name }}${{ (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'development')) && '-push' || '' }}
+  # SUFFIXED BY EVENT NAME, not just by `-push`.
+  #
+  # The previous expression gave a push on `development` its own lane
+  # (`-push`) but left EVERYTHING ELSE sharing `quality-development`. On this
+  # repo that is not a quiet lane: `Sync to Beta` keeps a PR open whose
+  # head_ref IS `development`, so its run computes `quality-development` too
+  # and is re-triggered on every merge.
+  #
+  # A `workflow_dispatch` therefore landed in the same group as that PR and
+  # was cancelled by it. Observed 2026-08-21: dispatch 32487948678 on
+  # `development` cancelled by pull_request run 32490160836, head_branch
+  # `development`, 25 minutes later. A run someone deliberately asked for
+  # could essentially never complete on this repo.
+  #
+  # That matters beyond ad-hoc verification: the fleet gate-drift sweep
+  # (.github#523) dispatches per app with `--ref development`, so under the
+  # old group its runs would be cancelled here and report neither pass nor
+  # fail — a routine that produces no verdict is indistinguishable from one
+  # that never ran.
+  #
+  # This is hermiq's form, already in use there. Pull requests keep the bare
+  # group (so a PR still supersedes its own earlier run); push, dispatch and
+  # schedule each get their own lane.
+  group: quality-${{ github.head_ref || github.ref_name }}${{ (github.event_name != 'pull_request' && (github.ref_name == 'main' || github.ref_name == 'development')) && format('-{0}', github.event_name) || '' }}
   cancel-in-progress: true
 
 # Permission CEILING for the called quality pipeline. GitHub statically


### PR DESCRIPTION
A `workflow_dispatch` on `development` cannot complete on this repo — it is cancelled by the `Sync to Beta` pull request.

## The mechanism

The caller's group suffixed only pushes:

```yaml
group: quality-${{ github.head_ref || github.ref_name }}${{ (github.event_name == 'push' && …) && '-push' || '' }}
```

- push on `development` → `quality-development-push` ✅ its own lane
- **workflow_dispatch** on `development` → `quality-development`
- **pull_request whose head_ref is `development`** → `quality-development`

`Sync to Beta` keeps exactly such a PR open, and it is re-triggered on every merge. So a dispatched run shares a group with a PR that fires constantly.

Measured 2026-08-21:

```
dispatch      32487948678  development  13:39Z  ->  cancelled
pull_request  32490160836  development  14:04Z  (the Sync-to-Beta run)
```

## Why it matters beyond ad-hoc verification

The fleet gate-drift sweep (ConductionNL/.github#523) dispatches per app with `--ref development`, because `schedule:` cannot choose a branch — cron runs from the repo's default branch. Under the old group its runs are cancelled here and report **neither pass nor fail**, and a routine that produces no verdict is indistinguishable from one that never ran.

## The change

Adopts **hermiq's form verbatim** — already live there, so this is an existing in-fleet pattern rather than a new invention:

```yaml
group: quality-${{ github.head_ref || github.ref_name }}${{ (github.event_name != 'pull_request' && (github.ref_name == 'main' || github.ref_name == 'development')) && format('-{0}', github.event_name) || '' }}
```

Pull requests keep the bare group, so a PR still supersedes its own earlier run. Push, dispatch and schedule each get their own lane.

## Fleet scope

ConductionNL/.github#540 keyed the **shared** workflow's group by event for the same reason, but a caller-level `concurrency:` governs the calling job and takes effect regardless. Surveyed today:

- **old form (12)**: openregister, opencatalogi, openconnector, docudesk, nldesign, launchpad, procest, pipelinq, **shillinq**, scholiq, portaliq, doriath
- **fixed form (1)**: hermiq
- **no caller concurrency (7)**: softwarecatalog, larpingapp, zaakafhandelapp, decidesk, openbuild, app-versions, hrmq — these are covered by #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)