### PR TITLE
chore(deps): refresh the shared Conduction locks

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -516,16 +516,16 @@
         },
         {
             "name": "conduction/hydra-gates",
-            "version": "v1.8.2",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ConductionNL/.github.git",
-                "reference": "3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491"
+                "reference": "9801ffdbff17d05f0934742190742d733ac912b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491",
-                "reference": "3dfcd1e56d27bd06eaa98a9a66e377e7e14fe491",
+                "url": "https://api.github.com/repos/ConductionNL/.github/zipball/9801ffdbff17d05f0934742190742d733ac912b4",
+                "reference": "9801ffdbff17d05f0934742190742d733ac912b4",
                 "shasum": ""
             },
             "require": {
@@ -540,11 +540,6 @@
                     "runner": "hydra-gates/scripts/run-hydra-gates.sh",
                     "helpers": "hydra-gates/scripts/lib",
                     "schemas": "hydra-gates/scripts/schemas"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "OCA\\OpenRegister\\Contract\\": "hydra-gates/contracts/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -569,9 +564,9 @@
             "support": {
                 "docs": "https://github.com/ConductionNL/.github/blob/main/hydra-gates/README.md",
                 "issues": "https://github.com/ConductionNL/.github/issues",
-                "source": "https://github.com/ConductionNL/.github/tree/v1.8.2"
+                "source": "https://github.com/ConductionNL/.github/tree/v1.9.0"
             },
-            "time": "2026-08-20T09:37:12+00:00"
+            "time": "2026-08-22T00:30:18+00:00"
         },
         {
             "name": "consolidation/annotated-command",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,29 @@ parameters:
     # App-specific only. The base already sets level, paths, bootstrapFiles,
     # excludePaths, scanDirectories and every fleet-wide ignore.
 
+    # OpenRegister's contract, which lib/ typehints in 174 places but does not own.
+    #
+    # This app already SHIPS the stubs, at tests/stubs/OpenRegister/Contract/ —
+    # but phpstan refuses to autoload them and says so:
+    #
+    #   Class OCA\OpenRegister\Contract\ObjectServiceInterface located in
+    #   ./tests/stubs/OpenRegister/Contract/ObjectServiceInterface.php does not
+    #   comply with psr-4 autoloading standard (rule: OCA\Shillinq\Tests\ =>
+    #   ./tests). Skipping.
+    #
+    # It resolved anyway until now, because conduction/hydra-gates declared
+    # `OCA\OpenRegister\Contract\` as a runtime psr-4 prefix. That was a bug —
+    # the prefix is longer than openregister's own, so a vendored copy in ANY app
+    # defined the contract for the whole process — and v1.9.0 removed it
+    # (ConductionNL/.github#531). The skip notice was always there; the removal is
+    # what made it matter.
+    #
+    # scanDirectories loads the files for ANALYSIS without going through psr-4,
+    # which is exactly the seam needed: the class must be visible to phpstan and
+    # must NOT go back into the runtime autoloader.
+    scanDirectories:
+        - %currentWorkingDirectory%/tests/stubs/OpenRegister/Contract
+
     # PHPDoc @return bool / @return array types are often intentionally broader than the
     # inferred type (e.g. SimpleXMLElement methods, third-party SDKs). Treating PHPDoc
     # types as certain causes spurious `=== true/false` / `=== null` "always false" errors.

--- a/widget/package.json
+++ b/widget/package.json
@@ -7,7 +7,7 @@
 	"homepage": "https://conduction.nl",
 	"repository": {
 		"type": "git",
-		"url": "https://codeberg.org/Conduction/shillinq"
+		"url": "https://github.com/ConductionNL/shillinq"
 	},
 	"main": "index.js",
 	"module": "index.js",


### PR DESCRIPTION
Weekly refresh of the two shared Conduction packages. **Lock-only** - both are
already declared with caret ranges that permit these versions, so what this app
*accepts* is unchanged; only what it currently resolves to moves.

| package | was | now |
|---|---|---|
| conduction/hydra-gates | v1.8.2 | v1.9.0 |
| @conduction/nextcloud-vue | 2.11.1 | 2.11.1 |

**Why this is automated.** Nothing here was ever pinned on purpose. The caret
always allowed the newer release; the lockfile is what froze it, and nobody
re-resolves a lock unless they happen to be touching dependencies. Measured
across the fleet on 2026-08-20: every app sat on hydra-gates v1.8.0 while
v1.8.1 was out, and fourteen sat below nc-vue 2.7.0 - twelve of them on 2.3.0.
Neither number was a decision.

**Why it is a PR and not a push.** Because a shared bump is not always safe and
this repository's suite is what knows. Taking hydra-gates v1.8.1 added
patchObject() to a published interface, which is a load-time fatal for any
concrete test double implementing it without the method - the suite dies before
a single test runs. Two apps needed stub updates first.

**If this PR is red, fix it on this branch.** While it stays open the weekly run
skips this app entirely and will not touch your commits - it never force-pushes
and never reuses a branch.

Opened by fleet-shared-dep-bump.yml in ConductionNL/.github.
