### PR TITLE
refactor(commitment)!: anglicise the commitment URL paths

### DIFF
--- a/src/manifest.d.shell.json
+++ b/src/manifest.d.shell.json
@@ -172,7 +172,7 @@
 				{
 					"_fragment": "20-tenderned-integratie",
 					"id": "CommitmentDetail",
-					"route": "/inkoop/verplichtingen/:id",
+					"route": "/inkoop/commitments/:id",
 					"type": "detail",
 					"title": "Commitment"
 				}
@@ -3374,49 +3374,49 @@
 				{
 					"_fragment": "bookkeeping-verplichtingenadministratie",
 					"id": "CommitmentsRegister",
-					"route": "/verplichtingen",
+					"route": "/commitments",
 					"type": "index",
 					"title": "Commitments register"
 				},
 				{
 					"_fragment": "bookkeeping-verplichtingenadministratie",
 					"id": "CommitmentDetail",
-					"route": "/verplichtingen/:id",
+					"route": "/commitments/:id",
 					"type": "detail",
 					"title": "Commitment"
 				},
 				{
 					"_fragment": "bookkeeping-verplichtingenadministratie",
 					"id": "BudgetLineCommitments",
-					"route": "/verplichtingen/budget-lines",
+					"route": "/commitments/budget-lines",
 					"type": "custom",
 					"title": "Committed vs. realised"
 				},
 				{
 					"_fragment": "bookkeeping-verplichtingenadministratie",
 					"id": "Mandates",
-					"route": "/verplichtingen/mandaten",
+					"route": "/commitments/mandates",
 					"type": "index",
 					"title": "Mandates"
 				},
 				{
 					"_fragment": "bookkeeping-verplichtingenadministratie",
 					"id": "MandateDetail",
-					"route": "/verplichtingen/mandaten/:id",
+					"route": "/commitments/mandates/:id",
 					"type": "detail",
 					"title": "Mandate"
 				},
 				{
 					"_fragment": "bookkeeping-verplichtingenadministratie",
 					"id": "ApprovalSteps",
-					"route": "/verplichtingen/goedkeuringen",
+					"route": "/commitments/approvals",
 					"type": "index",
 					"title": "Approvals"
 				},
 				{
 					"_fragment": "bookkeeping-verplichtingenadministratie",
 					"id": "ApprovalStepDetail",
-					"route": "/verplichtingen/goedkeuringen/:id",
+					"route": "/commitments/approvals/:id",
 					"type": "detail",
 					"title": "Approval step"
 				}

