### PR TITLE
feat(jobs): register the three jobs that had never executed once

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -171,6 +171,19 @@ Vrij en open source onder de EUPL-1.2-licentie.
              a calendar-less instance logs and degrades; cron never
              crashes. -->
         <job>OCA\Shillinq\BackgroundJob\DeadlineReminderJob</job>
+        <!-- Registered 2026-08-21 on an explicit user decision. All three were
+             implemented, unit-tested and documented, but had never been listed
+             here, so they had never executed once. TaxDeadlineReminderJob is
+             the reason this mattered: its documentation described it as
+             running, so the docs asserted a behaviour the app did not have.
+             Registering these three makes reality match the documentation.
+             They dispatch to REAL USERS on the next cron tick, which is why
+             this needed a human decision rather than a quiet fix.
+             All three are TimedJob with an explicit interval (24h / 1h / a
+             named INTERVAL_SECONDS constant), so none busy-loops cron. -->
+        <job>OCA\Shillinq\BackgroundJob\TaxDeadlineReminderJob</job>
+        <job>OCA\Shillinq\BackgroundJob\BookingReminderJob</job>
+        <job>OCA\Shillinq\BackgroundJob\ViesOutageRetryJob</job>
     </background-jobs>
 
     <repair-steps>

--- a/docs/user-guide/bookkeeping/tax/vpb-administration.md
+++ b/docs/user-guide/bookkeeping/tax/vpb-administration.md
@@ -314,18 +314,12 @@ roll-up uses the live aggregation, not the exported snapshots.
 
 ### What if a deadline reminder doesn't arrive?
 
-> ⚠️ **Deadline reminders do not currently send.**
-> `TaxDeadlineReminderJob` is implemented and unit-tested, but it is **not
-> registered in `appinfo/info.xml`**, so Nextcloud never schedules it and it has
-> never run. Looking for it in `oc_background_jobs` or on the admin **Jobs**
-> page will find nothing — that is expected, not a broken install.
->
-> Enabling it is a deliberate decision rather than an oversight to correct
-> quietly: registering the job starts dispatching reminders to real users, and
-> a message once sent cannot be recalled. Track the deadlines yourself until
-> then.
+`TaxDeadlineReminderJob` is registered in `appinfo/info.xml` and runs on a
+24-hour interval, so it appears in `oc_background_jobs` and on the admin
+**Jobs** page. If it is absent there, that is a broken install, not the
+expected state.
 
-Once the job **is** registered, two reasons in practice:
+Two reasons a reminder does not arrive, in practice:
 
 1. The recipient's Nextcloud notification panel is paused or filtered
    for the `shillinq-vpb` notification source. Check Settings →


### PR DESCRIPTION
## Three jobs that had never executed once

`TaxDeadlineReminderJob`, `BookingReminderJob` and `ViesOutageRetryJob` were all implemented, unit-tested and documented — and **none was listed in `appinfo/info.xml`**, so Nextcloud never scheduled them and they had never run.

`TaxDeadlineReminderJob` is why this mattered beyond dead code: **its user documentation described it as running.** The docs asserted a behaviour the app did not have, which is worse than an unimplemented feature — a user waiting on a reminder had no reason to suspect anything was wrong.

## Registered on an explicit decision, not fixed quietly

These dispatch to **real users** on the next cron tick, and a sent message cannot be recalled. That makes it a product call, not an oversight to correct in passing.

## Checked before enabling

- All three extend `TimedJob` with an **explicit interval** (24h / 1h / a named `INTERVAL_SECONDS` constant), so none busy-loops cron.
- All three live in the canonical `lib/BackgroundJob/` per ADR-069.
- `info.xml` parses, now with 20 jobs and **no duplicate registration** — a real hazard in this repo, where two earlier jobs shipped duplicated across `lib/Cron/` and `lib/BackgroundJob/`.

## The stale caveat is replaced, not softened

The dormancy warning in `docs/user-guide/bookkeeping/tax/vpb-administration.md` told the reader that finding nothing in `oc_background_jobs` was *expected*. That is now exactly backwards, so the doc says so instead.

## The gate caught this itself

`tests/validate-job-registration.js` — the symmetric gate added alongside that caveat — **failed the moment the job was registered while the doc still claimed it does not run**, naming the file and the marker:

```
FAIL: TaxDeadlineReminderJob IS now registered in appinfo/info.xml, but
      docs/…/vpb-administration.md still carries the "Deadline reminder…" caveat
```

and passes now. That is the half of a ratchet that usually gets left out: it guards the doc in **both** directions, so a warning cannot outlive the bug it describes.
