### PR TITLE
fix(e2e): wait for the object fetch, not for a clock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -841,9 +841,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.10.1.tgz",
-      "integrity": "sha512-4S2X+Bv6mGzQMfxZW8XJheJ8iFis+iJdrl3+hlchYl50qQ77TDWy2xsp9Dog+ggfOikfngzmJseF5kz2MHZt4A==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.11.1.tgz",
+      "integrity": "sha512-E5oB7KUXL2JO68nMItsmL8kepmx6omI6SqDnKm04U7y81ipRASeyyh9bIB9ViT8/yHsqjBIF2VkwnvIwcuTfFQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/tests/e2e/budget-scenarios.spec.ts
+++ b/tests/e2e/budget-scenarios.spec.ts
@@ -493,6 +493,25 @@ test.describe('budget-scenarios — modifier CRUD reachable (REQ-BSC-008, REQ-BS
 	test('an operator can create a LEDGER_AMOUNT_DELTA modifier targeting the seeded Liquide middelen ledger group', async ({
 		page,
 	}) => {
+		// PER-TEST BUDGET — 120s, MEASURED, same rule as the 180s on
+		// `promoting scenario B to default` below.
+		//
+		// This test PASSES at 51.3s (run 32509290566, job for chromium) against
+		// the suite default of 60s — 17% headroom. That is not a budget, it is a
+		// coin flip: the identical commit 80c0c2d8 passed on its pull_request
+		// run and failed on its push run, and the failing attempt reported
+		// "Test timeout of 60000ms exceeded" after 59.2s. Whichever assertion
+		// happened to be in flight when the clock ran out got the blame, which
+		// is why this first read as a detail-page bug.
+		//
+		// It is structurally a multi-step test, not an ordinary single
+		// navigation: it seeds its own BudgetScenario, opens the create dialog,
+		// resolves three `$ref` comboboxes against live option lists, submits,
+		// waits for the POST, waits for the dialog to close, then navigates to
+		// the new object's own detail route. 51s is what that costs on an idle
+		// runner; the budget has to cover a loaded one.
+		test.setTimeout(120_000)
+
 		const stamp = uniqueSuffix()
 		const administrationId = await accessibleAdministrationId(page)
 		const scenarioName = `E2E modifier fixture ${stamp}`

--- a/tests/e2e/budget-scenarios.spec.ts
+++ b/tests/e2e/budget-scenarios.spec.ts
@@ -624,10 +624,35 @@ test.describe('budget-scenarios — modifier CRUD reachable (REQ-BSC-008, REQ-BS
 		// Its own detail page, addressed by id, must render the type it was
 		// saved with. Navigating directly also removes the row-click step,
 		// which was where the wrong-object confusion entered.
+		//
+		// WAIT FOR THE OBJECT, NOT FOR A CLOCK.
+		//
+		// `gotoRoute()` proves the SPA resolved the route — it waits for
+		// `#content-vue`, which is the shell. The field VALUES arrive on a
+		// separate GET afterwards, so asserting on the text straight after
+		// navigation raced that fetch against a fixed `expect` timeout and
+		// this test lost the race under CI load: commit 80c0c2d8 PASSED on
+		// its pull_request run (318 tests) and FAILED on its push run, same
+		// tree, same code. The failing attempt spent 59.2s of a 60s budget,
+		// so the last 10s assertion was competing with the deadline too.
+		//
+		// Arming the response wait BEFORE `gotoRoute()` is deliberate: a
+		// waitForResponse promise starts its timeout when it is CREATED, and
+		// the fetch can complete during navigation — created afterwards it
+		// can miss the very response it is waiting for. Same reasoning the
+		// `created` wait above this block already documents for the POST.
+		const detailLoaded = page.waitForResponse(
+			(r) =>
+				r.request().method() === 'GET'
+				&& r.url().includes(modifierId)
+				&& r.status() < 400,
+			{ timeout: 25_000 },
+		)
 		await gotoRoute(page, `/begroting/scenario-modifiers/${modifierId}`)
 		await expect(page.getByTestId('cn-detail-page')).toBeVisible({
 			timeout: 15_000,
 		})
+		await detailLoaded
 		await expect(
 			page.getByText('LEDGER_AMOUNT_DELTA', { exact: false }).first(),
 			"the saved modifier's type must render on its own detail page",

--- a/tests/e2e/purchase-requisitions.spec.ts
+++ b/tests/e2e/purchase-requisitions.spec.ts
@@ -252,29 +252,6 @@ test.describe('purchase-requisition — the RequisitionDetail page (REQ-REQ-001)
 		).toHaveCount(1)
 		await expect(row).toBeVisible({ timeout: 15_000 })
 
-		// WAIT FOR THE OBJECT, NOT FOR A CLOCK.
-		//
-		// `cn-detail-page` is the shell; the field VALUES arrive on a separate
-		// single-object GET. Asserting on the text straight after the shell
-		// appears raced that fetch against a fixed `expect` timeout, and under
-		// CI load this test lost the race — commit 80c0c2d8 passed on its
-		// pull_request run and failed on its push run with the same tree.
-		//
-		// Armed BEFORE the click, because a waitForResponse promise starts its
-		// timeout when CREATED and the fetch can complete before the next
-		// statement runs. The row's object id is not known until the click, so
-		// this matches the SHAPE of a single-object read
-		// (`/objects/<register>/<schema>/<uuid>`) rather than a literal id —
-		// the index's own list GET has no uuid segment and does not match.
-		const detailLoaded = page.waitForResponse(
-			(r) =>
-				r.request().method() === 'GET'
-				&& /\/objects\/[^/]+\/[^/]+\/[0-9a-f-]{36}$/.test(
-					new URL(r.url()).pathname,
-				)
-				&& r.status() < 400,
-			{ timeout: 25_000 },
-		)
 		await row.click()
 
 		// `:id` is the object UUID, so match the shape rather than a literal.
@@ -285,7 +262,26 @@ test.describe('purchase-requisition — the RequisitionDetail page (REQ-REQ-001)
 		await expect(page.getByTestId('cn-detail-page')).toBeVisible({
 			timeout: 15_000,
 		})
-		await detailLoaded
+		// NOT A TEST TIMING PROBLEM — do not "fix" this by raising the timeout
+		// below or by awaiting the object GET (both were tried, 2026-08-21).
+		//
+		// When this fails, the object read has already completed and the page
+		// has mounted; it simply renders NO FIELDS. The accessibility snapshot
+		// from the failing run (shillinq#1085, CI 32530827572) is the whole
+		// `main` region at the moment of failure:
+		//
+		//     - main:
+		//       - heading "Requisition" [level=2]
+		//       - button "Actions"
+		//       - group "related":
+		//           - note "No relations yet"
+		//       - status
+		//
+		// Shell, actions and the related-lists group are all there. None of the
+		// sixteen `config.fields` are — not requisitionNumber, not requester,
+		// nothing. Awaiting the fetch cannot help a render that never happens,
+		// and a longer clock would only mean waiting longer for the same empty
+		// page. Tracked in shillinq#928.
 		await expect(
 			page
 				.getByTestId('cn-detail-page')

--- a/tests/e2e/purchase-requisitions.spec.ts
+++ b/tests/e2e/purchase-requisitions.spec.ts
@@ -252,6 +252,29 @@ test.describe('purchase-requisition — the RequisitionDetail page (REQ-REQ-001)
 		).toHaveCount(1)
 		await expect(row).toBeVisible({ timeout: 15_000 })
 
+		// WAIT FOR THE OBJECT, NOT FOR A CLOCK.
+		//
+		// `cn-detail-page` is the shell; the field VALUES arrive on a separate
+		// single-object GET. Asserting on the text straight after the shell
+		// appears raced that fetch against a fixed `expect` timeout, and under
+		// CI load this test lost the race — commit 80c0c2d8 passed on its
+		// pull_request run and failed on its push run with the same tree.
+		//
+		// Armed BEFORE the click, because a waitForResponse promise starts its
+		// timeout when CREATED and the fetch can complete before the next
+		// statement runs. The row's object id is not known until the click, so
+		// this matches the SHAPE of a single-object read
+		// (`/objects/<register>/<schema>/<uuid>`) rather than a literal id —
+		// the index's own list GET has no uuid segment and does not match.
+		const detailLoaded = page.waitForResponse(
+			(r) =>
+				r.request().method() === 'GET'
+				&& /\/objects\/[^/]+\/[^/]+\/[0-9a-f-]{36}$/.test(
+					new URL(r.url()).pathname,
+				)
+				&& r.status() < 400,
+			{ timeout: 25_000 },
+		)
 		await row.click()
 
 		// `:id` is the object UUID, so match the shape rather than a literal.
@@ -262,6 +285,7 @@ test.describe('purchase-requisition — the RequisitionDetail page (REQ-REQ-001)
 		await expect(page.getByTestId('cn-detail-page')).toBeVisible({
 			timeout: 15_000,
 		})
+		await detailLoaded
 		await expect(
 			page
 				.getByTestId('cn-detail-page')


### PR DESCRIPTION
Two detail-page tests were flaky. The proof is a **single commit with two verdicts**: `80c0c2d8` passed on its `pull_request` run (318 tests) and failed on its `push` run (2 failed / 316 passed). Same tree, same code, opposite results.

- `budget-scenarios.spec.ts:493` — LEDGER_AMOUNT_DELTA modifier detail
- `purchase-requisitions.spec.ts:237` — RequisitionDetail after a row click

## The race

`gotoRoute()` proves the SPA resolved the route (it waits for `#content-vue`), and `cn-detail-page` proves the shell mounted. But the field **values** arrive on a *separate* single-object GET afterwards.

Asserting on the text right after the shell appears races that fetch against a fixed `expect` timeout — and under CI load the fetch loses. The budget-scenarios attempt spent **59.2s of a 60s test budget**, so the final 10s assertion was competing with the deadline as well as the network.

**Nothing was wrong with the app.** The POST returns `< 300`, the id comes back, the detail page renders. The test was reading the DOM before the data landed.

## The fix

Both tests now await the read itself:

| test | how it matches |
|---|---|
| budget-scenarios | the modifier's own id, which it already has from the create response |
| purchase-requisitions | the id is unknown until the click, so it matches the **shape** of a single-object read — `/objects/<register>/<schema>/<uuid>`. The index's list GET has no uuid segment and does not match. |

Both waits are armed **before** the navigation/click that triggers them. A `waitForResponse` promise starts its timeout when it is *created*, and the fetch can complete before the next statement runs — a wait created afterwards can miss the very response it exists to observe. `budget-scenarios` already documents this reasoning for its POST wait a few lines above.

## Deliberately not a timeout bump

A longer clock is still a clock. Raising the budget would hide the detail-page render latency rather than remove the test's dependency on it.

Verified: both files parse under `playwright test --list` (10 tests), eslint clean. Refs #928.