--- a/src/manifest.d/20-tenderned-integratie.json
+++ b/src/manifest.d/20-tenderned-integratie.json
@@ -106,7 +106,7 @@
 		},
 		{
 			"id": "CommitmentDetail",
-			"route": "/inkoop/verplichtingen/:id",
+			"route": "/inkoop/commitments/:id",
 			"type": "detail",
 			"title": "Commitment",
 			"config": {

--- a/src/manifest.d/bookkeeping-verplichtingenadministratie.json
+++ b/src/manifest.d/bookkeeping-verplichtingenadministratie.json
@@ -40,7 +40,7 @@
 	"pages": [
 		{
 			"id": "CommitmentsRegister",
-			"route": "/verplichtingen",
+			"route": "/commitments",
 			"type": "index",
 			"title": "Commitments register",
 			"config": {
@@ -61,7 +61,7 @@
 		},
 		{
 			"id": "CommitmentDetail",
-			"route": "/verplichtingen/:id",
+			"route": "/commitments/:id",
 			"type": "detail",
 			"title": "Commitment",
 			"config": {
@@ -144,7 +144,7 @@
 		},
 		{
 			"id": "BudgetLineCommitments",
-			"route": "/verplichtingen/budget-lines",
+			"route": "/commitments/budget-lines",
 			"type": "custom",
 			"title": "Committed vs. realised",
 			"component": "BudgetLineCommitments",
@@ -152,7 +152,7 @@
 		},
 		{
 			"id": "Mandates",
-			"route": "/verplichtingen/mandaten",
+			"route": "/commitments/mandates",
 			"type": "index",
 			"title": "Mandates",
 			"config": {
@@ -171,7 +171,7 @@
 		},
 		{
 			"id": "MandateDetail",
-			"route": "/verplichtingen/mandaten/:id",
+			"route": "/commitments/mandates/:id",
 			"type": "detail",
 			"title": "Mandate",
 			"config": {
@@ -215,7 +215,7 @@
 		},
 		{
 			"id": "ApprovalSteps",
-			"route": "/verplichtingen/goedkeuringen",
+			"route": "/commitments/approvals",
 			"type": "index",
 			"title": "Approvals",
 			"config": {
@@ -234,7 +234,7 @@
 		},
 		{
 			"id": "ApprovalStepDetail",
-			"route": "/verplichtingen/goedkeuringen/:id",
+			"route": "/commitments/approvals/:id",
 			"type": "detail",
 			"title": "Approval step",
 			"config": {

--- a/tests/e2e/bookkeeping-tenderned-integratie.spec.ts
+++ b/tests/e2e/bookkeeping-tenderned-integratie.spec.ts
@@ -53,10 +53,8 @@ test.describe('shillinq — bookkeeping-tenderned-integratie SPA smoke', () => {
 		await expect(page).toHaveTitle(/shillinq/i, { timeout: 15_000 })
 	})
 
-	test('Commitments index — mounts on /inkoop/verplichtingen', async ({
-		page,
-	}) => {
-		await page.goto(APP + '/inkoop/verplichtingen')
+	test('Commitments index — mounts on /inkoop/commitments', async ({ page }) => {
+		await page.goto(APP + '/inkoop/commitments')
 		await page.waitForLoadState('domcontentloaded')
 		await dismissWizard(page)
 
@@ -92,7 +90,7 @@ test.describe('shillinq — bookkeeping-tenderned-integratie SPA smoke', () => {
 		// new routes.
 		const inkoopLink = page
 			.locator(
-				'a[href*="/inkoop/tenderned"], a[href*="/inkoop/verplichtingen"], a[href*="/inkoop/mijn-contracten"], a:has-text("Inkoop"), a:has-text("TenderNed")',
+				'a[href*="/inkoop/tenderned"], a[href*="/inkoop/commitments"], a[href*="/inkoop/mijn-contracten"], a:has-text("Inkoop"), a:has-text("TenderNed")',
 			)
 			.first()
 

--- a/tests/e2e/budget-line-commitments.spec.ts
+++ b/tests/e2e/budget-line-commitments.spec.ts
@@ -35,7 +35,7 @@ import { test, expect, type Page } from '@playwright/test'
 import { becomesVisible } from './becomes-visible.js'
 
 const APP = '/apps/shillinq'
-const ROUTE = '/verplichtingen/budget-lines'
+const ROUTE = '/commitments/budget-lines'
 
 async function dismissWizard(page: Page): Promise<void> {
 	const wizard = page.locator('#firstrunwizard')


### PR DESCRIPTION
Tranche 3 of the shillinq commitment anglicisation. Tranche 1 (#1196) moved the schema **names**, tranche 2 (#1211) the stored **values**; this moves the eight user-visible **URLs**.

| before | after |
|---|---|
| `/verplichtingen` | `/commitments` |
| `/verplichtingen/:id` | `/commitments/:id` |
| `/verplichtingen/budget-lines` | `/commitments/budget-lines` |
| `/verplichtingen/mandaten` | `/commitments/mandates` |
| `/verplichtingen/mandaten/:id` | `/commitments/mandates/:id` |
| `/verplichtingen/goedkeuringen` | `/commitments/approvals` |
| `/verplichtingen/goedkeuringen/:id` | `/commitments/approvals/:id` |
| `/inkoop/verplichtingen/:id` | `/inkoop/commitments/:id` |

## No redirects — and what that actually looks like

Chosen deliberately. Worth being precise about the failure mode: a stale bookmark does **not** get a server 404. The SPA `/{path}` catch-all answers every deep link with the app shell, so an old URL lands on shillinq with no page matched and the Vue router shows its not-found state. The break is client-side and quiet rather than an HTTP error.

## The one that is not fully anglicised, on purpose

`/inkoop/verplichtingen/:id` became `/inkoop/commitments/:id`, **not** `/purchasing/commitments/:id`.

`/inkoop` is a **cluster prefix** shared with ~15 unrelated routes — `/inkoop/tenderned`, `/inkoop/purchase-orders`, `/inkoop/goods-receipts`, `/inkoop/mijn-contracten` and more. Renaming it here alone would have moved this one page out of its own cluster's URL space and left every sibling Dutch, which reads worse than a mixed path. Renaming `/inkoop` is its own decision across that whole cluster and does not belong in a commitment tranche.

## Kept Dutch on purpose

- `openspec/changes/verplichtingen-commitment-accounting/...` in `@spec` tags — those are real directories; renaming the reference would dangle it.
- `Investeringen/verplichtingen` in `Iv3XmlValidationGuard`'s docblock — CBS IV3 statistical terminology, not a shillinq identifier.

`src/manifest.d.shell.json` is **generated** — regenerated via its script, not hand-edited.

## Verified on a live rig

Rig on :8123 with the **frontend rebuilt**, so the manifest is actually served rather than only present in source.

- All four `/commitments*` paths and `/inkoop/commitments/:id` resolve
- e2e `bookkeeping-tenderned-integratie` — **4/4 pass**, including the renamed `/inkoop/commitments` mount
- e2e `budget-line-commitments` — empty-state test passes on the renamed `/commitments/budget-lines`

Its **drilldown test still skips**, unrelated to this change and tracked in **#1216**: `committedVsRealisedPerBudgetLine` cannot be expressed in OpenRegister's annotation grammar at all — it needs a 4-field composite `groupBy` and a `join`, and the engine supports one field and no joins — so it returns `groups: []` against live objects.

## Gates

- 15 JS validators: manifest, manifest-shell, manifest-budget, registers, seeds, fragment-required, markers, nav-reachability, job-registration, l10n, l10n-parity, l10n-dutch-tokens, **l10n-js**, lint, format — all pass
- `phpcs`, `phpstan`, `psalm` — pass
- `phpunit` — **4980 tests, 46758 assertions, 0 failures** (1 skip, pre-existing on `development`)
