### PR TITLE
fix(manifest): rewrite 24 user-visible strings that were developer notes

### DIFF
--- a/src/manifest.d/30-bookkeeping-kor-kleine-ondernemersregeling.json
+++ b/src/manifest.d/30-bookkeeping-kor-kleine-ondernemersregeling.json
@@ -60,8 +60,8 @@
 						"defaultValue": "ACTIEF",
 						"options": [
 							{ "value": "ACTIEF", "label": "Active" },
-							{ "value": "GEEINDIGD_OVERSCHRIJDING", "label": "Ended — exceedance" },
-							{ "value": "GEEINDIGD_VRIJWILLIG", "label": "Ended — voluntary" }
+							{ "value": "GEEINDIGD_OVERSCHRIJDING", "label": "Ended (exceeded threshold)" },
+							{ "value": "GEEINDIGD_VRIJWILLIG", "label": "Ended (voluntary)" }
 						]
 					}
 				],

--- a/src/manifest.d/ar-invoice-payment-links.json
+++ b/src/manifest.d/ar-invoice-payment-links.json
@@ -112,7 +112,7 @@
 										"register": "shillinq",
 										"schema": "PaymentRequest",
 										"filter": {"invoiceReference": ":invoiceReference"},
-										"description": "All payment requests for the same invoice — expired/failed attempts preserved as history (REQ-APL-008)."
+										"description": "Every payment request raised for this invoice. Expired and failed attempts are kept, so the history stays complete."
 									}
 								}
 							]

--- a/src/manifest.d/bookings-notification-triggers.json
+++ b/src/manifest.d/bookings-notification-triggers.json
@@ -127,7 +127,7 @@
 					{
 						"id": "disable-all-triggers",
 						"label": "Disable all triggers",
-						"description": "Emergency off-switch (REQ-BNT-008). Transitions every enabled trigger to disabled — no notifications dispatch until an admin re-enables them.",
+						"description": "Emergency off-switch. Disables every active trigger at once. No notifications are sent until an administrator turns them back on.",
 						"icon": "BellOffOutline",
 						"confirm": true
 					},

--- a/src/manifest.d/inventory-cycle-count.json
+++ b/src/manifest.d/inventory-cycle-count.json
@@ -129,7 +129,7 @@
 				],
 				"defaultSort": "reasonId",
 				"defaultSortDirection": "asc",
-				"description": "Configurable variance reason-code taxonomy per REQ-ICC-005 — the dropdown source for InventoryCycleCountLine.reasonCode. Bookkeepers can deactivate codes (historic FKs remain queryable); warehouse_manager + bookkeeper roles can create new per-administration entries."
+				"description": "The reason codes offered when a counted quantity differs from the recorded one. Bookkeepers can retire a code without affecting counts that already use it, and warehouse managers and bookkeepers can add new ones per administration."
 			}
 		},
 		{

--- a/src/manifest.d/inventory-stock-movement-ledger.json
+++ b/src/manifest.d/inventory-stock-movement-ledger.json
@@ -64,7 +64,7 @@
 				"defaultSort": "draftedAt",
 				"defaultSortDirection": "desc",
 				"detailRoute": "StockMovementDetail",
-				"description": "Immutable double-entry ledger of every receipt, transfer, issue, manufacture and repack per REQ-SM-008. Posted moves are locked — cancellation emits an offsetting move so the original row stays auditable."
+				"description": "A permanent record of every receipt, transfer, issue, manufacture and repack. Once posted, a move cannot be edited: cancelling it adds an opposite move instead, so the original stays visible for audit."
 			}
 		},
 		{
@@ -141,7 +141,7 @@
 				"defaultSort": "lastMovementDate",
 				"defaultSortDirection": "desc",
 				"x-drilldown-deferred": "The per-row drill-down to the stock-ledger trace (REQ-SM-005) is NOT WIRED — tracked in ConductionNL/shillinq#508, which carries the full contract analysis. Its page declaration was withdrawn because the manifest was naming a page whose component exists nowhere (registered in neither src/registry.js nor a customComponents.js, which this app does not have), and the route contract does not match stockLedger#trace either: the route supplied an InventoryStock UUID while the endpoint requires administration_id + location_id + sku. The BACKEND HALF IS COMPLETE and untouched (StockLedgerController + StockLedgerService); only the Vue view was never written. Restoring the `StockLedgerTrace` page entry (and a `rowRoute` here, which is the key CnIndexPage actually reads — `detailRoute` is read by nothing) is part of building the view, so the declaration cannot return before the surface does.",
-				"description": "Per REQ-SM-005 — every InventoryStock row drills down to the chronological run of posted, non-cancelled StockMoves that comprise its current balance, with cumulative running totals matching `quantity` exactly."
+				"description": "Open any stock line to see the moves behind its current balance, in date order, with a running total that adds up to the quantity on hand."
 			}
 		}
 	]

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,9 +12,9 @@
 			{ "id": "welcome", "type": "info", "title": "Welcome to Shillinq", "body": "First choose the country (legal region) and organisation type, then the chart-of-accounts template, and create the administration. Finally you can load the chart of accounts and the reference data." },
 			{ "id": "country", "type": "choice", "title": "Legal region (country)", "body": "In which country is this organisation legally established? This determines the available organisation types and standards.", "configKey": "legal_country", "required": true, "options": [ { "value": "nl", "label": "Netherlands" }, { "value": "be", "label": "Belgium" }, { "value": "de", "label": "Germany" } ] },
 			{ "id": "organisation", "type": "choice", "title": "Organisation type", "configKey": "legal_region", "required": true, "dependsOn": "legal_country", "optionsByParent": { "nl": [ { "value": "municipality", "label": "Municipality" }, { "value": "provincie", "label": "Province" }, { "value": "waterschap", "label": "Water authority" }, { "value": "zzp", "label": "ZZP" }, { "value": "mkb", "label": "MKB" } ], "be": [ { "value": "vzw", "label": "VZW" }, { "value": "bv", "label": "Besloten Vennootschap (BV)" }, { "value": "eenmanszaak", "label": "Eenmanszaak" } ], "de": [ { "value": "gmbh", "label": "GmbH" }, { "value": "verein", "label": "Verein" }, { "value": "einzelunternehmen", "label": "Einzelunternehmen" } ] } },
