### PR TITLE
refactor(commitment)!: anglicise the last three Dutch property names

### DIFF
--- a/lib/Repair/RenameDutchColumnsMap.php
+++ b/lib/Repair/RenameDutchColumnsMap.php
@@ -540,7 +540,15 @@ final class RenameDutchColumnsMap {
 		'innovatiebox_winst' => 'innovation_box_profit',
 		'intake_datum' => 'intake_date',
 		'integrale_kostprijs' => 'integral_cost_price',
-		'interne_kenmerk' => 'interne_reference',
+		// Two sources, one destination, deliberately. An earlier pass moved
+		// `interne_kenmerk` to `interne_reference`, which is itself half Dutch;
+		// both now land on `internal_reference`. hasCollision() only refuses
+		// when BOTH source columns exist in the SAME table, which cannot happen
+		// here: an instance is either pre-first-rename (only interne_kenmerk)
+		// or post (only interne_reference). A table carrying both is genuinely
+		// ambiguous and being refused is the right answer.
+		'interne_kenmerk' => 'internal_reference',
+		'interne_reference' => 'internal_reference',
 		'investering' => 'investment',
 		'investering_eigen_middelen_score' => 'investment_own_resources_score',
 		'investerings_kasstroom' => 'investment_cash_flow',
@@ -997,6 +1005,11 @@ final class RenameDutchColumnsMap {
 		'detectie_moment' => 'detection_moment',
 		'dimensie' => 'dimension',
 		'directe_materialen' => 'direct_materials',
+		// Shares its destination with `stukken` => `documents`, which is safe:
+		// hasCollision() refuses only when both source columns exist in the
+		// SAME table, and no schema declares both (checked across every
+		// register.d fragment).
+		'documenten' => 'documents',
 		'doel' => 'purpose',
 		'doel_norm' => 'purpose_norm',
 		'domein' => 'domain',
@@ -1092,6 +1105,13 @@ final class RenameDutchColumnsMap {
 		'uitkomst' => 'outcome',
 		'urencriterium' => 'hours_criterion',
 		'vakantiegeld_pct' => 'holiday_allowance_pct',
+		// Declared by four schemas across three fragments (Commitment,
+		// CommitmentMovement, AnnualReport, InvestmentAsset). All four move
+		// together: this map is keyed by COLUMN NAME and applies to every shard
+		// table, so renaming the column for one owner while the others still
+		// declare `valuta` would leave those schemas reading a column that no
+		// longer exists.
+		'valuta' => 'currency',
 		'vanaf' => 'from',
 		'verkort_type' => 'abbreviated_type',
 		'verplicht' => 'mandatory',

--- a/lib/Settings/register.d/bookkeeping-investeringsaftrek.json
+++ b/lib/Settings/register.d/bookkeeping-investeringsaftrek.json
@@ -82,7 +82,7 @@
             "example": 5000000,
             "title": "Aanschafwaarde"
           },
-          "valuta": {
+          "currency": {
             "type": "string",
             "description": "ISO 4217 currency code. EUR-only in this tier.",
             "default": "EUR",

--- a/lib/Settings/register.d/bookkeeping-titel-9-jaarrekening.json
+++ b/lib/Settings/register.d/bookkeeping-titel-9-jaarrekening.json
@@ -30,7 +30,7 @@
           "financialYearEnd",
           "sizeCategory",
           "rapportageBasis",
-          "valuta",
+          "currency",
           "status"
         ],
         "properties": {
@@ -128,7 +128,7 @@
             "example": "rj-commercial",
             "title": "Rapportage Grondslag"
           },
-          "valuta": {
+          "currency": {
             "type": "string",
             "description": "ISO-4217 presentation currency of the jaarrekening.",
             "default": "EUR",
@@ -1251,7 +1251,7 @@
         "override": false
       },
       "rapportageBasis": "rj-commercial",
-      "valuta": "EUR",
+      "currency": "EUR",
       "status": "draft",
       "layoutDate": null,
       "determinationDate": null,
@@ -1286,7 +1286,7 @@
         "override": false
       },
       "rapportageBasis": "rj-commercial",
-      "valuta": "EUR",
+      "currency": "EUR",
       "status": "draft",
       "layoutDate": null,
       "determinationDate": null,

--- a/lib/Settings/register.d/bookkeeping-verplichtingenadministratie.json
+++ b/lib/Settings/register.d/bookkeeping-verplichtingenadministratie.json
@@ -147,7 +147,7 @@
             "example": 6050000,
             "title": "Totaalbedrag Incl BTW"
           },
-          "valuta": {
+          "currency": {
             "type": "string",
             "description": "ISO 4217 currency code. EUR-only in this tier.",
             "default": "EUR",
@@ -197,7 +197,7 @@
             "example": "Spoedlevering approved door CFO",
             "title": "Override Reden"
           },
-          "interne_reference": {
+          "internal_reference": {
             "type": "string",
             "nullable": true,
             "description": "Optional internal reference (contract number, dossier, etc.).",
@@ -216,7 +216,7 @@
             ],
             "title": "Rechtmatigheidstoetsen"
           },
-          "documenten": {
+          "documents": {
             "type": "array",
             "nullable": true,
             "description": "File URIs (e.g. docudesk) for the signed PO/contract/beschikking.",
@@ -618,7 +618,7 @@
             "example": 5000000,
             "title": "Bedrag"
           },
-          "valuta": {
+          "currency": {
             "type": "string",
             "description": "ISO 4217 currency code.",
             "default": "EUR",
@@ -1266,7 +1266,7 @@
       "status": "committed",
       "commencementDate": "2026-02-10",
       "total_amount_excl_vat": 4000000,
-      "interne_reference": "Eindafrekening 20% restant nog te ontvangen",
+      "internal_reference": "Eindafrekening 20% restant nog te ontvangen",
       "counterparty": {
         "kind": "grantRecipient",
         "name": "Stichting Cultuurhuis Zuidoost"

--- a/src/manifest.d/bookkeeping-titel-9-jaarrekening.json
+++ b/src/manifest.d/bookkeeping-titel-9-jaarrekening.json
@@ -102,7 +102,7 @@
 						"type": "string"
 					},
 					{
-						"key": "valuta",
+						"key": "currency",
 						"label": "Currency",
 						"type": "string"
 					},

--- a/src/manifest.d/bookkeeping-verplichtingenadministratie.json
+++ b/src/manifest.d/bookkeeping-verplichtingenadministratie.json
@@ -77,11 +77,11 @@
 					{"key": "term_to", "label": "Term until", "type": "string"},
 					{"key": "total_amount_excl_vat", "label": "Total amount (excl. BTW)", "type": "number"},
 					{"key": "total_amount_incl_vat", "label": "Total amount (incl. BTW)", "type": "number"},
-					{"key": "valuta", "label": "Currency", "type": "string"},
+					{"key": "currency", "label": "Currency", "type": "string"},
 					{"key": "vat_regime", "label": "BTW regime", "type": "string"},
 					{"key": "mandate_applied", "label": "Mandate", "type": "string"},
 					{"key": "override_reason", "label": "Override reason", "type": "string"},
-					{"key": "interne_reference", "label": "Internal reference", "type": "string"},
+					{"key": "internal_reference", "label": "Internal reference", "type": "string"},
 					{"key": "sourceReference", "label": "Source reference", "type": "string"}
 				],
 				"relatedObjects": [


### PR DESCRIPTION
Tranche 4 — the last of the commitment cluster's own Dutch identifiers.

| before | after | declared by |
|---|---|---|
| `valuta` | `currency` | Commitment, CommitmentMovement, AnnualReport, InvestmentAsset |
| `interne_reference` | `internal_reference` | Commitment |
| `documenten` | `documents` | Commitment |

## Why `valuta` moves in three fragments at once

`RenameDutchColumnsMap` is keyed by **column name** and applies to every shard table in the register — it has no per-schema scope. Four schemas across three fragments declare `valuta`. Renaming it for the commitment cluster alone would have moved the column under `bookkeeping-titel-9-jaarrekening` and `bookkeeping-investeringsaftrek` too, while those fragments still declared `valuta` — leaving two schemas reading a column that no longer exists. All four move together or none do.

`documenten` and `interne_reference` are declared only by `Commitment`, checked across every `register.d` fragment, so they carry no such constraint.

## Two destination collisions, examined rather than assumed

- **`stukken` → `documents` already exists.** `hasCollision()` refuses only when *both* source columns exist in the **same** table, and no schema declares both `stukken` and `documenten`.
- **`interne_kenmerk` → `interne_reference` already existed** — and that target is itself half-Dutch. Both now land on `internal_reference`. An instance is either pre-first-rename (only `interne_kenmerk`) or post (only `interne_reference`), never both, so the guard cannot fire. A table carrying both genuinely *is* ambiguous, and being refused is the right answer.

## Not renamed, deliberately

`Iv3ReportGenerator` and `VatReturnReportGenerator` both call `writeAttribute('valuta', 'EUR')`. Those are attribute names in the **IV3 and VAT-return XML formats** — an external government schema, not ours. Renaming them would produce a file the receiving system rejects. Dutch prose in RGS descriptions and seed text is likewise left alone.

## Verified on a live rig, against real data

Four shard tables carried the Dutch columns. After `occ maintenance:repair`:

```
RenameDutchColumns: 0 renamed, 6 back-filled, 0 refused, across 514 shard table(s).

 _id | valuta | currency | interne_reference                           | internal_reference
   3 | EUR    | EUR      | Eindafrekening 20% restant nog te ontvangen | Eindafrekening 20% restant nog te ontvangen
```

**"back-filled" rather than "renamed" is the documented path and the right one**: the schema sync had already added the English columns, so the step copied the data across and *left* the Dutch columns in place. That keeps the change reversible and makes a re-run a no-op.

## Gates

- 16 JS validators — including `check:l10n-js` and `check:schema-l10n` — all pass
- `phpcs`, `phpstan`, `psalm` — pass
- `phpunit` — **4980 tests, 46758 assertions, 0 failures** (1 skip, pre-existing on `development`)
