### PR TITLE
fix(notifications): put every trigger into a form the engine can dispatch

### DIFF
--- a/lib/Settings/register.d/add-shillinq-detachering-payroll-administratie.json
+++ b/lib/Settings/register.d/add-shillinq-detachering-payroll-administratie.json
@@ -631,7 +631,7 @@
         },
         "x-openregister-notifications": {
           "onIb47BatchSubmitted": {
-            "trigger": "ib47-submission:submitted",
+            "trigger": "ib47.submitted",
             "recipients": [
               {
                 "kind": "expression",

--- a/lib/Settings/register.d/bookings-notification-triggers.json
+++ b/lib/Settings/register.d/bookings-notification-triggers.json
@@ -256,93 +256,6 @@
             "description": "Human-readable rate-limit summary for the admin list (REQ-BNT-006/008)."
           }
         },
-        "x-openregister-notifications": {
-          "onTriggerEventFired": {
-            "trigger": "{{triggerType}}",
-            "channels": "{{channels}}",
-            "scheduleOffsetHours": "{{reminderHoursBeforeStart}}",
-            "appliesWhen": {
-              "field": "status",
-              "in": [
-                "enabled"
-              ]
-            },
-            "scopeBy": {
-              "field": "appliesToBookingSlug",
-              "matchBooking": "slug",
-              "nullMeansGlobal": true
-            },
-            "recipients": "{{recipients}}",
-            "selectTemplate": {
-              "byType": {
-                "booking.created": "BookingConfirmationTemplate",
-                "booking.changed": "BookingConfirmationTemplate",
-                "booking.cancelled": "BookingCancellationTemplate",
-                "booking.reminder": "BookingReminderTemplate"
-              },
-              "overrideSlug": "{{templateOverrideSlug}}",
-              "matchLocale": "recipient.languagePreference"
-            },
-            "skipWhen": {
-              "any": [
-                {
-                  "recipientField": "notificationOptOut[{{triggerType}}]",
-                  "equals": true,
-                  "onlyIf": "{{respectOptOut}}"
-                },
-                {
-                  "rateLimit": {
-                    "scope": "booking",
-                    "max": "{{rateLimitPerBookingPerHour}}",
-                    "windowMinutes": 60
-                  }
-                },
-                {
-                  "rateLimit": {
-                    "scope": "organizer",
-                    "max": "{{rateLimitPerOrganizerPerDay}}",
-                    "windowMinutes": 1440
-                  }
-                },
-                {
-                  "deduplicate": {
-                    "key": [
-                      "recipient",
-                      "triggerType",
-                      "bookingId"
-                    ],
-                    "windowMinutes": "{{deduplicationWindowMinutes}}"
-                  }
-                }
-              ]
-            },
-            "audit": {
-              "schema": "NotificationDelivery",
-              "writeOn": [
-                "sent",
-                "failed",
-                "skipped",
-                "queued"
-              ],
-              "fields": {
-                "triggerName": "{{name}}",
-                "triggerType": "{{triggerType}}",
-                "bookingId": "booking.id",
-                "channel": "channel",
-                "recipient": "recipient.address",
-                "status": "status",
-                "failureReason": "failureReason",
-                "retryCount": "retryCount",
-                "sentAt": "now"
-              }
-            },
-            "fallback": {
-              "mode": "next-channel",
-              "description": "On adapter failure, advance to the next channel in the trigger's own channels list. Each attempt is recorded in NotificationDelivery (REQ-BNT-004/005)."
-            },
-            "description": "Declarative trigger dispatch consumed from OR's notification engine (ADR-022, REQ-BNT-001/003/004/005/006/009). When the configured booking lifecycle event fires (booking.created / changed / cancelled / reminder), the engine evaluates appliesWhen (status=enabled), scope (appliesToBookingSlug null = global, else match), the recipient rules (each rule's condition expression), the skipWhen gates (opt-out, rate-limit per booking/organizer, dedupe), and dispatches the rendered template through the first available channel. Every attempt is recorded immutably in NotificationDelivery for audit (REQ-BNT-005). Pure-logic gating (rate-limit window, dedupe key, recipient-rule condition parsing, opt-out lookup) is implemented in Shillinq's Notification/ helper namespace for unit-test coverage; live dispatch stays in OR's engine."
-          }
-        },
         "x-openregister-rbac": {
           "roles": {
             "notification-administrator": {
@@ -380,7 +293,8 @@
             "booking:notification:delete": "delete"
           },
           "description": "Trigger administration is restricted to the notification-administrator role (full CRUD), booking-administrator (read/update, used for the admin monitor disable-all toggle), booking-organizer (read/update — limited to triggers scoped via appliesToBookingSlug to their own bookings), and auditor (read-only). Permission slugs map onto OR CRUD permissions; enable/disable are modelled as status updates gated by the lifecycle state machine."
-        }
+        },
+        "_note": "Design sketch removed from x-openregister-notifications (shillinq#1193). 'onTriggerEventFired' was never a notification rule and could never fire: its trigger was the literal placeholder '{{triggerType}}', its channels and recipients were '{{channels}}' / '{{recipients}}', and it used five keys the ADR-031 dialect has no concept of (scheduleOffsetHours, appliesWhen, scopeBy, selectTemplate, skipWhen). It described what a user-configured BookingNotificationTrigger OBJECT should contain — this schema's own instances — rather than a rule the engine dispatches for this schema. The intended behaviour it sketched: fire the object's triggerType for enabled triggers, scoped by appliesToBookingSlug (null meaning global), selecting a template by event type with a locale match and an override slug, offset by reminderHoursBeforeStart. That belongs in the service that reads these objects, not in a schema annotation. Kept here verbatim so the design is not lost: {\"onTriggerEventFired\":{\"trigger\":\"{{triggerType}}\",\"channels\":\"{{channels}}\",\"scheduleOffsetHours\":\"{{reminderHoursBeforeStart}}\",\"appliesWhen\":{\"field\":\"status\",\"in\":[\"enabled\"]},\"scopeBy\":{\"field\":\"appliesToBookingSlug\",\"matchBooking\":\"slug\",\"nullMeansGlobal\":true},\"recipients\":\"{{recipients}}\",\"selectTemplate\":{\"byType\":{\"booking.created\":\"BookingConfirmationTemplate\",\"booking.changed\":\"BookingConfirmationTemplate\",\"booking.cancelled\":\"BookingCancellationTemplate\",\"booking.reminder\":\"BookingReminderTemplate\"},\"overrideSlug\":\"{{templateOverrideSlug}}\",\"matchLocale\":\"recipient.languagePreference\"},\"skipWhen\":{\"any\":[{\"recipientField\":\"notificationOptOut[{{triggerType}}]\",\"equals\":true,\"onlyIf\":\"{{respectOptOut}}\"},{\"rateLimit\":{\"scope\":\"booking\",\"max\":\"{{rateLimitPerBookingPerHour}}\",\"windowMinutes\":60}},{\"rateLimit\":{\"scope\":\"organizer\",\"max\":\"{{rateLimitPerOrganizerPerDay}}\",\"windowMinutes\":1440}},{\"deduplicate\":{\"key\":[\"recipient\",\"triggerType\",\"bookingId\"],\"windowMinutes\":\"{{deduplicationWindowMinutes}}\"}}]},\"audit\":{\"schema\":\"NotificationDelivery\",\"writeOn\":[\"sent\",\"failed\",\"skipped\",\"queued\"],\"fields\":{\"triggerName\":\"{{name}}\",\"triggerType\":\"{{triggerType}}\",\"bookingId\":\"booking.id\",\"channel\":\"channel\",\"recipient\":\"recipient.address\",\"status\":\"status\",\"failureReason\":\"failureReason\",\"retryCount\":\"retryCount\",\"sentAt\":\"now\"}},\"fallback\":{\"mode\":\"next-channel\",\"description\":\"On adapter failure, advance to the next channel in the trigger's own channels list. Each attempt is recorded in NotificationDelivery (REQ-BNT-004/005).\"},\"description\":\"Declarative trigger dispatch consumed from OR's notification engine (ADR-022, REQ-BNT-001/003/004/005/006/009). When the configured booking lifecycle event fires (booking.created / changed / cancelled / reminder), the engine evaluates appliesWhen (status=enabled), scope (appliesToBookingSlug null = global, else match), the recipient rules (each rule's condition expression), the skipWhen gates (opt-out, rate-limit per booking/organizer, dedupe), and dispatches the rendered template through the first available channel. Every attempt is recorded immutably in NotificationDelivery for audit (REQ-BNT-005). Pure-logic gating (rate-limit window, dedupe key, recipient-rule condition parsing, opt-out lookup) is implemented in Shillinq's Notification/ helper namespace for unit-test coverage; live dispatch stays in OR's engine.\"}}"
       },
       "NotificationDelivery": {
         "slug": "NotificationDelivery",

--- a/lib/Settings/shillinq_register.json
+++ b/lib/Settings/shillinq_register.json
@@ -372,7 +372,9 @@
         },
         "x-openregister-notifications": {
           "onNewStatement": {
-            "trigger": "onCreate",
+            "trigger": {
+              "type": "created"
+            },
             "recipients": [
               {
                 "resolver": "bank-connection-operator",
@@ -4451,7 +4453,8 @@
             "message": "KOR-omzetdrempel van €{{thresholdAmount}} is overschreden (ytdRevenue: €{{ytdRevenue}}). Opt-out vereist; er wordt een journaalpost aangemaakt ter beoordeling."
           },
           "onOptOut": {
-            "trigger": "lifecycle.optOutFromExceeded,lifecycle.optOutFromOptedIn",
+            "_note": "Was a comma-separated pair, 'lifecycle.optOutFromExceeded,lifecycle.optOutFromOptedIn'. A trigger names ONE event; a comma-list matches neither. Both paths end in the same outcome — the administration left KOR — and the recipients and message are identical either way, so they collapse to one event the app raises from both places. If the two paths ever need different wording, split them into two rules rather than reintroducing a list.",
+            "trigger": "lifecycle.optOut",
             "description": "Notify vat-administrator when the administration opts out of KOR.",
             "recipients": {
               "role": "vat-administrator",
@@ -10627,7 +10630,7 @@
         "x-openregister-notifications": {
           "lowStockAlert": {
             "description": "Dispatches a low-stock alert when InventoryStock.quantity ≤ minimumLevel and lifecycleState = active and (snoozeUntil is null or snoozeUntil < now). REQ-IRA-004.",
-            "trigger": "aggregation:lowStockTrigger",
+            "trigger": "aggregation.lowStockTrigger",
             "guard": {
               "field": "lifecycleState",
               "equals": "active"
@@ -10676,7 +10679,7 @@
           },
           "spendingLimitExceeded": {
             "description": "Dispatches an escalation notification to procurement-manager role when auto-PO total exceeds spendingLimit. REQ-IRA-006.",
-            "trigger": "auto-po-spending-limit-exceeded",
+            "trigger": "purchase-order.spendingLimitExceeded",
             "notificationType": "inventory-spending-limit-exceeded",
             "recipientRole": "procurement-manager",
             "channels": [
@@ -14675,7 +14678,24 @@
         "x-openregister-notifications": {
           "filingDeadlineReminder": {
             "description": "REQ-SBR-008: notify operators 30 days before filingDeadline when the administration's entity type is in applicableEntityTypes and the filing is not yet submitted.",
-            "trigger": "scheduled",
+            "_note": "The applicableEntityTypes half of REQ-SBR-008 is not expressed here: it is a condition on the ADMINISTRATION, and a scheduled filter evaluates fields of the object it scans. The deadline window and the not-yet-submitted half are, so the rule now fires for the right documents and over-reaches only on entity type.",
+            "trigger": {
+              "type": "scheduled",
+              "intervalSec": 86400,
+              "filter": {
+                "filingDeadline": {
+                  "operator": "withinNext",
+                  "value": "P30D"
+                },
+                "filingState": {
+                  "operator": "notIn",
+                  "values": [
+                    "submitted",
+                    "approved"
+                  ]
+                }
+              }
+            },
             "scheduledDaysBeforeField": "filingDeadline",
             "daysBefore": 30,
             "condition": "filingState IN ('draft', 'validated') AND status = 'active'",
@@ -15593,7 +15613,7 @@
         },
         "x-openregister-notifications": {
           "onOverdue": {
-            "trigger": "lifecycle:markOverdue",
+            "trigger": "lifecycle.markOverdue",
             "recipients": [
               "subsidie-coordinator"
             ],
@@ -18909,7 +18929,7 @@
         },
         "x-openregister-notifications": {
           "onCriteriumMet": {
-            "trigger": "calculation-crossing:qualifiesForUrencriterium",
+            "trigger": "calculation.qualifiesForUrencriterium",
             "condition": "qualifiesForUrencriterium === true",
             "description": "Notify zzp-administrator when 1225-urencriterium is met. REQ-ZZP-004.",
             "recipients": {
@@ -18920,7 +18940,8 @@
             "message": "Het urencriterium voor {{taxYear}} is gehaald ({{ytdQualifyingHours}} uren). Zelfstandigenaftrek is van toepassing."
           },
           "onCriteriumAtRisk": {
-            "trigger": "scheduled:monthly",
+            "_note": "Kept as an app event rather than converted to {type: scheduled}. The condition is 'PROJECTED end-of-year qualifying hours < 1225' — a projection over ytdQualifyingHours and the remaining year, not a stored field, and the scheduled filter grammar has no numeric comparison. shillinq must compute the projection and raise this event; a monthly scheduled trigger could pick the cadence but not the test.",
+            "trigger": "zzp.criteriumAtRisk",
             "condition": "ytdQualifyingHours * (12 / currentMonth()) < 1225",
             "description": "Monthly projection: warn zzp-administrator when projected EOY qualifying hours < 1225. REQ-ZZP-004.",
             "recipients": {
@@ -23020,7 +23041,7 @@
       },
       "x-openregister-notifications": {
         "onSisaSubmitted": {
-          "trigger": "onAuditEvent:sisa.submitted",
+          "trigger": "audit.sisaSubmitted",
           "recipients": [
             {
               "resolver": "administration-financial-officer",

--- a/tests/Unit/Service/BookingNotificationTriggersFragmentTest.php
+++ b/tests/Unit/Service/BookingNotificationTriggersFragmentTest.php
@@ -130,46 +130,84 @@ final class BookingNotificationTriggersFragmentTest extends TestCase {
 	}//end testTriggerLifecycleDeclaresEnabledDisabledArchived()
 
 	/**
-	 * Trigger fragment defines the x-openregister-notifications binding the
-	 * engine consumes (selectTemplate.byType maps each trigger type onto
-	 * the bookings-email-templates schemas).
+	 * The trigger fragment carries the fields a dispatching service needs, and
+	 * declares no notification rule the engine cannot execute.
 	 *
-	 * The trigger type and channel list are read off the stored trigger
-	 * object itself, expressed with the canonical `{{prop}}` interpolation
-	 * token — the legacy `@self.` form is the one gate-18 (ADR-031)
-	 * rejects inside a notification block.
+	 * This test used to assert `trigger === '{{triggerType}}'` and
+	 * `channels === '{{channels}}'` on a rule named `onTriggerEventFired`,
+	 * describing them as "the canonical {{prop}} interpolation token". That was
+	 * a misreading of the dialect, and the test pinned it in place: `{{prop}}`
+	 * interpolation applies to subject and message TEXT, never to the trigger
+	 * itself — a trigger is compared literally, so `{{triggerType}}` could only
+	 * ever match an event named `{{triggerType}}`. The rule also used five keys
+	 * the dialect has no concept of. It was a design sketch of what a
+	 * user-configured trigger OBJECT contains, sitting in the slot reserved for
+	 * rules the engine dispatches FOR this schema, and it never fired.
+	 *
+	 * The sketch is preserved verbatim in the schema `_note`. What is asserted
+	 * here is what must actually hold: the object carries the fields that design
+	 * needs, and the schema declares no unexecutable rule.
 	 *
 	 * @return void
 	 */
-	public function testTriggerNotificationBindsToEmailTemplates(): void {
-		$data = $this->fragment();
-		$bind = $data['components']['schemas']['BookingNotificationTrigger']['x-openregister-notifications']['onTriggerEventFired'];
+	public function testTriggerCarriesTheFieldsADispatcherNeedsAndNoUnexecutableRule(): void {
+		$schema = $this->fragment()['components']['schemas']['BookingNotificationTrigger'];
 
-		self::assertSame('{{triggerType}}', $bind['trigger']);
-		self::assertSame('{{channels}}', $bind['channels']);
-		self::assertSame('BookingConfirmationTemplate', $bind['selectTemplate']['byType']['booking.created']);
-		self::assertSame('BookingCancellationTemplate', $bind['selectTemplate']['byType']['booking.cancelled']);
-		self::assertSame('BookingReminderTemplate', $bind['selectTemplate']['byType']['booking.reminder']);
-	}//end testTriggerNotificationBindsToEmailTemplates()
+		foreach (['triggerType', 'channels', 'recipients', 'appliesToBookingSlug', 'reminderHoursBeforeStart', 'templateOverrideSlug'] as $property) {
+			self::assertArrayHasKey(
+				$property,
+				$schema['properties'],
+				$property . ' is read by the service that dispatches these triggers'
+			);
+		}
+
+		self::assertArrayNotHasKey(
+			'x-openregister-notifications',
+			$schema,
+			'This schema describes user-configured triggers; a rule here would be dispatched FOR the schema, '
+			. 'which is not what the sketch meant. See the schema _note.'
+		);
+
+		self::assertStringContainsString(
+			'BookingConfirmationTemplate',
+			(string) ($schema['_note'] ?? ''),
+			'the template mapping the sketch defined must survive its removal'
+		);
+	}//end testTriggerCarriesTheFieldsADispatcherNeedsAndNoUnexecutableRule()
 
 	/**
-	 * No rule in the trigger fragment may carry the retired `@self.`
-	 * interpolation token (ADR-031 / gate-18). Written as a whole-block
-	 * scan so a future rule cannot reintroduce the legacy dialect in a
-	 * key this test does not name individually.
+	 * No NOTIFICATION block in this fragment may carry the retired `@self.`
+	 * interpolation token (ADR-031 / gate-18).
+	 *
+	 * Scoped to notification blocks on purpose. `@self.` is still the correct
+	 * token in `x-openregister-calculations` — this fragment uses it in
+	 * `count(@self.channels)` and three siblings — so a fragment-wide scan
+	 * reports legitimate usage as a violation. The previous version was scoped
+	 * correctly but asserted the block was non-empty first, which turned the
+	 * removal of a rule into a failure rather than a pass.
+	 *
+	 * Both traps are avoided by anchoring on the schemas (always present) and
+	 * scanning whatever notification blocks exist, however many that is.
 	 *
 	 * @return void
 	 */
 	public function testNoNotificationRuleUsesTheLegacySelfToken(): void {
-		$data = $this->fragment();
-		$notifications = ($data['components']['schemas']['BookingNotificationTrigger']['x-openregister-notifications'] ?? []);
+		$schemas = ($this->fragment()['components']['schemas'] ?? []);
 
-		self::assertNotEmpty($notifications);
-		self::assertStringNotContainsString(
-			'@self.',
-			(string)json_encode($notifications),
-			'x-openregister-notifications must use {{prop}}, not the legacy @self. token.'
-		);
+		self::assertNotEmpty($schemas, 'the fragment must declare schemas — an empty scan is not a pass');
+
+		foreach ($schemas as $name => $schema) {
+			$notifications = ($schema['x-openregister-notifications'] ?? null);
+			if (is_array($notifications) === false) {
+				continue;
+			}
+
+			self::assertStringNotContainsString(
+				'@self.',
+				(string) json_encode($notifications),
+				$name . ': x-openregister-notifications must use {{prop}}, not the legacy @self. token.'
+			);
+		}
 	}//end testNoNotificationRuleUsesTheLegacySelfToken()
 
 	/**


### PR DESCRIPTION
Closes ConductionNL/shillinq#1193 (the register half). Depends on ConductionNL/openregister#2802, which teaches the engine app-defined trigger events.

All 21 string triggers in this register were unexecutable. With #2802, **10 become valid exactly as written**. These are the other 11.

## Two were never app events — they were reserved types spelled as strings

| rule | was | now |
|---|---|---|
| `BankStatement.onNewStatement` | `"onCreate"` | `{"type": "created"}` |
| `SBRDocumentType.filingDeadlineReminder` | `"scheduled"` | a real scheduled trigger |

The second is worth reading. Its description already said what it wanted — *"30 days before filingDeadline … not yet submitted"* — and the grammar can now express it:

```json
{ "type": "scheduled", "intervalSec": 86400,
  "filter": { "filingDeadline": {"operator": "withinNext", "value": "P30D"},
              "filingState":    {"operator": "notIn", "values": ["submitted", "approved"]} } }
```

A `_note` records the half it **cannot** express: `applicableEntityTypes` is a condition on the *administration*, and a scheduled filter only sees fields of the object it scans. The rule now fires for the right documents and over-reaches only on entity type — stated rather than hidden.

## Six used a colon where the convention is a dot

`aggregation.lowStockTrigger` · `purchase-order.spendingLimitExceeded` · `lifecycle.markOverdue` · `calculation.qualifiesForUrencriterium` · `audit.sisaSubmitted` · `ib47.submitted`

One spelling, so the register is learnable.

## Three needed a judgement — each recorded, none guessed

- **`KorRegime.onOptOut`** was a comma-separated *pair*, `lifecycle.optOutFromExceeded,lifecycle.optOutFromOptedIn`. A trigger names one event; a list matches neither. Both paths mean "the administration left KOR", with identical recipients and message, so they collapse to `lifecycle.optOut`. If the wording ever diverges, split into two rules rather than reintroducing a list.
- **`ZzpDeduction.onCriteriumAtRisk`** stays an app event. Its condition is *projected* end-of-year qualifying hours < 1225 — a projection over `ytdQualifyingHours` and the remaining year, not a stored field, and the scheduled grammar has no numeric comparison. A monthly schedule could have picked the cadence but not the test, so converting it would have looked right and been wrong.
- **`BookingNotificationTrigger.onTriggerEventFired`** was not a rule at all. Its trigger was the literal `"{{triggerType}}"`, its `channels` and `recipients` were `{{…}}` placeholders, and it used five keys the ADR-031 dialect has no concept of (`scheduleOffsetHours`, `appliesWhen`, `scopeBy`, `selectTemplate`, `skipWhen`). It described what a user-configured `BookingNotificationTrigger` **object** contains — this schema's own instances — not a rule the engine dispatches for the schema. Removed from the annotation and preserved **verbatim** in the schema `_note`, because the design is real and belongs in the service that reads those objects.

## Verification

Validating every notification rule in the register against the engine:

| | before | after |
|---|--:|--:|
| rules with trigger/filter problems | **11** | **0** |
| total rules | 83 | 82 |

The count drops by exactly one — the pseudo-rule — and nothing else.

## What this does not do

These declarations are now **legal and would match**. They do not yet **fire**: no code in shillinq calls the dispatcher for any of these events. Raising them at the right moments is app work, and it is the remaining half of #1193 — worth its own change now that there is something valid to raise them against.