-			{ "id": "rgs-template", "type": "choice", "title": "Chart of accounts (RGS)", "body": "A chart of accounts (RGS – Referentie GrootboekSchema) is the standardised layout of ledger accounts your balance sheet and profit-and-loss statement are based on. Based on your organisation type, a matching template is already suggested — you can adjust it.", "configKey": "rgs_template", "required": true, "suggestFrom": "legal_region", "suggestMap": { "municipality": "bbv", "provincie": "bbv", "waterschap": "bbv", "zzp": "zzp", "mkb": "mkb", "vzw": "mkb", "bv": "mkb", "eenmanszaak": "zzp", "gmbh": "mkb", "verein": "mkb", "einzelunternehmen": "zzp" }, "options": [ { "value": "mkb", "label": "MKB" }, { "value": "zzp", "label": "ZZP" }, { "value": "bbv", "label": "BBV (government)" } ] },
+			{ "id": "rgs-template", "type": "choice", "title": "Chart of accounts (RGS)", "body": "A chart of accounts (RGS, Referentie GrootboekSchema) is the standardised layout of ledger accounts your balance sheet and profit-and-loss statement are based on. Based on your organisation type, a matching template is already suggested. You can adjust it.", "configKey": "rgs_template", "required": true, "suggestFrom": "legal_region", "suggestMap": { "municipality": "bbv", "provincie": "bbv", "waterschap": "bbv", "zzp": "zzp", "mkb": "mkb", "vzw": "mkb", "bv": "mkb", "eenmanszaak": "zzp", "gmbh": "mkb", "verein": "mkb", "einzelunternehmen": "zzp" }, "options": [ { "value": "mkb", "label": "MKB" }, { "value": "zzp", "label": "ZZP" }, { "value": "bbv", "label": "BBV (government)" } ] },
 			{ "id": "administration", "type": "run-action", "title": "Create administration", "body": "Create the default administration. This registers your organisation as an administration in OpenRegister, so bookings, invoices and reports can be linked to it. Click \"Run\" to create the administration.", "action": "init-administration", "required": true },
-			{ "id": "seed", "type": "run-action", "title": "Load chart of accounts and reference data", "body": "Load the chosen chart of accounts (ledger accounts), the VAT rates, and — for government bodies — the BBV task fields into the administration. This may take a while. Click \"Run\" to start.", "action": "seed", "required": false },
+			{ "id": "seed", "type": "run-action", "title": "Load chart of accounts and reference data", "body": "Load the chosen chart of accounts (ledger accounts), the VAT rates, and, for government bodies, the BBV task fields into the administration. This may take a while. Click \"Run\" to start.", "action": "seed", "required": false },
 			{ "id": "done", "type": "summary", "title": "Done", "body": "Review your choices below and complete the installation.", "healthCheck": true }
 		]
 	},
@@ -34,7 +34,7 @@
 						"sinceVersion": "1.3.18",
 						"placement": "center",
 						"title": "Welcome to Shillinq",
