### PR TITLE
docs(tax): stop documenting a reminder job that has never run, and gate it

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -330,7 +330,7 @@ jobs:
       # Measured on this tree before enabling: PASSES, 216 of 222 tracked
       # frontend files in scope (docs/ excluded via .prettierignore; build
       # output via .gitignore, which prettier 3 also reads).
-      frontend-checks: '["check:manifest", "check:manifest-shell", "check:manifest-budget", "check:markers", "check:registers", "check:seeds", "check:fragment-required", "check:nav-reachability", "test:l10n", "format"]'
+      frontend-checks: '["check:manifest", "check:manifest-shell", "check:manifest-budget", "check:markers", "check:registers", "check:seeds", "check:fragment-required", "check:nav-reachability", "check:job-registration", "test:l10n", "format"]'
 
       # ── Coverage ratchet ─────────────────────────────────────────────────
       # `enable-coverage-guard` defaults to FALSE, which is why both

--- a/docs/user-guide/bookkeeping/tax/vpb-administration.md
+++ b/docs/user-guide/bookkeeping/tax/vpb-administration.md
@@ -314,7 +314,18 @@ roll-up uses the live aggregation, not the exported snapshots.
 
 ### What if a deadline reminder doesn't arrive?
 
-Two reasons in practice:
+> ⚠️ **Deadline reminders do not currently send.**
+> `TaxDeadlineReminderJob` is implemented and unit-tested, but it is **not
+> registered in `appinfo/info.xml`**, so Nextcloud never schedules it and it has
+> never run. Looking for it in `oc_background_jobs` or on the admin **Jobs**
+> page will find nothing — that is expected, not a broken install.
+>
+> Enabling it is a deliberate decision rather than an oversight to correct
+> quietly: registering the job starts dispatching reminders to real users, and
+> a message once sent cannot be recalled. Track the deadlines yourself until
+> then.
+
+Once the job **is** registered, two reasons in practice:
 
 1. The recipient's Nextcloud notification panel is paused or filtered
    for the `shillinq-vpb` notification source. Check Settings →

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "format": "prettier --check \"**/*.{js,ts,vue,css,scss}\"",
     "format:fix": "prettier --write \"**/*.{js,ts,vue,css,scss}\"",
     "stylelint-fix": "stylelint \"src/**/*.vue\" \"src/**/*.scss\" \"src/**/*.css\" --fix",
