### PR TITLE
fix(notifications): onBudgetOvershoot never fired; make that explicit

### DIFF
--- a/lib/Settings/register.d/bookkeeping-rechtmatigheidsverantwoording.json
+++ b/lib/Settings/register.d/bookkeeping-rechtmatigheidsverantwoording.json
@@ -478,15 +478,12 @@
         },
         "x-openregister-notifications": {
           "onBudgetOvershoot": {
+            "_note": "This rule has never fired. It carried a field=>value map ({criterium: begroting, kind: error}) — the SCHEDULED path's grammar — on a CREATED trigger. createdFilterMatches() reads a single clause {field, operator, value}, so it looked for a 'field' key, found none, and returned false for every bevinding. It cannot be repaired as-is either: the intent is criterium=begroting AND kind=error, and the created path has no combinator, only one clause. Narrowing to criterium=begroting alone would notify the portefeuillehouder about warnings and uncertainties as well as errors, which is a different rule than REQ-RV-001 asks for. Left disabled and honest rather than half-right, pending combinators on the created path — the created-vs-scheduled convergence deferred by ConductionNL/openregister#2787. DO NOT re-enable without a filter: with none, this matches every Rechtmatigheidsbevinding.",
             "trigger": {
-              "type": "created",
-              "filter": {
-                "criterium": "begroting",
-                "kind": "error"
-              }
+              "type": "created"
             },
             "description": "REQ-RV-001: notify the portefeuillehouder of the affected programma when a begroting-fout bevinding is created.",
-            "enabled": true,
+            "enabled": false,
             "channels": [
               "nc-notification"
             ],

--- a/tests/Unit/Lifecycle/RechtmatigheidWorkflowTest.php
+++ b/tests/Unit/Lifecycle/RechtmatigheidWorkflowTest.php
@@ -164,11 +164,40 @@ class RechtmatigheidWorkflowTest extends TestCase {
 			message: 'trigger must be the canonical object form, not a legacy event string.'
 		);
 		self::assertSame(expected: 'created', actual: ($trigger['type'] ?? null));
-		self::assertTrue(condition: ($notif['enabled'] ?? false), message: 'Rule must be enabled.');
 
-		$filter = ($trigger['filter'] ?? []);
-		self::assertSame(expected: 'begroting', actual: ($filter['criterium'] ?? null));
-		self::assertSame(expected: 'error', actual: ($filter['kind'] ?? null));
+		// This assertion used to be `enabled === true` plus a filter of
+		// {criterium: begroting, kind: error}. That pinned a rule which could
+		// never fire: the created path reads ONE clause, {field, operator,
+		// value}, so a field=>value map made createdFilterMatches() return
+		// false for every bevinding. The test passed on the declaration while
+		// the feature was dead — the failure mode it existed to prevent.
+		//
+		// What is actually required is the invariant below: the rule is either
+		// live with a filter the engine can execute, or switched off with the
+		// reason written down. Both states are legitimate; "enabled with a
+		// filter that matches nothing" is not, and now fails here.
+		$filter  = ($trigger['filter'] ?? []);
+		$enabled = ($notif['enabled'] ?? false);
+
+		if ($enabled === true) {
+			self::assertArrayHasKey(
+				key: 'field',
+				array: $filter,
+				message: 'An enabled created-trigger rule needs a single {field, operator, value} clause — '
+					. 'a field=>value map is the scheduled path\'s grammar and matches nothing here.'
+			);
+			self::assertContains(
+				needle: ($filter['operator'] ?? 'equals'),
+				haystack: ['equals', 'in', 'notIn'],
+				message: 'createdFilterMatches() implements only equals|in|notIn.'
+			);
+		} else {
+			self::assertNotSame(
+				expected: '',
+				actual: (string)($notif['_note'] ?? ''),
+				message: 'A disabled rule must record why it is off and what unblocks it.'
+			);
+		}
 
 		$groups = [];
 		foreach (($notif['recipients'] ?? []) as $recipient) {


### PR DESCRIPTION
Re-cut clean from `development` — supersedes #1192, which became entangled with another session's in-progress `refactor(commitment)!` work in a shared checkout (explained there; that branch is left intact, nothing lost).

This PR is **two files**: one register fragment and one test.

## What was broken

`Rechtmatigheidsbevinding.onBudgetOvershoot` declared:

```json
"trigger": { "type": "created", "filter": { "criterium": "begroting", "kind": "error" } }
```

That is the **scheduled** path's grammar (a `field => value` map). The **created** path reads a single clause and bails when there is no `field` key:

```php
$field = (string)($filter['field'] ?? '');
if ($field === '') {
    return false;
}
```

It returned `false` for every bevinding ever created. **The portefeuillehouder has never been notified of a begroting error** — REQ-RV-001 has never been met in practice.

## Why disabled rather than rewritten

The intent is `criterium = begroting` **AND** `kind = error`. The created path has **no combinator** — one clause, operators `equals | in | notIn`.

Narrowing to `criterium = begroting` alone would notify about *warnings and uncertainties* as well as errors: a different rule than REQ-RV-001 describes. A rule that visibly does nothing is fixable; one that does the wrong thing convincingly is not.

So it is disabled with a `_note` recording what it needs, what it is blocked on (combinators for created triggers — the convergence deferred by ConductionNL/openregister#2787), and a warning not to re-enable it without a filter, since with none it matches *every* `Rechtmatigheidsbevinding`.

**Behaviour is unchanged**: it fired for nobody before and fires for nobody now. What changes is that the reason is written down instead of hiding in a shape mismatch.

## The test was part of the problem

`RechtmatigheidWorkflowTest` asserted the rule was **enabled** with that unusable filter — passing on the declaration while the feature was dead, which is the failure mode it existed to prevent. (The same anti-pattern turned up in procest this week: a test asserting an out-of-enum status.)

It now asserts the **invariant**:

- **enabled** → the filter must be a single `{field, operator, value}` clause with `operator` in `equals|in|notIn`;
- **disabled** → a `_note` must say why.

Both are legitimate states; "enabled with a filter that matches nothing" is not, and now fails here.

Verified as a real guard rather than a green light:

```
An enabled created-trigger rule needs a single {field, operator, value} clause —
a field=>value map is the scheduled path's grammar and matches nothing here.
FAILURES! Tests: 1, Assertions: 9, Failures: 1
```

and restoring the fix returns `OK (1 test, 21 assertions)`.

## Context

Found by a fleet sweep of notification trigger shapes after 24 dead **scheduled** filters (ConductionNL/openregister#2787, engine fixed in ConductionNL/openregister#2794). The sweep found the same class in three other apps: ConductionNL/integriq#1529 (merged), ConductionNL/decidiq#848, and ConductionNL/shillinq#1193 — 21 rules here declaring a string trigger the engine has no concept of, filed separately because it needs an architectural decision rather than a patch.
