### PR TITLE
chore: repoint shipped URLs from Codeberg to GitHub

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -31,16 +31,16 @@ Vrij en open source onder de EUPL-1.2-licentie.
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>Shillinq</namespace>
     <documentation>
-        <user>https://codeberg.org/Conduction/shillinq</user>
-        <admin>https://codeberg.org/Conduction/shillinq</admin>
-        <developer>https://codeberg.org/Conduction/shillinq</developer>
+        <user>https://github.com/ConductionNL/shillinq</user>
+        <admin>https://github.com/ConductionNL/shillinq</admin>
+        <developer>https://github.com/ConductionNL/shillinq</developer>
     </documentation>
     <category>organization</category>
-    <website>https://codeberg.org/Conduction/shillinq</website>
-    <bugs>https://codeberg.org/Conduction/shillinq/issues</bugs>
-    <repository>https://codeberg.org/Conduction/shillinq</repository>
+    <website>https://github.com/ConductionNL/shillinq</website>
+    <bugs>https://github.com/ConductionNL/shillinq/issues</bugs>
+    <repository>https://github.com/ConductionNL/shillinq</repository>
 
-    <screenshot>https://codeberg.org/Conduction/shillinq/raw/branch/main/img/app-store.svg</screenshot>
+    <screenshot>https://raw.githubusercontent.com/ConductionNL/shillinq/development/img/app-store.svg</screenshot>
 
     <dependencies>
         <php min-version="8.3"/>


### PR DESCRIPTION
## Why

ConductionNL moved onto Codeberg on 2026-05-29 and moved back off on 2026-07-23. The git layer completed — verified 2026-08-22, **zero codeberg remotes fleet-wide**. The shipped metadata did not.

`appinfo/info.xml` is published to the Nextcloud app store, so the stale URLs are user-visible:

| Field | Consequence |
|---|---|
| `<bugs>` | a bug reporter lands on an issue tracker nobody reads |
| `<screenshot>` | app-store listing images 404 |
| `<repository>` / `<website>` | contributors sent to a dead mirror |

## What changed

Every `codeberg.org/Conduction/…` URL in `appinfo/info.xml` repointed at this repo's real GitHub URL.

**The repo name was resolved from the API, not guessed from the directory.** The fleet was renamed on 2026-08-21, so several apps' directory names no longer match their repo (`docudesk`→`filinq`, `procest`→`dossiq`, `decidesk`→`decidiq`, …).

**Asset URLs were probed, not pattern-substituted.** Codeberg's `raw/branch/main/…` does *not* imply GitHub's `main`: this fleet keeps `img/` on `development` in several repos, so a blind `main` substitution would have recreated exactly the 404 this change exists to fix. Each rewritten asset URL was fetched until one returned 200. Nothing was left unresolved across the sweep.

## How this was produced

Entirely through the GitHub API — no local checkout was touched. The shared `apps-extra` workspace has parallel sessions live in it (7 repos with uncommitted work, one with 166 unpushed commits, one detached), and reading each file from its default branch rather than from a local tree also avoided reverting fixes that had already landed remotely. **9 of the 22 repos swept turned out to be already clean on their default branch** — a local-file sweep would have silently rolled those back.

## Keeping it fixed

ConductionNL/.github#546 adds **gate 94 `retired-git-host-metadata`** — full-tree (deliberately not diff-scoped, since this drift is already in the tree and no PR would otherwise touch `info.xml`). Once merged it reaches every app with no commit in any app, via the shared `quality.yml` workflow.
