### PR TITLE
plan(glline): scope 3 SpendAnalytics views to their administration

### DIFF
--- a/openspec/changes/glline-administration-scope/.openspec.yaml
+++ b/openspec/changes/glline-administration-scope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/glline-administration-scope/proposal.md
+++ b/openspec/changes/glline-administration-scope/proposal.md
@@ -1,0 +1,70 @@
+# Change: glline-administration-scope
+
+## Why
+
+Three of the four SpendAnalytics views aggregate **every administration in the
+register**. A member of administration A can read administration B's category,
+cost-centre and period totals.
+
+This is not a suspicion. `lib/Service/SpendAnalyticsService.php:36-70` documents
+it at length, and the measurement holds today on `development`: `GLLine`
+declares no administration or organisation property at all. Its properties are
+`transactionId`, `lineNumber`, `accountNumber`, `side`, `amount`, `currency`,
+`description`, `costCenter(Code)`, `costCarrierCode`, `projectCode`, `periodId`,
+`ozbCategory`, `dimensions`, `subLedgerType`, `subLedgerRef`, `accountRef`,
+`eliminationFlag`. The administration lives one hop away, on the parent
+`GLTransaction`.
+
+`spendBySupplier()` IS correctly scoped, because `APTransaction` carries
+`administrationId` and the aggregation filter can use it. The asymmetry between
+that view and the other three is the whole problem: the service looks scoped.
+
+`AdministrationContextService::canAccess()` on the controller reduces the
+audience from "any authenticated Nextcloud user" to "a member of some
+administration". It does not stop a member of A reading B's totals.
+
+## What the naive fix does, and why it is worse than the bug
+
+Adding `administrationId` to the GLLine aggregation filter **today** would
+address a property that does not exist. OpenRegister filters address the
+object's own JSON properties; an unmatched key matches nothing for every value.
+Every category, cost-centre and period total would silently read **zero**.
+
+The service's own docblock says exactly this, and says *"Do not 'fix' it by
+adding the unmatched filter."* A silent zero in a bookkeeping total is worse
+than the exposure it pretends to close, because the exposure is at least
+visible to whoever looks.
+
+Also already ruled out there, verified rather than assumed:
+- OpenRegister's `AggregationRunner` applies a `_organisation = ?` predicate.
+  `_organisation` is **OpenRegister's** tenancy axis, not shillinq's
+  administration — many administrations live inside one organisation, which is
+  the entire point of `AdministrationMembership`.
+- `x-openregister-rbac` on `APTransaction` is read by **zero** PHP.
+
+## What changes
+
+`administrationId` is denormalised onto `GLLine`, every writer sets it, existing
+rows are backfilled from their parent `GLTransaction`, and **only then** is the
+filter switched on.
+
+The ordering is the change. Enabling the filter before the backfill is complete
+produces the silent-zero failure above, on live bookkeeping data.
+
+## Scope
+
+- **57 files** reference `GLLine`.
+- At least **6** write it directly: `ProgrammaLinkGuard`,
+  `BackfillFiscalPeriods`, `CogsPosterService`, `InventoryGlAdjustmentPoster`,
+  `RuleTestDataSeeder`, `VatSuppletieDetectionService`.
+- Three consumer views change behaviour once the filter lands.
+
+## Non-goals
+
+- Changing `spendBySupplier()`, which is already scoped correctly.
+- Touching OpenRegister's `_organisation` axis. It is a different concept and
+  conflating the two is how this gets "fixed" wrongly a second time.
+- Making `administrationId` `required` on `GLLine` in the same change — a
+  required property on a schema with existing rows fails validation for every
+  un-backfilled row. Required comes after the backfill is proven complete, if
+  at all.

