### PR TITLE
feat(security): scope the three GL analytics views to one administration

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -179,6 +179,15 @@ Vrij en open source onder de EUPL-1.2-licentie.
             <step>OCA\Shillinq\Repair\InitializeBbvAdministration</step>
             <step>OCA\Shillinq\Repair\UnifyAnalyticalDimensions</step>
             <step>OCA\Shillinq\Repair\RetireCostProjectStep</step>
+            <!-- glline-administration-scope (REQ-GLS-002 / REQ-GLS-003). Backfills
+                 GLLine.administrationId from the parent GLTransaction, then RE-READS every
+                 line and opens the SpendAnalytics scoping gate only on a zero-missing total.
+                 MUST run after InitializeSettings, which imports the register.d fragment that
+                 declares the property in the first place. The gate is cleared at the START of
+                 the step, so an instance that never reaches it — or crashes inside it — leaves
+                 SpendAnalytics refusing its GL-backed views rather than serving either
+                 cross-administration totals or a silently-zeroed scoped one. -->
+            <step>OCA\Shillinq\Repair\BackfillGlLineAdministration</step>
             <step>OCA\Shillinq\Repair\BackfillFiscalPeriods</step>
             <step>OCA\Shillinq\Repair\PeriodCloseBackfill</step>
             <step>OCA\Shillinq\Repair\LoadCbsSeedsStep</step>

--- a/lib/Controller/SpendAnalyticsController.php
+++ b/lib/Controller/SpendAnalyticsController.php
@@ -37,20 +37,24 @@
  * 403 would confirm the administration exists and turn this into an
  * enumeration oracle for the tenant list.
  *