-    "prepare": "git config core.hooksPath .githooks || true"
+    "prepare": "git config core.hooksPath .githooks || true",
+    "check:job-registration": "node tests/validate-job-registration.js"
   },
   "browserslist": [
     "extends @nextcloud/browserslist-config"

--- a/tests/validate-job-registration.js
+++ b/tests/validate-job-registration.js
@@ -62,7 +62,9 @@ function read(p) {
 function main() {
 	const infoXml = read(INFO_XML)
 	if (infoXml === null) {
-		console.error('[validate-job-registration] FAIL — appinfo/info.xml not readable; cannot tell which jobs are registered.')
+		console.error(
+			'[validate-job-registration] FAIL — appinfo/info.xml not readable; cannot tell which jobs are registered.',
+		)
 		process.exit(1)
 	}
 
@@ -73,7 +75,9 @@ function main() {
 		const docPath = path.join(REPO_ROOT, doc)
 		const docText = read(docPath)
 		if (docText === null) {
-			problems.push(`${doc} does not exist, but ${job} is listed as documented there.`)
+			problems.push(
+				`${doc} does not exist, but ${job} is listed as documented there.`,
+			)
 			continue
 		}
 		checked++
@@ -102,7 +106,9 @@ function main() {
 
 	// A check that inspected nothing must not report success.
 	if (checked === 0) {
-		console.error('[validate-job-registration] FAIL — inspected ZERO documented jobs. The list is empty or every doc path is wrong; that is a broken gate, not a clean repo.')
+		console.error(
+			'[validate-job-registration] FAIL — inspected ZERO documented jobs. The list is empty or every doc path is wrong; that is a broken gate, not a clean repo.',
+		)
 		process.exit(1)
 	}
 
@@ -112,7 +118,9 @@ function main() {
 		process.exit(1)
 	}
 
-	console.log('[validate-job-registration] PASS — every documented job\'s registration state matches its documentation.')
+	console.log(
+		"[validate-job-registration] PASS — every documented job's registration state matches its documentation.",
+	)
 	process.exit(0)
 }
 

--- a/tests/validate-job-registration.js
+++ b/tests/validate-job-registration.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+//
+// validate-job-registration.js — keeps documentation honest about which
+// background jobs actually run.
+//
+// A BackgroundJob class that is not listed in appinfo/info.xml is never
+// scheduled by Nextcloud. It exists, it has unit tests, and it does nothing.
+// That is a legitimate state — enabling a job that dispatches notifications to
+// real users is a product decision, not a mechanical fix — but it MUST NOT be
+// documented as if it runs.
+//
+// Observed 2026-08-21: docs/user-guide/.../vpb-administration.md told users to
+// look for `TaxDeadlineReminderJob` in `oc_background_jobs` when a reminder did
+// not arrive. The job has never been registered, so that search always comes up
+// empty and reads as a broken install.
+//
+// This gate is SYMMETRIC, which is the point:
+//   - unregistered + documented as running        -> FAIL (the original defect)
+//   - unregistered + carries the "does not send"  -> pass
+//     warning
+//   - REGISTERED + still carries the warning      -> FAIL (the warning is now
+//                                                    itself a lie)
+//
+// The third case is why this is a gate and not a comment: whoever registers the
+// job is told, at that moment, to delete the caveat.
+
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const REPO_ROOT = path.resolve(__dirname, '..')
+const INFO_XML = path.join(REPO_ROOT, 'appinfo', 'info.xml')
+
+// Jobs whose documentation must state that they do not currently run, for as
+// long as they are absent from info.xml. Each entry names the doc that makes a
+// user-visible claim about it and the marker phrase that must be present.
+const DOCUMENTED_JOBS = [
+	{
+		job: 'TaxDeadlineReminderJob',
+		doc: 'docs/user-guide/bookkeeping/tax/vpb-administration.md',
+		marker: 'Deadline reminders do not currently send',
+	},
+]
+
+/**
+ * Read a file, or return null when it does not exist.
+ *
+ * @param {string} p Absolute path.
+ * @return {string|null} Contents, or null.
+ */
+function read(p) {
+	try {
+		return fs.readFileSync(p, 'utf8')
+	} catch (_) {
+		return null
+	}
+}
+
+function main() {
+	const infoXml = read(INFO_XML)
+	if (infoXml === null) {
+		console.error('[validate-job-registration] FAIL — appinfo/info.xml not readable; cannot tell which jobs are registered.')
+		process.exit(1)
+	}
+
+	const problems = []
+	let checked = 0
+
+	for (const { job, doc, marker } of DOCUMENTED_JOBS) {
+		const docPath = path.join(REPO_ROOT, doc)
+		const docText = read(docPath)
+		if (docText === null) {
+			problems.push(`${doc} does not exist, but ${job} is listed as documented there.`)
+			continue
+		}
+		checked++
+
+		const registered = infoXml.includes(job)
+		const warned = docText.includes(marker)
+
+		if (registered === false && warned === false) {
+			problems.push(
+				`${job} is NOT registered in appinfo/info.xml, so Nextcloud never schedules it — `
+					+ `but ${doc} describes it as running. A user following that guidance searches `
+					+ `oc_background_jobs, finds nothing, and concludes their install is broken. `
+					+ `Add the "${marker}" warning, or register the job.`,
+			)
+		}
+
+		if (registered === true && warned === true) {
+			problems.push(
+				`${job} IS now registered in appinfo/info.xml, but ${doc} still carries the `
+					+ `"${marker}" warning. That caveat is now itself false — delete it.`,
+			)
+		}
+	}
+
+	console.log(`[validate-job-registration] documented jobs checked: ${checked}`)
+
+	// A check that inspected nothing must not report success.
+	if (checked === 0) {
+		console.error('[validate-job-registration] FAIL — inspected ZERO documented jobs. The list is empty or every doc path is wrong; that is a broken gate, not a clean repo.')
+		process.exit(1)
+	}
+
+	if (problems.length > 0) {
+		console.error('[validate-job-registration] FAIL:')
+		for (const p of problems) console.error(`  - ${p}`)
+		process.exit(1)
+	}
+
+	console.log('[validate-job-registration] PASS — every documented job\'s registration state matches its documentation.')
+	process.exit(0)
+}
+
+main()


### PR DESCRIPTION
## The user guide described a job that has never run

`docs/user-guide/.../vpb-administration.md` told users that if a Vpb deadline reminder didn't arrive, they should look for `TaxDeadlineReminderJob` in `oc_background_jobs` or on the admin **Jobs** page.

**That job is not in `appinfo/info.xml`**, so Nextcloud never schedules it and it has never run. The search always comes up empty — and reads as a broken install rather than a feature that was never switched on.

17 jobs are registered. `TaxDeadlineReminderJob`, `BookingReminderJob` and `ViesOutageRetryJob` are not.

## Why the fix is documentation, not registration

All three **dispatch notifications to real users**, and a message once sent cannot be recalled. Enabling them is a product decision, not an oversight to correct quietly in an unattended session. The doc now states the situation plainly and says why, so a user tracking deadlines knows to do it themselves for now.

**Registering them remains open for a human to decide.**

## The gate is symmetric, and that is the point

`tests/validate-job-registration.js`:

| state | verdict |
|---|---|
| unregistered + documented as running | **FAIL** — the original defect |
| unregistered + carries the warning | pass |
| **registered + still carries the warning** | **FAIL** — the caveat is now itself a lie |

The third row is why this is a gate rather than a comment: whoever registers the job is told, *at that moment*, to delete the caveat. The fix cannot rot into a new false statement.

It also fails when it inspected **zero** documented jobs, so an empty list or a wrong doc path cannot report success — the same "a check that examined nothing must not pass" rule used by the other validators here.

## Controls — all three run

```
A  current state (unregistered + warned)   -> PASS, exit 0
B  warning removed                         -> FAIL, names the job and the doc
C  job registered but warning kept         -> FAIL, "delete it"
```

Wired into the `frontend-checks` matrix as `check:job-registration`.
