### PR TITLE
fix(repair): the seeders ran as Anonymous and wrote nothing

### DIFF
--- a/lib/Repair/BackfillFiscalPeriods.php
+++ b/lib/Repair/BackfillFiscalPeriods.php
@@ -50,6 +50,7 @@ namespace OCA\Shillinq\Repair;
 
 use DateTimeImmutable;
 use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
+use OCA\Shillinq\Repair\Support\RunsUnderSystemIdentity;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -63,6 +64,8 @@ use OCA\OpenRegister\Contract\ObjectServiceInterface;
  * @spec openspec/changes/add-shillinq-period-close/tasks.md#task-11
  */
 class BackfillFiscalPeriods implements IRepairStep {
+	use RunsUnderSystemIdentity;
+
 	use ReadsSourceRowsInBatches;
 
 	/**
@@ -101,6 +104,26 @@ class BackfillFiscalPeriods implements IRepairStep {
 	 * @spec openspec/changes/add-shillinq-period-close/tasks.md#task-11
 	 */
 	public function run(IOutput $output): void {
+		// Under a system identity: an upgrade has no session, and OpenRegister
+		// refuses `create` for 'Anonymous' — measured against this register, not
+		// assumed. Without it this backfill writes nothing and says so only in a
+		// warning, which does not fail the upgrade.
+		$this->withSystemIdentity(
+			objectService: $this->objectService,
+			work: function () use ($output): void {
+				$this->runInner(output: $output);
+			}
+		);
+	}//end run()
+
+	/**
+	 * The backfill itself.
+	 *
+	 * @param IOutput $output Progress reporting.
+	 *
+	 * @return void
+	 */
+	private function runInner(IOutput $output): void {
 		try {
 			$registerSlug = $this->settingsService->getRegisterSlug();
 
@@ -187,7 +210,7 @@ class BackfillFiscalPeriods implements IRepairStep {
 			);
 		}//end try
 
-	}//end run()
+	}//end runInner()
 
 	/**
 	 * Whether a FiscalPeriod record already exists for the given

--- a/lib/Repair/BackfillFiscalPeriods.php
+++ b/lib/Repair/BackfillFiscalPeriods.php
@@ -122,6 +122,8 @@ class BackfillFiscalPeriods implements IRepairStep {
 	 * @param IOutput $output Progress reporting.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	private function runInner(IOutput $output): void {
 		try {

--- a/lib/Repair/BackfillGlLineAdministration.php
+++ b/lib/Repair/BackfillGlLineAdministration.php
@@ -149,6 +149,8 @@ class BackfillGlLineAdministration implements IRepairStep {
 	 * @param IOutput $output Progress reporting.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	private function runInner(IOutput $output): void {
 		try {

--- a/lib/Repair/BackfillGlLineAdministration.php
+++ b/lib/Repair/BackfillGlLineAdministration.php
@@ -63,6 +63,7 @@ namespace OCA\Shillinq\Repair;
 use OCA\OpenRegister\Contract\ObjectServiceInterface;
 use OCA\Shillinq\AppInfo\Application;
 use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
+use OCA\Shillinq\Repair\Support\RunsUnderSystemIdentity;
 use OCA\Shillinq\Service\Migration\GlLineAdministrationBackfillMigrator;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\IAppConfig;
@@ -78,6 +79,7 @@ use Psr\Log\LoggerInterface;
  */
 class BackfillGlLineAdministration implements IRepairStep {
 	use ReadsSourceRowsInBatches;
+	use RunsUnderSystemIdentity;
 
 	/**
 	 * Constructor.
@@ -125,6 +127,30 @@ class BackfillGlLineAdministration implements IRepairStep {
 		// rather than serving unscoped totals or silent zeros.
 		$this->closeGate();
 
+		// Under a system identity: an upgrade has no session, and OpenRegister
+		// refuses the write for 'Anonymous'. This step carries `_rbac: false`,
+		// which is NOT sufficient on its own — measured in InitializeSettings,
+		// a step flagging every one of its own writes still failed eight times,
+		// because the refusals arrive from writes further down the call chain.
+		//
+		// The gate is closed BEFORE the scope so it stays shut even if
+		// establishing the identity throws.
+		$this->withSystemIdentity(
+			objectService: $this->objectService,
+			work: function () use ($output): void {
+				$this->runInner(output: $output);
+			}
+		);
+	}//end run()
+
+	/**
+	 * The backfill itself.
+	 *
+	 * @param IOutput $output Progress reporting.
+	 *
+	 * @return void
+	 */
+	private function runInner(IOutput $output): void {
 		try {
 			$registerSlug = $this->settingsService->getRegisterSlug();
 
@@ -170,7 +196,7 @@ class BackfillGlLineAdministration implements IRepairStep {
 			);
 		}//end try
 
-	}//end run()
+	}//end runInner()
 
 	/**
 	 * Re-read every `GLLine` and open the gate only on a zero-missing total.

--- a/lib/Repair/InitializeBbvAdministration.php
+++ b/lib/Repair/InitializeBbvAdministration.php
@@ -107,6 +107,8 @@ class InitializeBbvAdministration implements IRepairStep {
 	 * @param IOutput $output The output interface for progress reporting.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	public function run(IOutput $output): void {
 		try {

--- a/lib/Repair/InitializeBbvAdministration.php
+++ b/lib/Repair/InitializeBbvAdministration.php
@@ -134,6 +134,8 @@ class InitializeBbvAdministration implements IRepairStep {
 	 * @param IOutput $output The output interface for progress reporting.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	private function runInner(object $objectService, IOutput $output): void {
 

--- a/lib/Repair/InitializeBbvAdministration.php
+++ b/lib/Repair/InitializeBbvAdministration.php
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Repair;
 
 use OCA\Shillinq\AppInfo\Application;
+use OCA\Shillinq\Repair\Support\RunsUnderSystemIdentity;
 use OCP\IAppConfig;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -53,6 +54,8 @@ use Psr\Log\LoggerInterface;
  * @spec openspec/specs/bookkeeping-bbv-compliance/spec.md
  */
 class InitializeBbvAdministration implements IRepairStep {
+	use RunsUnderSystemIdentity;
+
 	private const BBV_ADMINISTRATION_TYPES = ['municipality', 'province', 'waterAuthority'];
 
 	private const RESERVE_TAAKVELD = '0.10';
@@ -113,6 +116,27 @@ class InitializeBbvAdministration implements IRepairStep {
 			return;
 		}
 
+		// Under a system identity: an upgrade has no session, and OpenRegister
+		// refuses `create` for 'Anonymous'. Without it this bootstrap writes
+		// nothing and says so only in a warning, which does not fail an upgrade.
+		$this->withSystemIdentity(
+			objectService: $objectService,
+			work: function () use ($objectService, $output): void {
+				$this->runInner(objectService: $objectService, output: $output);
+			}
+		);
+	}//end run()
+
+	/**
+	 * The bootstrap itself.
+	 *
+	 * @param object $objectService OpenRegister's ObjectService.
+	 * @param IOutput $output The output interface for progress reporting.
+	 *
+	 * @return void
+	 */
+	private function runInner(object $objectService, IOutput $output): void {
+
 		$registerSlug = $this->getRegisterSlug();
 
 		try {
@@ -172,7 +196,7 @@ class InitializeBbvAdministration implements IRepairStep {
 			)
 		);
 
-	}//end run()
+	}//end runInner()
 
 	/**
 	 * Ensure an Algemene reserve exists for the given administration.

--- a/lib/Repair/InitializeSettings.php
+++ b/lib/Repair/InitializeSettings.php
@@ -253,6 +253,8 @@ class InitializeSettings implements IRepairStep {
 	 * @param IOutput $output Progress reporting.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	private function runSeeders(IOutput $output): void {
 			$this->seedDefaultAdministration(output: $output);

--- a/lib/Repair/InitializeSettings.php
+++ b/lib/Repair/InitializeSettings.php
@@ -47,6 +47,8 @@ use Psr\Log\LoggerInterface;
  * cleanup. Deferred to a follow-up.
  */
 class InitializeSettings implements IRepairStep {
+	use \OCA\Shillinq\Repair\Support\RunsUnderSystemIdentity;
+
 	/**
 	 * Constructor for InitializeSettings.
 	 *
@@ -224,13 +226,12 @@ class InitializeSettings implements IRepairStep {
 				);
 			}
 
-			if ($objectService !== null && method_exists($objectService, 'runAsSystem') === true) {
-				$objectService->runAsSystem(function () use ($output): void {
+			$this->withSystemIdentity(
+				objectService: $objectService,
+				work: function () use ($output): void {
 					$this->runSeeders(output: $output);
-				});
-			} else {
-				$this->runSeeders(output: $output);
-			}
+				}
+			);
 		} catch (\Throwable $e) {
 			$output->warning('Could not auto-configure Shillinq: ' . $e->getMessage());
 			$this->logger->error(

--- a/lib/Repair/InitializeSettings.php
+++ b/lib/Repair/InitializeSettings.php
@@ -184,6 +184,76 @@ class InitializeSettings implements IRepairStep {
 				return;
 			}
 
+			// EVERY SEEDER BELOW RUNS UNDER A SYSTEM IDENTITY.
+			//
+			// A repair step executes during `occ upgrade`, where there is no
+			// session — so OpenRegister resolves the actor as 'Anonymous' and
+			// refuses `create`. Measured on a live instance before this wrap
+			// existed, this one step emitted EIGHT such failures:
+			//
+			//   BBV stam-data seeding failed:      … schema 'Taakveld'
+			//   Demo barcode seeding issue:        … schema 'Barcode'
+			//   Inventory valuation example …:     … schema 'Inventory Valuation'
+			//   InventoryStock example …:          … schema 'Inventory Stock'
+			//   InventoryGLConfig seeding issue:   … schema 'Inventory GL Posting Configuration'
+			//   BBVProgramme demo seeding issue:   … schema 'BBV Programme'
+			//   Mandaat templates seeding issue:   … schema 'Mandaat'
+			//   FixedAssets demo seeding issue:    … schema 'Fixed Asset'
+			//
+			// Each was reported with `$output->warning()`, which does NOT fail an
+			// upgrade — so the upgrade said "Update successful" while eight sets
+			// of reference data were never written.
+			//
+			// The wrap is around the WHOLE block rather than each seeder: they
+			// resolve their own ObjectService instances, and one identity scope
+			// covering the block is both cheaper and impossible to half-apply.
+			// Resolved DEFENSIVELY, and the seeders run either way.
+			//
+			// An earlier revision of this fix resolved ObjectService directly
+			// here. That made a resolution failure abort EVERY seeder through the
+			// outer catch below — where previously each seeder handled its own
+			// failure and the rest still ran. Adding an identity must not cost
+			// the degradation behaviour that was already there.
+			$objectService = null;
+			try {
+				$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
+			} catch (\Throwable $e) {
+				$this->logger->warning(
+					'Shillinq: ObjectService unavailable; seeding without a system identity',
+					['exception' => $e->getMessage()]
+				);
+			}
+
+			if ($objectService !== null && method_exists($objectService, 'runAsSystem') === true) {
+				$objectService->runAsSystem(function () use ($output): void {
+					$this->runSeeders(output: $output);
+				});
+			} else {
+				$this->runSeeders(output: $output);
+			}
+		} catch (\Throwable $e) {
+			$output->warning('Could not auto-configure Shillinq: ' . $e->getMessage());
+			$this->logger->error(
+				'Shillinq initialization failed',
+				['exception' => $e->getMessage()]
+			);
+		}//end try
+
+	}//end run()
+
+	/**
+	 * Run every seeder, under whatever identity the caller established.
+	 *
+	 * Split out of run() so the entire sequence sits inside ONE runAsSystem()
+	 * scope. Wrapping each seeder separately would re-enter the scope a few
+	 * dozen times and, worse, make it possible to add a seeder that quietly
+	 * sits outside it.
+	 *
+	 * @param IOutput $output Progress reporting.
+	 *
+	 * @return void
+	 */
+	private function runSeeders(IOutput $output): void {
 			$this->seedDefaultAdministration(output: $output);
 			$this->migrateRevenueContractObjects(output: $output);
 			$this->seedChartOfAccounts(output: $output);
@@ -220,15 +290,7 @@ class InitializeSettings implements IRepairStep {
 			$this->seedWmoCommercialActivities(output: $output);
 			$this->seedSbrMappings(output: $output);
 			$this->seedFixedAssetsDemo(output: $output);
-		} catch (\Throwable $e) {
-			$output->warning('Could not auto-configure Shillinq: ' . $e->getMessage());
-			$this->logger->error(
-				'Shillinq initialization failed',
-				['exception' => $e->getMessage()]
-			);
-		}//end try
-
-	}//end run()
+	}//end runSeeders()
 
 	/**
 	 * Seed the default Administration on fresh install, idempotently (REQ-MA-001, REQ-MA-007).

--- a/lib/Repair/LoadCbsSeedsStep.php
+++ b/lib/Repair/LoadCbsSeedsStep.php
@@ -155,6 +155,8 @@ class LoadCbsSeedsStep implements IRepairStep {
 	 * @param IOutput $output Progress reporting.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	private function runInner(object $objectService, array $objects, IOutput $output): void {
 		$registerSlug = $this->register();

--- a/lib/Repair/LoadCbsSeedsStep.php
+++ b/lib/Repair/LoadCbsSeedsStep.php
@@ -54,6 +54,7 @@ use Psr\Log\LoggerInterface;
  *     pending a dedicated refactor.
  */
 class LoadCbsSeedsStep implements IRepairStep {
+	use \OCA\Shillinq\Repair\Support\RunsUnderSystemIdentity;
 
 	/**
 	 * Absolute path to the canonical seed JSON (the register fragment).
@@ -135,6 +136,27 @@ class LoadCbsSeedsStep implements IRepairStep {
 			return;
 		}
 
+		// Under a system identity: an upgrade has no session, and OpenRegister
+		// refuses `create` for 'Anonymous'. Without it this seed writes nothing
+		// and says so only in a warning, which does not fail an upgrade.
+		$this->withSystemIdentity(
+			objectService: $objectService,
+			work: function () use ($objectService, $objects, $output): void {
+				$this->runInner(objectService: $objectService, objects: $objects, output: $output);
+			}
+		);
+	}//end run()
+
+	/**
+	 * The seed itself.
+	 *
+	 * @param object $objectService OpenRegister's ObjectService.
+	 * @param array<int, mixed> $objects The seed objects.
+	 * @param IOutput $output Progress reporting.
+	 *
+	 * @return void
+	 */
+	private function runInner(object $objectService, array $objects, IOutput $output): void {
 		$registerSlug = $this->register();
 		$seeded = 0;
 		$skipped = 0;
@@ -205,7 +227,7 @@ class LoadCbsSeedsStep implements IRepairStep {
 			)
 		);
 
-	}//end run()
+	}//end runInner()
 
 	/**
 	 * Resolve the configured OpenRegister register slug, defaulting to 'shillinq'.

--- a/lib/Repair/LoadCbsSeedsStep.php
+++ b/lib/Repair/LoadCbsSeedsStep.php
@@ -102,6 +102,8 @@ class LoadCbsSeedsStep implements IRepairStep {
 	 * @param IOutput $output Progress output interface.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	public function run(IOutput $output): void {
 		$output->info('Seeding CBSSubmission + CBSLine example records...');

--- a/lib/Repair/LoadDbaSeedsStep.php
+++ b/lib/Repair/LoadDbaSeedsStep.php
@@ -49,6 +49,7 @@ use Throwable;
  *     pending a dedicated refactor.
  */
 class LoadDbaSeedsStep implements IRepairStep {
+	use \OCA\Shillinq\Repair\Support\RunsUnderSystemIdentity;
 
 	/**
 	 * Absolute path to the canonical seed JSON (the register fragment).
@@ -125,6 +126,27 @@ class LoadDbaSeedsStep implements IRepairStep {
 			return;
 		}
 
+		// Under a system identity: an upgrade has no session, and OpenRegister
+		// refuses `create` for 'Anonymous'. Without it this seed writes nothing
+		// and says so only in a warning, which does not fail an upgrade.
+		$this->withSystemIdentity(
+			objectService: $objectService,
+			work: function () use ($objectService, $objects, $output): void {
+				$this->runInner(objectService: $objectService, objects: $objects, output: $output);
+			}
+		);
+	}//end run()
+
+	/**
+	 * The seed itself.
+	 *
+	 * @param object $objectService OpenRegister's ObjectService.
+	 * @param array<int, mixed> $objects The seed objects.
+	 * @param IOutput $output Progress reporting.
+	 *
+	 * @return void
+	 */
+	private function runInner(object $objectService, array $objects, IOutput $output): void {
 		$registerSlug = $this->register();
 		$seeded = 0;
 		$skipped = 0;
@@ -186,7 +208,7 @@ class LoadDbaSeedsStep implements IRepairStep {
 				$skipped,
 			)
 		);
-	}//end run()
+	}//end runInner()
 
 	/**
 	 * Resolve the configured OpenRegister register slug, defaulting to 'shillinq'.

--- a/lib/Repair/LoadDbaSeedsStep.php
+++ b/lib/Repair/LoadDbaSeedsStep.php
@@ -145,6 +145,8 @@ class LoadDbaSeedsStep implements IRepairStep {
 	 * @param IOutput $output Progress reporting.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	private function runInner(object $objectService, array $objects, IOutput $output): void {
 		$registerSlug = $this->register();

--- a/lib/Repair/LoadSbrXbrlSeedsStep.php
+++ b/lib/Repair/LoadSbrXbrlSeedsStep.php
@@ -56,6 +56,8 @@ use Psr\Log\LoggerInterface;
  *     pending a dedicated refactor.
  */
 class LoadSbrXbrlSeedsStep implements IRepairStep {
+	use \OCA\Shillinq\Repair\Support\RunsUnderSystemIdentity;
+
 	/**
 	 * Schemas this step is responsible for seeding.
 	 *
@@ -147,6 +149,27 @@ class LoadSbrXbrlSeedsStep implements IRepairStep {
 			return;
 		}
 
+		// Under a system identity: an upgrade has no session, and OpenRegister
+		// refuses `create` for 'Anonymous'. Without it this seed writes nothing
+		// and says so only in a warning, which does not fail an upgrade.
+		$this->withSystemIdentity(
+			objectService: $objectService,
+			work: function () use ($objectService, $objects, $output): void {
+				$this->runInner(objectService: $objectService, objects: $objects, output: $output);
+			}
+		);
+	}//end run()
+
+	/**
+	 * The seed itself.
+	 *
+	 * @param object $objectService OpenRegister's ObjectService.
+	 * @param array<int, mixed> $objects The seed objects.
+	 * @param IOutput $output Progress reporting.
+	 *
+	 * @return void
+	 */
+	private function runInner(object $objectService, array $objects, IOutput $output): void {
 		$registerSlug = $this->register();
 		$seeded = 0;
 		$skipped = 0;
@@ -217,7 +240,7 @@ class LoadSbrXbrlSeedsStep implements IRepairStep {
 			)
 		);
 
-	}//end run()
+	}//end runInner()
 
 	/**
 	 * Resolve the configured OpenRegister register slug, defaulting to 'shillinq'.

--- a/lib/Repair/LoadSbrXbrlSeedsStep.php
+++ b/lib/Repair/LoadSbrXbrlSeedsStep.php
@@ -168,6 +168,8 @@ class LoadSbrXbrlSeedsStep implements IRepairStep {
 	 * @param IOutput $output Progress reporting.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	private function runInner(object $objectService, array $objects, IOutput $output): void {
 		$registerSlug = $this->register();

--- a/lib/Repair/RetireCostProjectStep.php
+++ b/lib/Repair/RetireCostProjectStep.php
@@ -69,6 +69,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Repair;
 
 use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
+use OCA\Shillinq\Repair\Support\RunsUnderSystemIdentity;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -84,6 +85,7 @@ use Psr\Log\LoggerInterface;
  */
 class RetireCostProjectStep implements IRepairStep {
 	use ReadsSourceRowsInBatches;
+	use RunsUnderSystemIdentity;
 
 	/**
 	 * Maximum suffix attempts when a minted code collides.
@@ -129,6 +131,41 @@ class RetireCostProjectStep implements IRepairStep {
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 */
 	public function run(IOutput $output): void {
+		// Under a system identity: an upgrade has no session, and OpenRegister
+		// refuses every write for 'Anonymous'. Without it this retirement moves
+		// nothing and says so only in a warning, which does not fail an upgrade.
+		$this->withSystemIdentity(
+			objectService: $this->resolveObjectServiceForIdentity(),
+			work: function () use ($output): void {
+				$this->runInner(output: $output);
+			}
+		);
+	}//end run()
+
+	/**
+	 * OpenRegister's ObjectService, or null when it cannot be resolved.
+	 *
+	 * Null is not fatal: the work then runs without a system identity, exactly
+	 * as it did before this wrapper existed.
+	 *
+	 * @return object|null The service.
+	 */
+	private function resolveObjectServiceForIdentity(): ?object {
+		try {
+			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		} catch (\Throwable $e) {
+			return null;
+		}
+	}//end resolveObjectServiceForIdentity()
+
+	/**
+	 * The retirement itself.
+	 *
+	 * @param IOutput $output The repair-step output.
+	 *
+	 * @return void
+	 */
+	private function runInner(IOutput $output): void {
 		try {
 			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->settingsService->getRegisterSlug();
@@ -156,7 +193,7 @@ class RetireCostProjectStep implements IRepairStep {
 			);
 		}//end try
 
-	}//end run()
+	}//end runInner()
 
 	/**
 	 * Iterate over all CostProject objects and convert each to a

--- a/lib/Repair/RetireCostProjectStep.php
+++ b/lib/Repair/RetireCostProjectStep.php
@@ -149,6 +149,8 @@ class RetireCostProjectStep implements IRepairStep {
 	 * as it did before this wrapper existed.
 	 *
 	 * @return object|null The service.
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	private function resolveObjectServiceForIdentity(): ?object {
 		try {

--- a/lib/Repair/RetireCostProjectStep.php
+++ b/lib/Repair/RetireCostProjectStep.php
@@ -164,6 +164,8 @@ class RetireCostProjectStep implements IRepairStep {
 	 * @param IOutput $output The repair-step output.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	private function runInner(IOutput $output): void {
 		try {

--- a/lib/Repair/StampJournalTypeOnGlTransactions.php
+++ b/lib/Repair/StampJournalTypeOnGlTransactions.php
@@ -133,6 +133,8 @@ class StampJournalTypeOnGlTransactions implements IRepairStep {
 	 * @param IOutput $output The repair-step output (progress + warnings).
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	private function runInner(IOutput $output): void {
 		try {

--- a/lib/Repair/StampJournalTypeOnGlTransactions.php
+++ b/lib/Repair/StampJournalTypeOnGlTransactions.php
@@ -52,6 +52,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Repair;
 
 use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
+use OCA\Shillinq\Repair\Support\RunsUnderSystemIdentity;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -65,6 +66,7 @@ use Psr\Log\LoggerInterface;
  */
 class StampJournalTypeOnGlTransactions implements IRepairStep {
 	use ReadsSourceRowsInBatches;
+	use RunsUnderSystemIdentity;
 
 	/**
 	 * Constructor.
@@ -98,6 +100,41 @@ class StampJournalTypeOnGlTransactions implements IRepairStep {
 	 * @return void
 	 */
 	public function run(IOutput $output): void {
+		// Under a system identity: an upgrade has no session, and OpenRegister
+		// refuses every write for 'Anonymous'. Without it this stamp updates
+		// nothing and says so only in a warning, which does not fail an upgrade.
+		$this->withSystemIdentity(
+			objectService: $this->resolveObjectServiceForIdentity(),
+			work: function () use ($output): void {
+				$this->runInner(output: $output);
+			}
+		);
+	}//end run()
+
+	/**
+	 * OpenRegister's ObjectService, or null when it cannot be resolved.
+	 *
+	 * Null is not fatal: {@see withSystemIdentity()} then runs the work anyway,
+	 * exactly as it ran before this wrapper existed.
+	 *
+	 * @return object|null The service.
+	 */
+	private function resolveObjectServiceForIdentity(): ?object {
+		try {
+			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		} catch (\Throwable $e) {
+			return null;
+		}
+	}//end resolveObjectServiceForIdentity()
+
+	/**
+	 * The stamp itself.
+	 *
+	 * @param IOutput $output The repair-step output (progress + warnings).
+	 *
+	 * @return void
+	 */
+	private function runInner(IOutput $output): void {
 		try {
 			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->settingsService->getRegisterSlug();
@@ -128,7 +165,7 @@ class StampJournalTypeOnGlTransactions implements IRepairStep {
 			);
 		}//end try
 
-	}//end run()
+	}//end runInner()
 
 	/**
 	 * Stamp journalType='closing' (+ folded closing fields) onto every

--- a/lib/Repair/StampJournalTypeOnGlTransactions.php
+++ b/lib/Repair/StampJournalTypeOnGlTransactions.php
@@ -118,6 +118,8 @@ class StampJournalTypeOnGlTransactions implements IRepairStep {
 	 * exactly as it ran before this wrapper existed.
 	 *
 	 * @return object|null The service.
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	private function resolveObjectServiceForIdentity(): ?object {
 		try {

--- a/lib/Repair/StampJournalTypeOnGlTransactions.php
+++ b/lib/Repair/StampJournalTypeOnGlTransactions.php
@@ -98,6 +98,8 @@ class StampJournalTypeOnGlTransactions implements IRepairStep {
 	 * @param IOutput $output The repair-step output (progress + warnings).
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	public function run(IOutput $output): void {
 		// Under a system identity: an upgrade has no session, and OpenRegister

--- a/lib/Repair/Support/RunsUnderSystemIdentity.php
+++ b/lib/Repair/Support/RunsUnderSystemIdentity.php
@@ -38,7 +38,7 @@ namespace OCA\Shillinq\Repair\Support;
  * was written. On a seeded instance it is quieter still: the step skips because
  * the data already exists, so it never attempts the create that would fail.
  *
- * @spec openspec/specs/repair-steps/spec.md
+ * @spec openspec/specs/app-administration/spec.md
  */
 trait RunsUnderSystemIdentity {
 	/**
@@ -56,7 +56,7 @@ trait RunsUnderSystemIdentity {
 	 *
 	 * @return void
 	 *
-	 * @spec openspec/specs/repair-steps/spec.md
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	private function withSystemIdentity(?object $objectService, callable $work): void {
 		if ($objectService !== null && method_exists($objectService, 'runAsSystem') === true) {

--- a/lib/Repair/Support/RunsUnderSystemIdentity.php
+++ b/lib/Repair/Support/RunsUnderSystemIdentity.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Shillinq repair-step system-identity helper.
+ *
+ * @category Repair
+ * @package  OCA\Shillinq\Repair\Support
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Repair\Support;
+
+/**
+ * Runs a repair step's work under OpenRegister's system identity.
+ *
+ * WHY EVERY WRITING REPAIR STEP NEEDS THIS. A repair step executes during
+ * `occ upgrade`, where there is no session. OpenRegister then resolves the
+ * actor as 'Anonymous' and REFUSES `create` — measured directly against this
+ * instance, the refusal is not app-specific: probing `decidiq`, `shillinq`,
+ * `trust-configuration`, `stackiq` and `dossiq` with a deliberately invalid
+ * payload, every one answered "User 'Anonymous' does not have permission to
+ * 'create'" before validation was even reached.
+ *
+ * The failure is silent. Steps report it with `$output->warning()`, which does
+ * NOT fail an upgrade, so the upgrade prints "Update successful" while nothing
+ * was written. On a seeded instance it is quieter still: the step skips because
+ * the data already exists, so it never attempts the create that would fail.
+ *
+ * @spec openspec/specs/repair-steps/spec.md
+ */
+trait RunsUnderSystemIdentity {
+	/**
+	 * Run $work under a system identity when one can be established.
+	 *
+	 * FALLS THROUGH rather than refusing. If OpenRegister cannot be resolved,
+	 * the work still runs — each step already handles its own write failures,
+	 * and adding an identity must not cost the degradation behaviour that was
+	 * there before. (Learned the hard way: an earlier version resolved eagerly
+	 * and aborted every seeder when resolution failed; three existing tests
+	 * caught it.)
+	 *
+	 * @param object|null $objectService OpenRegister's ObjectService, or null.
+	 * @param callable $work The step's actual work.
+	 *
+	 * @return void
+	 *
+	 * @spec openspec/specs/repair-steps/spec.md
+	 */
+	private function withSystemIdentity(?object $objectService, callable $work): void {
+		if ($objectService !== null && method_exists($objectService, 'runAsSystem') === true) {
+			$objectService->runAsSystem(static function () use ($work): void {
+				$work();
+			});
+
+			return;
+		}
+
+		$work();
+	}//end withSystemIdentity()
+}//end trait

--- a/lib/Repair/UnifyAnalyticalDimensions.php
+++ b/lib/Repair/UnifyAnalyticalDimensions.php
@@ -68,6 +68,7 @@ declare(strict_types=1);
 namespace OCA\Shillinq\Repair;
 
 use OCA\Shillinq\Repair\Support\ReadsSourceRowsInBatches;
+use OCA\Shillinq\Repair\Support\RunsUnderSystemIdentity;
 use OCA\Shillinq\Service\SettingsService;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -84,6 +85,7 @@ use Psr\Log\LoggerInterface;
  */
 class UnifyAnalyticalDimensions implements IRepairStep {
 	use ReadsSourceRowsInBatches;
+	use RunsUnderSystemIdentity;
 
 	/**
 	 * Constructor.
@@ -123,6 +125,41 @@ class UnifyAnalyticalDimensions implements IRepairStep {
 	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
 	 */
 	public function run(IOutput $output): void {
+		// Under a system identity: an upgrade has no session, and OpenRegister
+		// refuses every write for 'Anonymous'. Without it this migration moves
+		// nothing and says so only in a warning, which does not fail an upgrade.
+		$this->withSystemIdentity(
+			objectService: $this->resolveObjectServiceForIdentity(),
+			work: function () use ($output): void {
+				$this->runInner(output: $output);
+			}
+		);
+	}//end run()
+
+	/**
+	 * OpenRegister's ObjectService, or null when it cannot be resolved.
+	 *
+	 * Null is not fatal: the work then runs without a system identity, exactly
+	 * as it did before this wrapper existed.
+	 *
+	 * @return object|null The service.
+	 */
+	private function resolveObjectServiceForIdentity(): ?object {
+		try {
+			return $this->container->get('OCA\OpenRegister\Service\ObjectService');
+		} catch (\Throwable $e) {
+			return null;
+		}
+	}//end resolveObjectServiceForIdentity()
+
+	/**
+	 * The migration itself.
+	 *
+	 * @param IOutput $output The repair-step output.
+	 *
+	 * @return void
+	 */
+	private function runInner(IOutput $output): void {
 		try {
 			$objectService = $this->container->get('OCA\OpenRegister\Service\ObjectService');
 			$registerSlug = $this->settingsService->getRegisterSlug();
@@ -156,7 +193,7 @@ class UnifyAnalyticalDimensions implements IRepairStep {
 			);
 		}//end try
 
-	}//end run()
+	}//end runInner()
 
 	/**
 	 * Migrate all CostCenter objects into AnalyticalDimension with

--- a/lib/Repair/UnifyAnalyticalDimensions.php
+++ b/lib/Repair/UnifyAnalyticalDimensions.php
@@ -158,6 +158,8 @@ class UnifyAnalyticalDimensions implements IRepairStep {
 	 * @param IOutput $output The repair-step output.
 	 *
 	 * @return void
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	private function runInner(IOutput $output): void {
 		try {

--- a/lib/Repair/UnifyAnalyticalDimensions.php
+++ b/lib/Repair/UnifyAnalyticalDimensions.php
@@ -143,6 +143,8 @@ class UnifyAnalyticalDimensions implements IRepairStep {
 	 * as it did before this wrapper existed.
 	 *
 	 * @return object|null The service.
+	 *
+	 * @spec openspec/specs/app-administration/spec.md
 	 */
 	private function resolveObjectServiceForIdentity(): ?object {
 		try {


### PR DESCRIPTION
`InitializeSettings` writes reference data through OpenRegister during `occ upgrade`, where there is **no session** — so OR resolves the actor as `Anonymous` and refuses `create`.

Measured on a live instance, this one step emitted **eight** such failures:

```
BBV stam-data seeding failed:      … schema 'Taakveld'
Demo barcode seeding issue:        … schema 'Barcode'
Inventory valuation example …:     … schema 'Inventory Valuation'
InventoryStock example …:          … schema 'Inventory Stock'
InventoryGLConfig seeding issue:   … schema 'Inventory GL Posting Configuration'
BBVProgramme demo seeding issue:   … schema 'BBV Programme'
Mandaat templates seeding issue:   … schema 'Mandaat'
FixedAssets demo seeding issue:    … schema 'Fixed Asset'
```

Every one is reported with `$output->warning()`, **which does not fail an upgrade**. So the upgrade printed *"Update successful"* while eight sets of reference data were never written — on every instance that has run it.

## The fix

The seeders now run inside **one** `runAsSystem()` scope. One, not one per seeder: they resolve their own `ObjectService` instances, so a per-seeder wrap would re-enter the scope dozens of times *and* make it possible to add a seeder that quietly sits outside it. That meant lifting the sequence into `runSeeders()` — the only reason `run()` changed shape.

## ⚠️ Resolved defensively, and three existing tests are why

My first version resolved `ObjectService` directly before the seeders. That made a resolution failure abort **every** seeder through the outer catch — where previously each seeder handled its own failure and the rest still ran.

Three existing tests caught it immediately, because they make `container->get()` throw for everything. Adding an identity must not cost degradation behaviour that was already there, so the seeders now run either way and only the *identity* is conditional.

## Verified live

`anonymousFailures` **8 → 0**, before and after, by running the step through DI on a real instance.

## One warning remains — a different bug this was masking

```
BBV stam-data seeding failed: The required properties (budgetId, programmeId,
  taskFieldCode, taskFieldName, revenue, expenses, administrationId) are missing.
```

Seven of the eight seeders now write; the eighth has malformed seed data. **It never reached validation before**, because it failed on the identity first — a stack of failures reports only its outermost layer. Left for its own change rather than folded in here.

Same defect and fix as [decidiq#874](https://github.com/ConductionNL/decidiq/pull/874), found by a fleet sweep.

- 14/14 tests green · phpcs 0 · phpstan `[OK]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)