--- a/openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+++ b/openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
@@ -1,0 +1,103 @@
+# Spec: glline-administration-scope
+
+## ADDED Requirements
+
+### Requirement: REQ-GLS-001 — `GLLine` MUST carry its own `administrationId`
+
+`GLLine` MUST declare an `administrationId` property, denormalised from its
+parent `GLTransaction`. It MUST NOT be added to the schema's `required` list in
+this change: a required property on a schema with existing rows fails validation
+for every row not yet backfilled.
+
+#### Scenario: A newly written GLLine carries its parent's administration
+
+- **GIVEN** a `GLTransaction` with `administrationId` `adm-A`
+- **WHEN** any writer creates a `GLLine` for that transaction
+- **THEN** the stored line MUST carry `administrationId` `adm-A`
+
+@e2e exclude storage-shape assertion with no browser-observable behaviour of its
+own; enforced by one unit test per writer
+
+### Requirement: REQ-GLS-002 — the backfill MUST abort rather than half-migrate
+
+The backfill migrator MUST resolve each `GLLine`'s administration through its
+`transactionId`, and MUST count-verify before committing: when the number of
+lines resolved does not equal the number seen, it MUST abort the whole batch
+untouched, following this repo's `assertCountsMatch()` precedent.
+
+A `GLLine` whose parent `GLTransaction` cannot be found MUST be reported as
+**unclassifiable**. It MUST NOT be assigned a default or guessed administration,
+and the migrator MUST exit non-zero while any remain, so a partial result cannot
+be read as success.
+
+#### Scenario: A missing parent aborts rather than guesses
+
+- **GIVEN** a `GLLine` whose `transactionId` matches no `GLTransaction`
+- **WHEN** the backfill runs
+- **THEN** it MUST report that line as unclassifiable, leave every row
+  unchanged, and exit non-zero
+
+#### Scenario: Re-running the backfill changes nothing
+
+- **GIVEN** a register whose `GLLine` rows are already backfilled
+- **WHEN** the backfill runs again
+- **THEN** no row MUST be modified
+
+@e2e exclude a data migration with no UI surface; enforced by unit tests over a
+faithful in-memory store
+
+### Requirement: REQ-GLS-003 — the filter MUST NOT be enabled before the backfill is proven complete
+
+`SpendAnalyticsService`'s category, cost-centre and period aggregations MUST NOT
+filter on `administrationId` until a check has confirmed that **zero** `GLLine`
+rows lack one.
+
+This ordering is normative, not advisory. OpenRegister filters address the
+object's own JSON properties, so filtering on a property that some rows lack
+matches nothing for those rows and yields a **silent zero** in a bookkeeping
+total — a wrong number that looks like a real one, which is worse than the
+cross-administration read it is meant to close.
+
+#### Scenario: Each scoped view can still return rows
+
+- **GIVEN** a backfilled register with GL activity in administration `adm-A`
+- **WHEN** an `adm-A` member opens the category, cost-centre and period views
+- **THEN** each MUST return at least one row
+
+This is the positive control. A view returning zero because its filter matches
+nothing is indistinguishable from a view with no data, and that is precisely the
+failure this requirement exists to prevent.
+
+#### Scenario: One administration's totals exclude another's
+
+- **GIVEN** GL activity in both `adm-A` and `adm-B`
+- **WHEN** an `adm-A` member opens the three views
+- **THEN** no `adm-B` row MUST contribute to any total
+
+@e2e glline-administration-scope::scoped-views-still-return-rows
+@e2e glline-administration-scope::totals-exclude-another-administration
+
+### Requirement: REQ-GLS-004 — the stale warning MUST be removed with the fix
+
+When the filter is enabled, the `⚠️ ADMINISTRATION SCOPE IS NOT UNIFORM` section
+of `SpendAnalyticsService`'s docblock — including its *"Do not 'fix' it by adding
+the unmatched filter"* instruction — MUST be deleted.
+
+Leaving it makes the file lie in the opposite direction, telling the next reader
+the views are unscoped when they are scoped, and warning them off a fix that has
+already landed.
+
+#### Scenario: The warning and the filter cannot both be present
+
+- **GIVEN** `SpendAnalyticsService` passes `administrationId` into the category,
+  cost-centre and period aggregations
+- **WHEN** the file is inspected
+- **THEN** it MUST NOT still contain the `ADMINISTRATION SCOPE IS NOT UNIFORM`
+  section or the "Do not 'fix' it by adding the unmatched filter" instruction
+
+This mirrors the symmetric shape used by `check:job-registration`: the state and
+the documentation of that state are checked together, so fixing one without the
+other fails rather than producing a new false statement.
+
+@e2e exclude documentation accuracy with no browser-observable behaviour;
+enforceable as a grep-level check in the same change