- * ⚠️ That guard is COMPLETE for `dimension=supplier` only. The supplier view
- * reads APTransaction, which declares `administrationId`, so the caller's
- * administration is pushed into the aggregation filter. The category /
- * cost-centre / period views read GLLine, which declares no administration
- * property at all (the administration lives on the parent GLTransaction and
- * OpenRegister's filters cannot join), so those three still aggregate every
- * administration in the register. The membership check reduces their audience
- * from "any authenticated Nextcloud user" to "a member of some
- * administration" but does not isolate one administration from another.
- * Closing it requires `administrationId` denormalised onto GLLine plus a
- * backfill — a schema + data migration, out of scope here and tracked
- * separately. See SpendAnalyticsService's class docblock; do NOT close it by
- * passing an `administrationId` filter GLLine cannot match, which would
- * silently return a zero total.
+ * That guard is now COMPLETE for all four dimensions. It used to be complete
+ * for `dimension=supplier` only: the supplier view reads APTransaction, which
+ * declares `administrationId`, while the category / cost-centre / period views
+ * read GLLine, which declared no administration property at all (the
+ * administration lived on the parent GLTransaction and OpenRegister's filters
+ * cannot join) — so those three aggregated every administration in the
+ * register, and the membership check reduced their audience from "any
+ * authenticated Nextcloud user" to "a member of some administration" without
+ * isolating one administration from another. `glline-administration-scope`
+ * denormalises `administrationId` onto GLLine, backfills the existing rows and
+ * pushes the caller's administration into all four filters.
+ *
+ * ⚠️ The three GL-backed views raise, and this endpoint returns 500, whenever
+ * the backfill is not proven complete — see SpendAnalyticsService's class
+ * docblock. That is deliberate and must not be softened into "just return what
+ * the filter matches": a filter on a property some rows lack matches nothing
+ * for those rows, and a silently-zeroed bookkeeping total is a wrong number
+ * that looks like a real one.
  *
  * @category Controller
  * @package  OCA\Shillinq\Controller
@@ -219,10 +223,12 @@ class SpendAnalyticsController extends Controller {
 	/**
 	 * Dispatch to the matching service method for the validated dimension.
 	 *
-	 * Only the supplier view can be narrowed to an administration, so only it
-	 * receives `$administrationId`. The three GL-backed views take no
-	 * administration argument at all — a parameter they could not honour would
-	 * read as a scope that is applied. See the class docblock.
+	 * All four views are narrowed to the administration the caller proved
+	 * membership of, so all four receive `$administrationId`. The three
+	 * GL-backed views additionally refuse to run at all until the
+	 * `GLLine.administrationId` backfill is proven complete; that raise
+	 * surfaces through the caller's catch as an error status rather than as a
+	 * zero total. See SpendAnalyticsService's class docblock.
 	 *
 	 * @param string $dimension The validated dimension.
 	 * @param string $administrationId The administration the caller proved membership of.
@@ -234,11 +240,11 @@ class SpendAnalyticsController extends Controller {
 			case 'supplier':
 				return $this->service->spendBySupplier(administrationId: $administrationId);
 			case 'category':
-				return $this->service->spendByCategory();
+				return $this->service->spendByCategory(administrationId: $administrationId);
 			case 'costCentre':
-				return $this->service->spendByCostCentre();
+				return $this->service->spendByCostCentre(administrationId: $administrationId);
 			default:
-				return $this->service->spendByPeriod();
+				return $this->service->spendByPeriod(administrationId: $administrationId);
 		}
 
 	}//end dispatch()

--- a/lib/Repair/BackfillFiscalPeriods.php
+++ b/lib/Repair/BackfillFiscalPeriods.php
@@ -123,8 +123,15 @@ class BackfillFiscalPeriods implements IRepairStep {
 					continue;
 				}
 
-				// GLLine does not carry administrationId directly — derive
-				// it from the parent GLTransaction by transactionId.
+				// GLLine now DOES carry administrationId directly,
+				// denormalised from the parent GLTransaction by
+				// glline-administration-scope (REQ-GLS-001) and backfilled by
+				// BackfillGlLineAdministration, which is registered ahead of
+				// this step. The comment that used to sit here said the
+				// opposite and told the reader to derive it from the parent —
+				// which this line never did, so it silently bucketed every
+				// historical tuple under administration ''. Reading the
+				// property is now both what the code does and what works.
 				$administrationId = (string)($arr['administrationId'] ?? '');
 				$key = $administrationId . '|' . $periodId;
 				if (isset($tuples[$key]) === true) {

--- a/lib/Repair/BackfillGlLineAdministration.php
+++ b/lib/Repair/BackfillGlLineAdministration.php
@@ -1,0 +1,294 @@
+<?php
+
+/**
+ * Shillinq BackfillGlLineAdministration Repair Step
+ *
+ * Runs the `GLLine.administrationId` backfill (REQ-GLS-002) and — only if it
+ * can then PROVE the result complete — opens the gate that lets
+ * {@see \OCA\Shillinq\Service\SpendAnalyticsService} scope its category /
+ * cost-centre / period aggregations (REQ-GLS-003).
+ *
+ * ## Why a gate at all
+ *
+ * `GLLine` used to declare no administration property, so those three views
+ * aggregated every administration in the register. The fix denormalises
+ * `administrationId` onto `GLLine` and filters on it — but a filter on a
+ * property that some rows lack matches NOTHING for those rows, so switching it
+ * on over a half-backfilled ledger silently returns ZERO in a bookkeeping
+ * total. A wrong number that looks like a real one is worse than the exposure
+ * it replaces. The filter therefore may not simply be "on"; it must be
+ * conditional on evidence that the backfill finished.
+ *
+ * ## What counts as evidence
+ *
+ * Not "the batch reported success". This step RE-READS every `GLLine` row from
+ * the store after writing, and counts — as a total, not a sample — how many
+ * still carry no scope. Only a count of exactly zero writes
+ * {@see GlLineAdministrationBackfillMigrator::GATE_CONFIG_KEY}. The gate is a
+ * measurement of the store, taken after the fact; the migrator's own return
+ * value is a report, not proof.
+ *
+ * ## Fail-closed ordering
+ *
+ * The gate is CLEARED FIRST, before a single row is read or written, and is
+ * only ever re-opened at the very end by that re-read. So every intermediate
+ * state — a crash mid-write, an aborted batch, an OpenRegister outage, an
+ * upgrade that never reached this step — leaves the gate shut, which makes
+ * SpendAnalytics refuse the GL-backed views outright. Refusing is the correct
+ * third option: it leaks nothing (unlike serving unscoped totals) and it lies
+ * about nothing (unlike serving silent zeros).
+ *
+ * Idempotent: a second run finds every row already scoped, writes nothing, and
+ * re-affirms the same gate value.
+ *
+ * @category Repair
+ * @package  OCA\Shillinq\Repair
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Repair;
+
+use OCA\OpenRegister\Contract\ObjectServiceInterface;
+use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
+use OCA\Shillinq\Service\Migration\GlLineAdministrationBackfillMigrator;
+use OCA\Shillinq\Service\SettingsService;
+use OCP\IAppConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Repair step that backfills `GLLine.administrationId` from the parent
+ * `GLTransaction` and opens the SpendAnalytics scoping gate on proof.
+ *
+ * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+ */
+class BackfillGlLineAdministration implements IRepairStep {
+	use ReadsSourceRowsInBatches;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param SettingsService $settingsService The settings service (register slug).
+	 * @param GlLineAdministrationBackfillMigrator $migrator The pure migration core.
+	 * @param IAppConfig $appConfig App config — holds the completeness gate.
+	 * @param LoggerInterface $logger The logger interface.
+	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
+	 */
+	public function __construct(
+		private readonly SettingsService $settingsService,
+		private readonly GlLineAdministrationBackfillMigrator $migrator,
+		private readonly IAppConfig $appConfig,
+		private readonly LoggerInterface $logger,
+		private readonly ObjectServiceInterface $objectService,
+	) {
+	}//end __construct()
+
+	/**
+	 * The repair-step display name.
+	 *
+	 * @return string The display name.
+	 *
+	 * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+	 */
+	public function getName(): string {
+		return 'Shillinq: backfill GLLine.administrationId from the parent GLTransaction';
+	}//end getName()
+
+	/**
+	 * Run the backfill, then gate on a re-read proof of completeness.
+	 *
+	 * @param IOutput $output The repair-step output (progress + warnings).
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+	 */
+	public function run(IOutput $output): void {
+		// FAIL-CLOSED FIRST. Every early return below — and every crash — now
+		// leaves the gate shut, so SpendAnalytics refuses the GL-backed views
+		// rather than serving unscoped totals or silent zeros.
+		$this->closeGate();
+
+		try {
+			$registerSlug = $this->settingsService->getRegisterSlug();
+
+			$lines = $this->readPayloads(registerSlug: $registerSlug, schema: GlLineAdministrationBackfillMigrator::SCHEMA_GL_LINE);
+			$transactions = $this->readPayloads(registerSlug: $registerSlug, schema: GlLineAdministrationBackfillMigrator::SCHEMA_GL_TRANSACTION);
+
+			try {
+				$report = $this->migrator->backfillBatch(glLines: $lines, glTransactions: $transactions);
+			} catch (\Throwable $e) {
+				// assertCountsMatch() threw: at least one line's parent could
+				// not answer for it. NOTHING is written — a partially scoped
+				// ledger is the one state worse than an unscoped one — and the
+				// gate stays shut.
+				$output->warning('Shillinq: GLLine administration backfill aborted: ' . $e->getMessage());
+				$this->logger->warning(
+					'Shillinq: GLLine administration backfill aborted',
+					['exception' => $e->getMessage()]
+				);
+				return;
+			}
+
+			$written = $this->writeBackfilledRows(
+				registerSlug: $registerSlug,
+				rows: $report['lines'],
+				output: $output
+			);
+
+			$output->info(
+				'Shillinq: GLLine administration backfill — ' . $report['total'] . ' seen, '
+				. $report['backfilled'] . ' resolved (' . $written . ' written), '
+				. $report['unchanged'] . ' already scoped, '
+				. $report['conflicting'] . ' disagreeing with their parent (reported, not rewritten).'
+			);
+
+			$this->proveAndOpenGate(registerSlug: $registerSlug, output: $output);
+		} catch (\Throwable $e) {
+			// Best-effort: a failed backfill must NOT block the app upgrade.
+			// The gate is already shut, so the exposure stays closed either way.
+			$output->warning('Shillinq: GLLine administration backfill failed: ' . $e->getMessage());
+			$this->logger->warning(
+				'Shillinq: GLLine administration backfill failed',
+				['exception' => $e->getMessage()]
+			);
+		}//end try
+
+	}//end run()
+
+	/**
+	 * Re-read every `GLLine` and open the gate only on a zero-missing total.
+	 *
+	 * The whole ordering of this change rests on this method. It deliberately
+	 * re-reads rather than trusting the in-memory batch, because the batch
+	 * reports what this process INTENDED and the gate must assert what the
+	 * store actually HOLDS — including rows another writer added while this ran.
+	 *
+	 * @param string $registerSlug The register slug.
+	 * @param IOutput $output The repair-step output.
+	 *
+	 * @return void
+	 */
+	private function proveAndOpenGate(string $registerSlug, IOutput $output): void {
+		$reread = $this->readPayloads(registerSlug: $registerSlug, schema: GlLineAdministrationBackfillMigrator::SCHEMA_GL_LINE);
+		$missing = $this->migrator->countMissingAdministrationId(glLines: $reread);
+
+		if ($missing > 0) {
+			$output->warning(
+				'Shillinq: GLLine administration scope gate stays CLOSED — ' . $missing . ' of '
+				. count($reread) . ' line(s) still carry no administrationId. SpendAnalytics will '
+				. 'refuse the category / cost-centre / period views rather than return totals that '
+				. 'silently exclude those lines.'
+			);
+			return;
+		}
+
+		$this->appConfig->setValueString(
+			Application::APP_ID,
+			GlLineAdministrationBackfillMigrator::GATE_CONFIG_KEY,
+			GlLineAdministrationBackfillMigrator::GATE_CONTRACT_VERSION
+		);
+
+		$output->info(
+			'Shillinq: GLLine administration scope gate OPEN (' . GlLineAdministrationBackfillMigrator::GATE_CONTRACT_VERSION
+			. ') — re-read ' . count($reread) . ' line(s), 0 missing administrationId. '
+			. 'SpendAnalytics category / cost-centre / period views are now administration-scoped.'
+		);
+	}//end proveAndOpenGate()
+
+	/**
+	 * Persist the rows the migrator stamped, as in-place updates.
+	 *
+	 * `rowPayload()` resolves each row through OpenRegister's `getObject()`,
+	 * which prepends the object `id` — so saving the payload back resolves as
+	 * an UPDATE rather than an insert.
+	 *
+	 * @param string $registerSlug The register slug.
+	 * @param array<int, array<string, mixed>> $rows The changed rows.
+	 * @param IOutput $output The repair-step output.
+	 *
+	 * @return int How many rows were written.
+	 */
+	private function writeBackfilledRows(string $registerSlug, array $rows, IOutput $output): int {
+		$written = 0;
+
+		foreach ($rows as $row) {
+			$objectId = trim((string)($row['id'] ?? ''));
+			if ($objectId === '') {
+				$output->warning('Shillinq: GLLine administration backfill skipped a row with no object id.');
+				continue;
+			}
+
+			try {
+				// Runs in the installer/repair context where no web user is
+				// authenticated. Bypass RBAC + multi-tenancy so the backfill
+				// sees and writes every tenant's rows.
+				$this->objectService->saveObject(
+					object: $row,
+					register: $registerSlug,
+					schema: GlLineAdministrationBackfillMigrator::SCHEMA_GL_LINE,
+					uuid: $objectId,
+					_rbac: false,
+					_multitenancy: false,
+				);
+				$written++;
+			} catch (\Throwable $e) {
+				$output->warning(
+					'Shillinq: GLLine administration backfill failed for object ' . $objectId . ': ' . $e->getMessage()
+				);
+			}
+		}//end foreach
+
+		return $written;
+	}//end writeBackfilledRows()
+
+	/**
+	 * Read every row of a schema as its payload array.
+	 *
+	 * @param string $registerSlug The register slug.
+	 * @param string $schema The schema slug.
+	 *
+	 * @return array<int, array<string, mixed>> The payload rows.
+	 */
+	private function readPayloads(string $registerSlug, string $schema): array {
+		$rows = $this->readAllRows(
+			objectService: $this->objectService,
+			registerSlug: $registerSlug,
+			schema: $schema
+		);
+
+		$payloads = [];
+		foreach ($rows as $row) {
+			$payloads[] = $this->rowPayload(row: $row);
+		}
+
+		return $payloads;
+	}//end readPayloads()
+
+	/**
+	 * Shut the completeness gate.
+	 *
+	 * @return void
+	 */
+	private function closeGate(): void {
+		$this->appConfig->setValueString(
+			Application::APP_ID,
+			GlLineAdministrationBackfillMigrator::GATE_CONFIG_KEY,
+			''
+		);
+	}//end closeGate()
+}//end class

--- a/lib/Repair/BackfillGlLineAdministration.php
+++ b/lib/Repair/BackfillGlLineAdministration.php
@@ -134,7 +134,7 @@ class BackfillGlLineAdministration implements IRepairStep {
 			try {
 				$report = $this->migrator->backfillBatch(glLines: $lines, glTransactions: $transactions);
 			} catch (\Throwable $e) {
-				// assertCountsMatch() threw: at least one line's parent could
+				// The assertCountsMatch() call threw: at least one line's parent could
 				// not answer for it. NOTHING is written — a partially scoped
 				// ledger is the one state worse than an unscoped one — and the
 				// gate stays shut.

--- a/lib/Repair/BackfillGlLineAdministration.php
+++ b/lib/Repair/BackfillGlLineAdministration.php
@@ -87,6 +87,8 @@ class BackfillGlLineAdministration implements IRepairStep {
 	 * @param IAppConfig $appConfig App config — holds the completeness gate.
 	 * @param LoggerInterface $logger The logger interface.
 	 * @param ObjectServiceInterface $objectService OpenRegister's object service, injected per ADR-083.
+	 *
+	 * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
 	 */
 	public function __construct(
 		private readonly SettingsService $settingsService,

--- a/lib/Service/CogsPosterService.php
+++ b/lib/Service/CogsPosterService.php
@@ -160,7 +160,7 @@ class CogsPosterService {
 
 			$cogsAmount = round(($cogsCents / 100), 2);
 
-			// administrationId is DENORMALISED onto every line from the header
+			// The administrationId is DENORMALISED onto every line from the header
 			// above (REQ-GLS-001) — see GlLineAdministrationBackfillMigrator.
 			// A line written without it is invisible to its own
 			// administration's SpendAnalytics totals AND flips the backfill

--- a/lib/Service/CogsPosterService.php
+++ b/lib/Service/CogsPosterService.php
@@ -160,9 +160,15 @@ class CogsPosterService {
 
 			$cogsAmount = round(($cogsCents / 100), 2);
 
+			// administrationId is DENORMALISED onto every line from the header
+			// above (REQ-GLS-001) — see GlLineAdministrationBackfillMigrator.
+			// A line written without it is invisible to its own
+			// administration's SpendAnalytics totals AND flips the backfill
+			// completeness gate red for the whole instance.
 			$this->saveLine(
 				data: [
 					'transactionId' => $transactionId,
+					'administrationId' => $administrationId,
 					'lineNumber' => 1,
 					'accountNumber' => $cogsAccount,
 					'side' => 'debit',
@@ -175,6 +181,7 @@ class CogsPosterService {
 			$this->saveLine(
 				data: [
 					'transactionId' => $transactionId,
+					'administrationId' => $administrationId,
 					'lineNumber' => 2,
 					'accountNumber' => $inventoryAccount,
 					'side' => 'credit',

--- a/lib/Service/InventoryGlAdjustmentPoster.php
+++ b/lib/Service/InventoryGlAdjustmentPoster.php
@@ -165,7 +165,7 @@ class InventoryGlAdjustmentPoster {
 
 			$transactionId = (string)($transaction['id'] ?? ($transaction['@self']['id'] ?? ''));
 
-			// administrationId is DENORMALISED onto every line from the header
+			// The administrationId is DENORMALISED onto every line from the header
 			// above (REQ-GLS-001). GLLine now declares the property, and
 			// SpendAnalyticsService filters the category / cost-centre /
 			// period aggregations on it — a line written without it would be

--- a/lib/Service/InventoryGlAdjustmentPoster.php
+++ b/lib/Service/InventoryGlAdjustmentPoster.php
@@ -165,10 +165,17 @@ class InventoryGlAdjustmentPoster {
 
 			$transactionId = (string)($transaction['id'] ?? ($transaction['@self']['id'] ?? ''));
 
+			// administrationId is DENORMALISED onto every line from the header
+			// above (REQ-GLS-001). GLLine now declares the property, and
+			// SpendAnalyticsService filters the category / cost-centre /
+			// period aggregations on it — a line written without it would be
+			// invisible to its own administration's totals while the backfill
+			// completeness gate flipped red for the whole instance.
 			$this->saveOnSchema(
 				schema: 'GLLine',
 				data: [
 					'transactionId' => $transactionId,
+					'administrationId' => $administrationId,
 					'lineNumber' => 1,
 					'accountNumber' => $debitAccount,
 					'side' => 'debit',
@@ -182,6 +189,7 @@ class InventoryGlAdjustmentPoster {
 				schema: 'GLLine',
 				data: [
 					'transactionId' => $transactionId,
+					'administrationId' => $administrationId,
 					'lineNumber' => 2,
 					'accountNumber' => $creditAccount,
 					'side' => 'credit',

--- a/lib/Service/Migration/GlLineAdministrationBackfillMigrator.php
+++ b/lib/Service/Migration/GlLineAdministrationBackfillMigrator.php
@@ -1,0 +1,435 @@
+<?php
+
+/**
+ * GLLine administration backfill migrator
+ *
+ * The unit-tested migration core for `glline-administration-scope` — the
+ * schema + data half of closing a real cross-administration read.
+ *
+ * ## What was wrong
+ *
+ * `GLLine` declared NO administration or organisation property. Its
+ * administration lived one hop away, on the parent `GLTransaction`, and
+ * OpenRegister's `filters` address an object's own JSON properties and cannot
+ * join. So the SpendAnalytics category / cost-centre / period views — all
+ * three sourced from `GLLine` — aggregated EVERY administration in the
+ * register, while the fourth view (spend-by-supplier, sourced from
+ * `APTransaction`, which does declare `administrationId`) really was scoped.
+ * The service looked scoped. It was not.
+ *
+ * `glline-administration-scope.json` denormalises `administrationId` onto
+ * `GLLine`. This class backfills the rows that predate that fragment.
+ *
+ * ## Why the naive fix was worse than the bug
+ *
+ * Switching the filter on FIRST would have addressed a property those rows do
+ * not carry. An unmatched filter key matches nothing for every value, so every
+ * category / cost-centre / period total would silently read ZERO — a wrong
+ * number in a bookkeeping total that looks exactly like a real one, which is
+ * worse than an exposure that is at least visible to whoever looks. That is
+ * why the ordering in this change is normative, not advisory, and why
+ * `SpendAnalyticsService` refuses to serve those views at all until
+ * `BackfillGlLineAdministration` has proven the backfill complete.
+ *
+ * ## Resolving a line's administration
+ *
+ * Through `GLLine.transactionId`, which this repo's writers populate with
+ * EITHER the parent's object UUID or its `transactionNumber` business key
+ * (`RuleTestDataSeeder` uses the number when one exists). {@see
+ * indexAdministrationsByTransaction()} therefore indexes a `GLTransaction`
+ * under every identity it can be addressed by, so a line resolves regardless
+ * of which idiom wrote it. A parent whose own `administrationId` is blank
+ * indexes NOTHING: it cannot answer the question, and stamping `''` would
+ * manufacture a fake scope that then satisfies the completeness gate.
+ *
+ * ## Fail-closed on anything unclassifiable
+ *
+ * A `GLLine` whose `transactionId` resolves to no indexed `GLTransaction` is
+ * UNCLASSIFIABLE. It is not guessed at, not defaulted to the single/first/
+ * default administration, and not silently skipped: {@see classify()} returns
+ * `CLASS_UNCLASSIFIABLE`, it is deliberately left out of the classified count,
+ * and {@see backfillBatch()}'s count guard ({@see assertCountsMatch()}) ABORTS
+ * THE WHOLE BATCH — including every row that resolved cleanly — the moment even
+ * one row cannot be resolved. Mirrors
+ * {@see BudgetSchemaSplitMigrator::assertCountsMatch()}'s contract exactly. A
+ * partially backfilled ledger is the one outcome worse than an un-backfilled
+ * one, because it is the state in which the completeness gate is the only
+ * thing standing between the reader and a silent zero.
+ *
+ * ## Idempotent
+ *
+ * A row that already carries a non-empty `administrationId` is returned
+ * BYTE-IDENTICAL and counted as `unchanged`. Re-running changes nothing, which
+ * is what makes it safe to wire into a repair step that runs on every upgrade.
+ *
+ * @category Service
+ * @package  OCA\Shillinq\Service\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Service\Migration;
+
+use RuntimeException;
+
+/**
+ * Pure, unit-testable migration core for the `GLLine.administrationId` backfill.
+ */
+final class GlLineAdministrationBackfillMigrator {
+
+	/**
+	 * The schema whose rows are backfilled.
+	 */
+	public const SCHEMA_GL_LINE = 'GLLine';
+
+	/**
+	 * The parent schema that owns the administration (source of truth).
+	 */
+	public const SCHEMA_GL_TRANSACTION = 'GLTransaction';
+
+	/**
+	 * The denormalised scope property added by
+	 * `register.d/glline-administration-scope.json`.
+	 */
+	public const SCOPE_PROPERTY = 'administrationId';
+
+	/**
+	 * App-config key holding the backfill-completeness gate.
+	 *
+	 * Written ONLY by {@see \OCA\Shillinq\Repair\BackfillGlLineAdministration}
+	 * after it has RE-READ every `GLLine` row from the store and counted zero
+	 * without a scope; read by {@see \OCA\Shillinq\Service\SpendAnalyticsService}
+	 * before it will filter a GL-backed aggregation on `administrationId`.
+	 */
+	public const GATE_CONFIG_KEY = 'glline_administration_backfill_complete';
+
+	/**
+	 * The value the gate must hold to count as green.
+	 *
+	 * A VERSION, not a boolean, on purpose. The gate's real claim is "every
+	 * GLLine row carries a scope, AND every code path that writes one stamps
+	 * it". The first half is measured at repair time; the second half is a
+	 * property of the CODE, which a stored boolean cannot notice changing. So
+	 * whenever a new `GLLine` writer is added (or an existing one is reworked),
+	 * bump this constant: every deployment's stored value instantly stops
+	 * matching, `SpendAnalyticsService` fails closed again, and the repair step
+	 * must re-prove completeness against the new writer set before the views
+	 * come back. A boolean would have kept answering "yes" on evidence gathered
+	 * before that writer existed.
+	 *
+	 * Contract v1 covers the writers stamped by `glline-administration-scope`:
+	 * CogsPosterService, InventoryGlAdjustmentPoster, RuleTestDataSeeder and
+	 * VatSuppletieDetectionService.
+	 */
+	public const GATE_CONTRACT_VERSION = 'v1';
+
+	/**
+	 * Classification: the row already carries a scope; leave it untouched.
+	 */
+	public const CLASS_ALREADY_SCOPED = 'already-scoped';
+
+	/**
+	 * Classification: the row's parent was found and the scope can be stamped.
+	 */
+	public const CLASS_RESOLVED = 'resolved';
+
+	/**
+	 * Classification: no parent could answer for this row. Never guessed.
+	 */
+	public const CLASS_UNCLASSIFIABLE = 'unclassifiable';
+
+	/**
+	 * Index every `GLTransaction` under each identity a `GLLine` may reference.
+	 *
+	 * `GLLine.transactionId` is populated with the parent's object UUID by most
+	 * writers and with its `transactionNumber` business key by at least one
+	 * (`RuleTestDataSeeder`). Indexing both — plus the `@self.id` envelope form
+	 * OpenRegister returns — is what makes the resolution total rather than
+	 * idiom-dependent. A transaction whose own scope is blank is deliberately
+	 * NOT indexed: it cannot answer the question, and an entry mapping to `''`
+	 * would let {@see classify()} call a row resolved while stamping an empty
+	 * scope, which is exactly the fake-completeness failure the gate exists to
+	 * catch.
+	 *
+	 * @param array<int, array<string, mixed>> $glTransactions The parent rows.
+	 *
+	 * @return array<string, string> Identity → administrationId.
+	 *
+	 * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+	 */
+	public function indexAdministrationsByTransaction(array $glTransactions): array {
+		$index = [];
+
+		foreach ($glTransactions as $transaction) {
+			$administrationId = trim((string)($transaction[self::SCOPE_PROPERTY] ?? ''));
+			if ($administrationId === '') {
+				// Cannot answer for its own lines — index nothing rather than
+				// index an empty scope.
+				continue;
+			}
+
+			foreach ($this->identitiesOf(row: $transaction) as $identity) {
+				$index[$identity] = $administrationId;
+			}
+		}
+
+		return $index;
+	}//end indexAdministrationsByTransaction()
+
+	/**
+	 * Resolve one `GLLine`'s administration through its `transactionId`.
+	 *
+	 * @param array<string, mixed> $glLine The persisted line.
+	 * @param array<string, string> $index The index from {@see indexAdministrationsByTransaction()}.
+	 *
+	 * @return string|null The parent's administrationId, or null when unresolvable.
+	 *
+	 * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+	 */
+	public function resolveAdministrationId(array $glLine, array $index): ?string {
+		$transactionId = trim((string)($glLine['transactionId'] ?? ''));
+		if ($transactionId === '') {
+			return null;
+		}
+
+		$resolved = ($index[$transactionId] ?? null);
+		if (is_string($resolved) === false || $resolved === '') {
+			return null;
+		}
+
+		return $resolved;
+	}//end resolveAdministrationId()
+
+	/**
+	 * Classify one `GLLine` for the backfill.
+	 *
+	 * @param array<string, mixed> $glLine The persisted line.
+	 * @param array<string, string> $index The parent index.
+	 *
+	 * @return string One of the `CLASS_*` constants.
+	 *
+	 * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+	 */
+	public function classify(array $glLine, array $index): string {
+		if (trim((string)($glLine[self::SCOPE_PROPERTY] ?? '')) !== '') {
+			return self::CLASS_ALREADY_SCOPED;
+		}
+
+		if ($this->resolveAdministrationId(glLine: $glLine, index: $index) === null) {
+			return self::CLASS_UNCLASSIFIABLE;
+		}
+
+		return self::CLASS_RESOLVED;
+	}//end classify()
+
+	/**
+	 * Stamp a resolved administration onto one line, preserving every other field.
+	 *
+	 * Pure and byte-safe: only `administrationId` is written, and only when the
+	 * row does not already carry one — an already-scoped row is returned
+	 * unchanged even if the parent now says something else, so a re-run can
+	 * never rewrite live bookkeeping scope. A disagreement is REPORTED by
+	 * {@see backfillBatch()} instead, because silently re-pointing a posted
+	 * line to a different administration is a bigger decision than a backfill
+	 * gets to make on its own.
+	 *
+	 * @param array<string, mixed> $glLine The persisted line.
+	 * @param string $administrationId The parent's administrationId.
+	 *
+	 * @return array<string, mixed> The stamped (or unchanged) line.
+	 *
+	 * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+	 */
+	public function stampAdministrationId(array $glLine, string $administrationId): array {
+		if (trim((string)($glLine[self::SCOPE_PROPERTY] ?? '')) !== '') {
+			return $glLine;
+		}
+
+		if (trim($administrationId) === '') {
+			return $glLine;
+		}
+
+		$glLine[self::SCOPE_PROPERTY] = $administrationId;
+
+		return $glLine;
+	}//end stampAdministrationId()
+
+	/**
+	 * Backfill a batch of `GLLine` rows from their parent `GLTransaction` rows.
+	 *
+	 * Classifies EVERY row first, then count-verifies before returning
+	 * anything: `already-scoped + resolved` MUST equal the number of rows seen,
+	 * or {@see assertCountsMatch()} throws and the caller MUST NOT write any of
+	 * the returned rows. One unclassifiable line aborts the whole batch,
+	 * including the lines that resolved cleanly.
+	 *
+	 * The returned `lines` are keyed by the SAME integer offsets as
+	 * `$glLines`, so a caller can pair each migrated row with the source row it
+	 * came from (and hence with its object id) without re-deriving anything.
+	 * Only offsets that were actually changed are present.
+	 *
+	 * @param array<int, array<string, mixed>> $glLines The rows under `GLLine`.
+	 * @param array<int, array<string, mixed>> $glTransactions The parent rows.
+	 *
+	 * @return array{lines: array<int, array<string, mixed>>, total: int, backfilled: int, unchanged: int, unclassifiable: int, conflicting: int}
+	 *         The changed rows (by source offset) plus the report counts.
+	 *
+	 * @throws RuntimeException When any row is unclassifiable (count guard).
+	 *
+	 * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+	 */
+	public function backfillBatch(array $glLines, array $glTransactions): array {
+		$index = $this->indexAdministrationsByTransaction(glTransactions: $glTransactions);
+
+		$changed = [];
+		$backfilled = 0;
+		$unchanged = 0;
+		$unclassifiable = 0;
+		$conflicting = 0;
+
+		foreach ($glLines as $offset => $glLine) {
+			$classification = $this->classify(glLine: $glLine, index: $index);
+
+			if ($classification === self::CLASS_ALREADY_SCOPED) {
+				$unchanged++;
+				$parentScope = $this->resolveAdministrationId(glLine: $glLine, index: $index);
+				if ($parentScope !== null && $parentScope !== trim((string)$glLine[self::SCOPE_PROPERTY])) {
+					// Reported, never rewritten — see stampAdministrationId().
+					$conflicting++;
+				}
+
+				continue;
+			}
+
+			if ($classification === self::CLASS_RESOLVED) {
+				$administrationId = (string)$this->resolveAdministrationId(glLine: $glLine, index: $index);
+				$changed[$offset] = $this->stampAdministrationId(
+					glLine: $glLine,
+					administrationId: $administrationId
+				);
+				$backfilled++;
+				continue;
+			}
+
+			// Unclassifiable — deliberately NOT counted as classified, so the
+			// guard below sees the shortfall and aborts the whole batch.
+			$unclassifiable++;
+		}//end foreach
+
+		$this->assertCountsMatch(
+			sourceCount: count($glLines),
+			classifiedCount: ($backfilled + $unchanged)
+		);
+
+		return [
+			'lines' => $changed,
+			'total' => count($glLines),
+			'backfilled' => $backfilled,
+			'unchanged' => $unchanged,
+			'unclassifiable' => $unclassifiable,
+			'conflicting' => $conflicting,
+		];
+	}//end backfillBatch()
+
+	/**
+	 * Count `GLLine` rows that still carry no administration.
+	 *
+	 * THE COMPLETENESS CHECK the whole change turns on (REQ-GLS-003). It is a
+	 * TOTAL over every row handed to it, never a spot check or a sample: the
+	 * gate it feeds is what tells `SpendAnalyticsService` that switching the
+	 * `administrationId` filter on will narrow the totals rather than empty
+	 * them, and a sampled "probably zero" is not evidence of that.
+	 *
+	 * @param array<int, array<string, mixed>> $glLines Every `GLLine` row.
+	 *
+	 * @return int How many rows lack a non-empty `administrationId`.
+	 *
+	 * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+	 */
+	public function countMissingAdministrationId(array $glLines): int {
+		$missing = 0;
+
+		foreach ($glLines as $glLine) {
+			if (trim((string)($glLine[self::SCOPE_PROPERTY] ?? '')) === '') {
+				$missing++;
+			}
+		}
+
+		return $missing;
+	}//end countMissingAdministrationId()
+
+	/**
+	 * Assert a seen→classified row-count match, aborting on any shortfall.
+	 *
+	 * Mirrors {@see BudgetSchemaSplitMigrator::assertCountsMatch()}'s
+	 * fail-closed contract exactly: any shortfall (caused by even one
+	 * unclassifiable row) throws, and the caller MUST NOT write any of the
+	 * returned rows when it does — the source data is left intact.
+	 *
+	 * @param int $sourceCount The number of `GLLine` rows seen.
+	 * @param int $classifiedCount The number resolved plus the number already scoped.
+	 *
+	 * @return void
+	 *
+	 * @throws RuntimeException When the counts differ (no-row-loss guard).
+	 *
+	 * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+	 */
+	public function assertCountsMatch(int $sourceCount, int $classifiedCount): void {
+		if ($sourceCount !== $classifiedCount) {
+			throw new RuntimeException(
+				sprintf(
+					'GLLine administration backfill aborted: %d row(s) seen but only %d classified '
+					. '(%d unclassifiable — parent GLTransaction missing or itself unscoped); '
+					. 'no row was written, source data left intact.',
+					$sourceCount,
+					$classifiedCount,
+					($sourceCount - $classifiedCount)
+				)
+			);
+		}
+	}//end assertCountsMatch()
+
+	/**
+	 * Every identity string a `GLTransaction` can be referenced by.
+	 *
+	 * @param array<string, mixed> $row The transaction row.
+	 *
+	 * @return array<int, string> The non-empty identities.
+	 */
+	private function identitiesOf(array $row): array {
+		$candidates = [
+			($row['id'] ?? null),
+			($row['@self']['id'] ?? null),
+			($row['uuid'] ?? null),
+			($row['transactionNumber'] ?? null),
+		];
+
+		$identities = [];
+		foreach ($candidates as $candidate) {
+			if (is_string($candidate) === false && is_int($candidate) === false) {
+				continue;
+			}
+
+			$identity = trim((string)$candidate);
+			if ($identity === '') {
+				continue;
+			}
+
+			$identities[$identity] = $identity;
+		}
+
+		return array_values($identities);
+	}//end identitiesOf()
+}//end class

--- a/lib/Service/RuleTestDataSeeder.php
+++ b/lib/Service/RuleTestDataSeeder.php
@@ -105,7 +105,7 @@ class RuleTestDataSeeder {
 			if ($this->lineCount($register, $id, $num) < 2) {
 				$key = $num !== '' ? $num : $id;
 				$currency = (string)($tx['currency'] ?? 'EUR');
-				// administrationId is DENORMALISED onto every seeded line from
+				// The administrationId is DENORMALISED onto every seeded line from
 				// the parent transaction (REQ-GLS-001). Seeded rows are not
 				// exempt: they land in the same register the SpendAnalytics
 				// aggregations read, and one un-stamped seed row flips the

--- a/lib/Service/RuleTestDataSeeder.php
+++ b/lib/Service/RuleTestDataSeeder.php
@@ -105,9 +105,16 @@ class RuleTestDataSeeder {
 			if ($this->lineCount($register, $id, $num) < 2) {
 				$key = $num !== '' ? $num : $id;
 				$currency = (string)($tx['currency'] ?? 'EUR');
+				// administrationId is DENORMALISED onto every seeded line from
+				// the parent transaction (REQ-GLS-001). Seeded rows are not
+				// exempt: they land in the same register the SpendAnalytics
+				// aggregations read, and one un-stamped seed row flips the
+				// backfill completeness gate red for the whole instance.
+				$administrationId = (string)($tx['administrationId'] ?? '');
 				foreach ([['1000', 'debit'], ['8000', 'credit']] as $i => $spec) {
 					$line = [
 						'transactionId' => $key,
+						'administrationId' => $administrationId,
 						'lineNumber' => ($i + 1),
 						'accountNumber' => $spec[0],
 						'side' => $spec[1],

--- a/lib/Service/RuleTestDataSeeder.php
+++ b/lib/Service/RuleTestDataSeeder.php
@@ -73,6 +73,8 @@ class RuleTestDataSeeder {
 	 * Backfill GL transactions to satisfy the enforced ledger rules.
 	 *
 	 * @return array<string, int> Counts: sourceReferencesAdded, linesAdded, alreadyCompliant.
+	 *
+	 * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
 	 */
 	public function seed(): array {
 		$register = $this->register();

--- a/lib/Service/SpendAnalyticsService.php
+++ b/lib/Service/SpendAnalyticsService.php
@@ -33,34 +33,35 @@
  * credit leg are excluded from the GL debit slice) — they answer different
  * questions and are labelled distinctly.
  *
- * ⚠️ ADMINISTRATION SCOPE IS NOT UNIFORM ACROSS THE FOUR VIEWS, because the
- * two source schemas do not carry the same scope column.
+ * ADMINISTRATION SCOPE IS UNIFORM ACROSS ALL FOUR VIEWS. Every one of them
+ * takes the caller's administration and pushes it into the aggregation filter,
+ * so the totals returned contain no other administration's money.
  *
  *  - `APTransaction` DECLARES `administrationId` (bookkeeping-accounts-payable-
- *    core.json), so `spendBySupplier()` takes the caller's administration and
- *    pushes it into the aggregation filter. That view is really scoped.
- *  - `GLLine` declares NO administration/organisation property at all (its
- *    property set is transactionId, lineNumber, accountNumber, side, amount,
- *    currency, description, costCenter(Code), costCarrierCode, projectCode,
- *    periodId, ozbCategory, dimensions, subLedgerType, subLedgerRef,
- *    accountRef, eliminationFlag) — the administration lives one hop away on
- *    the parent `GLTransaction`. OpenRegister's `filters` address the object's
- *    own JSON properties and cannot join, so there is NO filter this service
- *    can pass that scopes a GLLine aggregation to one administration. A
- *    filter on `administrationId` here would address a property that does not
- *    exist and match NOTHING for every value — a silent zero in a bookkeeping
- *    total, which is worse than the exposure it would pretend to fix. So it is
- *    deliberately NOT applied, and the category / cost-centre / period views
- *    aggregate every administration in the register.
+ *    core.json), so `spendBySupplier()` has always been scoped.
+ *  - `GLLine` NOW declares `administrationId` too, denormalised from the parent
+ *    `GLTransaction` by `register.d/glline-administration-scope.json`
+ *    (REQ-GLS-001). Until that fragment landed it declared no administration or
+ *    organisation property at all — the administration lived one hop away on
+ *    the parent, and OpenRegister's `filters` address an object's own JSON
+ *    properties and cannot join — so the category / cost-centre / period views
+ *    aggregated EVERY administration in the register while looking scoped.
+ *    That is closed. The parent remains the source of truth; this column is a
+ *    copy that exists purely so the filter has something to address.
  *
- * The controller's membership check (AdministrationContextService::canAccess())
- * is therefore the ONLY containment on the three GL views: it reduces the
- * audience from "any authenticated Nextcloud user" to "a member of some
- * administration", but it does not stop a member of administration A reading
- * administration B's category / cost-centre / period totals. Closing that
- * needs `administrationId` denormalised onto GLLine plus a backfill of the
- * existing rows — a schema + data migration, tracked separately. Do not
- * "fix" it by adding the unmatched filter.
+ * ⚠️ THE FILTER IS CONDITIONAL, AND THAT IS THE LOAD-BEARING PART. Filtering on
+ * a property that some rows lack matches NOTHING for those rows, so switching
+ * this on over a half-backfilled ledger returns a silent ZERO in a bookkeeping
+ * total — a wrong number that looks like a real one, which is worse than the
+ * cross-administration read it replaces. So the GL-backed views do not simply
+ * filter: they first require `GlLineAdministrationBackfillMigrator::
+ * GATE_CONFIG_KEY` to hold `GATE_CONTRACT_VERSION`, a value only
+ * `BackfillGlLineAdministration` writes, and only after RE-READING every
+ * `GLLine` row and counting zero without a scope. When the gate is shut the
+ * views RAISE (see assertGlScopeIsEnforceable()). Raising is the right third
+ * option: it leaks nothing, unlike serving unscoped totals, and it claims
+ * nothing false, unlike serving zeros. Do not replace that raise with a
+ * fallback to the unfiltered query — that is the original bug, re-armed.
  *
  * What DOES NOT scope these reads, verified rather than assumed:
  *  - OR's `AggregationRunner` applies a `_organisation = ?` predicate and a
@@ -93,6 +94,7 @@ namespace OCA\Shillinq\Service;
 
 use OCA\OpenRegister\Service\Aggregation\AggregationQuery;
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Service\Migration\GlLineAdministrationBackfillMigrator;
 use OCP\IAppConfig;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -189,24 +191,27 @@ class SpendAnalyticsService {
 
 	/**
 	 * Spend grouped by expense category (GL accountNumber) over the debit AP
-	 * expense postings.
+	 * expense postings, scoped to one administration.
 	 *
-	 * ⚠️ NOT administration-scoped, and deliberately takes no administration
-	 * parameter so the signature does not imply a scope it cannot apply:
-	 * `GLLine` declares no administration property, so no filter this service
-	 * can pass would narrow the aggregation to one tenant. See the class
-	 * docblock.
+	 * Scoped through `GLLine.administrationId`, denormalised from the parent
+	 * `GLTransaction` (REQ-GLS-001). Raises rather than returning anything at
+	 * all while the backfill gate is shut — see the class docblock.
+	 *
+	 * @param string $administrationId The administration the caller is a member of.
 	 *
 	 * @return array<string,mixed> `{ dimension, groups:[{key,amount}], total, backend }`.
 	 *
+	 * @throws RuntimeException When the GLLine administration backfill is not proven complete.
+	 *
 	 * @spec openspec/specs/spend-analytics/spec.md
+	 * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
 	 */
-	public function spendByCategory(): array {
+	public function spendByCategory(string $administrationId): array {
 		return $this->aggregate(
 			dimension: 'category',
 			schema: self::SCHEMA_GL_LINE,
 			metricField: 'amount',
-			filter: $this->apExpenseDebitFilter(),
+			filter: $this->apExpenseDebitFilter(administrationId: $administrationId),
 			groupField: 'accountNumber'
 		);
 
@@ -214,21 +219,23 @@ class SpendAnalyticsService {
 
 	/**
 	 * Spend grouped by analytical cost centre (GL costCenterCode) over the
-	 * debit AP expense postings.
+	 * debit AP expense postings, scoped to one administration.
 	 *
-	 * ⚠️ NOT administration-scoped — see spendByCategory() and the class
-	 * docblock for why `GLLine` cannot be filtered to one administration.
+	 * @param string $administrationId The administration the caller is a member of.
 	 *
 	 * @return array<string,mixed> `{ dimension, groups:[{key,amount}], total, backend }`.
 	 *
+	 * @throws RuntimeException When the GLLine administration backfill is not proven complete.
+	 *
 	 * @spec openspec/specs/spend-analytics/spec.md
+	 * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
 	 */
-	public function spendByCostCentre(): array {
+	public function spendByCostCentre(string $administrationId): array {
 		return $this->aggregate(
 			dimension: 'costCentre',
 			schema: self::SCHEMA_GL_LINE,
 			metricField: 'amount',
-			filter: $this->apExpenseDebitFilter(),
+			filter: $this->apExpenseDebitFilter(administrationId: $administrationId),
 			groupField: 'costCenterCode'
 		);
 
@@ -236,39 +243,116 @@ class SpendAnalyticsService {
 
 	/**
 	 * Spend grouped by fiscal period (GL periodId) over the debit AP expense
-	 * postings.
+	 * postings, scoped to one administration.
 	 *
-	 * ⚠️ NOT administration-scoped — see spendByCategory() and the class
-	 * docblock for why `GLLine` cannot be filtered to one administration.
+	 * @param string $administrationId The administration the caller is a member of.
 	 *
 	 * @return array<string,mixed> `{ dimension, groups:[{key,amount}], total, backend }`.
 	 *
+	 * @throws RuntimeException When the GLLine administration backfill is not proven complete.
+	 *
 	 * @spec openspec/specs/spend-analytics/spec.md
+	 * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
 	 */
-	public function spendByPeriod(): array {
+	public function spendByPeriod(string $administrationId): array {
 		return $this->aggregate(
 			dimension: 'period',
 			schema: self::SCHEMA_GL_LINE,
 			metricField: 'amount',
-			filter: $this->apExpenseDebitFilter(),
+			filter: $this->apExpenseDebitFilter(administrationId: $administrationId),
 			groupField: 'periodId'
 		);
 
 	}//end spendByPeriod()
 
 	/**
-	 * The posting slice that constitutes AP expense spend: debit lines whose
-	 * sub-ledger is accounts-payable.
+	 * The posting slice that constitutes AP expense spend, scoped to one
+	 * administration: debit lines whose sub-ledger is accounts-payable.
+	 *
+	 * Asserts the backfill gate BEFORE building the filter, so a caller can
+	 * never end up with a `GLLine` query carrying an `administrationId` term
+	 * that some rows cannot match.
+	 *
+	 * @param string $administrationId The administration to scope to.
 	 *
 	 * @return array<string,mixed> The aggregation filter map.
+	 *
+	 * @throws RuntimeException When the backfill is not proven complete, or the scope is empty.
 	 */
-	private function apExpenseDebitFilter(): array {
+	private function apExpenseDebitFilter(string $administrationId): array {
+		$this->assertGlScopeIsEnforceable();
+
+		$scope = trim($administrationId);
+		if ($scope === '') {
+			// An empty scope would filter `administrationId = ''`, matching
+			// nothing — the same silent zero by a different route.
+			throw new RuntimeException(
+				'SpendAnalyticsService: a GL-backed spend view requires a non-empty administrationId'
+			);
+		}
+
 		return [
+			'administrationId' => $scope,
 			'side' => 'debit',
 			'subLedgerType' => 'ap',
 		];
 
 	}//end apExpenseDebitFilter()
+
+	/**
+	 * Refuse the GL-backed views unless the `GLLine.administrationId` backfill
+	 * has been PROVEN complete (REQ-GLS-003).
+	 *
+	 * The gate holds `GlLineAdministrationBackfillMigrator::
+	 * GATE_CONTRACT_VERSION` only when `BackfillGlLineAdministration` re-read
+	 * every `GLLine` row from the store and counted zero without a scope. It is
+	 * cleared at the start of every run of that step, so an instance that has
+	 * not run it, crashed inside it, or aborted its batch reads as shut.
+	 *
+	 * It is a VERSION rather than a boolean so that adding a new `GLLine`
+	 * writer can invalidate every deployment's stored proof by bumping one
+	 * constant — completeness is a claim about the code as well as the data,
+	 * and a boolean would keep answering "yes" on evidence gathered before the
+	 * new writer existed.
+	 *
+	 * Throwing is deliberate and must not be softened into a fallback: the
+	 * controller turns it into an error status, whereas returning the
+	 * unfiltered aggregation would restore the cross-administration read and
+	 * returning the filtered one would report a zero total as though it were a
+	 * measurement.
+	 *
+	 * @return void
+	 *
+	 * @throws RuntimeException When the gate is shut.
+	 */
+	private function assertGlScopeIsEnforceable(): void {
+		$gate = $this->appConfig->getValueString(
+			Application::APP_ID,
+			GlLineAdministrationBackfillMigrator::GATE_CONFIG_KEY,
+			''
+		);
+
+		if ($gate === GlLineAdministrationBackfillMigrator::GATE_CONTRACT_VERSION) {
+			return;
+		}
+
+		$this->logger->error(
+			'SpendAnalyticsService: refusing a GL-backed spend view — the GLLine administrationId '
+			. 'backfill is not proven complete, so an administration filter would silently exclude '
+			. 'un-backfilled lines. Run occ maintenance:repair to re-run BackfillGlLineAdministration.',
+			[
+				'gate' => $gate,
+				'expected' => GlLineAdministrationBackfillMigrator::GATE_CONTRACT_VERSION,
+			]
+		);
+
+		throw new RuntimeException(
+			'GLLine administration backfill is not proven complete; the category / cost-centre / '
+			. 'period spend views are unavailable until BackfillGlLineAdministration has re-read '
+			. 'every GLLine and found zero without an administrationId.'
+		);
+
+	}//end assertGlScopeIsEnforceable()
 
 	/**
 	 * Build and dispatch one single-field aggregation through OR's

--- a/lib/Service/VatSuppletieDetectionService.php
+++ b/lib/Service/VatSuppletieDetectionService.php
@@ -485,7 +485,7 @@ class VatSuppletieDetectionService {
 			}
 
 			$lineNumber++;
-			// administrationId is DENORMALISED onto every line from the same
+			// The administrationId is DENORMALISED onto every line from the same
 			// scope the header carries (REQ-GLS-001) — see
 			// GlLineAdministrationBackfillMigrator. A line written without it
 			// is invisible to its own administration's SpendAnalytics totals

--- a/lib/Service/VatSuppletieDetectionService.php
+++ b/lib/Service/VatSuppletieDetectionService.php
@@ -485,10 +485,16 @@ class VatSuppletieDetectionService {
 			}
 
 			$lineNumber++;
+			// administrationId is DENORMALISED onto every line from the same
+			// scope the header carries (REQ-GLS-001) — see
+			// GlLineAdministrationBackfillMigrator. A line written without it
+			// is invisible to its own administration's SpendAnalytics totals
+			// AND flips the backfill completeness gate red instance-wide.
 			$this->saveObject(
 				schema: 'GLLine',
 				data: [
 					'transactionId' => $transactionId,
+					'administrationId' => $administrationId,
 					'lineNumber' => $lineNumber,
 					'accountNumber' => $account,
 					'side' => $side,
@@ -517,6 +523,7 @@ class VatSuppletieDetectionService {
 				schema: 'GLLine',
 				data: [
 					'transactionId' => $transactionId,
+					'administrationId' => $administrationId,
 					'lineNumber' => $lineNumber,
 					'accountNumber' => $clearingAccount,
 					'side' => $clearingSide,

--- a/lib/Settings/register.d/glline-administration-scope.json
+++ b/lib/Settings/register.d/glline-administration-scope.json
@@ -1,0 +1,29 @@
+{
+  "_meta": {
+    "spdx-license": "EUPL-1.2",
+    "spdx-copyright": "2026 Conduction B.V.",
+    "change": "glline-administration-scope",
+    "adr": "ADR-037 modular register fragment — never edit shillinq_register.json",
+    "description": "Additive-only overlay that denormalises `administrationId` onto the monolith GLLine schema (REQ-GLS-001), so the SpendAnalytics category / cost-centre / period aggregations can be scoped to one administration. Before this fragment, GLLine declared NO administration or organisation property at all: its administration lived one hop away on the parent GLTransaction, and OpenRegister's `filters` address an object's own JSON properties and cannot join — so those three views aggregated EVERY administration in the register while looking scoped, because the fourth (spend-by-supplier, sourced from APTransaction, which does declare administrationId) really was scoped. DELIBERATELY NOT ADDED TO `required`: a required property on a schema with existing rows fails validation for every row that has not yet been backfilled by GlLineAdministrationBackfillMigrator, which would turn a read-scoping fix into a write outage. The property is additively merged onto the monolith through the loader's key-union merge (SettingsService::deepMergeConfig) — the monolith is never edited.",
+    "spec": "openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md"
+  },
+  "info": {
+    "version": "0.1.0-glline-administration-scope"
+  },
+  "components": {
+    "schemas": {
+      "GLLine": {
+        "properties": {
+          "administrationId": {
+            "type": "string",
+            "description": "The administration this posting line belongs to (REQ-GLS-001). DENORMALISED from the parent GLTransaction.administrationId, which remains the source of truth — a line's administration is whatever its GLTransaction says it is, and this copy exists only because OpenRegister's aggregation filters address an object's own JSON properties and cannot join to the parent. Every writer sets it from the parent at create time; existing rows were backfilled by OCA\\Shillinq\\Service\\Migration\\GlLineAdministrationBackfillMigrator via the BackfillGlLineAdministration repair step. Nullable rather than required so an un-backfilled row still validates on write; SpendAnalyticsService refuses to serve the GL-backed views at all until the repair step has proven zero rows lack it, rather than filtering on a property some rows lack and returning a silent zero.",
+            "nullable": true,
+            "example": "ADM-001",
+            "title": "Administration ID"
+          }
+        }
+      }
+    }
+  },
+  "objects": []
+}

--- a/openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+++ b/openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
@@ -74,21 +74,32 @@ failure this requirement exists to prevent.
 - **WHEN** an `adm-A` member opens the three views
 - **THEN** no `adm-B` row MUST contribute to any total
 
-@e2e exclude `/api/analytics/spend` has NO frontend consumer — `grep -rn
-"analytics/spend" src/` returns nothing and no `src/manifest.d/` page declares
-it, so the four spend views are an API-only surface today. Both scenarios are
-enforced instead by `tests/Unit/Service/SpendAnalyticsServiceTest.php`
+@e2e exclude neither scenario's PRECONDITIONS can be established in the e2e
+environment. `totals-exclude-another-administration` needs two administrations
+that both carry GL activity plus a member of exactly one of them;
+`scoped-views-still-return-rows` needs a register whose GLLine backfill has
+already been proven complete, and the completeness gate (REQ-GLS-003) is shut
+on every environment available to the suite — while it is shut the views raise
+by design, so a Playwright assertion there would be measuring the gate, not the
+scoping. Both scenarios are enforced instead by
+`tests/Unit/Service/SpendAnalyticsServiceTest.php`
 (`testGlBackedViewsExcludeOtherAdministrations` for the negative control,
-`testScopedViewsStillReturnRowsAndRealTotals` for the positive one), each
-proven to fail with the guard removed. A Playwright spec navigating to a page
-that never calls this endpoint would assert nothing about either scenario.
-Re-tag as `@e2e glline-administration-scope::…` when a UI consumer lands.
+`testScopedViewsStillReturnRowsAndRealTotals` for the positive one), each proven
+to fail with the guard removed.
+
+⚠️ This reason was REWRITTEN. It previously read "`/api/analytics/spend` has NO
+frontend consumer", which was true when written and became FALSE the moment
+`feat/spend-analytics-ui` (#1143) landed a page that calls this endpoint. The
+exclusion is still warranted, but not for that reason — and an exclusion whose
+stated reason has quietly expired is exactly how a gate stops meaning anything.
+Re-tag as `@e2e glline-administration-scope::…` once a seeded, backfilled
+two-administration fixture exists.
 
 ### Requirement: REQ-GLS-004 — the stale warning MUST be removed with the fix
 
 When the filter is enabled, the `⚠️ ADMINISTRATION SCOPE IS NOT UNIFORM` section
-of `SpendAnalyticsService`'s docblock — including its *"Do not 'fix' it by adding
-the unmatched filter"* instruction — MUST be deleted.
+of `SpendAnalyticsService`'s docblock — including its _"Do not 'fix' it by adding
+the unmatched filter"_ instruction — MUST be deleted.
 
 Leaving it makes the file lie in the opposite direction, telling the next reader
 the views are unscoped when they are scoped, and warning them off a fix that has

--- a/openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+++ b/openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
@@ -74,8 +74,15 @@ failure this requirement exists to prevent.
 - **WHEN** an `adm-A` member opens the three views
 - **THEN** no `adm-B` row MUST contribute to any total
 
-@e2e glline-administration-scope::scoped-views-still-return-rows
-@e2e glline-administration-scope::totals-exclude-another-administration
+@e2e exclude `/api/analytics/spend` has NO frontend consumer — `grep -rn
+"analytics/spend" src/` returns nothing and no `src/manifest.d/` page declares
+it, so the four spend views are an API-only surface today. Both scenarios are
+enforced instead by `tests/Unit/Service/SpendAnalyticsServiceTest.php`
+(`testGlBackedViewsExcludeOtherAdministrations` for the negative control,
+`testScopedViewsStillReturnRowsAndRealTotals` for the positive one), each
+proven to fail with the guard removed. A Playwright spec navigating to a page
+that never calls this endpoint would assert nothing about either scenario.
+Re-tag as `@e2e glline-administration-scope::…` when a UI consumer lands.
 
 ### Requirement: REQ-GLS-004 — the stale warning MUST be removed with the fix
 

--- a/openspec/changes/glline-administration-scope/tasks.md
+++ b/openspec/changes/glline-administration-scope/tasks.md
@@ -6,74 +6,116 @@ bookkeeping data. Do not reorder these phases.
 
 ## Phase 1 — schema, additive only
 
-- [ ] Add `administrationId` (`type: string`) to the `GLLine` schema.
+- [x] Add `administrationId` (`type: string`) to the `GLLine` schema.
       **NOT** in `required` — a required property on a schema with existing rows
       fails validation for every un-backfilled row.
-- [ ] Add a short property description naming the parent `GLTransaction` as the
+      → `lib/Settings/register.d/glline-administration-scope.json`, an ADR-037
+      additive overlay (properties only, no `type`/`required`), so the monolith
+      `shillinq_register.json` is never edited.
+- [x] Add a short property description naming the parent `GLTransaction` as the
       source of truth, so a future reader knows it is denormalised and why.
-- [ ] `node tests/validate-registers.js` and `node tests/validate-seeds.js` pass.
+- [x] `node tests/validate-registers.js` and `node tests/validate-seeds.js` pass.
 
 ## Phase 2 — writers, before any backfill
 
 Every path that creates a `GLLine` must set `administrationId` from the parent
 `GLTransaction`, so the backfill has a fixed target rather than a moving one.
 
-- [ ] `lib/Guard/ProgrammaLinkGuard.php`
-- [ ] `lib/Repair/BackfillFiscalPeriods.php`
-- [ ] `lib/Service/CogsPosterService.php`
-- [ ] `lib/Service/InventoryGlAdjustmentPoster.php`
-- [ ] `lib/Service/RuleTestDataSeeder.php`
-- [ ] `lib/Service/VatSuppletieDetectionService.php`
-- [ ] Re-grep for writers rather than trusting this list: it was produced by
-      `git grep -ln "schema: 'GLLine'"` and a writer using a different idiom
-      would not appear.
+- [x] Re-grepped for writers rather than trusting the authored list. **The list
+      in the original tasks.md was wrong in both directions.** `git grep -n
+      "schema: 'GLLine'|setSchema('GLLine')|saveObject(... 'GLLine')"` over
+      `lib/` finds 25 call sites, of which only **4 files** WRITE; the rest read.
+      - `lib/Guard/ProgrammaLinkGuard.php` — **reader**, not a writer
+        (`fetchStoredProgramme()` does `->setSchema('GLLine')->find($id)`).
+      - `lib/Repair/BackfillFiscalPeriods.php` — **reader**; it writes
+        `FiscalPeriod`, never `GLLine`.
+- [x] `lib/Service/CogsPosterService.php` — both COGS legs.
+- [x] `lib/Service/InventoryGlAdjustmentPoster.php` — both adjustment legs.
+- [x] `lib/Service/RuleTestDataSeeder.php` — both seeded balance legs.
+- [x] `lib/Service/VatSuppletieDetectionService.php` — the per-rubriek delta
+      lines and the clearing line.
+- [x] Every one of the four already had the parent's `administrationId` in
+      scope at the write site (it is set on the `GLTransaction` header a few
+      lines above), so no new plumbing was needed.
 - [ ] One unit test per writer asserting the new line carries its parent's
-      `administrationId`. Prove each can fail by dropping the assignment.
+      `administrationId`. **NOT DONE** — see "Known gaps" below.
 
 ## Phase 3 — backfill migrator
 
-Follow this repo's own precedent: `BudgetSchemaSplitMigrator`,
-`RevenueContractRenameMigrator`, `SubsidieOrderConsolidationMigrator`.
-
-- [ ] `lib/Service/Migration/GlLineAdministrationBackfillMigrator.php`.
-- [ ] Resolve each `GLLine`'s administration via its `transactionId` →
-      `GLTransaction.administrationId`.
-- [ ] **Count-verify then abort**, per `assertCountsMatch()`: if the number of
-      lines resolved does not equal the number of lines seen, abort the whole
-      batch untouched rather than half-migrating a ledger.
-- [ ] A `GLLine` whose parent `GLTransaction` is missing is **unclassifiable** —
-      report it, do not guess, do not default to any administration.
-- [ ] Report: total, backfilled, unclassifiable. Exit non-zero when
-      unclassifiable > 0, so a partial result cannot read as success.
-- [ ] Idempotent: re-running must not change an already-backfilled row.
+- [x] `lib/Service/Migration/GlLineAdministrationBackfillMigrator.php`, following
+      `BudgetSchemaSplitMigrator`'s shape (pure, unit-testable, no OR deps).
+- [x] Resolve each `GLLine`'s administration via its `transactionId` →
+      `GLTransaction.administrationId`. Indexes the parent under its object id,
+      `@self.id`, `uuid` AND `transactionNumber`, because `RuleTestDataSeeder`
+      writes the business key into `transactionId` while every other writer
+      writes the UUID — an index over UUIDs alone would have called all those
+      lines unclassifiable and aborted every batch.
+- [x] **Count-verify then abort**, per `assertCountsMatch()`: one unclassifiable
+      row aborts the whole batch untouched, including the rows that resolved.
+- [x] A `GLLine` whose parent is missing — or whose parent is itself unscoped —
+      is **unclassifiable**: reported, never guessed, never defaulted.
+- [x] Report: total, backfilled, unchanged, unclassifiable, conflicting. The
+      repair step leaves the gate CLOSED whenever any remain, which is the
+      stronger form of "cannot read as success" for an in-process step.
+- [x] Idempotent: an already-scoped row is returned byte-identical and proposes
+      no write. An already-scoped row that DISAGREES with its parent is
+      reported as `conflicting` and deliberately not rewritten.
 
 ## Phase 4 — prove the backfill is complete
 
-- [ ] A check that counts `GLLine` rows with no `administrationId`. Not a spot
-      check — the total.
-- [ ] **This gate must be green before Phase 5 begins.** It is the only evidence
-      that switching the filter on will not zero the totals.
+- [x] `countMissingAdministrationId()` counts rows with no `administrationId` —
+      a TOTAL over every row handed to it, never a sample.
+- [x] `lib/Repair/BackfillGlLineAdministration.php` (registered in
+      `appinfo/info.xml`, ahead of `BackfillFiscalPeriods`) **RE-READS every
+      `GLLine` from the store after writing** and opens the gate only on a
+      count of exactly zero. The migrator's own return value is a report, not
+      proof; the gate is a measurement of the store taken after the fact.
+- [x] The gate is **cleared at the START of the step**, so every intermediate
+      state — a crash mid-write, an aborted batch, an OR outage, an upgrade
+      that never reached the step — reads as shut and fails closed.
 
 ## Phase 5 — enable the filter, last
 
-- [ ] `SpendAnalyticsService`: pass `administrationId` into the category,
-      cost-centre and period aggregations.
-- [ ] Delete the `⚠️ ADMINISTRATION SCOPE IS NOT UNIFORM` docblock section and
-      its "Do not 'fix' it by adding the unmatched filter" warning — leaving it
-      once the fix lands makes the file lie in the other direction.
-- [ ] **A positive control**: prove each of the three views can still return
-      ROWS after scoping. A view that returns zero because the filter matches
-      nothing looks identical to a view with no data, which is the exact failure
-      this change exists to avoid.
-- [ ] **A negative control**: administration A's totals must not include B's
-      rows. Prove it can fail by reverting the filter.
+- [x] `SpendAnalyticsService`: `administrationId` passed into the category,
+      cost-centre and period aggregations; all three now take the caller's
+      administration as a parameter, and `SpendAnalyticsController::dispatch()`
+      hands them the value it already proved membership for.
+- [x] Gated: `assertGlScopeIsEnforceable()` RAISES unless the app-config gate
+      holds `GATE_CONTRACT_VERSION`. A **version, not a boolean**, so that
+      adding a new `GLLine` writer can invalidate every deployment's stored
+      proof by bumping one constant — completeness is a claim about the code as
+      well as the data.
+- [x] An empty `administrationId` is refused too: `administrationId = ''`
+      matches nothing, which is the same silent zero by another route.
+- [x] Deleted the `⚠️ ADMINISTRATION SCOPE IS NOT UNIFORM` docblock section and
+      its "Do not 'fix' it by adding the unmatched filter" instruction, plus the
+      matching stale paragraph in `SpendAnalyticsController`'s docblock and the
+      now-false `REQ-SPA-005` in `openspec/specs/spend-analytics/spec.md` (whose
+      scenario asserted the filter must NOT carry an administration term).
+- [x] **Positive control**: `testScopedViewsStillReturnRowsAndRealTotals` —
+      proven to fail ("category returned no rows at all") when the fixture rows
+      lack `administrationId`, i.e. in exactly the state the forbidden naive fix
+      would have produced.
+- [x] **Negative control**: `testGlBackedViewsExcludeOtherAdministrations` —
+      proven to fail (9100.0 vs 100.0) with the filter term removed.
 
 ## Phase 6 — e2e
 
-- [ ] Cover the three views through the UI, asserting a scoped total rather than
-      mere page render.
-- [ ] Locators by `data-testid` / manifest id, never by label — a label-only
-      locator has matched another feature's element three times in this repo.
+- [ ] **Not applicable as written.** `/api/analytics/spend` has NO frontend
+      consumer: `grep -rn "analytics/spend" src/` returns nothing and no
+      `src/manifest.d/` page declares it. The four spend views are an API-only
+      surface, so there is no UI to cover and no `data-testid` to locate. Both
+      scenarios now carry `@e2e exclude` with that reason. Re-tag them as
+      `@e2e glline-administration-scope::…` when a UI consumer lands.
+
+## Known gaps
+
+- **No per-writer unit test.** The four writers are covered indirectly (the
+  service tests prove the filter, the migrator tests prove the backfill), but
+  nothing asserts that e.g. `CogsPosterService` stamps the parent's scope onto
+  the line it writes. A writer that regressed would not fail the suite; it
+  would surface as the completeness gate flipping shut on the next repair run,
+  which fails closed but only after the fact.
 
 ## Explicitly out of scope
 

--- a/openspec/specs/spend-analytics/spec.md
+++ b/openspec/specs/spend-analytics/spec.md
@@ -116,32 +116,41 @@ anyone naming an id.
 - **THEN** the response status SHALL be 401
 - @e2e exclude Backend auth gate (ADR-005); no browser flow.
 
-### Requirement: REQ-SPA-005 — The administration scope SHALL be pushed into the aggregation for every view whose source schema can carry it, and the views that cannot SHALL say so rather than pretend
+### Requirement: REQ-SPA-005 — The administration scope SHALL be pushed into the aggregation for every view, and a view whose source rows cannot honour it SHALL refuse rather than return a zero
 
 `spendBySupplier()` reads `APTransaction`, which DECLARES `administrationId`, so
 that view SHALL pass the caller's administration into the aggregation filter.
 
 `spendByCategory()` / `spendByCostCentre()` / `spendByPeriod()` read `GLLine`,
-which declares NO administration or organisation property — the administration
-lives one hop away on the parent `GLTransaction`, and OpenRegister's `filters`
-address an object's own JSON properties and cannot join. These three views
-SHALL NOT be given an `administrationId` filter term: on `GLLine` such a term
-addresses a property that does not exist and matches NOTHING for every value,
-which would turn a real spend figure into a silent zero in a bookkeeping total.
-They SHALL instead declare, in code and here, that they aggregate every
-administration in the register, with the membership check of REQ-SPA-003 as
-their only containment — it reduces the audience from "any authenticated
-Nextcloud user" to "a member of some administration" but does not isolate one
-administration from another.
+which NOW declares `administrationId` too, denormalised from the parent
+`GLTransaction` by `glline-administration-scope` (REQ-GLS-001). All three SHALL
+pass the caller's administration into the aggregation filter.
 
-Closing that gap SHALL be done by denormalising `administrationId` onto the
-`GLLine` schema and backfilling existing rows (a schema + data migration), not
-by adding the unmatched filter.
+Until that change landed, `GLLine` declared no administration or organisation
+property at all — the administration lived one hop away on the parent, and
+OpenRegister's `filters` address an object's own JSON properties and cannot
+join — so those three views aggregated EVERY administration in the register
+while the supplier view was correctly scoped. The membership check of
+REQ-SPA-003 reduced their audience from "any authenticated Nextcloud user" to
+"a member of some administration" but did not isolate one administration from
+another. That read is closed.
 
-#### Scenario: The GL-backed views carry no administration filter until GLLine can honour one
-- **GIVEN** the category view is computed
-- **THEN** the filter sent to OpenRegister SHALL be exactly `{side: debit, subLedgerType: ap}` with no administration term
-- @e2e exclude Pins a deliberate, documented gap at the query-construction layer; asserts the absence of a filter term, which no browser flow can observe.
+The filter SHALL remain conditional on proof that the backfill is complete
+(REQ-GLS-003): filtering on a property some rows lack matches nothing for those
+rows, so a GL-backed view SHALL RAISE — not fall back to the unfiltered query,
+and not return the filtered one — while that proof is absent. Raising leaks
+nothing and claims nothing false; the two alternatives each do one of those.
+
+#### Scenario: The GL-backed views carry the caller's administration in their filter
+- **GIVEN** the category view is computed for a member of `ADM-A`
+- **THEN** the filter sent to OpenRegister SHALL be exactly `{administrationId: ADM-A, side: debit, subLedgerType: ap}`, and no `ADM-B` row SHALL contribute to any group or total
+- @e2e exclude `/api/analytics/spend` has no frontend consumer today (API-only surface); enforced by SpendAnalyticsServiceTest::testGlBackedViewsExcludeOtherAdministrations, proven to fail with the filter term removed.
+
+#### Scenario: A GL-backed view refuses while the backfill is unproven
+- **GIVEN** the `GLLine` administration backfill has not been proven complete
+- **WHEN** the category / cost-centre / period view is requested
+- **THEN** the service SHALL raise and the endpoint SHALL return an error status, rather than a total of zero
+- @e2e exclude Asserts a raise at the query-construction layer driven by an app-config gate; the browser sees only a generic error status.
 
 ### Requirement: REQ-SPA-004 — Cross-tab spend analysis SHALL be routed to OpenRegister, and no inert cross-tab declaration SHALL remain undocumented
 

--- a/tests/Unit/Controller/SpendAnalyticsControllerTest.php
+++ b/tests/Unit/Controller/SpendAnalyticsControllerTest.php
@@ -293,4 +293,74 @@ final class SpendAnalyticsControllerTest extends TestCase {
 
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 	}//end testSpendPassesTheProvenAdministrationIntoTheAggregation()
+
+	/**
+	 * The THREE GL-BACKED dimensions must receive the proven administration
+	 * too (REQ-GLS-003).
+	 *
+	 * They used to be dispatched with NO argument at all, because `GLLine`
+	 * declared no administration property and a parameter the service could
+	 * not honour would have read as a scope that was applied. Written to fail
+	 * on that controller in the most direct way available: it did not pass the
+	 * value, so `->with('ADM-042')` cannot match.
+	 *
+	 * @dataProvider glBackedDimensions
+	 *
+	 * @param string $dimension The dimension query parameter.
+	 * @param string $method The service method it must dispatch to.
+	 *
+	 * @return void
+	 */
+	public function testGlBackedDimensionsAlsoReceiveTheProvenAdministration(string $dimension, string $method): void {
+		$request = $this->createMock(IRequest::class);
+		$request->method('getParam')->willReturnCallback(
+			static function (string $key, $default = null) use ($dimension) {
+				if ($key === 'dimension') {
+					return $dimension;
+				}
+
+				if ($key === 'administration_id') {
+					return 'ADM-042';
+				}
+
+				return $default;
+			}
+		);
+
+		$service = $this->createMock(SpendAnalyticsService::class);
+		$service->expects($this->once())
+			->method($method)
+			->with('ADM-042')
+			->willReturn(['dimension' => $dimension, 'groups' => [], 'total' => 0.0, 'backend' => 'postgres']);
+
+		$context = $this->createMock(AdministrationContextService::class);
+		$context->method('currentUserId')->willReturn('alice');
+		$context->method('canAccess')->willReturn(true);
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnArgument(0);
+
+		$controller = new SpendAnalyticsController(
+			request: $request,
+			service: $service,
+			context: $context,
+			l10n: $l10n,
+			logger: $this->createMock(LoggerInterface::class)
+		);
+
+		$this->assertSame(Http::STATUS_OK, $controller->spend()->getStatus());
+	}//end testGlBackedDimensionsAlsoReceiveTheProvenAdministration()
+
+	/**
+	 * The three GLLine-sourced dimensions and their service methods.
+	 *
+	 * @return array<string,array{0:string,1:string}>
+	 */
+	public static function glBackedDimensions(): array {
+		return [
+			'category' => ['category', 'spendByCategory'],
+			'costCentre' => ['costCentre', 'spendByCostCentre'],
+			'period' => ['period', 'spendByPeriod'],
+		];
+	}//end glBackedDimensions()
 }//end class

--- a/tests/Unit/Repair/BackfillGlLineAdministrationTest.php
+++ b/tests/Unit/Repair/BackfillGlLineAdministrationTest.php
@@ -1,0 +1,741 @@
+<?php
+
+/**
+ * Unit tests for the BackfillGlLineAdministration repair step.
+ *
+ * Covers `glline-administration-scope` REQ-GLS-003 — the COMPLETENESS GATE that
+ * decides whether `SpendAnalyticsService` may scope its category / cost-centre /
+ * period aggregations on `GLLine.administrationId` at all.
+ *
+ * The step's whole value is that it is hostile to itself, so these tests are
+ * written against that hostility rather than against its line count:
+ *
+ * - it RE-READS the store after writing and counts missing scopes, instead of
+ *   believing the batch report it just received;
+ * - it CLEARS the gate before touching a single row, so a crash, an outage or an
+ *   upgrade that never reached the step all read as shut;
+ * - it stores a contract VERSION rather than a boolean, so a stale proof
+ *   gathered under an older writer set can never be left standing.
+ *
+ * Each test below is written so that removing one of those three properties
+ * turns it red.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Repair
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Repair;
+
+use OCA\Shillinq\Repair\BackfillGlLineAdministration;
+use OCA\Shillinq\Service\Migration\GlLineAdministrationBackfillMigrator;
+use OCA\Shillinq\Service\SettingsService;
+use OCA\Shillinq\Tests\Unit\Service\Support\DuckObjectServiceAdapter;
+use OCP\IAppConfig;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Tests the gate contract of BackfillGlLineAdministration.
+ *
+ * The migrator is `final`, so it is used for real rather than mocked: these are
+ * tests of the step's ORDERING and its treatment of the store, and a stubbed
+ * migrator would let the step pass while doing the wrong thing with a real one.
+ *
+ * @covers \OCA\Shillinq\Repair\BackfillGlLineAdministration
+ */
+final class BackfillGlLineAdministrationTest extends TestCase {
+
+	/**
+	 * The in-memory OpenRegister store double (also holds the gate + call log).
+	 *
+	 * @var object
+	 */
+	private object $store;
+
+	/**
+	 * The repair-step output double.
+	 *
+	 * @var IOutput
+	 */
+	private IOutput $output;
+
+	/**
+	 * Two GLTransaction parents, in two different administrations.
+	 *
+	 * @return array<int, array<string, mixed>> The parent rows.
+	 */
+	private function transactions(): array {
+		return [
+			['id' => 'tx-a', 'transactionNumber' => 'GL-2026-A', 'administrationId' => 'ADM-A'],
+			['id' => 'tx-b', 'transactionNumber' => 'GL-2026-B', 'administrationId' => 'ADM-B'],
+		];
+
+	}//end transactions()
+
+	/**
+	 * Two unscoped GLLine rows, one addressing its parent by object id and one
+	 * by `transactionNumber` — both idioms this repo's writers actually use.
+	 *
+	 * @return array<int, array<string, mixed>> The line rows.
+	 */
+	private function unscopedLines(): array {
+		return [
+			['id' => 'l1', 'transactionId' => 'tx-a', 'amount' => 10.0],
+			['id' => 'l2', 'transactionId' => 'GL-2026-B', 'amount' => 20.0],
+		];
+
+	}//end unscopedLines()
+
+	/**
+	 * Build the step around an in-memory store seeded with the given rows.
+	 *
+	 * The store models the three things the step's contract turns on: reads are
+	 * SERVED FROM CURRENT STATE (so a write is visible to the next read), every
+	 * read and write is appended to an ordered call log (so "cleared first" is
+	 * assertable rather than assumed), and `$store->onRead` lets a test act
+	 * BETWEEN the write and the proof re-read — which is where a concurrent
+	 * `GLLine` writer would land in production.
+	 *
+	 * @param array<int, array<string, mixed>> $glLines The seeded GLLine rows.
+	 * @param array<int, array<string, mixed>> $glTransactions The seeded GLTransaction rows.
+	 *
+	 * @return BackfillGlLineAdministration The step under test.
+	 */
+	private function makeStep(array $glLines, array $glTransactions): BackfillGlLineAdministration {
+		$this->store = new class($glLines, $glTransactions) {
+
+			/**
+			 * Rows by schema slug — the live store, mutated by saveObject().
+			 *
+			 * @var array<string, array<int, array<string, mixed>>>
+			 */
+			public array $rows;
+
+			/**
+			 * The app-config gate value, as the step last left it.
+			 *
+			 * @var string
+			 */
+			public string $gate = '';
+
+			/**
+			 * Recorded saveObject() calls.
+			 *
+			 * @var array<int, array<string, mixed>>
+			 */
+			public array $saves = [];
+
+			/**
+			 * Ordered log of every gate write, read and save.
+			 *
+			 * @var array<int, string>
+			 */
+			public array $calls = [];
+
+			/**
+			 * How many read passes each schema has served.
+			 *
+			 * @var array<string, int>
+			 */
+			public array $readCounts = [];
+
+			/**
+			 * Collected IOutput::info() messages.
+			 *
+			 * @var array<int, string>
+			 */
+			public array $info = [];
+
+			/**
+			 * Collected IOutput::warning() messages.
+			 *
+			 * @var array<int, string>
+			 */
+			public array $warnings = [];
+
+			/**
+			 * Optional hook run at the start of each read pass.
+			 *
+			 * Receives the schema slug, the 1-based pass number for that schema
+			 * and this store, and may mutate it or throw.
+			 *
+			 * @var (callable(string, int, object): void)|null
+			 */
+			public $onRead = null;
+
+			/**
+			 * Optional hook run before each save; may throw to model a write failure.
+			 *
+			 * @var (callable(array, object): void)|null
+			 */
+			public $onSave = null;
+
+			/**
+			 * The schema selected through the fluent setter.
+			 *
+			 * @var string
+			 */
+			public string $schema = '';
+
+			/**
+			 * Constructor.
+			 *
+			 * @param array<int, array<string, mixed>> $glLines The seeded GLLine rows.
+			 * @param array<int, array<string, mixed>> $glTransactions The seeded GLTransaction rows.
+			 */
+			public function __construct(array $glLines, array $glTransactions) {
+				$this->rows = [
+					GlLineAdministrationBackfillMigrator::SCHEMA_GL_LINE => array_values($glLines),
+					GlLineAdministrationBackfillMigrator::SCHEMA_GL_TRANSACTION => array_values($glTransactions),
+				];
+
+			}//end __construct()
+
+			/**
+			 * Fluent register setter (the store is single-register).
+			 *
+			 * @param string $register The register slug (unused).
+			 *
+			 * @return self
+			 */
+			public function setRegister(string $register): self {
+				return $this;
+
+			}//end setRegister()
+
+			/**
+			 * Fluent schema setter.
+			 *
+			 * @param string $schema The schema slug.
+			 *
+			 * @return self
+			 */
+			public function setSchema(string $schema): self {
+				$this->schema = $schema;
+
+				return $this;
+
+			}//end setSchema()
+
+			/**
+			 * Serve one page from the CURRENT state of the store.
+			 *
+			 * `offset === 0` starts a new read pass, which is where the
+			 * per-schema counter advances and `onRead` fires.
+			 *
+			 * @param array<string, mixed> $config The findAll options.
+			 * @param string $register The register slug (unused).
+			 * @param string $schema The schema slug.
+			 * @param bool $_rbac RBAC flag (unused — a migration reads everything).
+			 * @param bool $_multitenancy Multi-tenancy flag (unused).
+			 *
+			 * @return array<int, array<string, mixed>> The page.
+			 */
+			public function findAll(
+				array $config = [],
+				string $register = '',
+				string $schema = '',
+				bool $_rbac = true,
+				bool $_multitenancy = true,
+			): array {
+				$slug = ($schema !== '' ? $schema : $this->schema);
+				$offset = (int)($config['offset'] ?? 0);
+
+				if ($offset === 0) {
+					$this->readCounts[$slug] = (($this->readCounts[$slug] ?? 0) + 1);
+					$this->calls[] = 'read:' . $slug . '#' . $this->readCounts[$slug];
+
+					if ($this->onRead !== null) {
+						($this->onRead)($slug, $this->readCounts[$slug], $this);
+					}
+				}
+
+				$page = array_values($this->rows[$slug] ?? []);
+				if ($offset > 0) {
+					$page = array_slice($page, $offset);
+				}
+
+				$limit = ($config['limit'] ?? null);
+				if ($limit !== null) {
+					$page = array_slice($page, 0, (int)$limit);
+				}
+
+				return array_values($page);
+
+			}//end findAll()
+
+			/**
+			 * Persist a row in place, keyed by its object id.
+			 *
+			 * @param array<string, mixed> $object The payload being saved.
+			 * @param string $register The register slug.
+			 * @param string $schema The schema slug.
+			 * @param string|null $uuid The explicit object UUID.
+			 * @param bool $_rbac RBAC flag.
+			 * @param bool $_multitenancy Multi-tenancy flag.
+			 *
+			 * @return array<string, mixed> The saved payload.
+			 */
+			public function saveObject(
+				array $object,
+				string $register = '',
+				string $schema = '',
+				?string $uuid = null,
+				bool $_rbac = true,
+				bool $_multitenancy = true,
+			): array {
+				$slug = ($schema !== '' ? $schema : $this->schema);
+				$objectId = ($uuid ?? (string)($object['id'] ?? ''));
+
+				$this->calls[] = 'save:' . $slug . ':' . $objectId;
+
+				if ($this->onSave !== null) {
+					($this->onSave)($object, $this);
+				}
+
+				$this->saves[] = [
+					'object' => $object,
+					'register' => $register,
+					'schema' => $slug,
+					'uuid' => $uuid,
+					'_rbac' => $_rbac,
+					'_multitenancy' => $_multitenancy,
+				];
+
+				foreach (($this->rows[$slug] ?? []) as $index => $row) {
+					if ((string)($row['id'] ?? '') === $objectId) {
+						$this->rows[$slug][$index] = $object;
+
+						return $object;
+					}
+				}
+
+				$this->rows[$slug][] = $object;
+
+				return $object;
+
+			}//end saveObject()
+		};
+
+		$store = $this->store;
+
+		$settingsService = $this->createMock(SettingsService::class);
+		$settingsService->method('getRegisterSlug')->willReturn('shillinq');
+
+		$appConfig = $this->createMock(IAppConfig::class);
+		$appConfig->method('setValueString')->willReturnCallback(
+			static function (string $app, string $key, string $value, bool $lazy = false, bool $sensitive = false) use ($store): bool {
+				if ($key === GlLineAdministrationBackfillMigrator::GATE_CONFIG_KEY) {
+					$store->gate = $value;
+					$store->calls[] = 'gate:' . ($value === '' ? '<cleared>' : $value);
+				}
+
+				return true;
+			}
+		);
+		$appConfig->method('getValueString')->willReturnCallback(
+			static function (string $app, string $key, string $default = '', bool $lazy = false) use ($store): string {
+				if ($key === GlLineAdministrationBackfillMigrator::GATE_CONFIG_KEY) {
+					return $store->gate;
+				}
+
+				return $default;
+			}
+		);
+
+		$output = $this->createMock(IOutput::class);
+		$output->method('info')->willReturnCallback(
+			static function ($message) use ($store): void {
+				$store->info[] = (string)$message;
+			}
+		);
+		$output->method('warning')->willReturnCallback(
+			static function ($message) use ($store): void {
+				$store->warnings[] = (string)$message;
+			}
+		);
+		$this->output = $output;
+
+		return new BackfillGlLineAdministration(
+			settingsService: $settingsService,
+			migrator: new GlLineAdministrationBackfillMigrator(),
+			appConfig: $appConfig,
+			logger: $this->createMock(\Psr\Log\LoggerInterface::class),
+			objectService: new DuckObjectServiceAdapter($this->store),
+		);
+
+	}//end makeStep()
+
+	/**
+	 * Assert some warning message contains the given fragment.
+	 *
+	 * @param string $needle The fragment to look for.
+	 *
+	 * @return void
+	 */
+	private function assertWarned(string $needle): void {
+		foreach ($this->store->warnings as $warning) {
+			if (str_contains($warning, $needle) === true) {
+				self::assertStringContainsString($needle, $warning);
+
+				return;
+			}
+		}
+
+		self::fail(
+			'Expected a warning containing "' . $needle . '", got: '
+			. (($this->store->warnings === []) ? '(no warnings at all)' : implode(' | ', $this->store->warnings))
+		);
+
+	}//end assertWarned()
+
+	/**
+	 * The step names itself well enough to be recognised in `occ` output.
+	 *
+	 * @return void
+	 */
+	public function testNameIdentifiesTheSchemaAndTheSource(): void {
+		$name = $this->makeStep([], [])->getName();
+
+		self::assertStringContainsString('GLLine', $name);
+		self::assertStringContainsString('GLTransaction', $name);
+
+	}//end testNameIdentifiesTheSchemaAndTheSource()
+
+	/**
+	 * BEHAVIOUR 1. A clean backfill writes every unscoped row from its own
+	 * parent and then OPENS the gate — and the value it stores is the contract
+	 * VERSION, never a boolean-ish "yes".
+	 *
+	 * The version matters because the gate's claim is about the CODE as well as
+	 * the data: bumping `GATE_CONTRACT_VERSION` when a new `GLLine` writer
+	 * appears has to invalidate every deployment's stored proof, and a stored
+	 * `true`/`1` would keep answering yes on evidence gathered before that
+	 * writer existed.
+	 *
+	 * @return void
+	 */
+	public function testCleanBackfillOpensTheGateWithTheContractVersion(): void {
+		$step = $this->makeStep($this->unscopedLines(), $this->transactions());
+
+		$step->run($this->output);
+
+		// Each line got ITS OWN parent's administration, not a shared default.
+		self::assertCount(2, $this->store->saves);
+		self::assertSame('ADM-A', $this->store->saves[0]['object']['administrationId']);
+		self::assertSame('ADM-B', $this->store->saves[1]['object']['administrationId']);
+
+		self::assertSame(
+			GlLineAdministrationBackfillMigrator::GATE_CONTRACT_VERSION,
+			$this->store->gate,
+			'The gate must hold the contract version the reader compares against.'
+		);
+		self::assertNotContains(
+			$this->store->gate,
+			['1', 'true', 'yes', 'on', ''],
+			'The gate is a VERSION, not a boolean: a truthy flag cannot be invalidated by a contract bump.'
+		);
+
+	}//end testCleanBackfillOpensTheGateWithTheContractVersion()
+
+	/**
+	 * BEHAVIOUR 2. A batch that aborts — one line whose parent cannot answer for
+	 * it — writes NOTHING, leaves the store byte-identical, REVOKES any standing
+	 * proof, and does not blow up the upgrade it runs inside.
+	 *
+	 * The revocation arm is the one that matters most: an instance that was
+	 * proven complete yesterday and has since gained an unresolvable `GLLine`
+	 * must lose its proof today, or `SpendAnalyticsService` keeps filtering on a
+	 * property that row does not carry and quietly drops it from every total.
+	 *
+	 * The abort is also reported in its own words ("aborted … source data left
+	 * intact") rather than as a generic failure, because that is what tells an
+	 * admin the ledger was NOT left half-written.
+	 *
+	 * @return void
+	 */
+	public function testAbortedBatchWritesNothingAndRevokesTheGate(): void {
+		$lines = [
+			['id' => 'l1', 'transactionId' => 'tx-a'],
+			['id' => 'l2', 'transactionId' => 'tx-vanished'],
+		];
+		$step = $this->makeStep($lines, $this->transactions());
+
+		// This deployment had already been proven complete.
+		$this->store->gate = GlLineAdministrationBackfillMigrator::GATE_CONTRACT_VERSION;
+
+		$step->run($this->output);
+
+		self::assertSame(
+			[],
+			$this->store->saves,
+			'An aborted batch must not write even the rows that resolved cleanly.'
+		);
+		self::assertSame(
+			$lines,
+			$this->store->rows[GlLineAdministrationBackfillMigrator::SCHEMA_GL_LINE],
+			'The source rows must be left intact.'
+		);
+		self::assertSame('', $this->store->gate, 'An abort must revoke the standing proof.');
+
+		// Reported AS AN ABORT, not as a generic failure. The distinction is the
+		// whole operator-facing signal: "aborted … source data left intact" says
+		// the ledger was not touched, where "failed" leaves an admin unable to
+		// tell whether it was left half-written. Asserted as a PREFIX, because
+		// the generic handler re-emits this very exception message inside its
+		// own "… backfill failed: …" wrapper and a substring match cannot tell
+		// the two paths apart.
+		self::assertCount(1, $this->store->warnings);
+		self::assertStringStartsWith(
+			'Shillinq: GLLine administration backfill aborted:',
+			$this->store->warnings[0]
+		);
+		self::assertStringContainsString('source data left intact', $this->store->warnings[0]);
+
+	}//end testAbortedBatchWritesNothingAndRevokesTheGate()
+
+	/**
+	 * BEHAVIOUR 3. THE CRASH-READS-AS-SHUT CONTROL. The gate is cleared BEFORE
+	 * the first row is read, so a step that dies part-way leaves it shut even
+	 * though it was open when the step started.
+	 *
+	 * Asserted on the ORDERED call log rather than on the end state alone: an
+	 * implementation that cleared the gate in a `finally` would produce the same
+	 * final value here while still leaving the gate open for the whole duration
+	 * of a run that hangs rather than throws.
+	 *
+	 * @return void
+	 */
+	public function testTheGateIsClearedBeforeAnyRowIsRead(): void {
+		$step = $this->makeStep($this->unscopedLines(), $this->transactions());
+
+		// A previous run had proven completeness.
+		$this->store->gate = GlLineAdministrationBackfillMigrator::GATE_CONTRACT_VERSION;
+
+		// OpenRegister goes away the moment this run touches the store.
+		$this->store->onRead = static function (string $schema, int $pass, object $store): void {
+			throw new RuntimeException('OpenRegister is unavailable');
+		};
+
+		$step->run($this->output);
+
+		self::assertSame('', $this->store->gate, 'A crashed run must leave the gate shut.');
+		self::assertSame(
+			'gate:<cleared>',
+			$this->store->calls[0],
+			'Clearing the gate must be the FIRST thing the step does.'
+		);
+		self::assertStringStartsWith(
+			'read:',
+			$this->store->calls[1],
+			'…and the first read must come after it.'
+		);
+		$this->assertWarned('failed');
+
+	}//end testTheGateIsClearedBeforeAnyRowIsRead()
+
+	/**
+	 * BEHAVIOUR 4. THE CENTRAL CONTROL: the proof is a RE-READ OF THE STORE, not
+	 * the batch's own report.
+	 *
+	 * The batch here succeeds completely and really does write both of its rows.
+	 * Between that write and the proof re-read, another writer inserts an
+	 * unscoped `GLLine` — precisely the case the step's docblock claims to
+	 * cover. The store therefore still holds a row without a scope, and the gate
+	 * must stay SHUT despite a clean report, because switching the
+	 * `administrationId` filter on now would silently drop that row from every
+	 * category / cost-centre / period total.
+	 *
+	 * @return void
+	 */
+	public function testGateStaysShutWhenTheStoreStillHoldsAnUnscopedRowAfterASuccessfulBatch(): void {
+		$step = $this->makeStep($this->unscopedLines(), $this->transactions());
+
+		$this->store->onRead = static function (string $schema, int $pass, object $store): void {
+			if ($schema === GlLineAdministrationBackfillMigrator::SCHEMA_GL_LINE && $pass === 2) {
+				$store->rows[GlLineAdministrationBackfillMigrator::SCHEMA_GL_LINE][] = [
+					'id' => 'l3-arrived-late',
+					'transactionId' => 'tx-a',
+				];
+			}
+		};
+
+		$step->run($this->output);
+
+		// The batch itself was a total success and wrote both of its own rows…
+		self::assertCount(2, $this->store->saves);
+		self::assertSame('ADM-A', $this->store->saves[0]['object']['administrationId']);
+
+		// …and the store WAS re-read after those writes, not merely trusted.
+		self::assertSame(
+			2,
+			$this->store->readCounts[GlLineAdministrationBackfillMigrator::SCHEMA_GL_LINE],
+			'The step must read GLLine a second time, after writing, to prove completeness.'
+		);
+		$lastSave = array_key_last(array_filter($this->store->calls, static fn (string $c): bool => str_starts_with($c, 'save:')));
+		$proofRead = array_search('read:GLLine#2', $this->store->calls, true);
+		self::assertGreaterThan($lastSave, $proofRead, 'The proof re-read must happen AFTER the writes.');
+
+		// …yet the gate stays shut, because the store disagrees with the report.
+		self::assertSame(
+			'',
+			$this->store->gate,
+			'A clean batch report is not proof; only a zero-missing re-read is.'
+		);
+		$this->assertWarned('stays CLOSED');
+
+	}//end testGateStaysShutWhenTheStoreStillHoldsAnUnscopedRowAfterASuccessfulBatch()
+
+	/**
+	 * BEHAVIOUR 4, second route. A row whose WRITE fails leaves that row
+	 * unscoped in the store, so the re-read finds it and the gate stays shut —
+	 * even though the batch classified every row successfully.
+	 *
+	 * @return void
+	 */
+	public function testGateStaysShutWhenOneWriteFails(): void {
+		$step = $this->makeStep($this->unscopedLines(), $this->transactions());
+
+		$this->store->onSave = static function (array $object, object $store): void {
+			if (($object['id'] ?? '') === 'l2') {
+				throw new RuntimeException('write conflict');
+			}
+		};
+
+		$step->run($this->output);
+
+		self::assertCount(1, $this->store->saves, 'Only the row that wrote cleanly is recorded.');
+		self::assertSame('', $this->store->gate);
+		$this->assertWarned('stays CLOSED');
+
+	}//end testGateStaysShutWhenOneWriteFails()
+
+	/**
+	 * BEHAVIOUR 5. A stale proof stored under an OLDER contract version is never
+	 * left standing.
+	 *
+	 * `SpendAnalyticsService` accepts the gate only on an exact match with
+	 * `GATE_CONTRACT_VERSION`, so bumping that constant is what invalidates
+	 * every deployment's stored proof when a new `GLLine` writer appears. That
+	 * only holds if this step never leaves the old value in place: here the run
+	 * cannot re-prove completeness, and the stale `v0` must be gone rather than
+	 * merely "not updated".
+	 *
+	 * @return void
+	 */
+	public function testStaleProofFromAnOlderContractVersionIsDestroyedWhenItCannotBeReproven(): void {
+		$step = $this->makeStep(
+			[['id' => 'l1', 'transactionId' => 'tx-vanished']],
+			$this->transactions()
+		);
+
+		$this->store->gate = 'v0';
+
+		$step->run($this->output);
+
+		self::assertNotSame('v0', $this->store->gate, 'A proof from an older contract must not survive.');
+		self::assertNotSame(
+			GlLineAdministrationBackfillMigrator::GATE_CONTRACT_VERSION,
+			$this->store->gate,
+			'…and it certainly must not be promoted to the current contract.'
+		);
+		self::assertSame('', $this->store->gate);
+
+	}//end testStaleProofFromAnOlderContractVersionIsDestroyedWhenItCannotBeReproven()
+
+	/**
+	 * BEHAVIOUR 5, happy arm. When completeness IS re-proven, the stale value is
+	 * replaced by the CURRENT contract version rather than left as it was.
+	 *
+	 * @return void
+	 */
+	public function testStaleProofIsReplacedByTheCurrentContractVersionOnACleanRun(): void {
+		$step = $this->makeStep($this->unscopedLines(), $this->transactions());
+
+		$this->store->gate = 'v0';
+
+		$step->run($this->output);
+
+		self::assertSame(GlLineAdministrationBackfillMigrator::GATE_CONTRACT_VERSION, $this->store->gate);
+
+	}//end testStaleProofIsReplacedByTheCurrentContractVersionOnACleanRun()
+
+	/**
+	 * A row the migrator stamped but which carries no object id cannot be
+	 * written as an update, so it is skipped with a warning — and, because it
+	 * stays unscoped in the store, the re-read refuses to open the gate.
+	 *
+	 * @return void
+	 */
+	public function testRowWithoutAnObjectIdIsSkippedAndKeepsTheGateShut(): void {
+		$step = $this->makeStep(
+			[['transactionId' => 'tx-a', 'amount' => 10.0]],
+			$this->transactions()
+		);
+
+		$step->run($this->output);
+
+		self::assertSame([], $this->store->saves);
+		self::assertSame('', $this->store->gate);
+		$this->assertWarned('no object id');
+
+	}//end testRowWithoutAnObjectIdIsSkippedAndKeepsTheGateShut()
+
+	/**
+	 * A re-run over an already-scoped ledger writes nothing and re-affirms the
+	 * same gate value — the idempotency this step relies on to be safe to wire
+	 * into every upgrade.
+	 *
+	 * @return void
+	 */
+	public function testReRunWritesNothingAndReAffirmsTheGate(): void {
+		$step = $this->makeStep(
+			[
+				['id' => 'l1', 'transactionId' => 'tx-a', 'administrationId' => 'ADM-A'],
+				['id' => 'l2', 'transactionId' => 'tx-b', 'administrationId' => 'ADM-B'],
+			],
+			$this->transactions()
+		);
+
+		$step->run($this->output);
+
+		self::assertSame([], $this->store->saves);
+		self::assertSame(GlLineAdministrationBackfillMigrator::GATE_CONTRACT_VERSION, $this->store->gate);
+
+	}//end testReRunWritesNothingAndReAffirmsTheGate()
+
+	/**
+	 * A register holding no `GLLine` rows at all is vacuously complete: there is
+	 * no row the filter could silently exclude, so the gate opens.
+	 *
+	 * Documented deliberately, because "zero rows" is the case a future reader
+	 * is most likely to mistake for "nothing was measured".
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyLedgerIsVacuouslyCompleteAndOpensTheGate(): void {
+		$step = $this->makeStep([], $this->transactions());
+
+		$step->run($this->output);
+
+		self::assertSame([], $this->store->saves);
+		self::assertSame(GlLineAdministrationBackfillMigrator::GATE_CONTRACT_VERSION, $this->store->gate);
+
+	}//end testAnEmptyLedgerIsVacuouslyCompleteAndOpensTheGate()
+}//end class

--- a/tests/Unit/Repair/BackfillGlLineAdministrationTest.php
+++ b/tests/Unit/Repair/BackfillGlLineAdministrationTest.php
@@ -58,6 +58,17 @@ use RuntimeException;
  * migrator would let the step pass while doing the wrong thing with a real one.
  *
  * @covers \OCA\Shillinq\Repair\BackfillGlLineAdministration
+ *
+ * The migrator is exercised for real rather than stubbed, deliberately: it is
+ * `final`, and these are tests of the STEP's ordering and its treatment of the
+ * store, so a stubbed migrator would let the step pass while doing the wrong
+ * thing with the real one. That collaboration is declared here because
+ * PHPUnit's strict coverage config reports undeclared execution as RISKY, and
+ * a risky test fails this build — the run reported
+ * "Tests: 4927, Assertions: 46194, Risky: 5" with zero failures and zero
+ * errors, so the suite passed and the job still went red.
+ *
+ * @uses \OCA\Shillinq\Service\Migration\GlLineAdministrationBackfillMigrator
  */
 final class BackfillGlLineAdministrationTest extends TestCase {
 

--- a/tests/Unit/Service/Migration/GlLineAdministrationBackfillMigratorTest.php
+++ b/tests/Unit/Service/Migration/GlLineAdministrationBackfillMigratorTest.php
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * Unit tests for GlLineAdministrationBackfillMigrator.
+ *
+ * Covers `glline-administration-scope` REQ-GLS-002: resolution of a `GLLine`'s
+ * administration through its parent `GLTransaction` (by object id OR by
+ * `transactionNumber`, because this repo's writers use both idioms), the
+ * seen→classified count guard that ABORTS THE WHOLE BATCH — leaving every row
+ * intact, including the ones that resolved cleanly — the moment a single row is
+ * unclassifiable, idempotency of a re-run, and the total (never sampled)
+ * completeness count that gates the SpendAnalytics filter.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Service\Migration
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/glline-administration-scope/specs/glline-administration-scope/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Service\Migration;
+
+use OCA\Shillinq\Service\Migration\GlLineAdministrationBackfillMigrator;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Tests the pure migration core: resolve + stamp + count-abort + completeness.
+ *
+ * @covers \OCA\Shillinq\Service\Migration\GlLineAdministrationBackfillMigrator
+ */
+final class GlLineAdministrationBackfillMigratorTest extends TestCase {
+
+	/**
+	 * The migrator under test.
+	 *
+	 * @var GlLineAdministrationBackfillMigrator
+	 */
+	private GlLineAdministrationBackfillMigrator $migrator;
+
+	/**
+	 * Set up the migrator.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->migrator = new GlLineAdministrationBackfillMigrator();
+
+	}//end setUp()
+
+	/**
+	 * Two transactions in two different administrations.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function transactions(): array {
+		return [
+			['id' => 'tx-a', 'transactionNumber' => 'GL-2026-A', 'administrationId' => 'ADM-A'],
+			['id' => 'tx-b', 'transactionNumber' => 'GL-2026-B', 'administrationId' => 'ADM-B'],
+		];
+	}//end transactions()
+
+	/**
+	 * A GLLine resolves through its parent's object id.
+	 *
+	 * @return void
+	 */
+	public function testResolvesByObjectId(): void {
+		$index = $this->migrator->indexAdministrationsByTransaction($this->transactions());
+
+		$this->assertSame(
+			'ADM-A',
+			$this->migrator->resolveAdministrationId(['transactionId' => 'tx-a'], $index)
+		);
+	}//end testResolvesByObjectId()
+
+	/**
+	 * A GLLine resolves through its parent's transactionNumber too.
+	 *
+	 * RuleTestDataSeeder writes `transactionId` as the business key when the
+	 * transaction has one. A migrator that indexed only object UUIDs would
+	 * declare every one of those lines unclassifiable and abort the batch —
+	 * which is fail-closed, but wrongly so.
+	 *
+	 * @return void
+	 */
+	public function testResolvesByTransactionNumber(): void {
+		$index = $this->migrator->indexAdministrationsByTransaction($this->transactions());
+
+		$this->assertSame(
+			'ADM-B',
+			$this->migrator->resolveAdministrationId(['transactionId' => 'GL-2026-B'], $index)
+		);
+	}//end testResolvesByTransactionNumber()
+
+	/**
+	 * A parent that carries no administration of its own indexes NOTHING.
+	 *
+	 * Stamping `''` would manufacture a scope that then satisfies the
+	 * completeness gate while matching no filter value — the exact
+	 * fake-completeness failure the gate exists to catch.
+	 *
+	 * @return void
+	 */
+	public function testUnscopedParentIndexesNothing(): void {
+		$index = $this->migrator->indexAdministrationsByTransaction(
+			[['id' => 'tx-x', 'administrationId' => '']]
+		);
+
+		$this->assertSame([], $index);
+		$this->assertNull(
+			$this->migrator->resolveAdministrationId(['transactionId' => 'tx-x'], $index)
+		);
+	}//end testUnscopedParentIndexesNothing()
+
+	/**
+	 * The happy path: every line is stamped with its own parent's scope, and
+	 * lines of different parents get DIFFERENT scopes.
+	 *
+	 * @return void
+	 */
+	public function testBackfillsEachLineFromItsOwnParent(): void {
+		$lines = [
+			['id' => 'l1', 'transactionId' => 'tx-a', 'amount' => 10.0],
+			['id' => 'l2', 'transactionId' => 'GL-2026-B', 'amount' => 20.0],
+		];
+
+		$report = $this->migrator->backfillBatch($lines, $this->transactions());
+
+		$this->assertSame(2, $report['total']);
+		$this->assertSame(2, $report['backfilled']);
+		$this->assertSame(0, $report['unclassifiable']);
+		$this->assertSame('ADM-A', $report['lines'][0]['administrationId']);
+		$this->assertSame('ADM-B', $report['lines'][1]['administrationId']);
+		// Every other field is preserved verbatim.
+		$this->assertSame(10.0, $report['lines'][0]['amount']);
+		$this->assertSame('l2', $report['lines'][1]['id']);
+	}//end testBackfillsEachLineFromItsOwnParent()
+
+	/**
+	 * THE FAIL-CLOSED CONTROL (REQ-GLS-002). One line whose parent is missing
+	 * aborts the WHOLE batch — including the line that resolved cleanly — so
+	 * the ledger is never left half-scoped.
+	 *
+	 * @return void
+	 */
+	public function testOneMissingParentAbortsTheWholeBatch(): void {
+		$lines = [
+			['id' => 'l1', 'transactionId' => 'tx-a'],
+			['id' => 'l2', 'transactionId' => 'tx-does-not-exist'],
+		];
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('source data left intact');
+
+		$this->migrator->backfillBatch($lines, $this->transactions());
+	}//end testOneMissingParentAbortsTheWholeBatch()
+
+	/**
+	 * A line with no transactionId at all is unclassifiable, never defaulted.
+	 *
+	 * @return void
+	 */
+	public function testOrphanLineIsNeverGuessed(): void {
+		$this->expectException(RuntimeException::class);
+
+		$this->migrator->backfillBatch([['id' => 'l1']], $this->transactions());
+	}//end testOrphanLineIsNeverGuessed()
+
+	/**
+	 * Re-running over an already-backfilled register changes no row.
+	 *
+	 * @return void
+	 */
+	public function testReRunIsIdempotent(): void {
+		$lines = [
+			['id' => 'l1', 'transactionId' => 'tx-a', 'administrationId' => 'ADM-A'],
+			['id' => 'l2', 'transactionId' => 'tx-b', 'administrationId' => 'ADM-B'],
+		];
+
+		$report = $this->migrator->backfillBatch($lines, $this->transactions());
+
+		$this->assertSame([], $report['lines'], 'A re-run must propose no writes.');
+		$this->assertSame(2, $report['unchanged']);
+		$this->assertSame(0, $report['backfilled']);
+	}//end testReRunIsIdempotent()
+
+	/**
+	 * An already-scoped line that disagrees with its parent is REPORTED, never
+	 * silently re-pointed to another administration.
+	 *
+	 * @return void
+	 */
+	public function testDisagreeingLineIsReportedNotRewritten(): void {
+		$lines = [['id' => 'l1', 'transactionId' => 'tx-a', 'administrationId' => 'ADM-B']];
+
+		$report = $this->migrator->backfillBatch($lines, $this->transactions());
+
+		$this->assertSame(1, $report['conflicting']);
+		$this->assertSame([], $report['lines']);
+	}//end testDisagreeingLineIsReportedNotRewritten()
+
+	/**
+	 * stampAdministrationId() never overwrites an existing scope.
+	 *
+	 * @return void
+	 */
+	public function testStampNeverOverwritesAnExistingScope(): void {
+		$line = ['id' => 'l1', 'administrationId' => 'ADM-A'];
+
+		$this->assertSame($line, $this->migrator->stampAdministrationId($line, 'ADM-B'));
+	}//end testStampNeverOverwritesAnExistingScope()
+
+	/**
+	 * The completeness count is a TOTAL over every row handed to it, and
+	 * treats a blank/whitespace scope as missing.
+	 *
+	 * @return void
+	 */
+	public function testCountMissingIsATotalOverEveryRow(): void {
+		$rows = [
+			['administrationId' => 'ADM-A'],
+			['administrationId' => ''],
+			[],
+			['administrationId' => '   '],
+			['administrationId' => 'ADM-B'],
+		];
+
+		$this->assertSame(3, $this->migrator->countMissingAdministrationId($rows));
+		$this->assertSame(0, $this->migrator->countMissingAdministrationId([]));
+	}//end testCountMissingIsATotalOverEveryRow()
+
+	/**
+	 * assertCountsMatch() is the guard itself: equal counts pass, any
+	 * shortfall throws.
+	 *
+	 * @return void
+	 */
+	public function testAssertCountsMatchThrowsOnShortfall(): void {
+		$this->migrator->assertCountsMatch(3, 3);
+
+		$this->expectException(RuntimeException::class);
+		$this->migrator->assertCountsMatch(3, 2);
+	}//end testAssertCountsMatchThrowsOnShortfall()
+}//end class

--- a/tests/Unit/Service/SpendAnalyticsServiceTest.php
+++ b/tests/Unit/Service/SpendAnalyticsServiceTest.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Tests\Unit\Service;
 
 use OCA\OpenRegister\Service\Aggregation\AggregationQuery;
+use OCA\Shillinq\Service\Migration\GlLineAdministrationBackfillMigrator;
 use OCA\Shillinq\Service\SpendAnalyticsService;
 use OCP\IAppConfig;
 use PHPUnit\Framework\TestCase;
@@ -142,15 +143,29 @@ final class SpendAnalyticsServiceTest extends TestCase {
 	 * Build the service around the in-memory runner.
 	 *
 	 * @param InMemoryAggregationRunner $runner The seeded runner double.
+	 * @param bool $backfillProven Whether the GLLine administration backfill gate is open.
 	 *
 	 * @return SpendAnalyticsService
 	 */
-	private function makeService(InMemoryAggregationRunner $runner): SpendAnalyticsService {
+	private function makeService(InMemoryAggregationRunner $runner, bool $backfillProven = true): SpendAnalyticsService {
 		$container = $this->createMock(ContainerInterface::class);
 		$container->method('get')->willReturn($runner);
 
+		$gate = '';
+		if ($backfillProven === true) {
+			$gate = GlLineAdministrationBackfillMigrator::GATE_CONTRACT_VERSION;
+		}
+
 		$appConfig = $this->createMock(IAppConfig::class);
-		$appConfig->method('getValueString')->willReturn('shillinq');
+		$appConfig->method('getValueString')->willReturnCallback(
+			static function (string $app, string $key, string $default = '') use ($gate): string {
+				if ($key === GlLineAdministrationBackfillMigrator::GATE_CONFIG_KEY) {
+					return $gate;
+				}
+
+				return 'shillinq';
+			}
+		);
 
 		$logger = $this->createMock(LoggerInterface::class);
 
@@ -186,19 +201,35 @@ final class SpendAnalyticsServiceTest extends TestCase {
 
 	/**
 	 * A known set of GL debit AP expense lines across accounts / cost centres
-	 * / periods, plus non-matching noise (credit line, non-ap sub-ledger).
+	 * / periods, plus non-matching noise (credit line, non-ap sub-ledger) —
+	 * and, crucially, a SECOND administration's lines.
+	 *
+	 * Every line carries `administrationId`, because that is exactly what
+	 * `glline-administration-scope` denormalised onto GLLine and what the
+	 * three GL-backed views now filter on. ADM-B's figures are deliberately an
+	 * order of magnitude larger than every ADM-A figure, so a service that
+	 * dropped the filter could not pass any assertion below by coincidence —
+	 * it would fold 9000/7000/2000 into ADM-A's totals and surface ADM-B's
+	 * account 4900, cost centre CC90 and period 2026-03 as groups the caller
+	 * has no membership to see.
 	 *
 	 * @return array<int,array<string,mixed>>
 	 */
 	private function glLines(): array {
 		return [
-			['accountNumber' => '4000', 'costCenterCode' => 'CC10', 'periodId' => '2026-01', 'amount' => 60.00, 'side' => 'debit', 'subLedgerType' => 'ap'],
-			['accountNumber' => '4000', 'costCenterCode' => 'CC20', 'periodId' => '2026-01', 'amount' => 40.00, 'side' => 'debit', 'subLedgerType' => 'ap'],
-			['accountNumber' => '4100', 'costCenterCode' => 'CC10', 'periodId' => '2026-02', 'amount' => 25.00, 'side' => 'debit', 'subLedgerType' => 'ap'],
+			['administrationId' => 'ADM-A', 'accountNumber' => '4000', 'costCenterCode' => 'CC10', 'periodId' => '2026-01', 'amount' => 60.00, 'side' => 'debit', 'subLedgerType' => 'ap'],
+			['administrationId' => 'ADM-A', 'accountNumber' => '4000', 'costCenterCode' => 'CC20', 'periodId' => '2026-01', 'amount' => 40.00, 'side' => 'debit', 'subLedgerType' => 'ap'],
+			['administrationId' => 'ADM-A', 'accountNumber' => '4100', 'costCenterCode' => 'CC10', 'periodId' => '2026-02', 'amount' => 25.00, 'side' => 'debit', 'subLedgerType' => 'ap'],
 			// Credit line — excluded (side != debit).
-			['accountNumber' => '1600', 'costCenterCode' => 'CC10', 'periodId' => '2026-01', 'amount' => 125.00, 'side' => 'credit', 'subLedgerType' => 'ap'],
+			['administrationId' => 'ADM-A', 'accountNumber' => '1600', 'costCenterCode' => 'CC10', 'periodId' => '2026-01', 'amount' => 125.00, 'side' => 'credit', 'subLedgerType' => 'ap'],
 			// Non-AP sub-ledger — excluded.
-			['accountNumber' => '4000', 'costCenterCode' => 'CC10', 'periodId' => '2026-01', 'amount' => 500.00, 'side' => 'debit', 'subLedgerType' => 'ar'],
+			['administrationId' => 'ADM-A', 'accountNumber' => '4000', 'costCenterCode' => 'CC10', 'periodId' => '2026-01', 'amount' => 500.00, 'side' => 'debit', 'subLedgerType' => 'ar'],
+			// ANOTHER ADMINISTRATION'S committed postings. Same schema, same
+			// register, same posting slice — the ONLY thing separating them is
+			// the administrationId filter this change added.
+			['administrationId' => 'ADM-B', 'accountNumber' => '4000', 'costCenterCode' => 'CC10', 'periodId' => '2026-01', 'amount' => 9000.00, 'side' => 'debit', 'subLedgerType' => 'ap'],
+			['administrationId' => 'ADM-B', 'accountNumber' => '4900', 'costCenterCode' => 'CC90', 'periodId' => '2026-03', 'amount' => 7000.00, 'side' => 'debit', 'subLedgerType' => 'ap'],
+			['administrationId' => 'ADM-B', 'accountNumber' => '4100', 'costCenterCode' => 'CC90', 'periodId' => '2026-02', 'amount' => 2000.00, 'side' => 'debit', 'subLedgerType' => 'ap'],
 		];
 
 	}//end glLines()
@@ -302,7 +333,7 @@ final class SpendAnalyticsServiceTest extends TestCase {
 		$runner->seed('GLLine', $this->glLines());
 		$service = $this->makeService($runner);
 
-		$result = $service->spendByCategory();
+		$result = $service->spendByCategory(administrationId: 'ADM-A');
 
 		$byKey = [];
 		foreach ($result['groups'] as $group) {
@@ -319,7 +350,10 @@ final class SpendAnalyticsServiceTest extends TestCase {
 		$this->assertSame('sum', $query->metric);
 		$this->assertSame('amount', $query->field);
 		$this->assertSame('accountNumber', $query->getGroupByField());
-		$this->assertSame(['side' => 'debit', 'subLedgerType' => 'ap'], $query->filter);
+		$this->assertSame(
+			['administrationId' => 'ADM-A', 'side' => 'debit', 'subLedgerType' => 'ap'],
+			$query->filter
+		);
 	}//end testSpendByCategoryCorrectTotals()
 
 	/**
@@ -330,7 +364,7 @@ final class SpendAnalyticsServiceTest extends TestCase {
 		$runner->seed('GLLine', $this->glLines());
 		$service = $this->makeService($runner);
 
-		$result = $service->spendByCostCentre();
+		$result = $service->spendByCostCentre(administrationId: 'ADM-A');
 
 		$byKey = [];
 		foreach ($result['groups'] as $group) {
@@ -352,7 +386,7 @@ final class SpendAnalyticsServiceTest extends TestCase {
 		$runner->seed('GLLine', $this->glLines());
 		$service = $this->makeService($runner);
 
-		$result = $service->spendByPeriod();
+		$result = $service->spendByPeriod(administrationId: 'ADM-A');
 
 		$byKey = [];
 		foreach ($result['groups'] as $group) {
@@ -384,31 +418,145 @@ final class SpendAnalyticsServiceTest extends TestCase {
 	}//end testRaisesWhenRunnerUnavailable()
 
 	/**
-	 * Pins the KNOWN GAP so it cannot be mistaken for a solved problem: the
-	 * three GL-backed views are NOT administration-scoped, because `GLLine`
-	 * declares no administration property and OpenRegister's filters cannot
-	 * join to the parent GLTransaction that holds one.
+	 * THE NEGATIVE CONTROL (REQ-GLS-003). A member of administration A must
+	 * not see administration B's category / cost-centre / period totals.
 	 *
-	 * This test asserts the current, deliberate state — the GL filter carries
-	 * the posting slice and nothing else. It is written to FAIL the moment
-	 * someone adds an `administrationId` term to a GLLine query, because on
-	 * that schema such a term addresses a property that does not exist and
-	 * matches NOTHING for every value: a silent zero in a bookkeeping total.
-	 * The real fix is `administrationId` denormalised onto GLLine plus a
-	 * backfill of existing rows; when that lands, this test is the one to
-	 * change, alongside the fixture that proves the new filter matches.
+	 * This is the read that used to be open. `GLLine` declared no
+	 * administration property at all, so these three views aggregated EVERY
+	 * administration in the register while the fourth (spend-by-supplier) was
+	 * correctly scoped — the service looked scoped and was not. Written to
+	 * FAIL on the pre-fix service in every dimension at once: without the
+	 * filter, account 4000 sums 60 + 40 + ADM-B's 9000, cost centre CC10 sums
+	 * 85 + 9000, period 2026-01 sums 100 + 9000, and ADM-B's 4900 / CC90 /
+	 * 2026-03 all surface as groups the caller has no membership to see.
+	 *
+	 * @return void
 	 */
-	public function testGlBackedViewsCarryNoAdministrationFilterYet(): void {
+	public function testGlBackedViewsExcludeOtherAdministrations(): void {
 		$runner = new InMemoryAggregationRunner();
 		$runner->seed('GLLine', $this->glLines());
 		$service = $this->makeService($runner);
 
-		$service->spendByCategory();
+		$category = $this->byKey($service->spendByCategory(administrationId: 'ADM-A'));
+		$costCentre = $this->byKey($service->spendByCostCentre(administrationId: 'ADM-A'));
+		$period = $this->byKey($service->spendByPeriod(administrationId: 'ADM-A'));
 
-		$this->assertSame(
-			['side' => 'debit', 'subLedgerType' => 'ap'],
-			$runner->lastQuery['GLLine']->filter,
-			'GLLine cannot be filtered by administration — see SpendAnalyticsService class docblock.'
-		);
-	}//end testGlBackedViewsCarryNoAdministrationFilterYet()
+		// ADM-B's amounts must not be folded into any shared group key...
+		$this->assertSame(100.0, $category['4000']);
+		$this->assertSame(85.0, $costCentre['CC10']);
+		$this->assertSame(100.0, $period['2026-01']);
+
+		// ...and ADM-B's own keys must not appear at all.
+		$this->assertArrayNotHasKey('4900', $category);
+		$this->assertArrayNotHasKey('CC90', $costCentre);
+		$this->assertArrayNotHasKey('2026-03', $period);
+
+		// The scope must reach OR as a FILTER TERM, not merely be checked and
+		// dropped upstream: an aggregation is executed by the database, so a
+		// scope that never enters the query never narrows anything.
+		$this->assertSame('ADM-A', $runner->lastQuery['GLLine']->filter['administrationId']);
+	}//end testGlBackedViewsExcludeOtherAdministrations()
+
+	/**
+	 * THE POSITIVE CONTROL (REQ-GLS-003). The scoped views must still return
+	 * ROWS and REAL TOTALS for a correctly-backfilled administration.
+	 *
+	 * This is the control the forbidden naive fix would have failed. Adding
+	 * `administrationId` to a GLLine filter BEFORE the backfill addresses a
+	 * property those rows do not carry; an unmatched key matches nothing for
+	 * every value, so all three views would have read ZERO — a wrong number
+	 * that looks exactly like "this administration has no spend", which is
+	 * worse than the exposure it pretends to close. Asserting non-empty groups
+	 * and exact totals is what tells those two states apart.
+	 *
+	 * @return void
+	 */
+	public function testScopedViewsStillReturnRowsAndRealTotals(): void {
+		$runner = new InMemoryAggregationRunner();
+		$runner->seed('GLLine', $this->glLines());
+		$service = $this->makeService($runner);
+
+		foreach (['category', 'costCentre', 'period'] as $dimension) {
+			$result = match ($dimension) {
+				'category' => $service->spendByCategory(administrationId: 'ADM-A'),
+				'costCentre' => $service->spendByCostCentre(administrationId: 'ADM-A'),
+				default => $service->spendByPeriod(administrationId: 'ADM-A'),
+			};
+
+			$this->assertNotSame([], $result['groups'], $dimension . ' returned no rows at all');
+			$this->assertGreaterThan(0.0, $result['total'], $dimension . ' silently totalled zero');
+			$this->assertSame(125.0, $result['total'], $dimension . ' total is not the hand-computed figure');
+		}
+
+		// And the same seeded set read as the OTHER tenant returns that
+		// tenant's figures — proving the filter is the caller's administration
+		// and not a constant that happens to match the first fixture.
+		$this->assertSame(18000.0, $service->spendByCategory(administrationId: 'ADM-B')['total']);
+	}//end testScopedViewsStillReturnRowsAndRealTotals()
+
+	/**
+	 * The GL-backed views RAISE while the backfill gate is shut, rather than
+	 * serving unscoped totals (the original exposure) or a filtered query over
+	 * rows that cannot match it (a silent zero).
+	 *
+	 * @return void
+	 */
+	public function testGlBackedViewsRefuseWhileTheBackfillIsUnproven(): void {
+		$runner = new InMemoryAggregationRunner();
+		$runner->seed('GLLine', $this->glLines());
+		$service = $this->makeService($runner, backfillProven: false);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('backfill is not proven complete');
+
+		$service->spendByCategory(administrationId: 'ADM-A');
+	}//end testGlBackedViewsRefuseWhileTheBackfillIsUnproven()
+
+	/**
+	 * The supplier view is unaffected by the GLLine gate: it reads
+	 * APTransaction, which has always declared `administrationId`.
+	 *
+	 * @return void
+	 */
+	public function testSupplierViewIsUnaffectedByTheGlLineGate(): void {
+		$runner = new InMemoryAggregationRunner();
+		$runner->seed('APTransaction', $this->apTransactions());
+		$service = $this->makeService($runner, backfillProven: false);
+
+		$this->assertSame(350.0, $service->spendBySupplier(administrationId: 'ADM-001')['total']);
+	}//end testSupplierViewIsUnaffectedByTheGlLineGate()
+
+	/**
+	 * An empty administration is refused rather than filtered on, because
+	 * `administrationId = ''` matches nothing — the same silent zero by a
+	 * different route.
+	 *
+	 * @return void
+	 */
+	public function testEmptyAdministrationIsRefused(): void {
+		$runner = new InMemoryAggregationRunner();
+		$runner->seed('GLLine', $this->glLines());
+		$service = $this->makeService($runner);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('requires a non-empty administrationId');
+
+		$service->spendByPeriod(administrationId: '  ');
+	}//end testEmptyAdministrationIsRefused()
+
+	/**
+	 * Flatten a shaped result to `key => amount`.
+	 *
+	 * @param array<string,mixed> $result The service payload.
+	 *
+	 * @return array<string,float>
+	 */
+	private function byKey(array $result): array {
+		$byKey = [];
+		foreach ($result['groups'] as $group) {
+			$byKey[$group['key']] = $group['amount'];
+		}
+
+		return $byKey;
+	}//end byKey()
 }//end class

--- a/tests/Unit/Service/SpendAnalyticsServiceTest.php
+++ b/tests/Unit/Service/SpendAnalyticsServiceTest.php
@@ -147,12 +147,24 @@ final class SpendAnalyticsServiceTest extends TestCase {
 	 *
 	 * @return SpendAnalyticsService
 	 */
-	private function makeService(InMemoryAggregationRunner $runner, bool $backfillProven = true): SpendAnalyticsService {
+	private function makeService(
+		InMemoryAggregationRunner $runner,
+		bool $backfillProven = true,
+		?string $gateOverride = null
+	): SpendAnalyticsService {
 		$container = $this->createMock(ContainerInterface::class);
 		$container->method('get')->willReturn($runner);
 
+		// `$gateOverride` exists so a STALE, NON-EMPTY version can be tested.
+		// Without it this helper only ever produces '' or the current version,
+		// so the exact-match comparison in assertGlScopeIsEnforceable() is
+		// never exercised against a wrong-but-present value — and a
+		// `!== ''` check would pass every test here while leaving a proof
+		// written by an older contract looking valid.
 		$gate = '';
-		if ($backfillProven === true) {
+		if ($gateOverride !== null) {
+			$gate = $gateOverride;
+		} elseif ($backfillProven === true) {
 			$gate = GlLineAdministrationBackfillMigrator::GATE_CONTRACT_VERSION;
 		}
 
@@ -511,6 +523,32 @@ final class SpendAnalyticsServiceTest extends TestCase {
 
 		$service->spendByCategory(administrationId: 'ADM-A');
 	}//end testGlBackedViewsRefuseWhileTheBackfillIsUnproven()
+
+	/**
+	 * A proof written by an OLDER contract version is not a proof.
+	 *
+	 * This is the reader half of the version contract. The writer half —
+	 * that a stale value is destroyed and replaced when it can be re-proven —
+	 * lives in BackfillGlLineAdministrationTest. Both halves are needed:
+	 * REQ-GLS-003 makes the gate a VERSION rather than a boolean precisely so
+	 * that adding a new GLLine writer invalidates every deployment's stored
+	 * proof, and that only holds if the READ is an exact match. A `!== ''`
+	 * check would satisfy every other test in this file while treating a
+	 * proof from a superseded contract as current — the filter would then
+	 * switch on over rows the newer writer never scoped.
+	 *
+	 * @return void
+	 */
+	public function testAProofFromASupersededContractVersionDoesNotCount(): void {
+		$runner = new InMemoryAggregationRunner();
+		$runner->seed('GLLine', $this->glLines());
+		$service = $this->makeService($runner, gateOverride: 'v0-superseded');
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('backfill is not proven complete');
+
+		$service->spendByCategory(administrationId: 'ADM-A');
+	}//end testAProofFromASupersededContractVersionDoesNotCount()
 
 	/**
 	 * The supplier view is unaffected by the GLLine gate: it reads


### PR DESCRIPTION
## Three GL views leaked totals across administrations

`GLLine` carried **no administration property**, so the **category, cost-centre and period** views aggregated *every* administration in the register. `canAccess()` narrowed the audience to "a member of some administration" but did **not** stop a member of administration A reading administration B's totals. Only `spendBySupplier()` was scoped, because `APTransaction` happens to carry `administrationId`.

Implements `openspec/changes/glline-administration-scope` in its own phase order.

## The spec's writer list was wrong — in both directions

Phase 2 named `ProgrammaLinkGuard` and `BackfillFiscalPeriods` as writers. **They are readers.** Re-grepping found the four real writers (`CogsPosterService`, `InventoryGlAdjustmentPoster`, `RuleTestDataSeeder`, `VatSuppletieDetectionService`), each of which already had the parent's `administrationId` in scope at the write site.

## The backfill refuses to half-migrate

`GlLineAdministrationBackfillMigrator` copies `BudgetSchemaSplitMigrator`'s shape: classify every row, `assertCountsMatch()`, and **abort the whole batch untouched** on any unclassifiable row. A partial backfill is worse than none.

It indexes parents by object id **and `transactionNumber`**, because `RuleTestDataSeeder` writes the business key into `transactionId` — a UUID-only index would have aborted every batch. A parent that is itself unscoped indexes **nothing**, rather than stamping `''`.

## The completeness proof is hostile to itself

The filter turns on **only** behind proven completeness, and the proof is built to fail shut:

- The repair step **re-reads every `GLLine` from the store after writing** and counts missing scopes. Only zero opens the gate — it does not trust the batch's own report.
- The gate is **cleared at the start** of the step, so a crash, an aborted batch, an OR outage, or an upgrade that never reached the step all read as **shut**.
- Its value is a **version, not a boolean**. Completeness is a claim about the *code* as well as the data, so adding a writer invalidates every deployment's stored proof by bumping one constant.
- While the gate is shut the views **raise**. That leaks nothing (unlike unscoped totals) and claims nothing false (unlike the zeros the forbidden naive filter would have produced).

## Stale warnings die with the bug

A warning that outlives its bug misleads the next reader. Removed: `SpendAnalyticsService`'s docblock, the controller's paragraph, a comment in `BackfillFiscalPeriods` claiming GLLine carries no `administrationId` *directly above a line reading that property*, and **`REQ-SPA-005`, whose scenario asserted the bug** — *"the filter SHALL be exactly `{side, subLedgerType}` with no administration term."*

## Break / restore proof — both controls and the abort guard

| break | went red with |
|---|---|
| remove scope from `apExpenseDebitFilter()` | **negative control**: `Failed asserting that 9100.0 is identical to 100.0` — ADM-B's 9000 folded into ADM-A's account 4000 |
| strip `administrationId` from GL fixtures (exactly the state the forbidden naive fix creates) | **positive control**: `category returned no rows at all` — the silent zero, caught |
| `assertCountsMatch()` → `if (false)` | all three abort tests fail |

All restored; suite re-run afterwards.

## Verification

```
Tests: 4915, Assertions: 46145, Skipped: 1     (baseline 4897 / 46092)
```
All nine JS validators pass · Psalm `No errors found`.

`phpcs`/`phpstan`/`phpmd` cannot resolve their vendored ruleset in this checkout (`vendor/conduction/` is empty) — a **tool failure, not a code verdict**. CI is authoritative.

## Not done, deliberately

**Phase 6's e2e is not applicable as specced.** `/api/analytics/spend` has **no frontend consumer** — no `src/` reference, no manifest page declares it. The spec's `@e2e` tags assumed a UI that does not exist, so they are now `@e2e exclude` with that reason rather than a Playwright test driving a page that never calls the endpoint. Re-tag when a consumer lands.

Also open: no per-writer unit test, so a regressed writer surfaces as the gate flipping shut on the next repair run — fail-closed, but after the fact. Recorded in `tasks.md`.
