### PR TITLE
fix(admin): resolve the integriq app id in the provisioning deep link

### DIFF
--- a/lib/Controller/ExternalAdaptersAdminController.php
+++ b/lib/Controller/ExternalAdaptersAdminController.php
@@ -452,6 +452,8 @@ class ExternalAdaptersAdminController extends Controller {
 	 * @param IRequest $request Nextcloud request.
 	 * @param ContainerInterface $container DI container for adapter resolution.
 	 * @param LoggerInterface $logger Structured logger.
+	 * @param IAppManager $appManager App manager, used to resolve the integriq
+	 *                                app id across the fleet rename.
 	 */
 	public function __construct(
 		IRequest $request,

--- a/lib/Controller/ExternalAdaptersAdminController.php
+++ b/lib/Controller/ExternalAdaptersAdminController.php
@@ -68,6 +68,8 @@ use OCA\Shillinq\Service\External\Salarisbureau\SalarisbureauAdapterInterface;
 use OCA\Shillinq\Service\External\Sisa\BzkSisaUploadAdapterInterface;
 use OCA\Shillinq\Service\External\TreasuryRate\TreasuryRateAdapterInterface;
 use OCA\Shillinq\Service\External\Uwv\UwvLoonaangifteAdapterInterface;
+use OCA\Shillinq\Support\FleetAppId;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
@@ -455,6 +457,7 @@ class ExternalAdaptersAdminController extends Controller {
 		IRequest $request,
 		private readonly ContainerInterface $container,
 		private readonly LoggerInterface $logger,
+		private readonly IAppManager $appManager,
 	) {
 		parent::__construct(appName: Application::APP_ID, request: $request);
 	}//end __construct()
@@ -556,7 +559,16 @@ class ExternalAdaptersAdminController extends Controller {
 	 * @return array{status:string,openconnectorObjectId?:string,deepLink:string}
 	 */
 	private function resolveProvisioning(string $sourceSlug): array {
-		$deepLink = '/apps/openconnector/sources';
+		// The deep link is a ROUTING KEY: NC mounts routes under the registered
+		// app id, which is `integriq` on development and `openconnector` on
+		// beta/main. Resolve it rather than hardcoding either, or half the fleet
+		// gets a 404 from this link.
+		//
+		// NOTE: the register slug passed to setRegister() below stays
+		// 'openconnector' deliberately. OpenRegister register slugs are frozen
+		// across the rename — they are literals already written into stored
+		// data, so changing one orphans the records it names.
+		$deepLink = (FleetAppId::appPath($this->appManager, 'integriq', 'sources') ?? '/apps/openconnector/sources');
 
 		try {
 			$objectService = $this->container->get('OCA\\OpenRegister\\Service\\ObjectService');

--- a/lib/Support/FleetAppId.php
+++ b/lib/Support/FleetAppId.php
@@ -107,7 +107,7 @@ final class FleetAppId
      */
     public static function isInstalled(IAppManager $appManager, string $canonical): bool
     {
-        return self::resolve($appManager, $canonical) !== null;
+        return self::resolve(appManager: $appManager, canonical: $canonical) !== null;
 
     }//end isInstalled()
 
@@ -125,7 +125,7 @@ final class FleetAppId
      */
     public static function isEnabledForUser(IAppManager $appManager, string $canonical): bool
     {
-        $id = self::resolve($appManager, $canonical);
+        $id = self::resolve(appManager: $appManager, canonical: $canonical);
         if ($id === null) {
             return false;
         }
@@ -155,7 +155,7 @@ final class FleetAppId
      */
     public static function appPath(IAppManager $appManager, string $canonical, string $suffix = ''): ?string
     {
-        $id = self::resolve($appManager, $canonical);
+        $id = self::resolve(appManager: $appManager, canonical: $canonical);
         if ($id === null) {
             return null;
         }

--- a/lib/Support/FleetAppId.php
+++ b/lib/Support/FleetAppId.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * FleetAppId — resolve a Conduction fleet app's installed id across the rename.
+ *
+ * The fleet is mid-rename: `openconnector` became `integriq`, `docudesk`
+ * became `filinq`, and so on. The new id has landed on each app's
+ * `development` branch, but `beta` and `main` still ship the old one, so at
+ * any given moment the id a running instance answers to depends on which
+ * branch that app was deployed from.
+ *
+ * That matters because every cross-app reference is a DUCK-TYPED RUNTIME
+ * LOOKUP. `IAppManager::isInstalled('openconnector')` against an instance
+ * running `integriq` does not error — it returns false, and the integration
+ * silently does nothing. A hard swap to the new id has the same failure in
+ * the other direction against a beta/main deployment.
+ *
+ * So neither id alone is correct. This resolver takes a LIST, newest first,
+ * and returns whichever the instance actually has. Callers ask for the
+ * canonical (new) name and get back the id that is really installed.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Support
+ * @package  OCA\Shillinq\Support
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Shillinq\Support;
+
+use OCP\App\IAppManager;
+use Throwable;
+
+/**
+ * Resolves fleet app ids across the in-flight rename.
+ */
+final class FleetAppId
+{
+
+    /**
+     * Candidate ids per canonical app, NEWEST FIRST.
+     *
+     * Order is the contract: the first entry that is installed wins, so a
+     * fully migrated instance resolves to the new id and a beta/main instance
+     * falls back to the old one. Adding a new rename means prepending, never
+     * replacing — dropping the old id here is what silently breaks the
+     * integrations this class exists to protect.
+     *
+     * @var array<string, list<string>>
+     */
+    private const CANDIDATES = [
+        'integriq' => ['integriq', 'openconnector'],
+        'filinq'   => ['filinq', 'docudesk'],
+        'thematiq' => ['thematiq', 'nldesign'],
+        'stackiq'  => ['stackiq', 'softwarecatalog'],
+        'larpinq'  => ['larpinq', 'larpingapp'],
+        'dossiq'   => ['dossiq', 'procest'],
+        'learniq'  => ['learniq', 'scholiq'],
+        'decidiq'  => ['decidiq', 'decidesk'],
+        'buildiq'  => ['buildiq', 'openbuild'],
+        'keepiq'   => ['keepiq', 'doriath'],
+    ];
+
+
+    /**
+     * The id this instance actually has installed, or null if none is.
+     *
+     * @param IAppManager $appManager The Nextcloud app manager.
+     * @param string      $canonical  Canonical (new) app name, e.g. 'integriq'.
+     *
+     * @return string|null The installed id, or null when the app is absent.
+     */
+    public static function resolve(IAppManager $appManager, string $canonical): ?string
+    {
+        foreach ((self::CANDIDATES[$canonical] ?? [$canonical]) as $candidate) {
+            try {
+                if ($appManager->isInstalled($candidate) === true) {
+                    return $candidate;
+                }
+            } catch (Throwable $e) {
+                // An app manager that cannot answer for one candidate must not
+                // abort the search — the next candidate may still resolve.
+                continue;
+            }
+        }
+
+        return null;
+
+    }//end resolve()
+
+
+    /**
+     * Whether any candidate id for this app is installed.
+     *
+     * @param IAppManager $appManager The Nextcloud app manager.
+     * @param string      $canonical  Canonical (new) app name, e.g. 'integriq'.
+     *
+     * @return bool True when the app is present under some id.
+     */
+    public static function isInstalled(IAppManager $appManager, string $canonical): bool
+    {
+        return self::resolve($appManager, $canonical) !== null;
+
+    }//end isInstalled()
+
+
+    /**
+     * Whether the app is installed AND enabled for the current user.
+     *
+     * Resolves the id first so the enabled check runs against the same id the
+     * instance actually has, rather than against a name it never registered.
+     *
+     * @param IAppManager $appManager The Nextcloud app manager.
+     * @param string      $canonical  Canonical (new) app name, e.g. 'integriq'.
+     *
+     * @return bool True when present and enabled for the current user.
+     */
+    public static function isEnabledForUser(IAppManager $appManager, string $canonical): bool
+    {
+        $id = self::resolve($appManager, $canonical);
+        if ($id === null) {
+            return false;
+        }
+
+        try {
+            return $appManager->isEnabledForUser($id);
+        } catch (Throwable $e) {
+            return false;
+        }
+
+    }//end isEnabledForUser()
+
+
+    /**
+     * Build an app-scoped path using the id the instance actually has.
+     *
+     * A URL like `/apps/openconnector/api/sources` is a routing key: Nextcloud
+     * mounts routes under the REGISTERED app id, so the path is only valid for
+     * the id that is really installed. Hardcoding either name yields a 404 on
+     * half the fleet.
+     *
+     * @param IAppManager $appManager The Nextcloud app manager.
+     * @param string      $canonical  Canonical (new) app name, e.g. 'integriq'.
+     * @param string      $suffix     Path after the app segment, no leading slash.
+     *
+     * @return string|null The path, or null when the app is not installed.
+     */
+    public static function appPath(IAppManager $appManager, string $canonical, string $suffix = ''): ?string
+    {
+        $id = self::resolve($appManager, $canonical);
+        if ($id === null) {
+            return null;
+        }
+
+        $path = '/apps/'.$id;
+        if ($suffix !== '') {
+            $path .= '/'.ltrim($suffix, '/');
+        }
+
+        return $path;
+
+    }//end appPath()
+
+
+}//end class

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -52,6 +52,7 @@
             <property name="exceptions" value="
                 DateTimeImmutable,
                 OCP\Server,
+                OCA\Shillinq\Support\FleetAppId,
                 OCA\OpenRegister\Lifecycle\GuardResult,
                 OCA\OpenRegister\Service\Aggregation\AggregationQuery,
                 OCA\OpenRegister\AppHost\Observability\MetricSample,


### PR DESCRIPTION
A cross-app id reference is a **duck-typed runtime lookup**. `isInstalled('openconnector')` against an instance running `integriq` does **not** error — it returns `false`, and the integration silently stops working. A URL segment behaves the same way: `/apps/<id>/` is a routing key, so the wrong name is a **404**, not a diagnosable failure.

## The fleet is mid-rename, and the two halves disagree

Measured 2026-08-26 from `appinfo/info.xml` — the only authority on an app's id:

| branch | integriq | filinq | stackiq | dossiq | buildiq | keepiq | decidiq | larpinq |
|---|---|---|---|---|---|---|---|---|
| `development` | integriq | filinq | stackiq | dossiq | buildiq | keepiq | decidiq | larpinq |
| `beta` / `main` | openconnector | docudesk | softwarecatalog | procest | openbuild | doriath | decidesk | larpingapp |

So **neither id alone is correct**. Hardcoding the new one breaks against beta/main; keeping the old one breaks against development. That is why this is a resolver rather than a find-and-replace.

## The change

Adds `FleetAppId`, which holds a **list of candidate ids, newest first**, and returns whichever the instance actually registered. Callers ask for the canonical (new) name and get back the real one.

The same class is being added to openregister (#2867), learniq, pipelinq and shillinq. It is duplicated per app on purpose: it is a **transitional shim** that should be deleted once beta and main carry the new ids, and a shared package would outlive the problem it solves.

## What is deliberately NOT changed

- **OpenRegister register slugs.** These are frozen across the rename — they are literals already written into stored data, so renaming one orphans the records it names.
- **Docblock examples** mentioning old ids. Not executable.

## Verification

Covered by 12 unit tests in openregister #2867, including a **mutation check**: removing the legacy fallback from the candidate map fails 5 of them, so the tests would notice if the resolver stopped resolving.
