### PR TITLE
fix(e2e): clear the high-severity CodeQL alert that landed with #1143

### DIFF
--- a/tests/e2e/spend-analytics.spec.ts
+++ b/tests/e2e/spend-analytics.spec.ts
@@ -273,10 +273,16 @@ test.describe('spend-analytics-ui — the SpendAnalytics dashboard page', () => 
 		).toBeVisible({ timeout: 15_000 })
 		await leaf.locator('a.app-navigation-entry-link').first().click()
 
-		await expect(page).toHaveURL(
-			new RegExp(`${SPEND_ROUTE.replace(/\//g, '\\/')}$`),
-			{ timeout: 15_000 },
-		)
+		// A predicate, not `new RegExp(SPEND_ROUTE.replace(/\//g, '\\/'))`. That
+		// hand-rolled escaping only handled forward slashes, so every other
+		// regex metacharacter in the route (`.`, `?`, `+`, and a backslash
+		// itself) would have been interpreted rather than matched — CodeQL
+		// flagged it as js/incomplete-sanitization. Asking the URL directly
+		// whether its path ends with the route needs no escaping at all and
+		// says what the assertion actually means.
+		await expect(page).toHaveURL((url) => url.pathname.endsWith(SPEND_ROUTE), {
+			timeout: 15_000,
+		})
 		await expect(page.getByTestId('spend-analytics-panel')).toBeVisible({
 			timeout: 15_000,
 		})


### PR DESCRIPTION
CodeQL raised this on #1143, but that PR merged at 02:15Z before the fix was pushed — so the finding is now on `development`.

```
js/incomplete-sanitization — Incomplete string escaping or encoding   [high]
tests/e2e/spend-analytics.spec.ts
"This does not escape backslash characters in the input."
```

The assertion built a RegExp out of the route:

```ts
new RegExp(`${SPEND_ROUTE.replace(/\//g, '\\/')}$`)
```

That escapes forward slashes and nothing else, so a backslash — or any other regex metacharacter the route might contain (`.`, `?`, `+`) — would be *interpreted* rather than matched.

`SPEND_ROUTE` is a local constant today, so this was never exploitable. It was still wrong, and the fix is **not** "escape more characters": Playwright's `toHaveURL()` accepts a predicate, so the assertion can just ask the URL whether its path ends with the route. No regex, nothing to escape, and it reads as what it means:

```ts
await expect(page).toHaveURL((url) => url.pathname.endsWith(SPEND_ROUTE), {
	timeout: 15_000,
})
```

Only the assertion *mechanism* changes; what is asserted is identical.

## Verification

This exact change already ran green on the #1143 branch before it was superseded — run `32557628105`, all four spend-analytics tests passed, including the navigation test that contains this assertion:

```
✓ 278 … the page is reachable by clicking the Spend analysis leaf … (22.5s)
✓ 285 … all four dimensions render their groups and the endpoint's own total (15.0s)
✓ 289 … a shut completeness gate renders as unavailable, with no total and no table (13.8s)
✓ 293 … a measured empty result reads as "no rows", not as unavailable (13.1s)
```

`prettier --check` passes.