### PR TITLE
fix(commitment): make the budget-line aggregation actually return data

### DIFF
--- a/l10n/en.js
+++ b/l10n/en.js
@@ -1631,6 +1631,7 @@ OC.L10N.register(
         "No approvers required yet — add lines.": "No approvers required yet — add lines.",
         "No attribute definitions are available.": "No attribute definitions are available.",
         "No barcode decoder available; use manual entry.": "No barcode decoder available; use manual entry.",
+        "No active administration — cannot scope budget lines.": "No active administration — cannot scope budget lines.",
         "No budget lines": "No budget lines",
         "No checklist items yet.": "No checklist items yet.",
         "No client administrations": "No client administrations",

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -1630,6 +1630,7 @@
         "No approvers required yet — add lines.": "No approvers required yet — add lines.",
         "No attribute definitions are available.": "No attribute definitions are available.",
         "No barcode decoder available; use manual entry.": "No barcode decoder available; use manual entry.",
+        "No active administration — cannot scope budget lines.": "No active administration — cannot scope budget lines.",
         "No budget lines": "No budget lines",
         "No checklist items yet.": "No checklist items yet.",
         "No client administrations": "No client administrations",

--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -1631,6 +1631,7 @@ OC.L10N.register(
         "No approvers required yet — add lines.": "Nog geen goedkeurders vereist — voeg regels toe.",
         "No attribute definitions are available.": "Er zijn geen attribuutdefinities beschikbaar.",
         "No barcode decoder available; use manual entry.": "Geen barcodedecoder beschikbaar; gebruik handmatige invoer.",
+        "No active administration — cannot scope budget lines.": "Geen actieve administratie — budgetregels kunnen niet worden afgebakend.",
         "No budget lines": "Geen budgetregels",
         "No checklist items yet.": "Nog geen checklist-items.",
         "No client administrations": "Geen klantadministraties",

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -1630,6 +1630,7 @@
         "No approvers required yet — add lines.": "Nog geen goedkeurders vereist — voeg regels toe.",
         "No attribute definitions are available.": "Er zijn geen attribuutdefinities beschikbaar.",
         "No barcode decoder available; use manual entry.": "Geen barcodedecoder beschikbaar; gebruik handmatige invoer.",
+        "No active administration — cannot scope budget lines.": "Geen actieve administratie — budgetregels kunnen niet worden afgebakend.",
         "No budget lines": "Geen budgetregels",
         "No checklist items yet.": "Nog geen checklist-items.",
         "No client administrations": "Geen klantadministraties",

--- a/lib/Settings/register.d/bookkeeping-verplichtingenadministratie.json
+++ b/lib/Settings/register.d/bookkeeping-verplichtingenadministratie.json
@@ -521,30 +521,30 @@
         "x-openregister-aggregations": {
           "committedVsRealisedPerBudgetLine": {
             "description": "REQ-VPL-011: per-budget-line committed-vs-realised rollup, grouped by budget coderingscombinatie (programma + kostenplaats + boekjaar + grootboekrekening). Excludes afgesloten regels. verplicht = sum(restant_verplicht); gerealiseerd = sum(gefactureerd_bedrag); geautoriseerd is joined from the matching CommitmentBudget (administrationId + programmaCode = programma + boekjaar); vrij = geautoriseerd - verplicht - gerealiseerd is computed by the drilldown view (BudgetLineCommitments.vue) from these three declared figures — no parallel PHP reporting service (ADR-031).",
-            "source": "CommitmentLine",
+            "_grammar_note": "Rewritten into OpenRegister's actual annotation vocabulary (openregister#2846 + #2849). It previously used `source` and a `sum` list, neither of which the engine reads — the runner recognised the aggregation by NAME and understood none of its body, returning metric:\"\", field:null, groups:[] against live objects with no error at all (issue #1216). `source` is dropped because this is an intra-schema aggregation declared ON CommitmentLine; `from` is the cross-schema key and would have sent it down a different path. `sum: [a, b]` becomes `metrics: [{metric, field}, ...]`, the multi-metric spelling. `on` uses the explicit {parentField: joinedField} map rather than the string shorthand: the shorthand names only the joined side and leaves the parent side to be inferred from the group fields, which happens to give the right answer here but is a guess, and the map is the only spelling that could express a composite key later.",
             "groupBy": [
               "programme",
               "costCentre",
               "financialYear",
               "generalLedgerAccount"
             ],
+            "_scoping_note": "administrationId is NOT declared here, deliberately. It used to read `@self.administrationId`, which is not a placeholder the resolver knows — `$currentUser` is the only one — so it was left literal, matched nothing, and filtered every row away. Declaring it as a constant is impossible because it differs per caller, so scoping is supplied BY the caller as a narrowing filter: BudgetLineCommitments.vue passes filter[administrationId] from /api/administrations/context. openregister#2852 makes that safe — a request filter may ADD a constraint and can never relax or replace a declared one, so this cannot become a way to widen the set. Do not re-add a placeholder here without first checking PlaceholderResolver actually implements it.",
             "filter": {
-              "administrationId": "@self.administrationId",
               "afgesloten": false
             },
+            "metrics": [
+              { "metric": "sum", "field": "remaining_committed" },
+              { "metric": "sum", "field": "invoiced_amount" }
+            ],
             "join": {
               "through": "CommitmentBudget",
-              "on": "CommitmentBudget.programmeCode",
+              "on": { "programme": "programmeCode" },
               "filter": {},
               "select": [
                 "CommitmentBudget.authorised_amount",
                 "CommitmentBudget.realised_amount"
               ]
-            },
-            "sum": [
-              "remaining_committed",
-              "invoiced_amount"
-            ]
+            }
           }
         },
         "x-openregister-audit-trail": {

--- a/src/views/BudgetLineCommitments.vue
+++ b/src/views/BudgetLineCommitments.vue
@@ -201,6 +201,7 @@ export default {
 			expandedKey: null,
 			drilldownLoading: false,
 			drilldownItems: [],
+			administrationId: '',
 		}
 	},
 
@@ -210,6 +211,40 @@ export default {
 
 	methods: {
 		formatAmount,
+
+		/**
+		 * Resolve the caller's active administration.
+		 *
+		 * The aggregation is scoped by the CALLER, not by its declaration. It
+		 * used to declare `administrationId: "@self.administrationId"`, which
+		 * is not a placeholder OpenRegister implements — it was left literal,
+		 * matched nothing, and the page showed an empty state over live data
+		 * (#1216). A declaration cannot name a per-caller value, so the filter
+		 * is passed from here instead.
+		 *
+		 * Returns '' when the context cannot be read, and loadRows() then
+		 * REFUSES to query rather than falling back to an unscoped call — an
+		 * unscoped aggregation would return every administration's figures,
+		 * which is worse than showing nothing.
+		 *
+		 * @return {Promise<string>} The active administration id, or ''.
+		 * @spec openspec/specs/bookkeeping-verplichtingenadministratie/spec.md
+		 */
+		async resolveAdministrationId() {
+			try {
+				const { data } = await axios.get(
+					generateUrl('/apps/shillinq/api/administrations/context'),
+				)
+				return (
+					data?.activeAdministrationId
+					|| data?.administrations?.[0]?.administrationId
+					|| ''
+				)
+			} catch {
+				return ''
+			}
+		},
+
 		/** @spec openspec/specs/bookkeeping-verplichtingenadministratie/spec.md */
 		async loadRows() {
 			this.loading = true
@@ -217,10 +252,27 @@ export default {
 			this.rows = []
 
 			try {
+				this.administrationId = await this.resolveAdministrationId()
+				if (!this.administrationId) {
+					// Deliberately not a fallback to an unscoped call: the
+					// declared filter no longer carries administrationId, so
+					// omitting it here would aggregate across every
+					// administration the register holds.
+					this.errorMessage = this.t(
+						'shillinq',
+						'No active administration — cannot scope budget lines.',
+					)
+					return
+				}
+
 				const url = generateUrl(
 					`/apps/openregister/api/objects/aggregations/${REGISTER_SLUG}/CommitmentLine/committedVsRealisedPerBudgetLine`,
 				)
-				const { data } = await axios.get(url)
+				// A NARROWING filter (openregister#2852): it may add a
+				// constraint and can never relax one the declaration sets.
+				const { data } = await axios.get(url, {
+					params: { 'filter[administrationId]': this.administrationId },
+				})
 				this.rows = normaliseBudgetLineRows(data)
 			} catch (error) {
 				const status = error?.response?.status
@@ -263,11 +315,17 @@ export default {
 			this.drilldownItems = []
 
 			try {
-				const filters = drilldownFilters(row)
-				const params = {}
-				Object.keys(filters).forEach((key) => {
-					params[`filters[${key}]`] = filters[key]
-				})
+				// OpenRegister filters on BARE property params — `?programme=5.1
+				// &costCentre=FAC-2026`. This used to wrap them as
+				// `filters[programme]`, which the objects endpoint does not
+				// read: the request succeeded, matched everything, and then the
+				// unmatched wrapper keys were themselves treated as property
+				// filters that match nothing. Either way it came back
+				// `{"results":[],"total":0}` with HTTP 200 and the drilldown
+				// rendered "No underlying commitments found" over live rows.
+				// Control params keep their underscore (`_limit`); property
+				// filters are bare.
+				const params = { ...drilldownFilters(row), _limit: 100 }
 				const url = generateUrl(
 					`/apps/openregister/api/objects/${REGISTER_SLUG}/CommitmentLine`,
 				)

--- a/src/views/budgetLineCommitmentsHelpers.js
+++ b/src/views/budgetLineCommitmentsHelpers.js
@@ -21,43 +21,78 @@
 /**
  * Normalise the raw aggregation payload into budget-line rows.
  *
+ * READS THE ENVELOPE OPENREGISTER ACTUALLY RETURNS. This previously looked for
+ * `payload.buckets` holding flat rows (`bucket.programme`,
+ * `bucket.remaining_committed`, ...). No such shape exists — the engine returns
+ *
+ *   { groups: [ { keys:   { programme, costCentre, financialYear,
+ *                           generalLedgerAccount },
+ *                 values: { sum_remaining_committed, sum_invoiced_amount },
+ *                 joined: { 'CommitmentBudget.authorised_amount': n,
+ *                           'CommitmentBudget.realised_amount':  n } } ] }
+ *
+ * so `buckets` was always undefined and this always returned []. Together with
+ * the declaration being written in a grammar the engine did not read, that is
+ * why the page rendered its empty state over live data (issue #1216): every
+ * layer agreed on a shape none of them produced.
+ *
+ * The OUTPUT contract is unchanged — the template and drilldownFilters() read
+ * snake_case row fields — so only the parsing moved.
+ *
+ * The legacy flat spelling is still accepted per field. An instance whose
+ * OpenRegister predates the composite-groupBy work returns the single-key
+ * shape, and falling back keeps this readable rather than blank there.
+ *
  * @param {object} payload Raw response from the aggregation endpoint.
  * @return {Array<object>} Rows with programme/cost_centre/financial_year/general_ledger_account + the four amount columns (minor units).
  *
  * @spec openspec/changes/budget-core-schema/specs/budget-core-schema/spec.md#req-bcs-002
  */
 export function normaliseBudgetLineRows(payload) {
-	const buckets = Array.isArray(payload?.buckets)
-		? payload.buckets
-		: Array.isArray(payload)
-			? payload
-			: []
+	const groups = Array.isArray(payload?.groups)
+		? payload.groups
+		: Array.isArray(payload?.buckets)
+			? payload.buckets
+			: Array.isArray(payload)
+				? payload
+				: []
 
-	return buckets.map((bucket) => {
+	return groups.map((group) => {
+		const keys = group?.keys ?? group ?? {}
+		const values = group?.values ?? group ?? {}
+		const joined = group?.joined ?? group ?? {}
+
+		const programme = keys?.programme ?? ''
+		const costCentre = keys?.costCentre ?? keys?.cost_centre ?? ''
+		const financialYear = keys?.financialYear ?? keys?.financial_year ?? null
+		const glAccount =
+			keys?.generalLedgerAccount ?? keys?.general_ledger_account ?? ''
+
 		const geautoriseerd = Number(
-			bucket?.['CommitmentBudget.authorised_amount']
-				?? bucket?.geautoriseerd
+			joined?.['CommitmentBudget.authorised_amount']
+				?? group?.geautoriseerd
 				?? 0,
 		)
 		const mandatory = Number(
-			bucket?.remaining_committed ?? bucket?.verplicht ?? 0,
+			values?.sum_remaining_committed
+				?? values?.remaining_committed
+				?? group?.verplicht
+				?? 0,
 		)
 		const gerealiseerd = Number(
-			bucket?.invoiced_amount ?? bucket?.gerealiseerd ?? 0,
+			values?.sum_invoiced_amount
+				?? values?.invoiced_amount
+				?? group?.gerealiseerd
+				?? 0,
 		)
 		const vrij = geautoriseerd - mandatory - gerealiseerd
 
 		return {
-			key: [
-				bucket?.programme,
-				bucket?.cost_centre,
-				bucket?.financial_year,
-				bucket?.general_ledger_account,
-			].join('|'),
-			programme: String(bucket?.programme ?? ''),
-			cost_centre: String(bucket?.cost_centre ?? ''),
-			financial_year: bucket?.financial_year ?? null,
-			general_ledger_account: String(bucket?.general_ledger_account ?? ''),
+			key: [programme, costCentre, financialYear, glAccount].join('|'),
+			programme: String(programme ?? ''),
+			cost_centre: String(costCentre ?? ''),
+			financial_year: financialYear ?? null,
+			general_ledger_account: String(glAccount ?? ''),
 			geautoriseerd,
 			mandatory,
 			gerealiseerd,
@@ -90,8 +125,21 @@ export function formatAmount(cents) {
  * Build the exact-match filter set to drill down from a budget-line row to
  * its underlying CommitmentLine records.
  *
+ * KEYED BY SCHEMA PROPERTY NAME, NOT COLUMN NAME. OpenRegister filters on the
+ * property as declared — `costCentre`, `financialYear`, `generalLedgerAccount`
+ * — while the shard TABLE snake_cases them into columns. This used to emit the
+ * column spelling, and a filter on a property that does not exist does not
+ * error: it matches nothing and returns `{"results":[],"total":0}` with HTTP
+ * 200, so the drilldown rendered "No underlying commitments found" over rows
+ * that were plainly there. Measured on a live instance: `?programme=5.1&
+ * costCentre=FAC-2026` returns 6, the same query with `cost_centre` returns 0.
+ *
+ * The ROW keeps its snake_case shape — the template and its tests read
+ * `row.cost_centre` — so the mapping happens here, at the boundary where the
+ * request is built.
+ *
  * @param {object} row Normalised budget-line row.
- * @return {object} Filters keyed by CommitmentLine field name.
+ * @return {object} Filters keyed by CommitmentLine PROPERTY name.
  */
 export function drilldownFilters(row) {
 	const filters = {}
@@ -99,13 +147,13 @@ export function drilldownFilters(row) {
 		filters.programme = row.programme
 	}
 	if (row.cost_centre) {
-		filters.cost_centre = row.cost_centre
+		filters.costCentre = row.cost_centre
 	}
 	if (row.financial_year !== null && row.financial_year !== undefined) {
-		filters.financial_year = row.financial_year
+		filters.financialYear = row.financial_year
 	}
 	if (row.general_ledger_account) {
-		filters.general_ledger_account = row.general_ledger_account
+		filters.generalLedgerAccount = row.general_ledger_account
 	}
 	return filters
 }

--- a/tests/Unit/Service/CommitmentAccountingFragmentTest.php
+++ b/tests/Unit/Service/CommitmentAccountingFragmentTest.php
@@ -101,14 +101,48 @@ final class CommitmentAccountingFragmentTest extends TestCase {
 		self::assertArrayHasKey('committedVsRealisedPerBudgetLine', $rule['x-openregister-aggregations']);
 
 		$agg = $rule['x-openregister-aggregations']['committedVsRealisedPerBudgetLine'];
-		self::assertSame('CommitmentLine', $agg['source']);
+
+		// ASSERTS THE ENGINE'S VOCABULARY, NOT AN IMAGINED ONE. This used to
+		// pin `source` and a `sum` list. OpenRegister reads neither — the
+		// annotation keys are field / filter / from / groupBy / join / metric /
+		// metrics / select / where — so the runner recognised the aggregation
+		// by NAME and understood none of its body, returning groups:[] against
+		// live objects with no error (issue #1216). The test passed throughout,
+		// because it only ever compared the declaration to itself.
+		self::assertArrayNotHasKey('source', $agg, '`source` is not an engine key; the intra-schema aggregation needs none');
+		self::assertArrayNotHasKey('sum', $agg, '`sum` is not an engine key; use metrics[]');
+
 		self::assertSame(
 			['programme', 'costCentre', 'financialYear', 'generalLedgerAccount'],
 			$agg['groupBy']
 		);
-		self::assertContains('remaining_committed', $agg['sum']);
-		self::assertContains('invoiced_amount', $agg['sum']);
+
+		// Two figures over one grouping — the multi-metric spelling
+		// (openregister#2849). Each entry names a metric AND its field.
+		self::assertSame(
+			[
+				['metric' => 'sum', 'field' => 'remaining_committed'],
+				['metric' => 'sum', 'field' => 'invoiced_amount'],
+			],
+			$agg['metrics']
+		);
+
 		self::assertSame('CommitmentBudget', $agg['join']['through']);
+
+		// The explicit {parentField: joinedField} map, not the string
+		// shorthand. The shorthand names only the joined side and leaves the
+		// parent side to be INFERRED from the group fields; it happens to infer
+		// correctly here, but it is a guess, and only the map can express a
+		// composite join key.
+		self::assertSame(['programme' => 'programmeCode'], $agg['join']['on']);
+
+		// administrationId must NOT be declared: it differs per caller, and the
+		// `@self.administrationId` that used to stand here is not a placeholder
+		// OpenRegister implements — it was left literal and filtered every row
+		// away. Scoping is supplied by the caller as a NARROWING filter
+		// (openregister#2852), which cannot relax what is declared here.
+		self::assertArrayNotHasKey('administrationId', $agg['filter']);
+		self::assertFalse($agg['filter']['afgesloten']);
 
 	}//end testCommitmentLineDeclaresCommittedVsRealisedAggregation()
 

--- a/tests/vitest/budgetLineCommitmentsHelpers.spec.js
+++ b/tests/vitest/budgetLineCommitmentsHelpers.spec.js
@@ -116,7 +116,14 @@ describe('budgetLineCommitmentsHelpers — formatAmount', () => {
 })
 
 describe('budgetLineCommitmentsHelpers — drilldownFilters', () => {
-	it('builds exact-match filters for a complete row', () => {
+	// The ROW keeps its snake_case shape (the template reads row.cost_centre);
+	// the FILTER must use the schema PROPERTY names, which is what OpenRegister
+	// matches on. A filter naming a property that does not exist does not
+	// error — it returns {"results":[],"total":0} with HTTP 200 — so getting
+	// this wrong renders "No underlying commitments found" over live rows.
+	// Measured: ?programme=5.1&costCentre=FAC-2026 returns 6; the same query
+	// with cost_centre returns 0.
+	it('builds exact-match filters keyed by PROPERTY name, not column name', () => {
 		const filters = drilldownFilters({
 			programme: '5.1',
 			cost_centre: 'FAC-2026',
@@ -125,10 +132,22 @@ describe('budgetLineCommitmentsHelpers — drilldownFilters', () => {
 		})
 		expect(filters).toEqual({
 			programme: '5.1',
+			costCentre: 'FAC-2026',
+			financialYear: 2026,
+			generalLedgerAccount: '4400',
+		})
+	})
+
+	it('never emits the snake_case column spelling', () => {
+		const filters = drilldownFilters({
+			programme: '5.1',
 			cost_centre: 'FAC-2026',
 			financial_year: 2026,
 			general_ledger_account: '4400',
 		})
+		expect(Object.keys(filters)).not.toContain('cost_centre')
+		expect(Object.keys(filters)).not.toContain('financial_year')
+		expect(Object.keys(filters)).not.toContain('general_ledger_account')
 	})
 
 	it('omits empty/blank dimensions (e.g. a Contract-sourced rule with no general_ledger_account)', () => {
@@ -140,8 +159,88 @@ describe('budgetLineCommitmentsHelpers — drilldownFilters', () => {
 		})
 		expect(filters).toEqual({
 			programme: '5.1',
+			costCentre: 'FAC-2026',
+			financialYear: 2026,
+		})
+	})
+
+	it('keeps financialYear 0 rather than dropping it as falsy', () => {
+		// A 0 fiscal year is not a real budget year, but dropping it would
+		// silently WIDEN the drilldown to every year — a filter that quietly
+		// matches more is the failure mode this whole page has been bitten by.
+		const filters = drilldownFilters({
+			programme: '5.1',
+			financial_year: 0,
+		})
+		expect(filters.financialYear).toBe(0)
+	})
+
+	it('reads the envelope OpenRegister actually returns (groups/keys/values/joined)', () => {
+		// Captured verbatim from a live instance. The previous implementation
+		// looked for `payload.buckets` holding flat rows, which no version of
+		// the engine emits — so it returned [] and the page rendered its empty
+		// state over live data (issue #1216).
+		const rows = normaliseBudgetLineRows({
+			name: 'committedVsRealisedPerBudgetLine',
+			backend: 'postgres',
+			groups: [
+				{
+					keys: {
+						programme: '5.1',
+						costCentre: 'FAC-2026',
+						financialYear: 2026,
+						generalLedgerAccount: '4400',
+					},
+					values: {
+						sum_remaining_committed: 15000000,
+						sum_invoiced_amount: 2500000,
+					},
+					joined: {
+						'CommitmentBudget.authorised_amount': 80000000,
+						'CommitmentBudget.realised_amount': 2500000,
+					},
+				},
+			],
+		})
+
+		expect(rows).toHaveLength(1)
+		expect(rows[0]).toEqual({
+			key: '5.1|FAC-2026|2026|4400',
+			programme: '5.1',
 			cost_centre: 'FAC-2026',
 			financial_year: 2026,
+			general_ledger_account: '4400',
+			geautoriseerd: 80000000,
+			mandatory: 15000000,
+			gerealiseerd: 2500000,
+			// 80000000 - 15000000 - 2500000
+			vrij: 62500000,
 		})
+	})
+
+	it('still reads the legacy flat shape, for an older OpenRegister', () => {
+		const rows = normaliseBudgetLineRows({
+			buckets: [
+				{
+					programme: '5.1',
+					cost_centre: 'FAC-2026',
+					financial_year: 2026,
+					general_ledger_account: '4400',
+					remaining_committed: 100,
+					invoiced_amount: 25,
+					'CommitmentBudget.authorised_amount': 500,
+				},
+			],
+		})
+
+		expect(rows[0].mandatory).toBe(100)
+		expect(rows[0].gerealiseerd).toBe(25)
+		expect(rows[0].geautoriseerd).toBe(500)
+		expect(rows[0].vrij).toBe(375)
+	})
+
+	it('returns [] for an aggregation that produced no groups', () => {
+		expect(normaliseBudgetLineRows({ groups: [] })).toEqual([])
+		expect(normaliseBudgetLineRows({})).toEqual([])
 	})
 })


### PR DESCRIPTION
Closes #1216.

**Four layers each agreed on a shape none of them produced**, so the page rendered "No budget lines" over live objects — with no error anywhere.

### 1. The declaration spoke a grammar the engine does not read

It used `source` and a `sum` list. OpenRegister's annotation keys are `field / filter / from / groupBy / join / metric / metrics / select / where`. The runner recognised the aggregation **by name** and understood none of its body, answering `metric:""`, `field:null`, `groups:[]`.

Now: `source` dropped (an intra-schema aggregation needs none — `from` is the *cross*-schema key), `sum: [a,b]` → `metrics: [{metric, field}, …]`, and `on` uses the explicit `{parentField: joinedField}` map instead of the string shorthand, which names only the joined side and infers the parent one.

### 2. The scoping filter named a placeholder that does not exist

`administrationId: "@self.administrationId"` — the resolver implements `$currentUser` and nothing else, so it was left **literal** and matched every row away. It cannot be a constant either, since it differs per caller.

It is now supplied by the caller as a **narrowing** filter (openregister#2852), which can add a constraint but never relax a declared one. The view **refuses to query at all** when it cannot resolve an administration, rather than falling back to an unscoped call — showing every tenant's budget figures is worse than showing nothing.

### 3. The normaliser read a payload shape that never existed

It looked for `payload.buckets` holding flat rows. The engine returns `groups[].{keys, values, joined}`. So it returned `[]` regardless of the data.

### 4. The drilldown filtered on column names, wrapped in `filters[...]`

OpenRegister matches on the **property** name and reads **bare** params. Measured live:

```
?programme=5.1&costCentre=FAC-2026   → 6 rows
?programme=5.1&cost_centre=FAC-2026  → 0 rows
```

Both HTTP 200 — so the drilldown rendered "No underlying commitments found" over rows that were plainly there.

## Every one of those failed silently

None raised, logged, or returned 4xx. Each produced an empty set that reads exactly like *"no data yet"*.

**The tests were part of the problem.** `CommitmentAccountingFragmentTest` asserted `source` and `sum` — it compared the declaration to itself, so it passed throughout and would have gone on passing forever. It now asserts the engine's vocabulary, and explicitly asserts `source` / `sum` / `administrationId` are **absent**.

## Verified end to end on a live rig

The only thing that could have caught any of this:

- the aggregation returns real groups — composite keys, **both** sums, and the joined `CommitmentBudget` figures
- narrowing to a different administration returns **0 groups**
- attempting to relax the declared `afgesloten: false` is **refused**
- and the e2e drilldown test — which **skipped itself** for as long as this was broken, because an empty page reads as "nothing seeded" —

```
✓ renders the four committed-vs-realised columns and drills into a budget line
```

now passes.

## Gates

10 JS validators (incl. `check:l10n-js`, `check:schema-l10n`), `phpcs`, `vitest` **256**, `phpunit` **4980 tests / 46761 assertions, 0 failures** (1 skip, pre-existing on `development`).

Depends on openregister #2846, #2849 and #2852 — all merged.