--- a/openspec/changes/glline-administration-scope/tasks.md
+++ b/openspec/changes/glline-administration-scope/tasks.md
@@ -1,0 +1,82 @@
+# Tasks: glline-administration-scope
+
+**The order is the change.** Enabling the filter before the backfill is proven
+complete silently zeroes every category / cost-centre / period total on live
+bookkeeping data. Do not reorder these phases.
+
+## Phase 1 — schema, additive only
+
+- [ ] Add `administrationId` (`type: string`) to the `GLLine` schema.
+      **NOT** in `required` — a required property on a schema with existing rows
+      fails validation for every un-backfilled row.
+- [ ] Add a short property description naming the parent `GLTransaction` as the
+      source of truth, so a future reader knows it is denormalised and why.
+- [ ] `node tests/validate-registers.js` and `node tests/validate-seeds.js` pass.
+
+## Phase 2 — writers, before any backfill
+
+Every path that creates a `GLLine` must set `administrationId` from the parent
+`GLTransaction`, so the backfill has a fixed target rather than a moving one.
+
+- [ ] `lib/Guard/ProgrammaLinkGuard.php`
+- [ ] `lib/Repair/BackfillFiscalPeriods.php`
+- [ ] `lib/Service/CogsPosterService.php`
+- [ ] `lib/Service/InventoryGlAdjustmentPoster.php`
+- [ ] `lib/Service/RuleTestDataSeeder.php`
+- [ ] `lib/Service/VatSuppletieDetectionService.php`
+- [ ] Re-grep for writers rather than trusting this list: it was produced by
+      `git grep -ln "schema: 'GLLine'"` and a writer using a different idiom
+      would not appear.
+- [ ] One unit test per writer asserting the new line carries its parent's
+      `administrationId`. Prove each can fail by dropping the assignment.
+
+## Phase 3 — backfill migrator
+
+Follow this repo's own precedent: `BudgetSchemaSplitMigrator`,
+`RevenueContractRenameMigrator`, `SubsidieOrderConsolidationMigrator`.
+
+- [ ] `lib/Service/Migration/GlLineAdministrationBackfillMigrator.php`.
+- [ ] Resolve each `GLLine`'s administration via its `transactionId` →
+      `GLTransaction.administrationId`.
+- [ ] **Count-verify then abort**, per `assertCountsMatch()`: if the number of
+      lines resolved does not equal the number of lines seen, abort the whole
+      batch untouched rather than half-migrating a ledger.
+- [ ] A `GLLine` whose parent `GLTransaction` is missing is **unclassifiable** —
+      report it, do not guess, do not default to any administration.
+- [ ] Report: total, backfilled, unclassifiable. Exit non-zero when
+      unclassifiable > 0, so a partial result cannot read as success.
+- [ ] Idempotent: re-running must not change an already-backfilled row.
+
+## Phase 4 — prove the backfill is complete
+
+- [ ] A check that counts `GLLine` rows with no `administrationId`. Not a spot
+      check — the total.
+- [ ] **This gate must be green before Phase 5 begins.** It is the only evidence
+      that switching the filter on will not zero the totals.
+
+## Phase 5 — enable the filter, last
+
+- [ ] `SpendAnalyticsService`: pass `administrationId` into the category,
+      cost-centre and period aggregations.
+- [ ] Delete the `⚠️ ADMINISTRATION SCOPE IS NOT UNIFORM` docblock section and
+      its "Do not 'fix' it by adding the unmatched filter" warning — leaving it
+      once the fix lands makes the file lie in the other direction.
+- [ ] **A positive control**: prove each of the three views can still return
+      ROWS after scoping. A view that returns zero because the filter matches
+      nothing looks identical to a view with no data, which is the exact failure
+      this change exists to avoid.
+- [ ] **A negative control**: administration A's totals must not include B's
+      rows. Prove it can fail by reverting the filter.
+
+## Phase 6 — e2e
+
+- [ ] Cover the three views through the UI, asserting a scoped total rather than
+      mere page render.
+- [ ] Locators by `data-testid` / manifest id, never by label — a label-only
+      locator has matched another feature's element three times in this repo.
+
+## Explicitly out of scope
+
+- `spendBySupplier()` — already scoped.
+- OpenRegister's `_organisation` axis — a different concept.
+- Making `administrationId` required on `GLLine`.


