### PR TITLE
fix(walkthrough): end the tour on a call to action that opens the docs

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -62,9 +62,10 @@
 						"id": "done",
 						"sinceVersion": "1.3.18",
 						"placement": "center",
-						"title": "You're all set",
-						"body": "Nicely done — your first invoice is on the books. Head back to the Dashboard to track your finances, and reopen this tour anytime from the … menu.",
-						"target": { "kind": "page", "ref": "Dashboard" },
+						"title": "Your first invoice is on the books",
+						"body": "The Dashboard tracks your finances as invoices come and go. The documentation covers the rest.",
+						"task": "Open the documentation to keep going",
+						"target": { "kind": "nav-item", "ref": "Documentation" },
 						"advanceOn": { "type": "manual" }
 					}
 				]


### PR DESCRIPTION
The guided tour's final step had **no `task`**, so it stopped without telling the user where to go next. It now closes on the documentation, per the fleet rule that a walkthrough's last step points somewhere.

The CTA targets the `Documentation` nav item **that already exists in this app's menu**, so it lands on a real destination rather than a URL invented for the copy. I checked the URL resolves (HTTP 200) before pointing users at it.

### The same step carried voice defects

Measured against the shared `writing` skill (ConductionNL/hydra#610):

| Was | Why it fails |
|---|---|
| `Nicely done` | praise, not voice |
| `—` | em-dash, stripped fleet-wide |
| `reopen this tour anytime from the … menu` | housekeeping in the one line a user is most likely to act on |

The title now states what the user actually has; the body says what to do with it. No em-dashes, every sentence under 16 words, the task starts with a verb.

### Verification

JSON parses, the final step has a `task`, and its target resolves to a `Documentation` menu entry that exists in this manifest. CI's manifest-validation gate covers the schema.

Part of a fleet sweep across the 9 apps that ship a walkthrough. The survey read each manifest from `origin/development`, not from local working trees, because those sit on other sessions' branches and give a wrong answer.