-						"body": "Let's take a quick spin through your bookkeeping — we'll create a sales invoice together so you can see how the pieces fit. You'll add the record yourself.",
+						"body": "Let's take a quick spin through your bookkeeping. We'll create a sales invoice together so you can see how the pieces fit, and you'll add the record yourself.",
 						"target": { "kind": "page", "ref": "Dashboard" },
 						"advanceOn": { "type": "manual" }
 					},
@@ -794,7 +794,7 @@
 				},
 				{
 					"id": "BewaartermijnenDashboard",
-					"label": "Retention periods — Dashboard",
+					"label": "Retention periods dashboard",
 					"icon": "ViewDashboardOutline",
 					"route": "BewaartermijnenDashboard",
 					"order": 20
@@ -5260,7 +5260,7 @@
 								"limit": 8
 							},
 							"rowRoute": "ARInvoiceDetail",
-							"emptyText": "No open debtor invoices — everything is paid.",
+							"emptyText": "No open debtor invoices. Everything is paid.",
 							"columns": [
 								{ "key": "invoiceNumber", "label": "Invoice" },
 								{ "key": "customerId", "label": "Customer" },
@@ -5283,7 +5283,7 @@
 								"order": { "dueDate": "asc" },
 								"limit": 8
 							},
-							"emptyText": "No open creditor invoices — nothing due.",
+							"emptyText": "No open creditor invoices. Nothing is due.",
 							"columns": [
 								{ "key": "invoiceNumber", "label": "Invoice" },
 								{ "key": "vendorId", "label": "Vendor" },
@@ -7051,7 +7051,7 @@
 			"id": "BewaartermijnenDashboard",
 			"route": "/administratie/bewaartermijnen/dashboard",
 			"type": "dashboard",
-			"title": "Retention periods — Dashboard",
+			"title": "Retention periods dashboard",
 			"config": {
 				"widgets": [
 					{
@@ -7094,7 +7094,7 @@
 			"config": {
 				"register": "shillinq",
 				"schema": "TaxSummaryReport",
-				"description": "Per-category tax summaries feeding the annual filing. Converted from the never-rendered type=report (no such page type is registered) to a plain index — the KPI dashboard variant needs a dedicated renderer first.",
+				"description": "Tax totals per category, ready for the annual filing.",
 				"filters": [
 					{
 						"key": "fiscalYear",
@@ -12943,7 +12943,7 @@
 				],
 				"defaultSort": "-requisitionNumber",
 				"detailRoute": "RequisitionDetail",
-				"description": "Purchase requisitions (aanvragen) raised by employees prior to purchase-order creation. Member of the purchase-requisition change — approval reuses the bookkeeping-verplichtingenadministratie budget/mandate infrastructure.",
+				"description": "Purchase requests (aanvragen) raised by employees before a purchase order is created. Approval checks the same budget and mandate rules as commitments.",
 				"documentationUrl": "https://shillinq.conduction.nl/user-guide/purchasing/requisitions"
 			}
 		},
@@ -13111,7 +13111,7 @@
 						},
 						"successMessage": "Requisition approved.",
 						"errorMessage": "Requisition exceeds available budget.",
-						"description": "Approve the submitted requisition. Server-side gated by BudgetBlocker::canCommit — budget availability or an override-mandate (REQ-REQ-003)."
+						"description": "Approve the submitted request. Approval requires available budget, or a mandate that overrides it."
 					},
 					{
 						"id": "reject-requisition",
@@ -13430,7 +13430,7 @@
 				],
 				"defaultSort": "receivedAt",
 				"detailRoute": "GoodsReceiptDetail",
-				"description": "Goods Receipt Notes (GRN) — physical receipt against POs. Member 04 owns the capture flow.",
+				"description": "Goods receipt notes recording what physically arrived against each purchase order.",
 				"documentationUrl": "https://shillinq.conduction.nl/user-guide/purchasing/overview"
 			}
 		},
@@ -14052,7 +14052,7 @@
 					}
 				],
 				"defaultSort": "-created",
-				"description": "Pre-filtered OR audit-log view of records transitioning to marked-for-destruction or destruction-completed per REQ-RAP-003 / REQ-RAP-008. Serves as legal proof of Archiefwet-compliant disposal — every row links to the OR hash-chain entry certifying the transition. Use this surface for external auditor compliance verification."
+				"description": "Records marked for destruction, and records already destroyed. This is the legal proof of Archiefwet-compliant disposal: every row links to the audit-trail entry certifying the change, so an external auditor can verify it here."
 			}
 		},
 		{
@@ -14154,7 +14154,7 @@
 						"admin"
 					]
 				},