### PR DESCRIPTION
## A plan, deliberately — not the fix

Three of the four SpendAnalytics views aggregate **every administration in the register**. A member of administration A can read B's category, cost-centre and period totals. `spendBySupplier()` **is** scoped, because `APTransaction` carries `administrationId` — and that asymmetry is the whole problem: the service *looks* scoped.

`GLLine` declares no administration property at all. The administration lives one hop away on the parent `GLTransaction`, and OpenRegister filters address an object's own JSON properties and cannot join.

## Why this is a plan and not a patch

**57 files** reference `GLLine`; **6** write it directly. The change is a schema addition plus a backfill of live bookkeeping rows.

The service's own docblock already warns that the obvious shortcut is worse than the bug:

> *"A filter on `administrationId` here would address a property that does not exist and match NOTHING for every value — a silent zero in a bookkeeping total, which is worse than the exposure it would pretend to fix."*

...and states plainly: **"Do not 'fix' it by adding the unmatched filter."**

A data migration on a ledger — on a night when nine of my own claims needed correcting — is exactly the change that should have a human awake for it.

## The ordering is the substance

| Phase | Why it is where it is |
|---|---|
| 1. Schema, **additive, NOT required** | a required property fails validation on every un-backfilled row |
| 2. **Writers first** | so the backfill has a fixed target rather than a moving one |
| 3. Count-verified backfill | follows this repo's `assertCountsMatch()` abort-untouched precedent; a missing parent is **unclassifiable**, never guessed |
| 4. Prove **zero** rows lack the property | the only evidence that enabling the filter will not zero the totals |
| 5. Enable the filter — **last** | doing this earlier is the silent-zero failure, on live data |
| 6. e2e | locators by `data-testid`, never by label |

## Both controls, because one without the other proves nothing

- **Positive** — each scoped view can still return rows. A view returning zero because its filter matches nothing is indistinguishable from a view with no data, which is exactly the failure this change exists to prevent.
- **Negative** — administration A's totals exclude B's rows, proven able to fail by reverting the filter.

## REQ-GLS-004 — the warning must die with the bug

When the filter lands, the `ADMINISTRATION SCOPE IS NOT UNIFORM` docblock and its "do not fix it this way" instruction must be **deleted**. Leaving it makes the file lie in the opposite direction — telling the next reader the views are unscoped when they are scoped, and warning them off a fix that already landed.

The scenario asserts the warning and the filter cannot both be present: the same symmetric shape as `check:job-registration`, so fixing one without the other fails rather than producing a new false statement.

## Validation

`openspec validate glline-administration-scope --strict` → **valid**.

The validator caught REQ-GLS-004 missing a `#### Scenario:` block on the first pass — the gate doing its job.
