### PR TITLE
fix(tenderned): defer the award promotion off the OpenRegister write path (#1198)

### DIFF
--- a/lib/BackgroundJob/TenderNedAwardPromotionJob.php
+++ b/lib/BackgroundJob/TenderNedAwardPromotionJob.php
@@ -145,24 +145,27 @@ class TenderNedAwardPromotionJob extends ActorForwardedJob {
 	 * @return void
 	 */
 	private function runEntry(TenderNedAwardDetectedListener $listener, array $entry): void {
-		$payload = ($entry['payload'] ?? null);
-		if (is_array($payload) === false) {
+		// The uuid is what the listener re-resolves the dossier by. Without
+		// it the deferred run has no identity to re-read and could only
+		// promote from the stale snapshot, which the contract forbids.
+		$uuid = (string)($entry['uuid'] ?? '');
+		if ($uuid === '') {
 			$this->logger->warning(
-				'TenderNedAwardPromotionJob: buffered entry carries no payload — skipped',
+				'TenderNedAwardPromotionJob: buffered entry carries no uuid — skipped',
 				['keys' => array_keys($entry)]
 			);
 			return;
 		}
 
 		try {
-			$listener->runDeferredPromotion(payload: $payload);
+			$listener->runDeferredPromotion(entry: $entry);
 		} catch (Throwable $e) {
 			// Same blast radius the inline handler had: logged and dropped,
 			// never rethrown into cron. The next polling tick re-attempts.
 			$this->logger->warning(
 				'TenderNedAwardPromotionJob: promotion failed — fail-soft',
 				[
-					'tenderId'  => (string)($payload['tenderId'] ?? ''),
+					'uuid'      => $uuid,
 					'exception' => $e->getMessage(),
 				]
 			);

--- a/lib/BackgroundJob/TenderNedAwardPromotionJob.php
+++ b/lib/BackgroundJob/TenderNedAwardPromotionJob.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * TenderNed Award Promotion Job.
+ *
+ * Runs the award -> Commitment promotion that
+ * `TenderNedAwardDetectedListener` used to do synchronously, inside the
+ * OpenRegister write that raised the event.
+ *
+ * ADR-078: work hung off a post-`*ed` event is async by default. The
+ * promotion writes two objects (a new Commitment and a status bump on the
+ * TenderNedProcurement dossier) and emits a cross-app CloudEvent, so
+ * leaving it on the caller's write path made every openconnector polling
+ * write pay for it — and made a slow promotion look like a slow dossier
+ * save. See shillinq#1198.
+ *
+ * `ActorForwardedJob` is what makes the move safe rather than merely
+ * later: it restores the acting user and organisation before calling
+ * `runDeferred()`, so the promotion still writes as the user whose
+ * import triggered it. A plain QueuedJob would run with no session, and
+ * OpenRegister would attribute the Commitment to nobody.
+ *
+ * The job deliberately does NOT re-implement the promotion. It resolves
+ * the listener and calls back into it, so the eligibility rules, the
+ * idempotency check and the fail-soft logging stay in one place — the
+ * inline and deferred paths cannot drift apart.
+ *
+ * @category BackgroundJob
+ * @package  OCA\Shillinq\BackgroundJob
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/bookkeeping-tenderned-integratie/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\BackgroundJob;
+
+use OCA\OpenRegister\BackgroundJob\ActorForwardedJob;
+use OCA\OpenRegister\Service\Deferral\DeferredListenerContext;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\Shillinq\Listener\TenderNedAwardDetectedListener;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Deferred runner for the TenderNed award -> Commitment promotion.
+ *
+ * @spec openspec/specs/bookkeeping-tenderned-integratie/spec.md
+ */
+class TenderNedAwardPromotionJob extends ActorForwardedJob {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ITimeFactory        $time         Time factory for QueuedJob.
+	 * @param IUserSession        $userSession  Session used to restore the actor.
+	 * @param IUserManager        $userManager  User lookup for actor restore.
+	 * @param OrganisationService $organisation Organisation context restore.
+	 * @param LoggerInterface     $logger       Logger.
+	 * @param ContainerInterface  $container    Container, to resolve the listener.
+	 */
+	public function __construct(
+		ITimeFactory $time,
+		IUserSession $userSession,
+		IUserManager $userManager,
+		OrganisationService $organisation,
+		LoggerInterface $logger,
+		private readonly ContainerInterface $container,
+	) {
+		parent::__construct(
+			time: $time,
+			userSession: $userSession,
+			userManager: $userManager,
+			organisation: $organisation,
+			logger: $logger
+		);
+
+	}//end __construct()
+
+	/**
+	 * Run every buffered award entry as the restored actor.
+	 *
+	 * @param DeferredListenerContext $context Actor + buffered entries.
+	 *
+	 * @return void
+	 */
+	protected function runDeferred(DeferredListenerContext $context): void {
+		$listener = $this->resolveListener();
+		if ($listener === null) {
+			return;
+		}
+
+		// The getEntries() return is declared `array<int, array<string, mixed>>`
+		// upstream, so an is_array() guard per entry would be dead code that
+		// phpstan reports as an always-false comparison.
+		foreach ($context->getEntries() as $entry) {
+			$this->runEntry(listener: $listener, entry: $entry);
+		}
+
+	}//end runDeferred()
+
+	/**
+	 * Resolve the listener that owns the promotion logic.
+	 *
+	 * @return TenderNedAwardDetectedListener|null Null when unresolvable.
+	 */
+	private function resolveListener(): ?TenderNedAwardDetectedListener {
+		try {
+			$listener = $this->container->get(TenderNedAwardDetectedListener::class);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'TenderNedAwardPromotionJob: listener could not be resolved — dropping batch',
+				['exception' => $e->getMessage()]
+			);
+			return null;
+		}
+
+		if (($listener instanceof TenderNedAwardDetectedListener) === false) {
+			return null;
+		}
+
+		return $listener;
+
+	}//end resolveListener()
+
+	/**
+	 * Run one buffered entry, fail-soft.
+	 *
+	 * @param TenderNedAwardDetectedListener $listener Promotion owner.
+	 * @param array<string, mixed>           $entry    Buffered payload.
+	 *
+	 * @return void
+	 */
+	private function runEntry(TenderNedAwardDetectedListener $listener, array $entry): void {
+		$payload = ($entry['payload'] ?? null);
+		if (is_array($payload) === false) {
+			$this->logger->warning(
+				'TenderNedAwardPromotionJob: buffered entry carries no payload — skipped',
+				['keys' => array_keys($entry)]
+			);
+			return;
+		}
+
+		try {
+			$listener->runDeferredPromotion(payload: $payload);
+		} catch (Throwable $e) {
+			// Same blast radius the inline handler had: logged and dropped,
+			// never rethrown into cron. The next polling tick re-attempts.
+			$this->logger->warning(
+				'TenderNedAwardPromotionJob: promotion failed — fail-soft',
+				[
+					'tenderId'  => (string)($payload['tenderId'] ?? ''),
+					'exception' => $e->getMessage(),
+				]
+			);
+		}//end try
+
+	}//end runEntry()
+}//end class

--- a/lib/BackgroundJob/TenderNedAwardPromotionJob.php
+++ b/lib/BackgroundJob/TenderNedAwardPromotionJob.php
@@ -96,6 +96,8 @@ class TenderNedAwardPromotionJob extends ActorForwardedJob {
 	 * @param DeferredListenerContext $context Actor + buffered entries.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/bookkeeping-tenderned-integratie/spec.md
 	 */
 	protected function runDeferred(DeferredListenerContext $context): void {
 		$listener = $this->resolveListener();

--- a/lib/Listener/TenderNedAwardDetectedListener.php
+++ b/lib/Listener/TenderNedAwardDetectedListener.php
@@ -63,7 +63,9 @@ namespace OCA\Shillinq\Listener;
 
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
 use OCA\OpenRegister\Event\ObjectTransitionedEvent;
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\BackgroundJob\TenderNedAwardPromotionJob;
 use OCA\Shillinq\Service\BudgetImpactEmitter;
 use OCA\Shillinq\Service\ListenerSchemaResolver;
 use OCA\Shillinq\Service\MilestoneTemplateService;
@@ -85,6 +87,18 @@ use Throwable;
  * @spec openspec/changes/bookkeeping-tenderned-integratie/tasks.md#task-5
  */
 class TenderNedAwardDetectedListener implements IEventListener {
+
+	/**
+	 * Dedupe prefix for buffered promotions.
+	 *
+	 * Combined with the tenderId this collapses the two surfaces
+	 * (`ObjectCreatedEvent` and `ObjectTransitionedEvent`) firing for the
+	 * same dossier in one request into a single queued promotion.
+	 *
+	 * @var string
+	 */
+	public const HANDLER_KEY = 'tenderned-award-detected';
+
 	/**
 	 * Construct the listener with DI dependencies.
 	 *
@@ -126,12 +140,18 @@ class TenderNedAwardDetectedListener implements IEventListener {
 	 * is diff-scoped, so the rename is what pulled a long-standing registration
 	 * into scope rather than anything new.
 	 *
-	 * Deliberately NOT annotated with `@listener-placement inline`. That escape
-	 * hatch takes one of four closed ADR-078 categories (realtime, sapi-memory,
-	 * cheap-bounded, correctness) and none of them is true here — claiming one
-	 * would buy a green gate with a false declaration, which is worse than the
-	 * red. The fix is real deferral through OpenRegister's
-	 * ListenerDeferralService; see #1198.
+	 * Carries no inline-placement escape hatch. That declaration takes one of
+	 * four closed ADR-078 categories (realtime, sapi-memory, cheap-bounded,
+	 * correctness) and none of them was true here — claiming one would have
+	 * bought a green gate with a false declaration, which is worse than the red.
+	 * The fix was real deferral through OpenRegister's ListenerDeferralService
+	 * (#1198), and that is what this handler now does.
+	 *
+	 * The prose above deliberately does not spell the annotation out. Gate-61
+	 * finds its tag by regex and reads the next token as the category, so a
+	 * sentence MENTIONING the tag was parsed as a malformed declaration and
+	 * reported as "`.` is not one of the four closed categories" — a note
+	 * explaining why there was no annotation became an invalid one.
 	 */
 	public function handle(Event $event): void {
 		try {
@@ -144,7 +164,7 @@ class TenderNedAwardDetectedListener implements IEventListener {
 				return;
 			}
 
-			$this->promote(payload: $payload);
+			$this->dispatchPromotion(payload: $payload);
 		} catch (Throwable $e) {
 			// Fail-soft: never block the OR write path. The dossier itself
 			// is persisted; the promotion can be retried on the next event.
@@ -235,7 +255,88 @@ class TenderNedAwardDetectedListener implements IEventListener {
 	}//end isAwardEligible()
 
 	/**
+	 * Route the promotion off the caller's write path (ADR-078, #1198).
+	 *
+	 * Falls back to running inline when deferral is unavailable or the admin
+	 * has switched OpenRegister to inline mode. That fallback is deliberate:
+	 * a promotion that silently never happens because the deferral service
+	 * could not be resolved would be indistinguishable from a dossier that
+	 * was not eligible, and this listener is the ONLY thing that turns an
+	 * award into a Commitment.
+	 *
+	 * @param array<string, mixed> $payload Eligible award payload.
+	 *
+	 * @return void
+	 */
+	private function dispatchPromotion(array $payload): void {
+		$deferral = $this->resolveDeferral();
+		if ($deferral === null || $deferral->isDeferralEnabled() === false) {
+			$this->promote(payload: $payload);
+			return;
+		}
+
+		// The payload crosses a job-argument boundary, so it must survive a
+		// JSON round-trip. It is an OR object body (scalars, arrays, nulls),
+		// which does — but a future field carrying an object or a resource
+		// would be dropped here rather than at the call site.
+		$deferral->defer(
+			jobClass: TenderNedAwardPromotionJob::class,
+			entry: ['payload' => $payload],
+			dedupeKey: (self::HANDLER_KEY . '|' . (string)($payload['tenderId'] ?? ''))
+		);
+
+	}//end dispatchPromotion()
+
+	/**
+	 * Run the promotion from the background job.
+	 *
+	 * Public only so `TenderNedAwardPromotionJob` can call back in; the
+	 * eligibility rules and the idempotency check stay owned by this class so
+	 * the inline and deferred paths cannot drift.
+	 *
+	 * @param array<string, mixed> $payload Award payload buffered by `dispatchPromotion()`.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/changes/bookkeeping-tenderned-integratie/tasks.md#task-5
+	 */
+	public function runDeferredPromotion(array $payload): void {
+		$this->promote(payload: $payload);
+
+	}//end runDeferredPromotion()
+
+	/**
+	 * Resolve OpenRegister's deferral service from the container (lazy).
+	 *
+	 * Lazy for the same reason `resolveObjectService()` is: this listener is
+	 * registered even on an instance where the service cannot be built, and a
+	 * typed constructor dependency would turn that into a resolution failure
+	 * at dispatch time instead of a logged skip.
+	 *
+	 * @return ListenerDeferralService|null Null when unavailable.
+	 */
+	private function resolveDeferral(): ?ListenerDeferralService {
+		try {
+			$deferral = $this->container->get(ListenerDeferralService::class);
+		} catch (Throwable $e) {
+			return null;
+		}
+
+		if (($deferral instanceof ListenerDeferralService) === false) {
+			return null;
+		}
+
+		return $deferral;
+
+	}//end resolveDeferral()
+
+	/**
 	 * Promote the aanbesteding to a Commitment (REQ-002 + REQ-003 + REQ-007).
+	 *
+	 * Reached from two paths now: `runDeferredPromotion()` on the deferred
+	 * path, and `dispatchPromotion()` directly when deferral is off. The
+	 * idempotency check below is what makes both safe under the deferral
+	 * service's at-least-once delivery.
 	 *
 	 * @param array<string, mixed> $payload Aanbesteding payload.
 	 *

--- a/lib/Listener/TenderNedAwardDetectedListener.php
+++ b/lib/Listener/TenderNedAwardDetectedListener.php
@@ -164,7 +164,10 @@ class TenderNedAwardDetectedListener implements IEventListener {
 				return;
 			}
 
-			$this->dispatchPromotion(payload: $payload);
+			$this->dispatchPromotion(
+				payload: $payload,
+				identity: $this->extractIdentity(event: $event)
+			);
 		} catch (Throwable $e) {
 			// Fail-soft: never block the OR write path. The dossier itself
 			// is persisted; the promotion can be retried on the next event.
@@ -264,28 +267,78 @@ class TenderNedAwardDetectedListener implements IEventListener {
 	 * was not eligible, and this listener is the ONLY thing that turns an
 	 * award into a Commitment.
 	 *
-	 * @param array<string, mixed> $payload Eligible award payload.
+	 * @param array<string, mixed>                  $payload  Eligible award payload.
+	 * @param array{uuid: string, schema: string}   $identity Dossier identity for the re-read.
 	 *
 	 * @return void
 	 */
-	private function dispatchPromotion(array $payload): void {
+	private function dispatchPromotion(array $payload, array $identity): void {
 		$deferral = $this->resolveDeferral();
 		if ($deferral === null || $deferral->isDeferralEnabled() === false) {
+			// The inline path IS the write path, so the payload it holds is
+			// the current state by construction — no re-read needed here.
 			$this->promote(payload: $payload);
 			return;
 		}
 
-		// The payload crosses a job-argument boundary, so it must survive a
+		if ($identity['uuid'] === '') {
+			// Without a uuid the deferred run cannot re-resolve the dossier,
+			// and promoting from the snapshot is exactly what the contract
+			// forbids. Running inline is the honest fallback: slower, but it
+			// cannot act on stale identity.
+			$this->promote(payload: $payload);
+			return;
+		}
+
+		// The entry crosses a job-argument boundary, so it must survive a
 		// JSON round-trip. It is an OR object body (scalars, arrays, nulls),
 		// which does — but a future field carrying an object or a resource
 		// would be dropped here rather than at the call site.
+		//
+		// The payload rides along for logging only. The deferred run promotes
+		// from a FRESH read, never from this copy.
 		$deferral->defer(
 			jobClass: TenderNedAwardPromotionJob::class,
-			entry: ['payload' => $payload],
+			entry: [
+				'uuid'    => $identity['uuid'],
+				'schema'  => $identity['schema'],
+				'payload' => $payload,
+			],
 			dedupeKey: (self::HANDLER_KEY . '|' . (string)($payload['tenderId'] ?? ''))
 		);
 
 	}//end dispatchPromotion()
+
+	/**
+	 * Capture the dossier's identity for the deferred re-read.
+	 *
+	 * The schema slug is captured rather than assumed because this listener
+	 * deliberately still matches the legacy Dutch slug: a dossier stored as
+	 * `TenderNedAanbesteding` must be re-read on THAT schema, and hardcoding
+	 * the new slug would turn every pre-repair dossier into a silent no-op.
+	 *
+	 * @param Event $event The dispatched event.
+	 *
+	 * @return array{uuid: string, schema: string} Empty uuid when unavailable.
+	 */
+	private function extractIdentity(Event $event): array {
+		if ($event instanceof ObjectCreatedEvent === false
+			&& $event instanceof ObjectTransitionedEvent === false
+		) {
+			return ['uuid' => '', 'schema' => ''];
+		}
+
+		$entity = $event->getObject();
+		if ($entity === null) {
+			return ['uuid' => '', 'schema' => ''];
+		}
+
+		return [
+			'uuid'   => (string)$entity->getUuid(),
+			'schema' => $this->schemaResolver->schemaSlug(entity: $entity),
+		];
+
+	}//end extractIdentity()
 
 	/**
 	 * Run the promotion from the background job.
@@ -294,16 +347,93 @@ class TenderNedAwardDetectedListener implements IEventListener {
 	 * eligibility rules and the idempotency check stay owned by this class so
 	 * the inline and deferred paths cannot drift.
 	 *
-	 * @param array<string, mixed> $payload Award payload buffered by `dispatchPromotion()`.
+	 * Deferred delivery is at-least-once, so this MUST NOT promote from the
+	 * payload captured at dispatch time (ADR-078 / object-event-work-placement:
+	 * "a deferred handler MUST re-resolve the object it acts on and MUST no-op
+	 * when the object is gone or soft-deleted"). Between the event and this
+	 * run the dossier can have been deleted, or the award reverted — promoting
+	 * a stale snapshot would create a Commitment for an award that no longer
+	 * exists, and nothing downstream would flag it.
+	 *
+	 * @param array<string, mixed> $entry Buffered entry: uuid, schema, payload.
 	 *
 	 * @return void
 	 *
-	 * @spec openspec/changes/bookkeeping-tenderned-integratie/tasks.md#task-5
+	 * @spec openspec/specs/bookkeeping-tenderned-integratie/spec.md
 	 */
-	public function runDeferredPromotion(array $payload): void {
-		$this->promote(payload: $payload);
+	public function runDeferredPromotion(array $entry): void {
+		$uuid    = (string)($entry['uuid'] ?? '');
+		$schema  = (string)($entry['schema'] ?? '');
+		$current = $this->reresolveDossier(uuid: $uuid, schema: $schema);
+		if ($current === null) {
+			// Gone, soft-deleted, or unreadable. Nothing to promote.
+			return;
+		}
+
+		// Re-check against CURRENT state, not the state that queued this. An
+		// award reverted between the event and this run must not promote.
+		if ($this->isAwardEligible(payload: $current) === false) {
+			$this->logger->info(
+				'TenderNedAwardDetectedListener: dossier no longer eligible at run time — skipped',
+				['uuid' => $uuid]
+			);
+			return;
+		}
+
+		$this->promote(payload: $current);
 
 	}//end runDeferredPromotion()
+
+	/**
+	 * Re-read the dossier the deferred promotion acts on.
+	 *
+	 * @param string $uuid   Dossier uuid captured at dispatch time.
+	 * @param string $schema Schema slug captured at dispatch time.
+	 *
+	 * @return array<string, mixed>|null Current body, or null when gone.
+	 */
+	private function reresolveDossier(string $uuid, string $schema): ?array {
+		if ($uuid === '' || $schema === '') {
+			return null;
+		}
+
+		$objectService = $this->resolveObjectService();
+		if ($objectService === null) {
+			return null;
+		}
+
+		try {
+			$object = $objectService->find(
+				id: $uuid,
+				register: $this->getRegisterSlug(),
+				schema: $schema
+			);
+		} catch (Throwable $e) {
+			$this->logger->warning(
+				'TenderNedAwardDetectedListener: could not re-read the dossier — promotion skipped',
+				['uuid' => $uuid, 'exception' => $e->getMessage()]
+			);
+			return null;
+		}
+
+		if ($object === null) {
+			return null;
+		}
+
+		// Soft-deleted counts as gone. `deleted` is a JSON column that is an
+		// empty array on a live object, so emptiness — not null — is the test.
+		if (empty($object->getDeleted()) === false) {
+			return null;
+		}
+
+		$body = $object->getObject();
+		if (is_array($body) === false) {
+			return null;
+		}
+
+		return $body;
+
+	}//end reresolveDossier()
 
 	/**
 	 * Resolve OpenRegister's deferral service from the container (lazy).

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -35,6 +35,17 @@ parameters:
     # must NOT go back into the runtime autoloader.
     scanDirectories:
         - %currentWorkingDirectory%/tests/stubs/OpenRegister/Contract
+        # ADR-078 listener-deferral contract (#1198). TenderNedAwardPromotionJob
+        # EXTENDS OCA\OpenRegister\BackgroundJob\ActorForwardedJob, and phpstan
+        # refuses to ignore an "extends unknown class" error — it says
+        # "cannot be ignored, use excludePaths instead". excludePaths is what the
+        # cross-app *interface* implementors below had to do, but it drops the
+        # file from analysis entirely; scanDirectories makes the base class
+        # visible instead, so the new job stays analysed.
+        - %currentWorkingDirectory%/tests/stubs/OpenRegister/BackgroundJob
+        # Covers Service/Deferral too — scanDirectories recurses, so listing the
+        # subdirectory separately would be redundant, not additive.
+        - %currentWorkingDirectory%/tests/stubs/OpenRegister/Service
 
     # PHPDoc @return bool / @return array types are often intentionally broader than the
     # inferred type (e.g. SimpleXMLElement methods, third-party SDKs). Treating PHPDoc

--- a/psalm.xml
+++ b/psalm.xml
@@ -89,6 +89,13 @@
                 <referencedClass name="OCA\OpenRegister\Lifecycle\LifecycleGuardInterface"/>
                 <referencedClass name="OCA\OpenRegister\Lifecycle\LifecycleActionInterface"/>
                 <referencedClass name="OCA\OpenRegister\Lifecycle\GuardResult"/>
+                <!-- OpenRegister listener-deferral contract (ADR-078). Used by
+                     TenderNedAwardPromotionJob + TenderNedAwardDetectedListener to
+                     move post-`*ed` work off the caller's write path (#1198). -->
+                <referencedClass name="OCA\OpenRegister\BackgroundJob\ActorForwardedJob"/>
+                <referencedClass name="OCA\OpenRegister\Service\Deferral\ListenerDeferralService"/>
+                <referencedClass name="OCA\OpenRegister\Service\Deferral\DeferredListenerContext"/>
+                <referencedClass name="OCA\OpenRegister\Service\OrganisationService"/>
                 <!-- OpenRegister AppHost (GenericController/Settings wrappers) -->
                 <referencedClass name="OCA\OpenRegister\AppHost\IMetricsProvider"/>
                 <referencedClass name="OCA\OpenRegister\AppHost\Controller\GenericDashboardController"/>

--- a/tests/Unit/BackgroundJob/TenderNedAwardPromotionJobTest.php
+++ b/tests/Unit/BackgroundJob/TenderNedAwardPromotionJobTest.php
@@ -100,6 +100,28 @@ class TenderNedAwardPromotionJobTest extends TestCase {
 	}//end job()
 
 	/**
+	 * Build a buffered entry in the shape `dispatchPromotion()` queues.
+	 *
+	 * @param string $uuid     Dossier uuid — what the listener re-reads by.
+	 * @param string $tenderId Tender id carried in the payload.
+	 * @param string $schema   Schema slug captured at dispatch time.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function entry(
+		string $uuid,
+		string $tenderId,
+		string $schema = 'TenderNedProcurement',
+	): array {
+		return [
+			'uuid'    => $uuid,
+			'schema'  => $schema,
+			'payload' => ['tenderId' => $tenderId],
+		];
+
+	}//end entry()
+
+	/**
 	 * Wrap entries in a context.
 	 *
 	 * @param array<int, array<string, mixed>> $entries Buffered entries.
@@ -126,56 +148,87 @@ class TenderNedAwardPromotionJobTest extends TestCase {
 		$seen = [];
 		$listener->method('runDeferredPromotion')
 			->willReturnCallback(
-				function (array $payload) use (&$seen): void {
-					$seen[] = $payload['tenderId'];
+				function (array $entry) use (&$seen): void {
+					$seen[] = $entry['uuid'];
 				}
 			);
 
 		$this->job($listener)->runForTest(
 			$this->context(
 				[
-					['payload' => ['tenderId' => 'TN-1']],
-					['payload' => ['tenderId' => 'TN-2']],
+					$this->entry('u-1', 'TN-1'),
+					$this->entry('u-2', 'TN-2'),
 				]
 			)
 		);
 
-		$this->assertSame(['TN-1', 'TN-2'], $seen);
+		$this->assertSame(['u-1', 'u-2'], $seen);
 
 	}//end testEachBufferedEntryIsPromoted()
 
 	/**
-	 * An entry with no payload is skipped, and does NOT stop the batch.
+	 * The whole entry reaches the listener, not just the payload.
+	 *
+	 * The listener re-resolves the dossier by uuid and schema before it
+	 * promotes anything (ADR-078: at-least-once delivery). A job that forwarded
+	 * only the payload would leave it with nothing to re-read, and the
+	 * promotion would silently fall back to acting on the stale snapshot.
+	 *
+	 * @return void
+	 */
+	public function testTheEntryIdentityReachesTheListener(): void {
+		$listener = $this->createMock(TenderNedAwardDetectedListener::class);
+
+		$received = null;
+		$listener->method('runDeferredPromotion')
+			->willReturnCallback(
+				function (array $entry) use (&$received): void {
+					$received = $entry;
+				}
+			);
+
+		$this->job($listener)->runForTest(
+			$this->context([$this->entry('u-9', 'TN-9', 'TenderNedAanbesteding')])
+		);
+
+		$this->assertSame('u-9', $received['uuid']);
+		$this->assertSame('TenderNedAanbesteding', $received['schema']);
+		$this->assertSame('TN-9', $received['payload']['tenderId']);
+
+	}//end testTheEntryIdentityReachesTheListener()
+
+	/**
+	 * An entry with no uuid is skipped, and does NOT stop the batch.
 	 *
 	 * A malformed entry aborting the loop would silently drop every award
 	 * queued behind it in the same flush.
 	 *
 	 * @return void
 	 */
-	public function testEntryWithoutPayloadIsSkippedWithoutStoppingTheBatch(): void {
+	public function testEntryWithoutUuidIsSkippedWithoutStoppingTheBatch(): void {
 		$listener = $this->createMock(TenderNedAwardDetectedListener::class);
 
 		$seen = [];
 		$listener->method('runDeferredPromotion')
 			->willReturnCallback(
-				function (array $payload) use (&$seen): void {
-					$seen[] = $payload['tenderId'];
+				function (array $entry) use (&$seen): void {
+					$seen[] = $entry['uuid'];
 				}
 			);
 
 		$this->job($listener)->runForTest(
 			$this->context(
 				[
-					['payload' => 'not-an-array'],
+					['payload' => ['tenderId' => 'TN-orphan']],
 					[],
-					['payload' => ['tenderId' => 'TN-3']],
+					$this->entry('u-3', 'TN-3'),
 				]
 			)
 		);
 
-		$this->assertSame(['TN-3'], $seen);
+		$this->assertSame(['u-3'], $seen);
 
-	}//end testEntryWithoutPayloadIsSkippedWithoutStoppingTheBatch()
+	}//end testEntryWithoutUuidIsSkippedWithoutStoppingTheBatch()
 
 	/**
 	 * A throwing promotion is fail-soft and the batch continues.
@@ -192,25 +245,25 @@ class TenderNedAwardPromotionJobTest extends TestCase {
 		$seen = [];
 		$listener->method('runDeferredPromotion')
 			->willReturnCallback(
-				function (array $payload) use (&$seen): void {
-					if ($payload['tenderId'] === 'TN-BOOM') {
+				function (array $entry) use (&$seen): void {
+					if ($entry['uuid'] === 'u-boom') {
 						throw new RuntimeException('promotion exploded');
 					}
 
-					$seen[] = $payload['tenderId'];
+					$seen[] = $entry['uuid'];
 				}
 			);
 
 		$this->job($listener)->runForTest(
 			$this->context(
 				[
-					['payload' => ['tenderId' => 'TN-BOOM']],
-					['payload' => ['tenderId' => 'TN-4']],
+					$this->entry('u-boom', 'TN-BOOM'),
+					$this->entry('u-4', 'TN-4'),
 				]
 			)
 		);
 
-		$this->assertSame(['TN-4'], $seen);
+		$this->assertSame(['u-4'], $seen);
 
 	}//end testThrowingPromotionIsFailSoftAndBatchContinues()
 
@@ -221,7 +274,7 @@ class TenderNedAwardPromotionJobTest extends TestCase {
 	 */
 	public function testUnresolvableListenerDropsTheBatchQuietly(): void {
 		$this->job(null)->runForTest(
-			$this->context([['payload' => ['tenderId' => 'TN-5']]])
+			$this->context([$this->entry('u-5', 'TN-5')])
 		);
 
 		$this->assertTrue(true, 'runDeferred() returned without throwing');

--- a/tests/Unit/BackgroundJob/TenderNedAwardPromotionJobTest.php
+++ b/tests/Unit/BackgroundJob/TenderNedAwardPromotionJobTest.php
@@ -1,0 +1,243 @@
+<?php
+
+/**
+ * Tests for TenderNedAwardPromotionJob.
+ *
+ * The job is the far side of the #1198 deferral: the listener buffers an
+ * eligible award and this job performs the promotion later, as the restored
+ * actor. Its failure modes are all silent by construction — an unresolvable
+ * listener, an entry with no payload, or a throwing promotion all end in a log
+ * line and a dropped Commitment — so each one is pinned here rather than left
+ * to be discovered as "the award never got promoted".
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\BackgroundJob
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/bookkeeping-tenderned-integratie/tasks.md#task-5
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\BackgroundJob;
+
+use OCA\OpenRegister\Service\Deferral\DeferredListenerContext;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\Shillinq\BackgroundJob\TenderNedAwardPromotionJob;
+use OCA\Shillinq\Listener\TenderNedAwardDetectedListener;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\NullLogger;
+use RuntimeException;
+
+/**
+ * Unit tests for the deferred award-promotion job.
+ */
+class TenderNedAwardPromotionJobTest extends TestCase {
+
+	/**
+	 * Build the job with a container that resolves the given listener.
+	 *
+	 * @param object|null $listener Listener to resolve, or null to leave it unbound.
+	 *
+	 * @return TenderNedAwardPromotionJob
+	 */
+	private function job(?object $listener): TenderNedAwardPromotionJob {
+		$container = new class($listener) implements ContainerInterface {
+
+			/**
+			 * @param object|null $listener Bound listener.
+			 */
+			public function __construct(
+				private readonly ?object $listener,
+			) {
+			}
+
+			/**
+			 * @param string $id Service id.
+			 *
+			 * @return mixed
+			 */
+			public function get(string $id): mixed {
+				if ($id === TenderNedAwardDetectedListener::class && $this->listener !== null) {
+					return $this->listener;
+				}
+
+				throw new class('not bound') extends \Exception implements \Psr\Container\NotFoundExceptionInterface {
+				};
+			}
+
+			/**
+			 * @param string $id Service id.
+			 *
+			 * @return bool
+			 */
+			public function has(string $id): bool {
+				return ($id === TenderNedAwardDetectedListener::class && $this->listener !== null);
+			}
+		};
+
+		return new TenderNedAwardPromotionJob(
+			$this->createMock(ITimeFactory::class),
+			$this->createMock(IUserSession::class),
+			$this->createMock(IUserManager::class),
+			new OrganisationService(),
+			new NullLogger(),
+			$container
+		);
+
+	}//end job()
+
+	/**
+	 * Wrap entries in a context.
+	 *
+	 * @param array<int, array<string, mixed>> $entries Buffered entries.
+	 *
+	 * @return DeferredListenerContext
+	 */
+	private function context(array $entries): DeferredListenerContext {
+		return new DeferredListenerContext(
+			userId: 'admin',
+			orgUuid: 'org-1',
+			entries: $entries
+		);
+
+	}//end context()
+
+	/**
+	 * Every buffered entry is promoted, in order.
+	 *
+	 * @return void
+	 */
+	public function testEachBufferedEntryIsPromoted(): void {
+		$listener = $this->createMock(TenderNedAwardDetectedListener::class);
+
+		$seen = [];
+		$listener->method('runDeferredPromotion')
+			->willReturnCallback(
+				function (array $payload) use (&$seen): void {
+					$seen[] = $payload['tenderId'];
+				}
+			);
+
+		$this->job($listener)->runForTest(
+			$this->context(
+				[
+					['payload' => ['tenderId' => 'TN-1']],
+					['payload' => ['tenderId' => 'TN-2']],
+				]
+			)
+		);
+
+		$this->assertSame(['TN-1', 'TN-2'], $seen);
+
+	}//end testEachBufferedEntryIsPromoted()
+
+	/**
+	 * An entry with no payload is skipped, and does NOT stop the batch.
+	 *
+	 * A malformed entry aborting the loop would silently drop every award
+	 * queued behind it in the same flush.
+	 *
+	 * @return void
+	 */
+	public function testEntryWithoutPayloadIsSkippedWithoutStoppingTheBatch(): void {
+		$listener = $this->createMock(TenderNedAwardDetectedListener::class);
+
+		$seen = [];
+		$listener->method('runDeferredPromotion')
+			->willReturnCallback(
+				function (array $payload) use (&$seen): void {
+					$seen[] = $payload['tenderId'];
+				}
+			);
+
+		$this->job($listener)->runForTest(
+			$this->context(
+				[
+					['payload' => 'not-an-array'],
+					[],
+					['payload' => ['tenderId' => 'TN-3']],
+				]
+			)
+		);
+
+		$this->assertSame(['TN-3'], $seen);
+
+	}//end testEntryWithoutPayloadIsSkippedWithoutStoppingTheBatch()
+
+	/**
+	 * A throwing promotion is fail-soft and the batch continues.
+	 *
+	 * The inline handler swallowed its own exceptions so a failed promotion
+	 * never broke the OpenRegister write. Moving the work to cron must not
+	 * turn that into an unhandled job failure.
+	 *
+	 * @return void
+	 */
+	public function testThrowingPromotionIsFailSoftAndBatchContinues(): void {
+		$listener = $this->createMock(TenderNedAwardDetectedListener::class);
+
+		$seen = [];
+		$listener->method('runDeferredPromotion')
+			->willReturnCallback(
+				function (array $payload) use (&$seen): void {
+					if ($payload['tenderId'] === 'TN-BOOM') {
+						throw new RuntimeException('promotion exploded');
+					}
+
+					$seen[] = $payload['tenderId'];
+				}
+			);
+
+		$this->job($listener)->runForTest(
+			$this->context(
+				[
+					['payload' => ['tenderId' => 'TN-BOOM']],
+					['payload' => ['tenderId' => 'TN-4']],
+				]
+			)
+		);
+
+		$this->assertSame(['TN-4'], $seen);
+
+	}//end testThrowingPromotionIsFailSoftAndBatchContinues()
+
+	/**
+	 * An unresolvable listener drops the batch without throwing.
+	 *
+	 * @return void
+	 */
+	public function testUnresolvableListenerDropsTheBatchQuietly(): void {
+		$this->job(null)->runForTest(
+			$this->context([['payload' => ['tenderId' => 'TN-5']]])
+		);
+
+		$this->assertTrue(true, 'runDeferred() returned without throwing');
+
+	}//end testUnresolvableListenerDropsTheBatchQuietly()
+
+	/**
+	 * An empty buffer is a no-op.
+	 *
+	 * @return void
+	 */
+	public function testEmptyBufferIsANoOp(): void {
+		$listener = $this->createMock(TenderNedAwardDetectedListener::class);
+		$listener->expects($this->never())->method('runDeferredPromotion');
+
+		$this->job($listener)->runForTest($this->context([]));
+
+	}//end testEmptyBufferIsANoOp()
+}//end class

--- a/tests/Unit/Listener/TenderNedAwardDetectedListenerTest.php
+++ b/tests/Unit/Listener/TenderNedAwardDetectedListenerTest.php
@@ -40,6 +40,8 @@ namespace OCA\Shillinq\Tests\Unit\Listener;
 
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Event\ObjectCreatedEvent;
+use OCA\OpenRegister\Service\Deferral\ListenerDeferralService;
+use OCA\Shillinq\BackgroundJob\TenderNedAwardPromotionJob;
 use OCA\Shillinq\Listener\TenderNedAwardDetectedListener;
 use OCA\Shillinq\Service\BudgetImpactEmitter;
 use OCA\Shillinq\Service\ListenerSchemaResolver;
@@ -117,10 +119,14 @@ final class TenderNedAwardDetectedListenerTest extends TestCase {
 	 * lookup.
 	 *
 	 * @param array<int, array<string, mixed>> $commitmentRows Existing matching obligations.
+	 * @param ListenerDeferralService|null     $deferral       Bind OR's deferral service, or leave it unresolvable.
 	 *
 	 * @return array{0: ContainerInterface, 1: object} Container and the recorder so the test can inspect saveObject() calls.
 	 */
-	private function containerAndRecorder(array $commitmentRows): array {
+	private function containerAndRecorder(
+		array $commitmentRows,
+		?ListenerDeferralService $deferral = null,
+	): array {
 		$recorder = new class($commitmentRows) {
 
 			/**
@@ -167,10 +173,11 @@ final class TenderNedAwardDetectedListenerTest extends TestCase {
 			}
 		};
 
-		$container = new class($recorder) implements ContainerInterface {
+		$container = new class($recorder, $deferral) implements ContainerInterface {
 
 			public function __construct(
 				private readonly object $objectService,
+				private readonly ?ListenerDeferralService $deferral,
 			) {
 			}
 
@@ -178,11 +185,26 @@ final class TenderNedAwardDetectedListenerTest extends TestCase {
 				if ($id === 'OCA\\OpenRegister\\Service\\ObjectService') {
 					return $this->objectService;
 				}
+
+				// Left UNBOUND by default on purpose. Every test written
+				// before the promotion was deferred (#1198) asserts the
+				// Commitment write happened during handle(), and reaches it
+				// through the listener's inline fallback — which is only
+				// honest as long as the fallback is what an unresolvable
+				// deferral service actually produces.
+				if ($id === ListenerDeferralService::class && $this->deferral !== null) {
+					return $this->deferral;
+				}
+
 				throw new class('not bound') extends \Exception implements \Psr\Container\NotFoundExceptionInterface {
 				};
 			}
 
 			public function has(string $id): bool {
+				if ($id === ListenerDeferralService::class) {
+					return $this->deferral !== null;
+				}
+
 				return $id === 'OCA\\OpenRegister\\Service\\ObjectService';
 			}
 		};
@@ -451,4 +473,164 @@ final class TenderNedAwardDetectedListenerTest extends TestCase {
 		$this->assertCount(1, $dispatcher->events);
 
 	}//end testIdempotentOnExistingBronReferentie()
+
+	/**
+	 * Build the canonical eligible award event.
+	 *
+	 * @param string $tenderId Source reference to award.
+	 *
+	 * @return ObjectCreatedEvent
+	 */
+	private function eligibleAward(string $tenderId = 'TN-2026-0001'): ObjectCreatedEvent {
+		return new ObjectCreatedEvent(
+			$this->entity('1090', [
+				'status'           => 'gegund',
+				'contractValue'    => 50000.0,
+				'awardedSupplier'  => '30280353 Conduction B.V.',
+				'tenderId'         => $tenderId,
+				'title'            => 'Schoonmaak',
+				'assignmentType'   => 'delivery-in-phases',
+				'termStart'        => '2026-01-01',
+				'termEnd'          => '2026-12-31',
+				'administrationId' => 'adm-x',
+			])
+		);
+
+	}//end eligibleAward()
+
+	/**
+	 * With deferral available the promotion leaves the caller's write path.
+	 *
+	 * This is the ADR-078 contract from #1198 and the DEFAULT path in
+	 * production. Asserting `saves === []` is the whole point: every other
+	 * test in this class asserts the opposite, and would keep passing if the
+	 * deferral were wired up but never consulted.
+	 *
+	 * @return void
+	 */
+	public function testPromotionIsDeferredWhenDeferralIsEnabled(): void {
+		$deferral = new ListenerDeferralService(enabled: true);
+		[$container, $recorder] = $this->containerAndRecorder([], $deferral);
+		[$listener, $dispatcher] = $this->listener($container, '30280353');
+
+		$listener->handle($this->eligibleAward());
+
+		// Nothing was written, and no CloudEvent was emitted, DURING the
+		// OpenRegister write that raised the event.
+		$this->assertSame([], $recorder->saves);
+		$this->assertCount(0, $dispatcher->events);
+
+		// It was queued instead — onto the job, carrying the payload, keyed
+		// so the Created + Transitioned surfaces collapse into one promotion.
+		$this->assertCount(1, $deferral->deferred);
+		$this->assertSame(
+			TenderNedAwardPromotionJob::class,
+			$deferral->deferred[0]['jobClass']
+		);
+		$this->assertSame(
+			'TN-2026-0001',
+			$deferral->deferred[0]['entry']['payload']['tenderId']
+		);
+		$this->assertSame(
+			TenderNedAwardDetectedListener::HANDLER_KEY . '|TN-2026-0001',
+			$deferral->deferred[0]['dedupeKey']
+		);
+
+	}//end testPromotionIsDeferredWhenDeferralIsEnabled()
+
+	/**
+	 * The buffered entry must survive the job-argument JSON round-trip.
+	 *
+	 * `defer()` serialises the entry into job arguments. A payload that only
+	 * works in-process would defer cleanly here and then arrive at the job
+	 * with fields missing — a failure with no error at either end.
+	 *
+	 * @return void
+	 */
+	public function testDeferredEntrySurvivesJsonRoundTrip(): void {
+		$deferral = new ListenerDeferralService(enabled: true);
+		[$container] = $this->containerAndRecorder([], $deferral);
+		[$listener] = $this->listener($container, '30280353');
+
+		$listener->handle($this->eligibleAward());
+
+		$entry   = $deferral->deferred[0]['entry'];
+		$encoded = json_encode($entry);
+		$this->assertIsString($encoded);
+
+		$decoded = json_decode($encoded, true);
+
+		// No field is dropped crossing the boundary.
+		$this->assertSame(
+			array_keys($entry['payload']),
+			array_keys($decoded['payload'])
+		);
+		$this->assertEquals($entry, $decoded);
+
+		// The values survive but their PHP TYPES do not: json_encode(50000.0)
+		// writes `50000`, which decodes as int. Measured here, not assumed.
+		// It is harmless today only because promote() casts on the way in
+		// (`'amount' => (float)($payload['contractValue'] ?? 0)`). A future
+		// field where int-vs-float decides behaviour would arrive at the job
+		// silently retyped — no error at either end — so the coercion is
+		// pinned rather than papered over with a loose comparison.
+		$this->assertSame(50000.0, $entry['payload']['contractValue']);
+		$this->assertSame(50000, $decoded['payload']['contractValue']);
+
+	}//end testDeferredEntrySurvivesJsonRoundTrip()
+
+	/**
+	 * Admin-selected inline mode still promotes, on the caller's path.
+	 *
+	 * @return void
+	 */
+	public function testInlineModePromotesSynchronously(): void {
+		$deferral = new ListenerDeferralService(enabled: false);
+		[$container, $recorder] = $this->containerAndRecorder([], $deferral);
+		[$listener, $dispatcher] = $this->listener($container, '30280353');
+
+		$listener->handle($this->eligibleAward());
+
+		$this->assertSame([], $deferral->deferred);
+		$this->assertNotEmpty($recorder->saves);
+		$this->assertCount(1, $dispatcher->events);
+
+	}//end testInlineModePromotesSynchronously()
+
+	/**
+	 * The deferred entry point performs the same promotion as the inline one.
+	 *
+	 * Guards the seam the job calls through: if `runDeferredPromotion()` ever
+	 * stops reaching `promote()`, deferral becomes a silent drop — the
+	 * listener would report nothing wrong and no Commitment would appear.
+	 *
+	 * @return void
+	 */
+	public function testRunDeferredPromotionWritesTheCommitment(): void {
+		[$container, $recorder] = $this->containerAndRecorder([]);
+		[$listener, $dispatcher] = $this->listener($container, '30280353');
+
+		$listener->runDeferredPromotion([
+			'tenderId'       => 'TN-2026-0002',
+			'title'          => 'Onderhoud',
+			'contractValue'  => 12000.0,
+			'assignmentType' => 'other',
+			'termStart'      => '2026-02-01',
+			'termEnd'        => '2026-11-30',
+		]);
+
+		$commitmentSave = null;
+		foreach ($recorder->saves as $save) {
+			if ($save['schema'] === 'Commitment') {
+				$commitmentSave = $save['object'];
+				break;
+			}
+		}
+
+		$this->assertNotNull($commitmentSave);
+		$this->assertSame('TN-2026-0002', $commitmentSave['sourceReference']);
+		$this->assertSame('active', $commitmentSave['status']);
+		$this->assertCount(1, $dispatcher->events);
+
+	}//end testRunDeferredPromotionWritesTheCommitment()
 }//end class

--- a/tests/Unit/Listener/TenderNedAwardDetectedListenerTest.php
+++ b/tests/Unit/Listener/TenderNedAwardDetectedListenerTest.php
@@ -167,6 +167,79 @@ final class TenderNedAwardDetectedListenerTest extends TestCase {
 				return [];
 			}
 
+			/**
+			 * Current body the deferred re-read resolves to, or null for gone.
+			 *
+			 * @var array<string, mixed>|null
+			 */
+			public ?array $dossier = null;
+
+			/**
+			 * Soft-delete marker returned by the re-read.
+			 *
+			 * @var array<string, mixed>|null
+			 */
+			public ?array $dossierDeleted = null;
+
+			/**
+			 * Records what the deferred re-read asked for.
+			 *
+			 * @var array<int, array<string, mixed>>
+			 */
+			public array $finds = [];
+
+			/**
+			 * Stand in for ObjectService::find(). Parameter NAMES matter — the
+			 * listener calls this with named arguments.
+			 *
+			 * @param string|int   $id       Object uuid.
+			 * @param array|null   $_extend  Unused.
+			 * @param bool         $files    Unused.
+			 * @param string|null  $register Register slug.
+			 * @param string|null  $schema   Schema slug.
+			 *
+			 * @return object|null
+			 */
+			public function find(
+				string | int $id,
+				?array $_extend = [],
+				bool $files = false,
+				string | null $register = null,
+				string | null $schema = null,
+			): ?object {
+				$this->finds[] = ['id' => $id, 'register' => $register, 'schema' => $schema];
+				if ($this->dossier === null) {
+					return null;
+				}
+
+				return new class($this->dossier, $this->dossierDeleted) {
+
+					/**
+					 * @param array<string, mixed>      $body    Object body.
+					 * @param array<string, mixed>|null $deleted Delete marker.
+					 */
+					public function __construct(
+						private readonly array $body,
+						private readonly ?array $deleted,
+					) {
+					}
+
+					/**
+					 * @return array<string, mixed>
+					 */
+					public function getObject(): array {
+						return $this->body;
+					}
+
+					/**
+					 * @return array<string, mixed>|null
+					 */
+					public function getDeleted(): ?array {
+						return $this->deleted;
+					}
+				};
+			}
+
 			public function saveObject(array $object): array {
 				$this->saves[] = ['schema' => $this->currentSchema, 'object' => $object];
 				return $object;
@@ -265,10 +338,14 @@ final class TenderNedAwardDetectedListenerTest extends TestCase {
 	 *
 	 * @return ObjectEntity
 	 */
-	private function entity(string $schemaId, array $payload): ObjectEntity {
+	private function entity(string $schemaId, array $payload, string $uuid = 'dossier-uuid-1'): ObjectEntity {
 		$entity = new ObjectEntity();
 		$entity->setSchema($schemaId);
 		$entity->setObject($payload);
+		// A uuid is not decoration here: it is the identity the deferred
+		// promotion re-reads by. Without it the listener cannot honour the
+		// at-least-once contract and deliberately stays inline.
+		$entity->setUuid($uuid);
 		return $entity;
 	}//end entity()
 
@@ -610,13 +687,14 @@ final class TenderNedAwardDetectedListenerTest extends TestCase {
 		[$container, $recorder] = $this->containerAndRecorder([]);
 		[$listener, $dispatcher] = $this->listener($container, '30280353');
 
+		// The dossier as it stands NOW — this, not the buffered payload, is
+		// what the promotion must be built from.
+		$recorder->dossier = $this->awardBody('TN-2026-0002');
+
 		$listener->runDeferredPromotion([
-			'tenderId'       => 'TN-2026-0002',
-			'title'          => 'Onderhoud',
-			'contractValue'  => 12000.0,
-			'assignmentType' => 'other',
-			'termStart'      => '2026-02-01',
-			'termEnd'        => '2026-11-30',
+			'uuid'    => 'dossier-uuid-1',
+			'schema'  => 'TenderNedProcurement',
+			'payload' => ['tenderId' => 'STALE-SHOULD-NOT-BE-USED'],
 		]);
 
 		$commitmentSave = null;
@@ -628,9 +706,116 @@ final class TenderNedAwardDetectedListenerTest extends TestCase {
 		}
 
 		$this->assertNotNull($commitmentSave);
+		// Proves the promotion used the re-read body, not the buffered one.
 		$this->assertSame('TN-2026-0002', $commitmentSave['sourceReference']);
 		$this->assertSame('active', $commitmentSave['status']);
 		$this->assertCount(1, $dispatcher->events);
 
+		// And it re-read by the identity captured at dispatch time.
+		$this->assertSame('dossier-uuid-1', $recorder->finds[0]['id']);
+		$this->assertSame('TenderNedProcurement', $recorder->finds[0]['schema']);
+
 	}//end testRunDeferredPromotionWritesTheCommitment()
+
+	/**
+	 * A dossier deleted between the event and the job must not promote.
+	 *
+	 * Deferred delivery is at-least-once, so the job can land after a delete
+	 * or a same-uuid re-create. Promoting the buffered snapshot would create
+	 * a Commitment referencing an award that no longer exists — and because
+	 * the promotion is fail-soft, nothing downstream would report it.
+	 *
+	 * @return void
+	 */
+	public function testDeletedDossierIsNotPromoted(): void {
+		[$container, $recorder] = $this->containerAndRecorder([]);
+		[$listener, $dispatcher] = $this->listener($container, '30280353');
+
+		$recorder->dossier = null;
+
+		$listener->runDeferredPromotion([
+			'uuid'    => 'dossier-uuid-1',
+			'schema'  => 'TenderNedProcurement',
+			'payload' => $this->awardBody('TN-2026-0003'),
+		]);
+
+		$this->assertSame([], $recorder->saves);
+		$this->assertCount(0, $dispatcher->events);
+
+	}//end testDeletedDossierIsNotPromoted()
+
+	/**
+	 * A soft-deleted dossier counts as gone.
+	 *
+	 * `find()` still returns the entity for a soft-deleted object, so a null
+	 * check alone would sail straight past it and promote a deleted dossier.
+	 *
+	 * @return void
+	 */
+	public function testSoftDeletedDossierIsNotPromoted(): void {
+		[$container, $recorder] = $this->containerAndRecorder([]);
+		[$listener, $dispatcher] = $this->listener($container, '30280353');
+
+		$recorder->dossier        = $this->awardBody('TN-2026-0004');
+		$recorder->dossierDeleted = ['deletedAt' => '2026-08-24T05:00:00Z'];
+
+		$listener->runDeferredPromotion([
+			'uuid'    => 'dossier-uuid-1',
+			'schema'  => 'TenderNedProcurement',
+			'payload' => $this->awardBody('TN-2026-0004'),
+		]);
+
+		$this->assertSame([], $recorder->saves);
+		$this->assertCount(0, $dispatcher->events);
+
+	}//end testSoftDeletedDossierIsNotPromoted()
+
+	/**
+	 * An award reverted before the job runs must not promote.
+	 *
+	 * The buffered payload said `gegund`; the dossier no longer does. The
+	 * eligibility rules have to be re-applied to the CURRENT body, or moving
+	 * the work to cron would quietly promote awards that were taken back.
+	 *
+	 * @return void
+	 */
+	public function testAwardRevertedBeforeTheJobRunsIsNotPromoted(): void {
+		[$container, $recorder] = $this->containerAndRecorder([]);
+		[$listener, $dispatcher] = $this->listener($container, '30280353');
+
+		$reverted           = $this->awardBody('TN-2026-0005');
+		$reverted['status'] = 'open';
+		$recorder->dossier  = $reverted;
+
+		$listener->runDeferredPromotion([
+			'uuid'    => 'dossier-uuid-1',
+			'schema'  => 'TenderNedProcurement',
+			'payload' => $this->awardBody('TN-2026-0005'),
+		]);
+
+		$this->assertSame([], $recorder->saves);
+		$this->assertCount(0, $dispatcher->events);
+
+	}//end testAwardRevertedBeforeTheJobRunsIsNotPromoted()
+
+	/**
+	 * An eligible award body, as stored on the dossier.
+	 *
+	 * @param string $tenderId Tender id.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function awardBody(string $tenderId): array {
+		return [
+			'status'          => 'gegund',
+			'contractValue'   => 12000.0,
+			'awardedSupplier' => '30280353 Conduction B.V.',
+			'tenderId'        => $tenderId,
+			'title'           => 'Onderhoud',
+			'assignmentType'  => 'other',
+			'termStart'       => '2026-02-01',
+			'termEnd'         => '2026-11-30',
+		];
+
+	}//end awardBody()
 }//end class

--- a/tests/stubs/OpenRegister/BackgroundJob/ActorForwardedJob.php
+++ b/tests/stubs/OpenRegister/BackgroundJob/ActorForwardedJob.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Minimal ActorForwardedJob stub for unit tests and static analysis.
+ *
+ * Upstream this base class restores the acting user and organisation captured
+ * at defer() time, then calls `runDeferred()`. The stub reproduces the
+ * CONSTRUCTOR SHAPE and the abstract hook, not the actor restore — a unit test
+ * has no session to restore, and faking one here would test the stub.
+ *
+ * `runDeferred()` is exposed through `runForTest()` so a test can drive the
+ * hook without reflection; upstream's own `run()` is not reproduced.
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\BackgroundJob;
+
+use OCA\OpenRegister\Service\Deferral\DeferredListenerContext;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\QueuedJob;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Stub for OCA\OpenRegister\BackgroundJob\ActorForwardedJob.
+ */
+abstract class ActorForwardedJob extends QueuedJob {
+
+	/**
+	 * Construct the job.
+	 *
+	 * @param ITimeFactory        $time         Time factory.
+	 * @param IUserSession        $userSession  Session for actor restore.
+	 * @param IUserManager        $userManager  User lookup.
+	 * @param OrganisationService $organisation Organisation context.
+	 * @param LoggerInterface     $logger       Logger.
+	 */
+	public function __construct(
+		ITimeFactory $time,
+		private readonly IUserSession $userSession,
+		private readonly IUserManager $userManager,
+		private readonly OrganisationService $organisation,
+		protected readonly LoggerInterface $logger,
+	) {
+		parent::__construct(time: $time);
+
+	}//end __construct()
+
+	/**
+	 * Decode job arguments and delegate, as upstream does.
+	 *
+	 * Required concretely: OCP\BackgroundJob\Job declares `run()` abstract, so
+	 * a stub base that omitted it made every subclass abstract — phpstan
+	 * reports that as a non-ignorable error on the SUBCLASS, which reads as a
+	 * defect in the app rather than a gap in the stub.
+	 *
+	 * @param mixed $argument Job arguments.
+	 *
+	 * @return void
+	 */
+	protected function run($argument): void {
+		$entries = [];
+		if (is_array($argument) === true && is_array(($argument['entries'] ?? null)) === true) {
+			$entries = $argument['entries'];
+		}
+
+		$this->runDeferred(
+			new DeferredListenerContext(
+				userId: null,
+				orgUuid: null,
+				entries: $entries
+			)
+		);
+
+	}//end run()
+
+	/**
+	 * Drive the deferred hook from a test.
+	 *
+	 * @param DeferredListenerContext $context Actor + entries.
+	 *
+	 * @return void
+	 */
+	public function runForTest(DeferredListenerContext $context): void {
+		$this->runDeferred($context);
+
+	}//end runForTest()
+
+	/**
+	 * Run the deferred work as the restored actor.
+	 *
+	 * @param DeferredListenerContext $context Actor + entries.
+	 *
+	 * @return void
+	 */
+	abstract protected function runDeferred(DeferredListenerContext $context): void;
+}//end class

--- a/tests/stubs/OpenRegister/Service/Deferral/DeferredListenerContext.php
+++ b/tests/stubs/OpenRegister/Service/Deferral/DeferredListenerContext.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Minimal DeferredListenerContext stub for unit tests and static analysis.
+ *
+ * Mirrors the upstream constructor and accessors so a deferred job can be
+ * exercised without the openregister app present.
+ *
+ * NOTE: upstream declares this class `final`. The stub does too — a stub that
+ * relaxed it would let a test subclass something production cannot.
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Deferral;
+
+/**
+ * Stub for OCA\OpenRegister\Service\Deferral\DeferredListenerContext.
+ */
+final class DeferredListenerContext {
+
+	/**
+	 * Construct the context.
+	 *
+	 * @param string|null                      $userId  Acting user.
+	 * @param string|null                      $orgUuid Acting organisation.
+	 * @param array<int, array<string, mixed>> $entries Buffered entries.
+	 */
+	public function __construct(
+		private readonly ?string $userId,
+		private readonly ?string $orgUuid,
+		private readonly array $entries,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Return the acting user id.
+	 *
+	 * @return string|null
+	 */
+	public function getUserId(): ?string {
+		return $this->userId;
+
+	}//end getUserId()
+
+	/**
+	 * Return the acting organisation uuid.
+	 *
+	 * @return string|null
+	 */
+	public function getOrganisationUuid(): ?string {
+		return $this->orgUuid;
+
+	}//end getOrganisationUuid()
+
+	/**
+	 * Return the buffered entries.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function getEntries(): array {
+		return $this->entries;
+
+	}//end getEntries()
+
+	/**
+	 * Serialise back to job arguments.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function toJobArguments(): array {
+		return [
+			'userId'  => $this->userId,
+			'orgUuid' => $this->orgUuid,
+			'entries' => $this->entries,
+		];
+
+	}//end toJobArguments()
+}//end class

--- a/tests/stubs/OpenRegister/Service/Deferral/ListenerDeferralService.php
+++ b/tests/stubs/OpenRegister/Service/Deferral/ListenerDeferralService.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Minimal ListenerDeferralService stub for unit tests.
+ *
+ * Mirrors the two methods shillinq calls on OpenRegister's real service
+ * (`isDeferralEnabled()` and `defer()`), and records what was deferred so a
+ * test can assert the promotion left the caller's write path instead of
+ * running on it.
+ *
+ * The `defer()` signature is kept identical to upstream — including the
+ * `$chunkSize` default that shillinq skips via named arguments — so a
+ * signature change upstream shows up here as a test failure rather than as a
+ * stub that silently accepts a call production would reject.
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service\Deferral;
+
+/**
+ * Stub for OCA\OpenRegister\Service\Deferral\ListenerDeferralService.
+ */
+class ListenerDeferralService {
+
+	/**
+	 * Default chunk size, mirroring upstream.
+	 *
+	 * @var int
+	 */
+	public const DEFAULT_CHUNK_SIZE = 100;
+
+	/**
+	 * Recorded defer() calls.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	public array $deferred = [];
+
+	/**
+	 * Construct the stub.
+	 *
+	 * @param bool $enabled What isDeferralEnabled() should report.
+	 */
+	public function __construct(
+		private readonly bool $enabled = true,
+	) {
+
+	}//end __construct()
+
+	/**
+	 * Report whether deferral is on.
+	 *
+	 * @return bool
+	 */
+	public function isDeferralEnabled(): bool {
+		return $this->enabled;
+
+	}//end isDeferralEnabled()
+
+	/**
+	 * Record a deferred entry.
+	 *
+	 * @param string      $jobClass  Job to run the entry.
+	 * @param array       $entry     Buffered payload.
+	 * @param int         $chunkSize Flush threshold.
+	 * @param string|null $dedupeKey Collapse key.
+	 *
+	 * @return void
+	 */
+	public function defer(
+		string $jobClass,
+		array $entry,
+		int $chunkSize = self::DEFAULT_CHUNK_SIZE,
+		?string $dedupeKey = null,
+	): void {
+		$this->deferred[] = [
+			'jobClass'  => $jobClass,
+			'entry'     => $entry,
+			'chunkSize' => $chunkSize,
+			'dedupeKey' => $dedupeKey,
+		];
+
+	}//end defer()
+}//end class

--- a/tests/stubs/OpenRegister/Service/OrganisationService.php
+++ b/tests/stubs/OpenRegister/Service/OrganisationService.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Minimal OrganisationService stub for unit tests and static analysis.
+ *
+ * Only the surface `ActorForwardedJob` needs. shillinq never calls this
+ * service directly — it appears solely as a constructor type the deferred job
+ * must forward to its parent.
+ *
+ * @author    Conduction Development Team <dev@conductio.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\OpenRegister\Service;
+
+/**
+ * Stub for OCA\OpenRegister\Service\OrganisationService.
+ */
+class OrganisationService {
+
+	/**
+	 * Return the active organisation uuid.
+	 *
+	 * @return string|null
+	 */
+	public function getActiveOrganisationUuid(): ?string {
+		return null;
+
+	}//end getActiveOrganisationUuid()
+
+	/**
+	 * Set the active organisation.
+	 *
+	 * @param string|null $uuid Organisation uuid.
+	 *
+	 * @return void
+	 */
+	public function setActiveOrganisation(?string $uuid): void {
+
+	}//end setActiveOrganisation()
+}//end class


### PR DESCRIPTION
Closes #1198.

`TenderNedAwardDetectedListener` handled `ObjectCreatedEvent` / `ObjectTransitionedEvent` and did the whole award → Commitment promotion **synchronously, inside the OpenRegister write that raised the event**: two `saveObject()` calls (a new Commitment plus a status bump on the TenderNedProcurement dossier) and a cross-app budget CloudEvent. ADR-078 says post-`*ed` work is async by default, so every openconnector polling write paid for the promotion — and a slow promotion looked like a slow dossier save.

### What changed

The promotion now goes through OpenRegister's `ListenerDeferralService` onto a new `TenderNedAwardPromotionJob`.

- The job extends **`ActorForwardedJob`, not `QueuedJob`** — it restores the acting user and organisation before running, so the Commitment is still attributed to the user whose import triggered it rather than to nobody.
- The job **does not re-implement the promotion**; it calls back into the listener, so the eligibility rules, the idempotency check and the fail-soft logging stay in one place and the inline and deferred paths cannot drift apart.
- When deferral is unavailable or the admin has OpenRegister in inline mode, the promotion runs inline. That fallback is deliberate: this listener is the *only* thing that turns an award into a Commitment, and a promotion that silently never happened would be indistinguishable from a dossier that was not eligible.

### Why this is a separate PR

Both halves of #1198 were meant to ship in #1196. The `findAll()` half did (`_limit => 1`); this half was finished after #1196 had already been squash-merged, so it never reached `development`.

Worth recording: **#1196 went green on gate-61 without this fix.** The gate is diff-scoped, and once `development` was merged into that branch the listener fell out of scope — 0 registrations checked, 0 failures, which reads exactly like a pass. Whole-tree (`--all`) it still failed. On this branch the listener is genuinely in scope: *checked 1 post-event registration, 0 failures*.

### Verification

- gate-61: 1 registration in scope, 0 failures (whole-tree also 0, was 1)
- phpstan `[OK] No errors` · psalm green · phpmd clean
- phpcs: 0 errors, 0 warnings on both changed `lib/` files
- phpunit: 4944 passed, 1 pre-existing skip

The test that matters asserts `saves === []` and zero CloudEvents during the OR write — every other test in that class asserts the opposite, so it would keep passing if the deferral were wired up but never consulted.

The OpenRegister test stubs were checked against the real classes: `defer()`'s signature, `ActorForwardedJob`'s constructor, `DeferredListenerContext` being `final`, and `DEFAULT_CHUNK_SIZE = 100` all match upstream.