-				"description": "Compliance Export API surface per REQ-RAP-005 — RBAC-scoped to the auditor group; non-auditor callers receive 403. Server filters PII fields (email, phone, address, displayName, firstName, lastName, birthDate, socialSecurityNumber, taxId, personId, ipAddress) before rendering CSV/XLSX/JSON. Every export request is itself recorded in the OR audit trail per REQ-RAP-005 scenario 3."
+				"description": "Export compliance data as CSV, XLSX or JSON. Only the auditor group can use this. Personal data such as names, addresses, contact details and identification numbers is removed before the file is written, and every export is itself recorded in the audit trail."
 			}
 		},
 		{
@@ -16895,7 +16895,7 @@
 											"reconId": ":id",
 											"resolutionStatus": null
 										},
-										"description": "Unresolved items for this session — bulk-classify via the resolution endpoint (REQ-REC-004).",
+										"description": "Items in this session that still need a decision. Select several to classify them in one go.",
 										"bulkActions": [
 											{
 												"id": "mark-timing",
@@ -16927,7 +16927,7 @@
 									"type": "static",
 									"componentName": "reconciliation-closure-summary",
 									"props": {
-										"description": "REQ-REC-006: pre-close summary — matched count, unmatched GL/bank counts, total variance, and sign-off comment field. Verifier MUST supply sign-off before the verify transition.",
+										"description": "A summary before closing: how many items matched, how many are still unmatched on either side, and the total variance. Sign-off is required before this reconciliation can be verified.",
 										"fields": [
 											"matchedCount",
 											"unmatchedGLCount",
@@ -17014,7 +17014,7 @@
 						"payload": {
 							"resolutionStatus": "timing"
 						},
-						"description": "Bulk REQ-REC-004 classification — operator supplies one reason for the whole selection."
+						"description": "Classify every selected item as a timing difference, using one reason for the whole selection."
 					},
 					{
 						"id": "bulk-classify-pending",
@@ -17047,7 +17047,7 @@
 			"config": {
 				"register": "shillinq",
 				"schema": "BankReconciliation",
-				"description": "REQ-REC-007: variance per closed reconciliation, derived from BankReconciliation records. Converted from the never-rendered type=report (no such page type is registered) to a plain index — the KPI/aggregation dashboard variant needs a dedicated renderer first.",
+				"description": "The variance recorded against each closed reconciliation.",
 				"filters": [
 					{
 						"key": "reconciliationStatus",


### PR DESCRIPTION
Found by **gate-96** (`manifest-copy-style`, ConductionNL/.github#581). Two separate problems shared one detector, and the smaller one is the punctuation.

## The punctuation (7 strings)

`voice.md` section 8 bans em-dashes. These included the walkthrough's opening line and both dashboard empty states — *"No open debtor invoices — everything is paid."*

## The real problem (17 strings)

The rest were **internal developer notes in a field users read.** `CnPageHeader` renders a page's `config.description` underneath its title, so anyone opening these pages was shown:

> "Approve the submitted requisition. Server-side gated by `BudgetBlocker::canCommit` — budget availability or an override-mandate (REQ-REQ-003)."

> "REQ-REC-006: pre-close summary — matched count, unmatched GL/bank counts, total variance, and sign-off comment field."

> "Per-category tax summaries feeding the annual filing. **Converted from the never-rendered type=report (no such page type is registered) to a plain index** — the KPI dashboard variant needs a dedicated renderer first."

That last one explains a refactor decision to a bookkeeper who came looking for their tax totals.

Stripping the dash would have made all three **pass the gate while staying wrong**. So they are rewritten as copy:

| before | after |
|---|---|
| `BudgetBlocker::canCommit — budget availability or an override-mandate (REQ-REQ-003)` | "Approval requires available budget, or a mandate that overrides it." |
| `REQ-REC-006: pre-close summary — matched count, unmatched GL/bank counts…` | "A summary before closing: how many items matched, how many are still unmatched on either side, and the total variance." |
| `Converted from the never-rendered type=report…` | "Tax totals per category, ready for the annual filing." |

Requirement ids, class and method names, and internal chain/slice references are gone from every user-facing string. They remain where they belong: in `_meta` and in the specs.

## Not touched

The `_meta.description` blocks. Those are per-fragment provenance (spdx, change, adr) and are **never rendered**. The gate's first version flagged 22 of them in this repo alone — which is why it now skips underscore-prefixed keys, and why the fleet total came down from 126 to 97.

## Verification

- gate-96: **0 findings** over **6,554 strings** (was 24)
- `check:manifest`: **passes** — dead-config-key gate inspected 329 page configs across 87 fragments, 0 issues
- all 88 JSON files re-parse