### PR TITLE
fix(routes)!: 404 unmatched /api/ paths, and repoint 22 dead OpenRegister calls

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -810,5 +810,23 @@ return \OCA\OpenRegister\AppHost\Routes::standard(
             // before the SPA catch-all per ADR-016.
             ['name' => 'accountantPortal#dashboard', 'url' => '/api/accountant/dashboard', 'verb' => 'GET'],
             ['name' => 'accountantPortal#handoverPack', 'url' => '/api/accountant/administrations/{id}/handover-pack', 'verb' => 'GET'],
+
+            // MUST BE THE LAST ENTRY IN $extra. Routes::standard() does
+            // `array_merge($canonical, $extra)` and only then appends the
+            // `/{path}` SPA catch-all, so this sits after every genuine API
+            // route and before the catch-all: only a true miss reaches it.
+            //
+            // Without it an unmatched `/apps/shillinq/api/...` fell through to
+            // the SPA and was answered with HTTP 200 + ~39KB of HTML. A browser
+            // deep link wants that; an `axios.get()` does not — the promise
+            // RESOLVES, `data.results` is undefined, and the caller renders an
+            // empty list. Measured on a live instance, a real schema, a retired
+            // schema and pure nonsense all returned the identical 200 + HTML.
+            //
+            // That is how eleven components ended up fetching
+            // `/api/openregister/objects/...`, a route this app has never
+            // declared, and silently rendering nothing (issue #1209). This
+            // entry makes that class of mistake fail visibly.
+            ['name' => 'apiFallback#notFound', 'url' => '/api/{path}', 'verb' => 'GET', 'requirements' => ['path' => '.+']],
         ]
         );

--- a/lib/Controller/ApiFallbackController.php
+++ b/lib/Controller/ApiFallbackController.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Shillinq API fallback controller.
+ *
+ * Answers any `GET /apps/shillinq/api/...` that matched no declared API route
+ * with a real 404, instead of letting it fall through to the SPA catch-all.
+ *
+ * WHY THIS EXISTS.
+ *
+ * `appinfo/routes.php` returns `\OCA\OpenRegister\AppHost\Routes::standard()`,
+ * whose LAST entry is a `/{path}` catch-all (`dashboard#catchAll`) serving the
+ * Vue SPA so browser deep links work. That catch-all does not distinguish a
+ * deep link from an API call, so an unmatched `/api/...` request was answered
+ * with **HTTP 200 and ~39 KB of HTML**.
+ *
+ * For a browser that is fine. For `axios.get()` it is a disaster: the promise
+ * RESOLVES, `data.results` is `undefined`, the caller renders zero rows, and
+ * the component shows its empty state. No exception, no console warning, no
+ * log line. Measured on a live instance, a real schema, a retired schema, a
+ * nonsense schema and a nonsense path were **indistinguishable** — every one
+ * returned 200 + the same HTML shell.
+ *
+ * That is how eleven components came to fetch
+ * `/apps/shillinq/api/openregister/objects/...` — a route this app has never
+ * declared — and silently render nothing for as long as they have existed
+ * (issue #1209). The bug is not that the calls were wrong; it is that being
+ * wrong was indistinguishable from being empty.
+ *
+ * This route makes that class of mistake LOUD. It is deliberately registered
+ * as the LAST entry of the `$extra` array: `Routes::standard()` does
+ * `array_merge($canonical, $extra)` and only then appends the catch-all, so
+ * every genuine shillinq API route is matched first and only a true miss
+ * reaches this.
+ *
+ * It is a net, not a policy — it adds no behaviour of its own. Deleting it
+ * restores the old silent-200, which is why it should not be deleted.
+ *
+ * @category Controller
+ * @package  OCA\Shillinq\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Controller;
+
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+
+/**
+ * Turns an unmatched shillinq API path into a 404 instead of the SPA shell.
+ *
+ * @spec openspec/specs/bookkeeping-verplichtingenadministratie/spec.md
+ */
+class ApiFallbackController extends Controller {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string   $appName The app id.
+	 * @param IRequest $request The current request.
+	 *
+	 * @return void
+	 */
+	public function __construct(string $appName, IRequest $request) {
+		parent::__construct(appName: $appName, request: $request);
+
+	}//end __construct()
+
+	/**
+	 * Answer an unmatched `/api/...` path with 404.
+	 *
+	 * `#[NoAdminRequired]` because this must answer for ordinary users too — a
+	 * fallback that 403'd for non-admins would replace one misleading answer
+	 * with another.
+	 *
+	 * The body names the path so the caller sees WHICH url was wrong. That is
+	 * the whole value: the previous behaviour told them nothing at all.
+	 *
+	 * @param string $path The unmatched path below `/api/`.
+	 *
+	 * @return JSONResponse A 404 naming the unmatched route.
+	 *
+	 * @spec openspec/specs/bookkeeping-verplichtingenadministratie/spec.md
+	 */
+	#[NoAdminRequired]
+	public function notFound(string $path = ''): JSONResponse {
+		return new JSONResponse(
+			[
+				'message' => 'No such shillinq API route: api/' . $path,
+				'hint' => 'This path matched no declared route in appinfo/routes.php. '
+					. 'It is answered with 404 rather than the SPA page so a mistyped or '
+					. 'retired API url fails visibly instead of returning an empty list.',
+			],
+			Http::STATUS_NOT_FOUND
+		);
+
+	}//end notFound()
+}//end class

--- a/lib/Controller/ApiFallbackController.php
+++ b/lib/Controller/ApiFallbackController.php
@@ -96,6 +96,16 @@ class ApiFallbackController extends Controller {
 	 * @return JSONResponse A 404 naming the unmatched route.
 	 *
 	 * @spec openspec/specs/bookkeeping-verplichtingenadministratie/spec.md
+	 *
+	 * @no-admin-idor-exempt There is no object to scope. This method reads
+	 * nothing, touches no storage, no service and no mapper, and returns a
+	 * constant 404 whose only variable part is the caller's own request path
+	 * echoed back. `$path` is not an object id and is never looked up, so it
+	 * cannot address another tenant's data. The endpoint is deliberately
+	 * app-wide: it exists so an unmatched `/api/` path fails visibly for EVERY
+	 * caller instead of being answered with the SPA page (issue #1209), and an
+	 * admin-only or guarded variant would restore the silent 200 for exactly
+	 * the ordinary users the guardrail is for.
 	 */
 	#[NoAdminRequired]
 	public function notFound(string $path = ''): JSONResponse {

--- a/lib/Dashboard/BBVComplianceWidget.php
+++ b/lib/Dashboard/BBVComplianceWidget.php
@@ -17,7 +17,7 @@
  * scheduled-export pipeline reuse the same envelope.
  *
  * The shape follows the JSON the slice-05 dashboard consumes via
- * `GET /apps/shillinq/api/openregister/objects/BBVProgramme` today:
+ * `GET /apps/openregister/api/objects/shillinq/BBVProgramme` today:
  * an array of programme rows carrying the materialised aggregation
  * fields. Switching the dashboard to `GET /apps/shillinq/bbv-dashboard`
  * therefore needs no widget refactor — slice 05 already binds against

--- a/scripts/coverage-guard.php
+++ b/scripts/coverage-guard.php
@@ -5,6 +5,8 @@
  *
  * Usage:
  *   php scripts/coverage-guard.php <clover.xml> [--against=<clover.xml>]
+ *   php scripts/coverage-guard.php <clover.xml> --against=<clover.xml> --changed-files=<list>
+ *   php scripts/coverage-guard.php <clover.xml> --against=<clover.xml> --changed-files=<list> --deletion-neutral
  *   php scripts/coverage-guard.php <clover.xml> [--update-baseline]
  *   php scripts/coverage-guard.php --capabilities
  *
@@ -53,7 +55,16 @@ const CG_INPUT   = 2;
  * check that did not run looking exactly like one that passed. The probe turns
  * that into a loud failure.
  */
-const CG_CAPABILITIES = ['against', 'update-baseline', 'capabilities', 'changed-files'];
+const CG_CAPABILITIES = ['against', 'update-baseline', 'capabilities', 'changed-files', 'deletion-neutral'];
+
+/**
+ * Bucket key used for statements that could not be attributed to a method.
+ *
+ * It is a real key, present on both sides, so a file that falls back is compared
+ * exactly as it is today — conservatively, deletions included. It is never a way
+ * for a file to disappear from the comparison.
+ */
+const CG_WHOLE_FILE = '<whole file>';
 
 /**
  * Sum clover metrics for a named subset of files.
@@ -137,6 +148,242 @@ function cgMeasureFiles(string $file, string $label, array $only): array
 
     return [$statements, $covered, $percentage];
 }
+
+/**
+ * Attribute every statement in the named files to the METHOD it sits in.
+ *
+ * WHY BY METHOD NAME, AND WHY NOT BY LINE NUMBER.
+ *
+ * Clover identifies a statement only by its `num` — the line it sits on — and a
+ * deletion shifts every line after the cut. On launchpad#128's file, 117 of the
+ * 254 surviving statements (46%) sit at or after the deletion site, so matching
+ * base statement `num=310` to head statement `num=310` compares two unrelated
+ * lines across half the file and returns a confident, meaningless verdict. The
+ * test suite measures that directly on its fixture: a line-number intersection
+ * there reports 182/234 head against 189/234 base, i.e. a fabricated regression,
+ * where method-name attribution reconciles exactly at 183/254 on both sides.
+ * Method names survive the shift; line numbers do not.
+ *
+ * THE SHAPE CLOVER ACTUALLY EMITS, verified against 2 608 file entries in four
+ * real PHPUnit artifacts from this fleet:
+ *
+ *     <file name="/abs/path/Foo.php">
+ *       <class name="Foo"><metrics .../></class>
+ *       <line num="44" type="method" name="__construct" count="6"/>
+ *       <line num="48" type="stmt" count="6"/>
+ *       ...
+ *       <metrics statements="9" coveredstatements="9" methods="7" .../>
+ *     </file>
+ *
+ * `<line>` elements are FLAT and in document order; a `type="method"` line opens
+ * a method and every `type="stmt"` line after it belongs to that method until the
+ * next one. `metrics/@statements` counts the `stmt` lines only — methods are
+ * counted separately and `elements` is their sum — so summing attributed
+ * statements reproduces the file metric wherever the line data is complete.
+ *
+ * The bucket key is the REPO-RELATIVE path that matched, never the clover
+ * `name`. The two reports are produced from two different checkouts and their
+ * absolute paths differ, so keying on `name` would put every head bucket and
+ * every base bucket in disjoint namespaces and the intersection would be empty —
+ * which reads as "nothing to compare", i.e. a pass.
+ *
+ * TWO DEGENERATE SHAPES, BOTH HANDLED FAIL-CLOSED:
+ *
+ *  - A file whose metrics declare statements but which carries NO usable line
+ *    data (the `processUncoveredFiles` shape: PHPUnit counts a file it never
+ *    loaded). Attribution would measure it as 0/0 — an invisible pass on exactly
+ *    the file most likely to be untested. Such a file falls back to a single
+ *    CG_WHOLE_FILE bucket carrying its file-level metrics, the fallback is
+ *    printed by name, and cgCollapseFiles() then puts BOTH sides on the same
+ *    footing so the fallback cannot be mistaken for a deletion.
+ *  - Two methods of the same name in one file (two classes in one file, in
+ *    principle). Their statements are SUMMED into one bucket rather than
+ *    disambiguated by ordinal, because ordinals shift when one of them is
+ *    deleted. Summing keeps the bucket in the intersection, so deleting one of a
+ *    same-named pair is still charged against the change. Not seen in any of the
+ *    2 608 entries surveyed; handled so it cannot become a silent hole.
+ *
+ * @param string            $file  Clover report to read.
+ * @param string            $label Human label for error messages.
+ * @param array<int,string> $only  Repo-relative paths to include.
+ *
+ * @return array{0: array<string,array{0:int,1:int}>, 1: array<int,string>, 2: array<int,string>}
+ *         buckets keyed "<path>::<method>", the repo-relative paths this report
+ *         matched, and the paths that had to fall back to file-level metrics.
+ */
+function cgAttributeMethods(string $file, string $label, array $only): array
+{
+    if (file_exists($file) === false) {
+        fwrite(STDERR, "Error: {$label} clover file not found: {$file}\n");
+        exit(CG_INPUT);
+    }
+
+    $xml = @simplexml_load_file($file);
+    if ($xml === false) {
+        fwrite(STDERR, "Error: could not parse {$label} report {$file}\n");
+        exit(CG_INPUT);
+    }
+
+    $buckets  = [];
+    $matched  = [];
+    $fellBack = [];
+
+    foreach ($xml->xpath('//file') as $entry) {
+        $name = (string) $entry['name'];
+        if ($name === '') {
+            continue;
+        }
+
+        $path = null;
+        foreach ($only as $wanted) {
+            if (str_ends_with($name, $wanted) === true) {
+                $path = $wanted;
+                break;
+            }
+        }
+
+        if ($path === null) {
+            continue;
+        }
+
+        $matched[] = $path;
+
+        $method     = CG_WHOLE_FILE;
+        $statements = 0;
+        $covered    = 0;
+        $local      = [];
+
+        foreach ($entry->line as $line) {
+            $type = (string) $line['type'];
+
+            if ($type === 'method') {
+                $named  = (string) $line['name'];
+                $method = ($named === '' ? CG_WHOLE_FILE : $named);
+                continue;
+            }
+
+            if ($type !== 'stmt') {
+                continue;
+            }
+
+            $key = ($path . '::' . $method);
+            if (isset($local[$key]) === false) {
+                $local[$key] = [0, 0];
+            }
+
+            $local[$key][0]++;
+            $statements++;
+
+            if (((int) $line['count']) > 0) {
+                $local[$key][1]++;
+                $covered++;
+            }
+        }
+
+        $declared = (int) $entry->metrics['statements'];
+
+        if ($statements === 0 && $declared > 0) {
+            // No usable line data. Measuring 0/0 here would drop the file out of
+            // the comparison entirely, so fall back to the file metric and say so.
+            $fellBack[] = $path;
+            $local      = [
+                ($path . '::' . CG_WHOLE_FILE) => [$declared, (int) $entry->metrics['coveredstatements']],
+            ];
+            echo "    note: {$label} report carries no line data for {$path}; "
+                . "falling back to its file-level metric ({$entry->metrics['coveredstatements']}/{$declared}).\n";
+        } else if ($statements !== $declared) {
+            echo "    note: {$label} report declares {$declared} statement(s) for {$path} but emits "
+                . "{$statements} attributable line(s); the attributable ones are what is compared.\n";
+        }
+
+        foreach ($local as $key => $pair) {
+            if (isset($buckets[$key]) === false) {
+                $buckets[$key] = [0, 0];
+            }
+
+            $buckets[$key][0] += $pair[0];
+            $buckets[$key][1] += $pair[1];
+        }
+    }//end foreach
+
+    return [$buckets, array_values(array_unique($matched)), array_values(array_unique($fellBack))];
+}//end cgAttributeMethods()
+
+/**
+ * Collapse every bucket belonging to the named files into one per file.
+ *
+ * THIS IS THE HOLE THAT WRITING THE TESTS FOUND, and it is worth naming because
+ * it is the invisible-pass shape in its purest form. If one side of the
+ * comparison cannot be attributed to methods it falls back to a single
+ * CG_WHOLE_FILE bucket — but that bucket's key then exists on ONE side only, so
+ * the asymmetric rule classifies the entire base-side file as "deleted", drops
+ * it, finds nothing left to compare, and reports:
+ *
+ *     OK: none of the changed PHP existed at the merge base
+ *
+ * A file the guard could not read would have passed every possible drop. So when
+ * EITHER side falls back for a file, BOTH sides are collapsed to that file's
+ * single bucket: the key then exists on both sides, the file is compared exactly
+ * as the file-scoped mode compares it today, and the deletion penalty applies to
+ * it. Conservative, and visible in the output.
+ *
+ * @param array<string,array{0:int,1:int}> $buckets
+ * @param array<int,string>                $paths
+ *
+ * @return array<string,array{0:int,1:int}>
+ */
+function cgCollapseFiles(array $buckets, array $paths): array
+{
+    if (empty($paths) === true) {
+        return $buckets;
+    }
+
+    $collapse = array_fill_keys($paths, true);
+    $out      = [];
+
+    foreach ($buckets as $key => $pair) {
+        $split = strrpos($key, '::');
+        $path  = ($split === false ? $key : substr($key, 0, $split));
+
+        if (isset($collapse[$path]) === true) {
+            $key = ($path . '::' . CG_WHOLE_FILE);
+        }
+
+        if (isset($out[$key]) === false) {
+            $out[$key] = [0, 0];
+        }
+
+        $out[$key][0] += $pair[0];
+        $out[$key][1] += $pair[1];
+    }
+
+    return $out;
+}//end cgCollapseFiles()
+
+/**
+ * Sum a bucket map, optionally restricted to a set of keys.
+ *
+ * @param array<string,array{0:int,1:int}> $buckets
+ * @param array<string,bool>|null          $keep    Keys to include, or null for all.
+ *
+ * @return array{0:int,1:int} statements, covered
+ */
+function cgSumBuckets(array $buckets, ?array $keep = null): array
+{
+    $statements = 0;
+    $covered    = 0;
+
+    foreach ($buckets as $key => $pair) {
+        if ($keep !== null && isset($keep[$key]) === false) {
+            continue;
+        }
+
+        $statements += $pair[0];
+        $covered    += $pair[1];
+    }
+
+    return [$statements, $covered];
+}//end cgSumBuckets()
 
 /**
  * Read the changed-file list, keeping only PHP files the guard can measure.
@@ -299,6 +546,15 @@ $cloverFile   = ($positional[0] ?? 'coverage/clover.xml');
 $baselineFile = (__DIR__ . '/../.coverage-baseline');
 $against      = ($options['against'] ?? null);
 $changedList  = ($options['changed-files'] ?? null);
+$deletionFree = isset($options['deletion-neutral']);
+
+// A flag that is accepted and ignored is the silent-downgrade shape this script's
+// `--capabilities` probe exists to prevent, so refuse rather than fall through to
+// a comparison the caller did not ask for.
+if ($deletionFree === true && (is_string($changedList) === false || $changedList === '')) {
+    fwrite(STDERR, "Error: --deletion-neutral requires --changed-files (and therefore --against). It refines the file-scoped comparison; it has no meaning against the whole project.\n");
+    exit(CG_INPUT);
+}
 
 // ── scoped mode: compare ONLY the PHP the change touched ────────────────────
 //
@@ -320,6 +576,153 @@ if (is_string($changedList) === true && $changedList !== '') {
     }
 
     echo 'Scoped to ' . count($changed) . " changed PHP file(s).\n";
+
+    // ── deletion-neutral mode ───────────────────────────────────────────────
+    //
+    // WHAT THIS FIXES. `cgRatioDropped()` is a single integer cross-product with
+    // no tolerance, so the file-scoped ratchet demands, exactly:
+    //
+    //     the code you touched must be at least as well covered as the code you
+    //     did not.
+    //
+    // For ADDITIONS that is right, and it earns its keep: openconnector#1265
+    // covered 27 of 54 new statements against a 61.86% floor, needed 34, and
+    // writing the missing seven is what exposed a cascade that deleted nothing
+    // and reported success.
+    //
+    // For DELETIONS it INVERTS. Removing `d` statements of which `c` were covered
+    // lowers the ratio whenever c/d exceeds the ratio of what remains — i.e.
+    // whenever the deleted code was better tested than average. And dead code is
+    // dead because nothing CALLS it, not because nothing TESTED it: gate-57
+    // (orphaned-write-capability) exists to find precisely that code, so gate-57
+    // and this ratchet are in arithmetic opposition, not tension. Such a pull
+    // request cannot satisfy the ratchet from inside its own subject at all —
+    // the only moves are delete less, add filler, or delete additional
+    // *uncovered* statements until it balances. The gate can be satisfied by
+    // deleting more code and cannot be satisfied by testing anything.
+    //
+    // Measured, both blocked by the file-scoped rule:
+    //   opencatalogi#895  head 112/115 (97.39%)  base 148/151 (98.01%)  -0.62%
+    //   launchpad#128     head 183/254 (72.05%)  base 220/304 (72.37%)  -0.32%
+    //
+    // THE RULE, AND IT IS ASYMMETRIC ON PURPOSE:
+    //
+    //     drop BASE-ONLY methods (deletions) from the base side;
+    //     KEEP HEAD-ONLY methods (additions) on the head side.
+    //
+    // The symmetric version — "compare over statements present in both reports" —
+    // is the obvious one and it is broken. It also drops head-only statements, so
+    // a change adding 40 new statements with 0 of them covered compares an empty
+    // set to an empty set and PASSES. That is the openconnector#1265 shape, and
+    // the symmetric rule would have retired the half of this ratchet that works.
+    // A mutant reintroducing it is in the test suite and must stay there.
+    //
+    // Consequences, all four measured in quality-config/tests/test-coverage-guard.py:
+    //   pure deletion (opencatalogi) PASS  112/115 vs 112/115 — exactly neutral
+    //   pure deletion (launchpad)    PASS  183/254 vs 183/254
+    //   regression in survivors      FAIL  180/254 vs 183/254
+    //   new untested code            FAIL  183/294 (62.24%) vs 183/254 (72.05%)
+    //
+    // KNOWN RESIDUAL, stated rather than discovered: a RENAME reads as a delete
+    // plus an add. The old name leaves the base side, the new name arrives on the
+    // head side and must be covered. That is the right incentive — a renamed
+    // method is new code as far as the test suite is concerned — but it means a
+    // pure rename of a well-covered method is not free, and an author who did not
+    // expect it will read the failure as noise. It is documented here and in the
+    // failure message so it is legible when it happens.
+    if ($deletionFree === true) {
+        [$headBuckets, $headFiles, $headFellBack] = cgAttributeMethods($cloverFile, 'current', $changed);
+        [$baseBuckets, $baseFiles, $baseFellBack] = cgAttributeMethods($against, 'merge-base', $changed);
+
+        // Either side falling back forces BOTH sides to file level for that file —
+        // see cgCollapseFiles() for why anything else is an invisible pass.
+        $collapse = array_values(array_unique(array_merge($headFellBack, $baseFellBack)));
+        if (empty($collapse) === false) {
+            echo 'Falling back to file-level metrics on both sides for: ' . implode(', ', $collapse) . "\n";
+            $headBuckets = cgCollapseFiles($headBuckets, $collapse);
+            $baseBuckets = cgCollapseFiles($baseBuckets, $collapse);
+        }
+
+        echo 'Deletion-neutral: attributed by method name (head ' . count($headFiles) . ' file(s), '
+            . 'base ' . count($baseFiles) . ' file(s), ' . count($headBuckets) . ' head method(s), '
+            . count($baseBuckets) . " base method(s)).\n";
+
+        // A changed file the base measured and the head did not is normally a
+        // DELETED file, and treating it as deleted is the point of this mode. But
+        // it is also what an accidental coverage exclusion looks like, and the two
+        // are indistinguishable from here — so it is said out loud rather than
+        // absorbed silently.
+        $goneFiles = array_values(array_diff($baseFiles, $headFiles));
+        if (empty($goneFiles) === false) {
+            echo 'Measured at the merge base and absent from the head report: '
+                . implode(', ', $goneFiles) . "\n";
+            echo "    Treated as deleted. If one of those files still exists, it has been dropped from\n";
+            echo "    coverage measurement and that is the thing to fix, not this guard.\n";
+        }
+
+        if (empty($headBuckets) === true && empty($baseBuckets) === true) {
+            echo "OK: none of the changed PHP files appear in either coverage report.\n";
+            echo "    Nothing was measured, so nothing is claimed about them.\n";
+            exit(CG_OK);
+        }
+
+        $keep = [];
+        foreach ($headBuckets as $key => $unused) {
+            $keep[$key] = true;
+        }
+
+        $dropped = [];
+        foreach ($baseBuckets as $key => $pair) {
+            if (isset($keep[$key]) === false) {
+                $dropped[$key] = $pair;
+            }
+        }
+
+        [$statements, $covered]         = cgSumBuckets($headBuckets);
+        [$baseStatements, $baseCovered] = cgSumBuckets($baseBuckets, $keep);
+
+        $current = ($statements > 0 ? round((($covered / $statements) * 100), 2) : 0.0);
+        $base    = ($baseStatements > 0 ? round((($baseCovered / $baseStatements) * 100), 2) : 0.0);
+
+        if (empty($dropped) === false) {
+            [$droppedStatements, $droppedCovered] = cgSumBuckets($dropped);
+            echo 'Removed from the base side: ' . count($dropped)
+                . " method(s) absent from head, {$droppedCovered}/{$droppedStatements} statements.\n";
+            echo "    A method that no longer exists is not a coverage regression; it is deleted code.\n";
+        }
+
+        cgReport('Surviving code, head:', $statements, $covered, $current);
+        cgReport('Surviving code, base:', $baseStatements, $baseCovered, $base);
+
+        if ($baseStatements === 0) {
+            echo "OK: none of the changed PHP existed at the merge base, so there is no prior figure to drop below.\n";
+            exit(CG_OK);
+        }
+
+        if (cgRatioDropped($covered, $statements, $baseCovered, $baseStatements) === true) {
+            $delta = round(($base - $current), 2);
+            echo($delta > 0
+                ? "FAIL: coverage of the code this change KEEPS or ADDS dropped by {$delta}%.\n"
+                : "FAIL: coverage of the code this change KEEPS or ADDS dropped by less than 0.01% — too "
+                . "little to show in the percentage, but a real loss in the counts below.\n");
+            echo "      base {$baseCovered}/{$baseStatements} -> head {$covered}/{$statements} statements, "
+                . "comparing only methods that exist on BOTH sides plus everything new on this branch.\n";
+
+            if ($statements > $baseStatements) {
+                $added = ($statements - $baseStatements);
+                echo "      This change adds {$added} statements to those files. Adding code without tests drops coverage.\n";
+            }
+
+            echo "      Deleted methods were already excluded, so this is not a deletion penalty. If you\n";
+            echo "      RENAMED a method, note that a rename reads as a delete plus an add: the new name is\n";
+            echo "      new code here and has to be covered.\n";
+
+            exit(CG_DROPPED);
+        }
+
+        echo "OK: coverage of the surviving and added code did not drop.\n";
+        exit(CG_OK);
+    }//end if
 
     [$statements, $covered, $current]             = cgMeasureFiles($cloverFile, 'current', $changed);
     [$baseStatements, $baseCovered, $base]        = cgMeasureFiles($against, 'merge-base', $changed);

--- a/src/components/BudgetBBVMapping/BudgetBBVMappingIndex.vue
+++ b/src/components/BudgetBBVMapping/BudgetBBVMappingIndex.vue
@@ -6,8 +6,8 @@
  bookkeeping-waterschappen-bbv-variant).
 
  Renders the list of `BudgetBBVMapping` records served by the
- OpenRegister object endpoint (`/apps/shillinq/api/openregister/
- objects/BudgetBBVMapping`). The page wraps `CnIndexPage` from the
+ OpenRegister object endpoint (`/apps/openregister/api/objects/
+ shillinq/BudgetBBVMapping`). The page wraps `CnIndexPage` from the
  shared `@conduction/nextcloud-vue` library so columns, sort, paging,
  empty state and the Add-button affordance are all platform-rendered.
 

--- a/src/components/Dashboard/BBVComplianceDashboard.vue
+++ b/src/components/Dashboard/BBVComplianceDashboard.vue
@@ -16,7 +16,7 @@
    └────────────────────────────────────────────────────────────────┘
 
  The page fetches `BBVProgramme` objects from the OR endpoint
- (`/apps/shillinq/api/openregister/objects/BBVProgramme`). The slice-02
+ (`/apps/openregister/api/objects/shillinq/BBVProgramme`). The slice-02
  x-openregister-aggregations block materialises totalBudget, ytdSpend,
  utilization, utilizationPercentage and complianceStatus directly on
  each returned object, so every widget reads server-authoritative data —

--- a/src/components/goods-receipt-note/GoodsReceiptNoteDetail.vue
+++ b/src/components/goods-receipt-note/GoodsReceiptNoteDetail.vue
@@ -230,6 +230,7 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-04-goods-receipt-note/tasks.md */
 		async load() {
 			this.loading = true
 			try {
@@ -253,6 +254,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-04-goods-receipt-note/tasks.md */
 		async loadLines() {
 			try {
 				const response = await axios.get(
@@ -267,6 +269,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-04-goods-receipt-note/tasks.md */
 		async loadPurchaseOrders() {
 			const map = {}
 			for (const poId of this.grn.poIds || []) {
@@ -284,6 +287,7 @@ export default {
 			this.purchaseOrders = map
 		},
 
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-04-goods-receipt-note/tasks.md */
 		async loadMatches() {
 			try {
 				const response = await axios.get(

--- a/src/components/goods-receipt-note/GoodsReceiptNoteDetail.vue
+++ b/src/components/goods-receipt-note/GoodsReceiptNoteDetail.vue
@@ -184,6 +184,8 @@ import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { NcButton } from '@nextcloud/vue'
 
+const REGISTER_SLUG = 'shillinq'
+
 export default {
 	name: 'GoodsReceiptNoteDetail',
 	components: {
@@ -233,7 +235,7 @@ export default {
 			try {
 				const response = await axios.get(
 					generateUrl(
-						`/apps/shillinq/api/openregister/objects/GoodsReceiptNote/${this.id}`,
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/GoodsReceiptNote/${this.id}`,
 					),
 				)
 				this.grn = response.data || null
@@ -255,7 +257,7 @@ export default {
 			try {
 				const response = await axios.get(
 					generateUrl(
-						'/apps/shillinq/api/openregister/objects/GoodsReceiptLine',
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/GoodsReceiptLine`,
 					),
 					{ params: { filter: { grnId: this.id } } },
 				)
@@ -271,7 +273,7 @@ export default {
 				try {
 					const response = await axios.get(
 						generateUrl(
-							`/apps/shillinq/api/openregister/objects/PurchaseOrder/${poId}`,
+							`/apps/openregister/api/objects/${REGISTER_SLUG}/PurchaseOrder/${poId}`,
 						),
 					)
 					map[poId] = response.data || null
@@ -286,7 +288,7 @@ export default {
 			try {
 				const response = await axios.get(
 					generateUrl(
-						'/apps/shillinq/api/openregister/objects/ThreeWayMatch',
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/ThreeWayMatch`,
 					),
 					{ params: { filter: { grnIds: this.id } } },
 				)

--- a/src/components/goods-receipt-note/GoodsReceiptNoteForm.vue
+++ b/src/components/goods-receipt-note/GoodsReceiptNoteForm.vue
@@ -287,6 +287,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-04-goods-receipt-note/tasks.md */
 		async loadOpenPurchaseOrders() {
 			try {
 				const response = await axios.get(
@@ -312,6 +313,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-04-goods-receipt-note/tasks.md */
 		async refreshLines() {
 			if (this.selectedPoIds.length === 0) {
 				this.availableLines = []

--- a/src/components/goods-receipt-note/GoodsReceiptNoteForm.vue
+++ b/src/components/goods-receipt-note/GoodsReceiptNoteForm.vue
@@ -190,6 +190,8 @@ import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { NcButton, NcInputField, NcSelect, NcTextField } from '@nextcloud/vue'
 
+const REGISTER_SLUG = 'shillinq'
+
 export default {
 	name: 'GoodsReceiptNoteForm',
 	components: {
@@ -289,7 +291,7 @@ export default {
 			try {
 				const response = await axios.get(
 					generateUrl(
-						'/apps/shillinq/api/openregister/objects/PurchaseOrder',
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/PurchaseOrder`,
 					),
 				)
 				const records = response.data?.results || response.data || []
@@ -322,7 +324,7 @@ export default {
 				try {
 					const response = await axios.get(
 						generateUrl(
-							'/apps/shillinq/api/openregister/objects/PurchaseOrderLine',
+							`/apps/openregister/api/objects/${REGISTER_SLUG}/PurchaseOrderLine`,
 						),
 						{ params: { filter: { poId } } },
 					)

--- a/src/components/purchase-order/PurchaseOrderDetail.vue
+++ b/src/components/purchase-order/PurchaseOrderDetail.vue
@@ -309,6 +309,7 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-02-purchase-order-core/tasks.md */
 		async loadPurchaseOrder() {
 			this.loading = true
 			try {
@@ -330,6 +331,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-02-purchase-order-core/tasks.md */
 		async loadRelated() {
 			// The related-records lookups go through the OR REST surface; if the
 			// schemas are not yet registered (e.g. before slice 04/06 ship) we

--- a/src/components/purchase-order/PurchaseOrderDetail.vue
+++ b/src/components/purchase-order/PurchaseOrderDetail.vue
@@ -248,6 +248,8 @@ import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { NcButton } from '@nextcloud/vue'
 
+const REGISTER_SLUG = 'shillinq'
+
 export default {
 	name: 'PurchaseOrderDetail',
 	components: {
@@ -312,7 +314,7 @@ export default {
 			try {
 				const response = await axios.get(
 					generateUrl(
-						`/apps/shillinq/api/openregister/objects/PurchaseOrder/${this.id}`,
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/PurchaseOrder/${this.id}`,
 					),
 				)
 				this.purchaseOrder = response.data || null
@@ -335,7 +337,7 @@ export default {
 			try {
 				const grnResponse = await axios.get(
 					generateUrl(
-						'/apps/shillinq/api/openregister/objects/GoodsReceiptNote',
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/GoodsReceiptNote`,
 					),
 					{ params: { filter: { poIds: this.id } } },
 				)
@@ -346,7 +348,7 @@ export default {
 			try {
 				const matchResponse = await axios.get(
 					generateUrl(
-						'/apps/shillinq/api/openregister/objects/ThreeWayMatch',
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/ThreeWayMatch`,
 					),
 					{ params: { filter: { matchedPoIds: this.id } } },
 				)

--- a/src/components/supplier-invoice/SupplierInvoiceDetail.vue
+++ b/src/components/supplier-invoice/SupplierInvoiceDetail.vue
@@ -181,6 +181,8 @@
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 
+const REGISTER_SLUG = 'shillinq'
+
 export default {
 	name: 'SupplierInvoiceDetail',
 	props: {
@@ -268,7 +270,7 @@ export default {
 			try {
 				const response = await axios.get(
 					generateUrl(
-						`/apps/shillinq/api/openregister/objects/SupplierInvoice/${this.id}`,
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/SupplierInvoice/${this.id}`,
 					),
 				)
 				this.invoice = response.data || null
@@ -290,7 +292,7 @@ export default {
 			try {
 				const response = await axios.get(
 					generateUrl(
-						'/apps/shillinq/api/openregister/objects/ThreeWayMatch',
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/ThreeWayMatch`,
 					),
 					{ params: { filter: { invoiceId: this.id } } },
 				)

--- a/src/components/supplier-invoice/SupplierInvoiceDetail.vue
+++ b/src/components/supplier-invoice/SupplierInvoiceDetail.vue
@@ -265,6 +265,7 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-05-supplier-invoice-ingestion/tasks.md */
 		async loadInvoice() {
 			this.loading = true
 			try {
@@ -286,6 +287,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-05-supplier-invoice-ingestion/tasks.md */
 		async loadMatches() {
 			// ThreeWayMatch records are populated by slice 06; gracefully fall
 			// through to the empty state when the lookup isn't available yet.

--- a/src/components/three-way-match/ThreeWayMatchExceptionPanel.vue
+++ b/src/components/three-way-match/ThreeWayMatchExceptionPanel.vue
@@ -219,6 +219,8 @@
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 
+const REGISTER_SLUG = 'shillinq'
+
 const EXCEPTION_STATUSES = [
 	'exception_price',
 	'exception_quantity',
@@ -328,7 +330,7 @@ export default {
 			try {
 				const response = await axios.get(
 					generateUrl(
-						`/apps/shillinq/api/openregister/objects/ThreeWayMatch/${this.id}`,
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/ThreeWayMatch/${this.id}`,
 					),
 				)
 				this.match = response.data || null
@@ -371,7 +373,7 @@ export default {
 			try {
 				const response = await axios.get(
 					generateUrl(
-						`/apps/shillinq/api/openregister/objects/SupplierInvoice/${this.match.invoiceId}`,
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/SupplierInvoice/${this.match.invoiceId}`,
 					),
 				)
 				this.invoice = response.data || null
@@ -384,7 +386,7 @@ export default {
 			try {
 				const response = await axios.get(
 					generateUrl(
-						`/apps/shillinq/api/openregister/objects/PurchaseOrder/${poId}`,
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/PurchaseOrder/${poId}`,
 					),
 				)
 				this.po = response.data || null
@@ -397,7 +399,7 @@ export default {
 			try {
 				const response = await axios.get(
 					generateUrl(
-						`/apps/shillinq/api/openregister/objects/GoodsReceiptNote/${grnId}`,
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/GoodsReceiptNote/${grnId}`,
 					),
 				)
 				this.grn = response.data || null

--- a/src/components/three-way-match/ThreeWayMatchExceptionPanel.vue
+++ b/src/components/three-way-match/ThreeWayMatchExceptionPanel.vue
@@ -325,6 +325,7 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-08-exception-workflow/tasks.md */
 		async loadMatch() {
 			this.loading = true
 			try {
@@ -369,6 +370,7 @@ export default {
 			await Promise.all(tasks)
 		},
 
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-08-exception-workflow/tasks.md */
 		async loadInvoice() {
 			try {
 				const response = await axios.get(
@@ -382,6 +384,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-08-exception-workflow/tasks.md */
 		async loadPo(poId) {
 			try {
 				const response = await axios.get(
@@ -395,6 +398,7 @@ export default {
 			}
 		},
 
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-08-exception-workflow/tasks.md */
 		async loadGrn(grnId) {
 			try {
 				const response = await axios.get(

--- a/src/components/three-way-match/ThreeWayMatchIndex.vue
+++ b/src/components/three-way-match/ThreeWayMatchIndex.vue
@@ -262,6 +262,7 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-06-matching-engine/tasks.md */
 		async loadMatches() {
 			this.loading = true
 			this.error = ''

--- a/src/components/three-way-match/ThreeWayMatchIndex.vue
+++ b/src/components/three-way-match/ThreeWayMatchIndex.vue
@@ -142,6 +142,8 @@ import { CnDataTable } from '@conduction/nextcloud-vue'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 
+const REGISTER_SLUG = 'shillinq'
+
 export default {
 	name: 'ThreeWayMatchIndex',
 	components: {
@@ -266,7 +268,7 @@ export default {
 			try {
 				const response = await axios.get(
 					generateUrl(
-						'/apps/shillinq/api/openregister/objects/ThreeWayMatch',
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/ThreeWayMatch`,
 					),
 				)
 				const rows = response.data?.results || response.data || []
@@ -282,7 +284,7 @@ export default {
 					try {
 						const inv = await axios.get(
 							generateUrl(
-								`/apps/shillinq/api/openregister/objects/SupplierInvoice/${id}`,
+								`/apps/openregister/api/objects/${REGISTER_SLUG}/SupplierInvoice/${id}`,
 							),
 						)
 						this.invoices[id] = inv.data || null

--- a/src/components/vendor-performance/VendorPerformanceDetail.vue
+++ b/src/components/vendor-performance/VendorPerformanceDetail.vue
@@ -16,7 +16,7 @@
  index — the per-month rates above are computed from those exact records
  so the operator can cross-check the underlying activity.
 
- Data flow: GET /apps/shillinq/api/openregister/objects/VendorPerformance/{id}
+ Data flow: GET /apps/openregister/api/objects/shillinq/VendorPerformance/{id}
  — the route is the standard OR object endpoint and the scorecard is
  read-only from the UI's perspective (the cron writes it).
 
@@ -208,6 +208,8 @@
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 
+const REGISTER_SLUG = 'shillinq'
+
 export default {
 	name: 'VendorPerformanceDetail',
 	props: {
@@ -254,7 +256,7 @@ export default {
 			try {
 				const response = await axios.get(
 					generateUrl(
-						`/apps/shillinq/api/openregister/objects/VendorPerformance/${id}`,
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/VendorPerformance/${id}`,
 					),
 				)
 				this.scorecard = response.data || null

--- a/src/components/vendor-performance/VendorPerformanceDetail.vue
+++ b/src/components/vendor-performance/VendorPerformanceDetail.vue
@@ -244,6 +244,7 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-10-vendor-performance/tasks.md */
 		async loadScorecard() {
 			this.loading = true
 			this.error = ''

--- a/src/components/vendor-performance/VendorPerformanceIndex.vue
+++ b/src/components/vendor-performance/VendorPerformanceIndex.vue
@@ -14,7 +14,7 @@
  ineligible / all suppliers. The row count is bounded by the supplier base
  (typically <100 active suppliers) so an in-memory filter is well-sized.
 
- Data flow: GET /apps/shillinq/api/openregister/objects/VendorPerformance
+ Data flow: GET /apps/openregister/api/objects/shillinq/VendorPerformance
  — paginated by the OR endpoint; sorted in-memory after fetch.
 
  @spec openspec/changes/bookkeeping-purchase-order-3way-10-vendor-performance/tasks.md
@@ -128,6 +128,8 @@ import { CnDataTable } from '@conduction/nextcloud-vue'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 
+const REGISTER_SLUG = 'shillinq'
+
 export default {
 	name: 'VendorPerformanceIndex',
 	components: {
@@ -234,7 +236,7 @@ export default {
 			try {
 				const response = await axios.get(
 					generateUrl(
-						'/apps/shillinq/api/openregister/objects/VendorPerformance',
+						`/apps/openregister/api/objects/${REGISTER_SLUG}/VendorPerformance`,
 					),
 				)
 				const rows = response.data?.results || response.data || []

--- a/src/components/vendor-performance/VendorPerformanceIndex.vue
+++ b/src/components/vendor-performance/VendorPerformanceIndex.vue
@@ -230,6 +230,7 @@ export default {
 	},
 
 	methods: {
+		/** @spec openspec/changes/bookkeeping-purchase-order-3way-10-vendor-performance/tasks.md */
 		async loadRows() {
 			this.loading = true
 			this.error = ''

--- a/src/views/BudgetLineCommitments.vue
+++ b/src/views/BudgetLineCommitments.vue
@@ -182,6 +182,8 @@ import {
 	normaliseBudgetLineRows,
 } from './budgetLineCommitmentsHelpers.js'
 
+const REGISTER_SLUG = 'shillinq'
+
 export default {
 	name: 'BudgetLineCommitments',
 
@@ -216,7 +218,7 @@ export default {
 
 			try {
 				const url = generateUrl(
-					'/apps/shillinq/api/openregister/objects/CommitmentLine/aggregations/committedVsRealisedPerBudgetLine',
+					`/apps/openregister/api/objects/aggregations/${REGISTER_SLUG}/CommitmentLine/committedVsRealisedPerBudgetLine`,
 				)
 				const { data } = await axios.get(url)
 				this.rows = normaliseBudgetLineRows(data)
@@ -267,7 +269,7 @@ export default {
 					params[`filters[${key}]`] = filters[key]
 				})
 				const url = generateUrl(
-					'/apps/shillinq/api/openregister/objects/CommitmentLine',
+					`/apps/openregister/api/objects/${REGISTER_SLUG}/CommitmentLine`,
 				)
 				const { data } = await axios.get(url, { params })
 				const items = Array.isArray(data?.results)

--- a/src/views/bookkeeping/dimensions/SegmentPnLDashboard.vue
+++ b/src/views/bookkeeping/dimensions/SegmentPnLDashboard.vue
@@ -157,6 +157,8 @@ import {
 	NcLoadingIcon,
 } from '@nextcloud/vue'
 
+const REGISTER_SLUG = 'shillinq'
+
 const SEGMENT_AGGREGATION = {
 	costCenter: 'byCostCenter',
 	costCenterHierarchy: 'byCostCenterHierarchy',
@@ -246,7 +248,7 @@ export default {
 
 			try {
 				const url = generateUrl(
-					'/apps/shillinq/api/openregister/objects/GLLine/aggregations/'
+					`/apps/openregister/api/objects/aggregations/${REGISTER_SLUG}/GLLine/`
 						+ encodeURIComponent(aggregationName),
 				)
 				const { data } = await axios.get(url)

--- a/src/views/bookkeeping/dimensions/SegmentPnLDashboard.vue
+++ b/src/views/bookkeeping/dimensions/SegmentPnLDashboard.vue
@@ -234,6 +234,7 @@ export default {
 			this.loadSegment(segment)
 		},
 
+		/** @spec openspec/changes/bookkeeping-cost-centers-dimensions/tasks.md#task-14 */
 		async loadSegment(segment) {
 			this.loading = true
 			this.errorMessage = ''

--- a/tests/Unit/AppInfo/ApiFallbackRouteOrderTest.php
+++ b/tests/Unit/AppInfo/ApiFallbackRouteOrderTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * Unit tests for the `/api/{path}` fallback route's POSITION.
+ *
+ * The fallback only works because of where it sits: after every genuine API
+ * route this app declares, and before the SPA catch-all. That ordering is the
+ * entire mechanism, and nothing about it is visible in a diff that merely
+ * moves a line — exactly the kind of change that would silently restore the
+ * bug it exists to prevent (issue #1209).
+ *
+ * These tests read `appinfo/routes.php` as SOURCE TEXT rather than including
+ * it. Including it needs `\OCA\OpenRegister\AppHost\Routes`, which is not
+ * loadable in the unit bootstrap; stubbing it would mean re-implementing
+ * `standard()` in the fixture and then asserting against my own copy of the
+ * merge logic — a test that passes because the fixture agrees with itself.
+ * What this app actually controls is the ORDER OF ITS OWN `$extra` entries,
+ * and that is what is pinned here. AppHost's half of the contract —
+ * `array_merge($canonical, $extra)` followed by appending the `/{path}`
+ * catch-all — belongs to OpenRegister and is asserted in its own suite.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\AppInfo
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/bookkeeping-verplichtingenadministratie/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\AppInfo;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the fallback route as the last `$extra` entry shillinq declares.
+ *
+ * @spec openspec/specs/bookkeeping-verplichtingenadministratie/spec.md
+ */
+final class ApiFallbackRouteOrderTest extends TestCase {
+
+	/**
+	 * The route table source.
+	 *
+	 * @return string
+	 */
+	private function source(): string {
+		$path = __DIR__ . '/../../../appinfo/routes.php';
+		self::assertFileExists($path);
+		return (string)file_get_contents($path);
+
+	}//end source()
+
+	/**
+	 * Every declared route entry, in order, as [name, url] pairs.
+	 *
+	 * @return array<int, array{0: string, 1: string}>
+	 */
+	private function entries(): array {
+		$matches = [];
+		preg_match_all(
+			"/'name'\s*=>\s*'([^']+)'\s*,\s*'url'\s*=>\s*'([^']+)'/",
+			$this->source(),
+			$matches,
+			PREG_SET_ORDER
+		);
+
+		$out = [];
+		foreach ($matches as $m) {
+			$out[] = [$m[1], $m[2]];
+		}
+
+		return $out;
+
+	}//end entries()
+
+	/**
+	 * The fallback is declared, with the shape that makes it reachable.
+	 *
+	 * `{path}` without a `.+` requirement matches ONE segment. The dead url
+	 * that motivated this — `api/openregister/objects/CommitmentLine/
+	 * aggregations/committedVsRealisedPerBudgetLine` — is six segments deep, so
+	 * a single-segment fallback would let exactly the case it exists to catch
+	 * fall straight through to the SPA again.
+	 *
+	 * @return void
+	 */
+	public function testFallbackIsDeclaredAndMatchesMultiSegmentPaths(): void {
+		$source = $this->source();
+
+		self::assertStringContainsString(
+			"'name' => 'apiFallback#notFound', 'url' => '/api/{path}'",
+			$source,
+			'The /api/{path} fallback must be declared'
+		);
+		self::assertMatchesRegularExpression(
+			"/'apiFallback#notFound'.*'requirements'\s*=>\s*\['path'\s*=>\s*'\.\+'\]/s",
+			$source,
+			"The fallback's {path} must carry the .+ requirement or it only matches one segment"
+		);
+
+	}//end testFallbackIsDeclaredAndMatchesMultiSegmentPaths()
+
+	/**
+	 * The fallback is the LAST route entry in the file.
+	 *
+	 * `Routes::standard()` appends the SPA catch-all after `$extra`, so being
+	 * last here means sitting immediately before it.
+	 *
+	 * @return void
+	 */
+	public function testFallbackIsTheLastDeclaredEntry(): void {
+		$entries = $this->entries();
+		self::assertNotEmpty($entries);
+
+		$last = end($entries);
+		self::assertSame(
+			'apiFallback#notFound',
+			$last[0],
+			'The fallback must be the last $extra entry, so nothing shillinq declares is shadowed by it'
+		);
+
+	}//end testFallbackIsTheLastDeclaredEntry()
+
+	/**
+	 * No genuine `/api/` route is declared after the fallback.
+	 *
+	 * One that was would be shadowed and answer 404 — the fallback would then
+	 * cause the very failure it exists to expose.
+	 *
+	 * @return void
+	 */
+	public function testNoRealApiRouteIsShadowedByTheFallback(): void {
+		$entries = $this->entries();
+
+		$seenFallback = false;
+		$shadowed = [];
+		foreach ($entries as [$name, $url]) {
+			if ($name === 'apiFallback#notFound') {
+				$seenFallback = true;
+				continue;
+			}
+
+			if ($seenFallback === true && str_starts_with($url, '/api/') === true) {
+				$shadowed[] = $name . ' => ' . $url;
+			}
+		}
+
+		self::assertTrue($seenFallback, 'The fallback must be declared');
+		self::assertSame([], $shadowed, 'These /api/ routes are shadowed by the fallback and can never match');
+
+	}//end testNoRealApiRouteIsShadowedByTheFallback()
+
+	/**
+	 * The app declares a real number of API routes ahead of the fallback.
+	 *
+	 * A guard against the file being gutted or the regex silently matching
+	 * nothing: a fallback that is "last" among two entries proves nothing.
+	 *
+	 * @return void
+	 */
+	public function testTheFallbackGuardsAPopulatedRouteTable(): void {
+		$apiRoutes = 0;
+		foreach ($this->entries() as [$name, $url]) {
+			if ($name !== 'apiFallback#notFound' && str_starts_with($url, '/api/') === true) {
+				$apiRoutes++;
+			}
+		}
+
+		self::assertGreaterThan(100, $apiRoutes, 'Expected the full shillinq API surface ahead of the fallback');
+
+	}//end testTheFallbackGuardsAPopulatedRouteTable()
+}//end class

--- a/tests/Unit/Controller/ApiFallbackControllerTest.php
+++ b/tests/Unit/Controller/ApiFallbackControllerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * Unit tests for ApiFallbackController.
+ *
+ * The controller is small on purpose — it is a net, not a policy — but the
+ * two things it must get right are exactly the two that made the bug it
+ * closes invisible: the STATUS must be 404 rather than 200, and the body must
+ * NAME the path so the caller learns which url was wrong. A 404 with an empty
+ * body would still be a large improvement on the SPA shell, but it would
+ * leave the reader hunting.
+ *
+ * @category Test
+ * @package  OCA\Shillinq\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/specs/bookkeeping-verplichtingenadministratie/spec.md
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * phpcs:disable CustomSniffs.Functions.NamedParameters
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Tests\Unit\Controller;
+
+use OCA\Shillinq\Controller\ApiFallbackController;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the 404 fallback for unmatched shillinq API paths.
+ *
+ * @spec openspec/specs/bookkeeping-verplichtingenadministratie/spec.md
+ */
+final class ApiFallbackControllerTest extends TestCase {
+
+	/**
+	 * Build the controller with a mocked request.
+	 *
+	 * @return ApiFallbackController
+	 */
+	private function controller(): ApiFallbackController {
+		return new ApiFallbackController('shillinq', $this->createMock(IRequest::class));
+
+	}//end controller()
+
+	/**
+	 * The status is 404, not 200.
+	 *
+	 * This is the whole point: the SPA catch-all answered these with 200, which
+	 * made `axios.get()` RESOLVE and the caller render an empty list.
+	 *
+	 * @return void
+	 */
+	public function testStatusIs404(): void {
+		$response = $this->controller()->notFound('openregister/objects/CommitmentLine');
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+
+	}//end testStatusIs404()
+
+	/**
+	 * The body names the unmatched path.
+	 *
+	 * Without this the caller knows only that something 404'd, which is the
+	 * state the old behaviour left them in.
+	 *
+	 * @return void
+	 */
+	public function testBodyNamesTheUnmatchedPath(): void {
+		$data = $this->controller()->notFound('openregister/objects/CommitmentLine')->getData();
+
+		self::assertArrayHasKey('message', $data);
+		self::assertStringContainsString(
+			'api/openregister/objects/CommitmentLine',
+			$data['message'],
+			'The response must name the path that did not match'
+		);
+		self::assertArrayHasKey('hint', $data);
+		self::assertNotSame('', (string)$data['hint']);
+
+	}//end testBodyNamesTheUnmatchedPath()
+
+	/**
+	 * A multi-segment path survives intact in the message.
+	 *
+	 * The url that motivated this is six segments deep; a fallback that
+	 * reported only the first segment would misdirect the reader.
+	 *
+	 * @return void
+	 */
+	public function testMultiSegmentPathIsReportedWhole(): void {
+		$path = 'openregister/objects/CommitmentLine/aggregations/committedVsRealisedPerBudgetLine';
+		$data = $this->controller()->notFound($path)->getData();
+
+		self::assertStringContainsString($path, (string)$data['message']);
+
+	}//end testMultiSegmentPathIsReportedWhole()
+
+	/**
+	 * An empty path still answers 404 rather than erroring.
+	 *
+	 * The route declares a default, so the method must tolerate being called
+	 * with nothing.
+	 *
+	 * @return void
+	 */
+	public function testEmptyPathStillAnswers404(): void {
+		$response = $this->controller()->notFound();
+
+		self::assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+		self::assertArrayHasKey('message', $response->getData());
+
+	}//end testEmptyPathStillAnswers404()
+}//end class


### PR DESCRIPTION
Closes #1209.

## The bug

Eleven components fetched `/apps/shillinq/api/openregister/objects/...` — **a route this app has never declared.** All 227 route entries checked; none matches.

`appinfo/routes.php` returns `\OCA\OpenRegister\AppHost\Routes::standard()`, whose last entry is a `/{path}` catch-all serving the Vue SPA so browser deep links resolve. It cannot tell a deep link from an API call, so those requests were answered with **HTTP 200 and ~39 KB of HTML**.

For a browser that is correct. For `axios.get()` it is a disaster: the promise **resolves**, `data.results` is `undefined`, the caller renders zero rows and shows its empty state. No exception, no console warning, no log line.

Measured on a live rig, these were **indistinguishable** — all 200 + the same HTML:

| URL | |
|---|---|
| `…/objects/CommitmentLine` | a real schema |
| `…/objects/Verplichtingsregel` | a retired schema |
| `…/objects/ThisSchemaDoesNotExistXyz` | nonsense |
| `/apps/shillinq/api/zzz/nonsense/path` | nonsense |

A wrong URL and an empty result set produced the same bytes. That is why this survived as long as those components have existed.

**Blast radius:** Purchase Orders, Supplier Invoices, Goods Receipt Notes, Three-Way Match, Vendor Performance, Budget-Line Commitments, Segment P&L.

## Commit 1 — make it loud

A single `/api/{path}` route, declared as the **last** entry of `$extra`, answering 404 with a body naming the path. `Routes::standard()` does `array_merge($canonical, $extra)` then appends the catch-all, so all 236 genuine routes match first and only a true miss reaches it. Verified against the built table: `apiFallback#notFound` at index 236, `dashboard#catchAll` at 237.

It adds no behaviour of its own — a net, not a policy. `#[NoAdminRequired]`, because a fallback that 403'd for ordinary users would swap one misleading answer for another.

`{path}` carries a `.+` requirement. Without it `{path}` matches **one** segment, and the six-segment URL that motivated this would fall through to the SPA exactly as before — the fix would look applied and change nothing.

**Four tests** read `routes.php` as source text rather than including it. Including it needs `\OCA\OpenRegister\AppHost\Routes`, absent from the unit bootstrap; stubbing it would mean re-implementing `standard()` in the fixture and asserting against my own copy of the merge logic — a test that passes because the fixture agrees with itself. What this app controls is the order of its own entries, so that is what is pinned. Confirmed to **fail (2 failures)** with the fallback moved earlier.

## Commit 2 — make it work

22 live call sites across 10 files repointed to OpenRegister's real endpoint, with `const REGISTER_SLUG = 'shillinq'` added to each (none had it), matching the pattern already used in `ReceiptCapture.vue` and `BudgetScenarioComparison.vue`. Five stale doc comments corrected.

**The aggregation path was not what the issue assumed.** Checking OpenRegister's route table rather than guessing showed the literal `aggregations` segment sits **before** `{register}/{schema}`:

```php
['name' => 'aggregation#aggregate',
 'url'  => '/api/objects/aggregations/{register}/{schema}/{name}', 'verb' => 'GET'],
```

So it is `…/api/objects/aggregations/shillinq/CommitmentLine/committedVsRealisedPerBudgetLine`, **not** `…/{Schema}/aggregations/{name}`. Worth noting: both aggregation call sites catch 404/501 and render *"Aggregation endpoint unavailable on this OpenRegister build"* — so the assumed shape would have surfaced as a benign compatibility message rather than an error. The same silent-failure family, avoided only by reading the route table.

## One deliberate residual

`grep -rn "apps/shillinq/api/openregister" src/` is **empty**. One hit remains in `lib/` — the class docblock of `ApiFallbackController`, the controller added here *to 404 that exact path*. The dead path is the subject of that documentation, not a stale pointer; rewriting it would make the sentence false.

## Not changed, and why

`BudgetScenarioComparison.vue:367` passes a bare `limit: 500`. That looked like an instance of the `_limit` control-param rule, but `ObjectService.php:3189` reads `if (isset($query['limit']) === false && isset($query['_limit']) === true)` — bare `limit` is the canonical key and `_limit` its alias, so it is fine. Flagged rather than "fixed".

## Verified

- `phpunit` — **4939 tests, 46213 assertions, 0 failures** (1 skip, pre-existing on `development`)
- `phpcs`, `phpmd`, `psalm`, `phpstan` — pass
- `eslint`, `prettier --check`, `lint`, `format` — pass (100 warnings, all pre-existing; 0 errors)
- No JSON reformatted, so the REQ-MBP-001 manifest budget is untouched
