### PR TITLE
fix(aggregations): an administration is a normal property, not @self metadata

### DIFF
--- a/l10n/en.js
+++ b/l10n/en.js
@@ -2982,7 +2982,8 @@ OC.L10N.register(
         "The request failed.": "The request failed.",
         "This view is unavailable — no figure is shown because none could be trusted.": "This view is unavailable — no figure is shown because none could be trusted.",
         "Unknown error": "Unknown error",
-        "You are not a member of any administration, so there is no spend to report on.": "You are not a member of any administration, so there is no spend to report on."
+        "You are not a member of any administration, so there is no spend to report on.": "You are not a member of any administration, so there is no spend to report on.",
+        "No active administration — cannot scope segment P&L.": "No active administration — cannot scope segment P&L."
     },
     "nplurals=2; plural=(n != 1);"
 )

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -2984,7 +2984,8 @@
         "The request failed.": "The request failed.",
         "This view is unavailable — no figure is shown because none could be trusted.": "This view is unavailable — no figure is shown because none could be trusted.",
         "Unknown error": "Unknown error",
-        "You are not a member of any administration, so there is no spend to report on.": "You are not a member of any administration, so there is no spend to report on."
+        "You are not a member of any administration, so there is no spend to report on.": "You are not a member of any administration, so there is no spend to report on.",
+        "No active administration — cannot scope segment P&L.": "No active administration — cannot scope segment P&L."
     },
     "plurals": "",
     "pluralForm": "nplurals=2; plural=(n != 1);"

--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -1632,6 +1632,7 @@ OC.L10N.register(
         "No attribute definitions are available.": "Er zijn geen attribuutdefinities beschikbaar.",
         "No barcode decoder available; use manual entry.": "Geen barcodedecoder beschikbaar; gebruik handmatige invoer.",
         "No active administration — cannot scope budget lines.": "Geen actieve administratie — budgetregels kunnen niet worden afgebakend.",
+        "No active administration — cannot scope segment P&L.": "Geen actieve administratie — segment-winst-en-verliesrekening kan niet worden afgebakend.",
         "No budget lines": "Geen budgetregels",
         "No checklist items yet.": "Nog geen checklist-items.",
         "No client administrations": "Geen klantadministraties",

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -1631,6 +1631,7 @@
         "No attribute definitions are available.": "Er zijn geen attribuutdefinities beschikbaar.",
         "No barcode decoder available; use manual entry.": "Geen barcodedecoder beschikbaar; gebruik handmatige invoer.",
         "No active administration — cannot scope budget lines.": "Geen actieve administratie — budgetregels kunnen niet worden afgebakend.",
+        "No active administration — cannot scope segment P&L.": "Geen actieve administratie — segment-winst-en-verliesrekening kan niet worden afgebakend.",
         "No budget lines": "Geen budgetregels",
         "No checklist items yet.": "Nog geen checklist-items.",
         "No client administrations": "Geen klantadministraties",

--- a/lib/Settings/register.d/30-bookkeeping-ib-aangifte-zzp.json
+++ b/lib/Settings/register.d/30-bookkeeping-ib-aangifte-zzp.json
@@ -482,7 +482,6 @@
             "description": "Revenue excl. VAT summed over GL revenue postings for the fiscal year (REQ-IB-001). The matched journaalposten are linked into IBAuditTrail.",
             "source": "GLLine",
             "filter": {
-              "administrationId": "@self.administrationId",
               "accountClass": "revenue"
             },
             "sum": [
@@ -493,7 +492,6 @@
             "description": "Cost of goods sold summed over GL cost-of-sales postings (REQ-IB-001).",
             "source": "GLLine",
             "filter": {
-              "administrationId": "@self.administrationId",
               "accountClass": "cost-of-sales"
             },
             "sum": [

--- a/lib/Settings/register.d/add-shillinq-bbv-compliance.json
+++ b/lib/Settings/register.d/add-shillinq-bbv-compliance.json
@@ -103,9 +103,7 @@
             "groupBy": [
               "BbvAccountMapping.programmeCode"
             ],
-            "filter": {
-              "administrationId": "@self.administrationId"
-            },
+            "filter": {},
             "join": {
               "through": "BbvAccountMapping",
               "on": "BbvAccountMapping.accountNumber",
@@ -125,9 +123,7 @@
             "groupBy": [
               "BbvAccountMapping.autorisatieniveau"
             ],
-            "filter": {
-              "administrationId": "@self.administrationId"
-            },
+            "filter": {},
             "join": {
               "through": "BbvAccountMapping",
               "on": "BbvAccountMapping.accountNumber",

--- a/lib/Settings/register.d/add-shillinq-bookkeeping-operations.json
+++ b/lib/Settings/register.d/add-shillinq-bookkeeping-operations.json
@@ -192,7 +192,6 @@
               "reverseCharge"
             ],
             "filter": {
-              "administrationId": "@self.administrationId",
               "periodYear": "@self.periodYear"
             },
             "sum": [
@@ -374,7 +373,6 @@
               "counterpartyVatNumber"
             ],
             "filter": {
-              "administrationId": "@self.administrationId",
               "icp": true,
               "periodYear": "@self.periodYear"
             },
@@ -746,9 +744,7 @@
             "groupBy": [
               "taskField"
             ],
-            "filter": {
-              "administrationId": "@self.administrationId"
-            },
+            "filter": {},
             "sum": [
               "debit",
               "credit"
@@ -997,7 +993,6 @@
               "accountNumber"
             ],
             "filter": {
-              "administrationId": "@self.administrationId",
               "periodYear": "@self.periodYear",
               "periodQuarter": "@self.periodQuarter",
               "bcfCompensable": true
@@ -1326,7 +1321,6 @@
             "description": "Sum of GLLine net postings on accounts where isSchatkistAccount=true for the business day (REQ-SBK-004).",
             "source": "GLLine",
             "filter": {
-              "administrationId": "@self.administrationId",
               "isTreasuryAccount": true,
               "postingDate": "@self.businessDate"
             },

--- a/lib/Settings/register.d/bookkeeping-btw-oss-eu.json
+++ b/lib/Settings/register.d/bookkeeping-btw-oss-eu.json
@@ -368,7 +368,6 @@
               "ossContext.destinationCountry"
             ],
             "filter": {
-              "administrationId": "@self.administrationId",
               "ossContext.ossEligible": true
             },
             "sum": [
@@ -628,7 +627,6 @@
               "ossContext.appliedRateCategory"
             ],
             "filter": {
-              "administrationId": "@self.administrationId",
               "ossContext.ossReportingPeriod": "@self.periodYear-@self.periodQuarter"
             },
             "sum": [

--- a/lib/Settings/register.d/bookkeeping-cost-centers-dimensions.json
+++ b/lib/Settings/register.d/bookkeeping-cost-centers-dimensions.json
@@ -374,9 +374,7 @@
             "groupBy": [
               "costCenterCode"
             ],
-            "filter": {
-              "administrationId": "@self.administrationId"
-            },
+            "filter": {},
             "join": {
               "through": "AnalyticalDimension",
               "on": "AnalyticalDimension.code",
@@ -398,9 +396,7 @@
             "groupBy": [
               "AnalyticalDimension.parentCode"
             ],
-            "filter": {
-              "administrationId": "@self.administrationId"
-            },
+            "filter": {},
             "join": {
               "through": "AnalyticalDimension",
               "on": "AnalyticalDimension.code",
@@ -422,9 +418,7 @@
             "groupBy": [
               "costCarrierCode"
             ],
-            "filter": {
-              "administrationId": "@self.administrationId"
-            },
+            "filter": {},
             "join": {
               "through": "AnalyticalDimension",
               "on": "AnalyticalDimension.code",
@@ -446,9 +440,7 @@
             "groupBy": [
               "projectCode"
             ],
-            "filter": {
-              "administrationId": "@self.administrationId"
-            },
+            "filter": {},
             "join": {
               "through": "Project",
               "on": "Project.code",
@@ -467,9 +459,7 @@
             "groupBy": [
               "dimensions.*"
             ],
-            "filter": {
-              "administrationId": "@self.administrationId"
-            },
+            "filter": {},
             "join": {
               "through": "AnalyticalDimension",
               "on": "AnalyticalDimension.code",

--- a/lib/Settings/register.d/bookkeeping-detachering-payroll-administratie.json
+++ b/lib/Settings/register.d/bookkeeping-detachering-payroll-administratie.json
@@ -471,7 +471,6 @@
               "deductionType"
             ],
             "filter": {
-              "administrationId": "@self.administrationId",
               "taxYear": "@self.period.year"
             },
             "sum": [

--- a/lib/Settings/register.d/bookkeeping-icp-opgaaf.json
+++ b/lib/Settings/register.d/bookkeeping-icp-opgaaf.json
@@ -194,9 +194,7 @@
           "icpLedgerByBuyerSupplyType": {
             "description": "The ICP ledger (REQ-ICP-003): group all qualifying IcpSupply records for a period+administration by (buyerVatId, supplyType), SUM amountExclVat with sign preserved (credit notes are negative), sort by buyerVatId ascending. Triangulation (T) lines are never merged with L or S even when the buyerVatId matches (REQ-ICP-006). When the OpenRegister aggregation engine cannot express the period-window selection, IcpService computes the same result in PHP via the real ObjectService API.",
             "source": "IcpSupply",
-            "filter": {
-              "administrationId": "@self.administrationId"
-            },
+            "filter": {},
             "groupBy": [
               "IcpSupply.buyerVatId",
               "IcpSupply.supplyType"

--- a/lib/Settings/register.d/bookkeeping-ifrs-rj-dual-gaap.json
+++ b/lib/Settings/register.d/bookkeeping-ifrs-rj-dual-gaap.json
@@ -522,7 +522,6 @@
             "source": "DualTransaction",
             "filter": {
               "period": "@self.period",
-              "administrationId": "@self.administrationId",
               "state": "reconciled"
             },
             "groupBy": [

--- a/lib/Settings/register.d/bookkeeping-ifrs15-revenue.json
+++ b/lib/Settings/register.d/bookkeeping-ifrs15-revenue.json
@@ -1199,8 +1199,7 @@
             "description": "Declarative shape of the per-contract, per-period revenue roll-up RevenueCutoffService computes (REQ-IFRS15-008). Groups RevenueRecognitionEvent by (contractId, period) within an administration, sums recognisedAmount into periodRecognised, carries priorCumulativeRecognised from the prior period, derives cumulativeRecognised = priorCumulativeRecognised + periodRecognised and remainingAmount = transactionPriceAllocated - cumulativeRecognised, and forecasts the remaining amount forward over remainingMonths (60+, IFRS 15.120). contractGroupId enables group-level rollup for combination-of-contracts (REQ-IFRS15-011). When the OpenRegister aggregation engine cannot express the prior-period carry or the forward forecast, RevenueCutoffService computes the same result in PHP via the real ObjectService API.",
             "source": "RevenueRecognitionEvent",
             "filter": {
-              "contractId": "@self.contractId",
-              "administrationId": "@self.administrationId"
+              "contractId": "@self.contractId"
             },
             "groupBy": [
               "RevenueRecognitionEvent.contractId",

--- a/lib/Settings/register.d/bookkeeping-innovatiebox-administratie.json
+++ b/lib/Settings/register.d/bookkeeping-innovatiebox-administratie.json
@@ -531,8 +531,7 @@
               ]
             },
             "filter": {
-              "financialYear": "@self.boekjaar",
-              "administrationId": "@self.administrationId"
+              "financialYear": "@self.boekjaar"
             },
             "groupBy": [
               "IBProfitAttribution.qualifying_asset_id"

--- a/lib/Settings/register.d/bookkeeping-intercompany-elimination.json
+++ b/lib/Settings/register.d/bookkeeping-intercompany-elimination.json
@@ -336,8 +336,7 @@
             "description": "Declarative shape of the per-relation, per-period matching the engine computes (REQ-ICE-003). Groups IntercompanyTransaction by (relationId, periodId) within the consolidation, sums entity-A-side and entity-B-side amounts (debit minus credit per side) into totalAmountA/totalAmountB, and derives mismatchAmount = totalAmountA - totalAmountB. The tolerance evaluation that sets matchStatus runs in the create lifecycle guard. When the OpenRegister aggregation engine cannot express the per-side conditional sum, the same result is computed in PHP from the real ObjectService API (findAll).",
             "source": "IntercompanyTransaction",
             "filter": {
-              "relationId": "@self.relationId",
-              "administrationId": "@self.administrationId"
+              "relationId": "@self.relationId"
             },
             "groupBy": [
               "IntercompanyTransaction.relationId"
@@ -753,8 +752,7 @@
             "description": "Declarative shape of the per-pair, per-period counterparty roll-up the engine computes (REQ-ICE-007). Groups IntercompanyTransaction by (entityAId, entityBId, periodId) within the consolidation and sums receivables, payables, sales and purchase flows, counting transactions and related mismatches. When the OpenRegister aggregation engine cannot express the multi-source roll-up, the same result is computed in PHP from the real ObjectService API (findAll).",
             "source": "IntercompanyTransaction",
             "filter": {
-              "periodId": "@self.periodId",
-              "administrationId": "@self.administrationId"
+              "periodId": "@self.periodId"
             },
             "groupBy": [
               "IntercompanyTransaction.counterpartyEntityId",

--- a/lib/Settings/register.d/bookkeeping-kor-kleine-ondernemersregeling.json
+++ b/lib/Settings/register.d/bookkeeping-kor-kleine-ondernemersregeling.json
@@ -318,7 +318,6 @@
             "description": "Declaratieve vorm van de KOR-drempel-benutting die KorMonitorService berekent (REQ-KOR-002). Somt KOR-eligible AR-omzet (vrijstellingsGrondslag = KOR_ART25_OB, status != draft, leveringsDatum in jaar) per administratie + jaar, exclusief uitgeslotenPosten; drempelBenutting = lopendeOmzet / drempel; prognoseEindeJaar via lineaire trend op maandgemiddelde. Wanneer de aggregatie-engine de maand-trend + uitsluitingen niet native kan uitdrukken, berekent KorMonitorService hetzelfde resultaat in PHP via de echte ObjectService API.",
             "source": "ARInvoice",
             "filter": {
-              "administrationId": "@self.administrationId",
               "vrijstellingsGrondslag": "KOR_ART25_OB",
               "leveringsDatumYear": "@self.jaar"
             },

--- a/lib/Settings/register.d/bookkeeping-programmabegroting.json
+++ b/lib/Settings/register.d/bookkeeping-programmabegroting.json
@@ -191,8 +191,7 @@
             "description": "Declarative shape of the sluitend-criterium SluitendCalculator computes (REQ-008, REQ-011). Walks the Meerjarenraming records for jaren T+1..T+4 of this begroting and sets sluitendStructureel = (every jaar has lastenStructureel ≤ batenStructureel) and sluitendReëel = (every jaar has saldoReëel ≥ 0 after nominaleOntwikkeling correction). When the aggregation engine cannot express the per-year all-quantifier with the cross-schema nominale correction, SluitendCalculator computes the same result in PHP from the real ObjectService API.",
             "source": "Meerjarenraming",
             "filter": {
-              "budgetId": "@self.id",
-              "administrationId": "@self.administrationId"
+              "budgetId": "@self.id"
             },
             "operations": {
               "structurallyBalanced": {
@@ -309,8 +308,7 @@
             "description": "Declarative shape of the Programma roll-up ProgrammaAggregator computes (REQ-002, design D1). Sums child Taakveld.baten and Taakveld.lasten (in integer cents to avoid drift), derives saldoVoorMutaties = batenTotaal - lastenTotaal and saldoNaMutaties = saldoVoorMutaties + mutatiesReserves.",
             "source": "Taakveld",
             "filter": {
-              "programmeId": "@self.id",
-              "administrationId": "@self.administrationId"
+              "programmeId": "@self.id"
             },
             "operations": {
               "revenueTotal": {

--- a/lib/Settings/register.d/bookkeeping-rechtmatigheidsverantwoording.json
+++ b/lib/Settings/register.d/bookkeeping-rechtmatigheidsverantwoording.json
@@ -235,9 +235,7 @@
             "groupBy": [
               "administrationId"
             ],
-            "filter": {
-              "administrationId": "@self.administrationId"
-            },
+            "filter": {},
             "sum": [
               "amount_involved"
             ]
@@ -467,9 +465,7 @@
             "groupBy": [
               "financialYear"
             ],
-            "filter": {
-              "administrationId": "@self.administrationId"
-            },
+            "filter": {},
             "sum": [
               "amount_error",
               "amount_uncertainty"

--- a/lib/Settings/register.d/bookkeeping-sbr-xbrl-reporting.json
+++ b/lib/Settings/register.d/bookkeeping-sbr-xbrl-reporting.json
@@ -378,7 +378,6 @@
             "source": "Account",
             "filter": {
               "status": "active",
-              "administrationId": "@self.administrationId",
               "_not_exists": {
                 "schema": "XBRLMapping",
                 "match": {
@@ -395,7 +394,6 @@
             "source": "Account",
             "filter": {
               "status": "active",
-              "administrationId": "@self.administrationId",
               "_not_exists": {
                 "schema": "XBRLMapping",
                 "match": {
@@ -415,8 +413,7 @@
             "description": "Percentage of active accounts with active XBRLMapping for the selected taxonomy version (REQ-SBR-007). Surfaced in the Mapping Validation index.",
             "source": "Account",
             "filter": {
-              "status": "active",
-              "administrationId": "@self.administrationId"
+              "status": "active"
             },
             "compute": "(count_where(XBRLMapping, status='active', taxonomyVersion=@self.taxonomyVersion, sourceAccountId in @source.ids) / count(@source)) * 100"
           },
@@ -424,7 +421,6 @@
             "description": "Delta between total GL debits and credits for the filing period (REQ-SBR-006 GL Balance check). MUST be zero before validation passes.",
             "source": "GLLine",
             "filter": {
-              "administrationId": "@self.administrationId",
               "transactionDate_gte": "@self.fiscalYearStart",
               "transactionDate_lte": "@self.fiscalYearEnd"
             },

--- a/lib/Settings/register.d/bookkeeping-trial-balance.json
+++ b/lib/Settings/register.d/bookkeeping-trial-balance.json
@@ -128,7 +128,6 @@
             },
             "filter": {
               "periodId": "@self.periodId",
-              "administrationId": "@self.administrationId",
               "eliminationFlag": false
             },
             "groupBy": [

--- a/lib/Settings/register.d/bookkeeping-vpb-corporate-tax.json
+++ b/lib/Settings/register.d/bookkeeping-vpb-corporate-tax.json
@@ -327,7 +327,6 @@
               ]
             },
             "filter": {
-              "administrationId": "@self.administrationId",
               "periodId": "@self.periodId"
             },
             "group": [

--- a/lib/Settings/register.d/bookkeeping-waterschappen-bbv-variant-02-aggregation-compliance.json
+++ b/lib/Settings/register.d/bookkeeping-waterschappen-bbv-variant-02-aggregation-compliance.json
@@ -81,9 +81,6 @@
               },
               "fiscalYear": {
                 "equals": "@self.fiscalYear"
-              },
-              "administrationId": {
-                "equals": "@self.administrationId"
               }
             },
             "groupBy": [
@@ -119,9 +116,6 @@
               },
               "fiscalYear": {
                 "equals": "@self.fiscalYear"
-              },
-              "administrationId": {
-                "equals": "@self.administrationId"
               },
               "postingDate": {
                 "between": [

--- a/lib/Settings/register.d/bookkeeping-wet-fido-treasury.json
+++ b/lib/Settings/register.d/bookkeeping-wet-fido-treasury.json
@@ -339,7 +339,6 @@
             "description": "Declarative shape of the daily kasgeldlimiet recompute (REQ-FDO-002). Sums net short-term debt = (opgenomen kasgeldleningen + rekening-courant draws + schuld RO + overige korte schuld < 1 jaar) − (korte vorderingen < 1 jaar) from the prior 90 banking days of GL short-term debt postings, divides by the number of banking days to obtain the rolling 3-month average, sets currentExposure and derives headroom = calculatedCeiling − currentExposure. status follows the enforcement ladder over consecutive quarters. When the engine cannot express the rolling window, the same result is computed from the real ObjectService API (find/findAll) over the GL ledger.",
             "source": "GLLine",
             "filter": {
-              "administrationId": "@self.organisationId",
               "shortTermDebt": true,
               "windowDays": 90
             },
@@ -481,7 +480,6 @@
             "description": "Declarative shape of the 4-year forward rente-risiconorm projection (REQ-FDO-003). Reads recorded Leningen with repaymentSchedule and floating-rate renteherzieningsmoment, projects per-year herfinanciering (maturing principal) + rate-reset volume for the next four years, sets forwardLooking4Year and derives headroomPerYear = ceiling − exposure per year. Recomputed on every lening-entry and floating-rate reset-event. When the engine cannot express the forward arithmetic, the same result is computed from the real ObjectService API (find/findAll) over recorded Leningen.",
             "source": "Lening",
             "filter": {
-              "organisationId": "@self.organisationId",
               "type": [
                 "onderhandse-lening",
                 "obligatie",
@@ -1185,7 +1183,6 @@
             "description": "Declarative shape of the quarterly-rapportage auto-generation (REQ-FDO-006). Aggregates the quarter's Leningen + Derivaten mutations, the closing kasgeldlimiet / rente-risiconorm / schatkistbankieren snapshots and the overridesApplied list into a draft rapportage on Day 10 after quarter-end. When the engine cannot express the cross-schema roll-up, the same result is computed from the real ObjectService API (find/findAll).",
             "source": "Lening",
             "filter": {
-              "organisationId": "@self.organisationId",
               "quarter": "@self.kwartaal",
               "auditYear": "@self.auditYear"
             },

--- a/lib/Settings/register.d/budget-core-schema.json
+++ b/lib/Settings/register.d/budget-core-schema.json
@@ -406,9 +406,7 @@
             "groupBy": [
               "accountNumber"
             ],
-            "filter": {
-              "administrationId": "@self.administrationId"
-            },
+            "filter": {},
             "join": {
               "through": "GLTransaction",
               "on": "GLTransaction.state",

--- a/lib/Settings/register.d/inventory-stock-movement-ledger.json
+++ b/lib/Settings/register.d/inventory-stock-movement-ledger.json
@@ -400,8 +400,7 @@
             "description": "Stock-ledger reconciliation per REQ-SM-005: InventoryStock.quantity = initialStock + SUM(destination posted moves) - SUM(source posted moves). Excludes cancelled rows.",
             "source": "StockMove",
             "filter": {
-              "lifecycleState": "posted",
-              "administrationId": "@self.administrationId"
+              "lifecycleState": "posted"
             },
             "operation": "computed",
             "expression": "SUM(quantity WHERE destinationLocationId = @location AND itemId = @item) - SUM(quantity WHERE sourceLocationId = @location AND itemId = @item)",
@@ -411,8 +410,7 @@
             "description": "Reserved-stock visibility per REQ-SM-009: SUM(draft moves whose source is this location for this item). Powers the Reserved Stock index and the Available = quantity - reservedQty breakdown on the InventoryStock detail.",
             "source": "StockMove",
             "filter": {
-              "lifecycleState": "draft",
-              "administrationId": "@self.administrationId"
+              "lifecycleState": "draft"
             },
             "operation": "sum",
             "field": "quantity",
@@ -424,9 +422,7 @@
           "movesByType": {
             "description": "Stock Movements index filter aggregation per REQ-SM-008: count of moves per movementType for the dashboard tile.",
             "source": "StockMove",
-            "filter": {
-              "administrationId": "@self.administrationId"
-            },
+            "filter": {},
             "operation": "count",
             "field": "id",
             "groupBy": "movementType"

--- a/lib/Settings/shillinq_register.json
+++ b/lib/Settings/shillinq_register.json
@@ -2032,7 +2032,6 @@
               "select": "Account.accountType"
             },
             "filter": {
-              "administrationId": "@self.administrationId",
               "fiscalYearId": "@self.fiscalYearId",
               "eliminationFlag": false
             },
@@ -2246,7 +2245,6 @@
           "trialBalanceTotals": {
             "description": "Computes totalDebits, totalCredits, and isBalanced flag from GLLine entries for the fiscal period. Satisfies REQ-FS-005 verification check. No TrialBalanceService — pure declarative aggregation per ADR-031.",
             "filter": {
-              "administrationId": "@self.administrationId",
               "fiscalYearId": "@self.fiscalYearId",
               "eliminationFlag": false
             },
@@ -2284,7 +2282,6 @@
               ]
             },
             "filter": {
-              "administrationId": "@self.administrationId",
               "fiscalYearId": "@self.fiscalYearId",
               "eliminationFlag": false
             },
@@ -2836,7 +2833,6 @@
             "groupBy": "BbvAccountMapping.iv3Bucket",
             "valueField": "debit - credit",
             "filter": {
-              "administrationId": "@self.administrationId",
               "periodId": {
                 "from": "BookkeepingPeriod",
                 "where": {
@@ -3081,7 +3077,6 @@
             "filter": {
               "eliminationFlag": false,
               "GLTransaction.state": "posted",
-              "administrationId": "@self.administrationId",
               "fiscalYearId": "@self.fiscalYearId"
             },
             "operations": {
@@ -4409,7 +4404,6 @@
             "operation": "sum",
             "field": "totalAmountExclVat",
             "filter": {
-              "administrationId": "@self.administrationId",
               "invoiceYear": "@self.currentCalendarYear",
               "state": {
                 "not": [
@@ -8139,7 +8133,6 @@
               "register": "shillinq",
               "schema": "ClosingEntry",
               "filter": {
-                "administrationId": "@self.administrationId",
                 "fiscalYearId": "@self.id",
                 "entryType": {
                   "in": [
@@ -8186,7 +8179,6 @@
               "register": "shillinq",
               "schema": "ClosingEntry",
               "filter": {
-                "administrationId": "@self.administrationId",
                 "fiscalYearId": "@self.id",
                 "entryType": "depreciation",
                 "approvalStatus": {
@@ -8205,7 +8197,6 @@
               "register": "shillinq",
               "schema": "FixedAsset",
               "filter": {
-                "administrationId": "@self.administrationId",
                 "lifecycleState": "active"
               }
             }
@@ -8217,7 +8208,6 @@
               "register": "shillinq",
               "schema": "ClosingEntry",
               "filter": {
-                "administrationId": "@self.administrationId",
                 "fiscalYearId": "@self.id",
                 "currency": {
                   "!=": "EUR"
@@ -8232,7 +8222,6 @@
               "register": "shillinq",
               "schema": "GLTransaction",
               "filter": {
-                "administrationId": "@self.administrationId",
                 "fiscalYearId": "@self.id",
                 "currency": {
                   "!=": "EUR"
@@ -8247,7 +8236,6 @@
               "register": "shillinq",
               "schema": "GLTransaction",
               "filter": {
-                "administrationId": "@self.administrationId",
                 "fiscalYearId": "@self.id",
                 "state": "posted",
                 "relatedParty": true,
@@ -8264,7 +8252,6 @@
               "register": "shillinq",
               "schema": "GLTransaction",
               "filter": {
-                "administrationId": "@self.administrationId",
                 "fiscalYearId": "@self.id",
                 "state": "posted",
                 "relatedParty": true
@@ -8295,7 +8282,6 @@
               "register": "shillinq",
               "schema": "RetainedEarnings",
               "filter": {
-                "administrationId": "@self.administrationId",
                 "fiscalYear.yearNumber": "@self.yearNumber - 1"
               }
             }
@@ -8770,7 +8756,6 @@
               "register": "shillinq",
               "schema": "RetainedEarnings",
               "match": {
-                "administrationId": "@self.administrationId",
                 "fiscalYear.yearNumber": "@self.fiscalYear.yearNumber - 1"
               }
             },
@@ -13662,7 +13647,6 @@
             "sourceSchema": "Obligation",
             "sourceRegister": "shillinq",
             "filter": {
-              "administrationId": "@self.administrationId",
               "fiscalYear": "@self.fiscalYear",
               "grantIsSISAEligible": true,
               "status": {
@@ -13692,7 +13676,6 @@
             "sourceSchema": "ComplianceAuditTrail",
             "sourceRegister": "shillinq",
             "filter": {
-              "administrationId": "@self.administrationId",
               "fiscalYear": "@self.fiscalYear"
             },
             "operations": {
@@ -16911,7 +16894,6 @@
                   "schema": "WinstToerekening",
                   "condition": "WinstToerekening.ipAssetId IN (SELECT id FROM IPAssetValuation WHERE administrationId = @self.administrationId)",
                   "filter": {
-                    "administrationId": "@self.administrationId",
                     "fiscalYear": "@self.fiscalYear"
                   }
                 },
@@ -17524,7 +17506,6 @@
             ],
             "valueField": "amount",
             "filter": {
-              "administrationId": "@self.administrationId",
               "transactionDate": {
                 "gte": "@self.periodStart",
                 "lte": "@self.periodEnd"
@@ -17931,7 +17912,6 @@
             "groupBy": "VatTariff.rubriek",
             "valueField": "amount",
             "filter": {
-              "administrationId": "@self.administrationId",
               "periodStart": {
                 "gte": "@self.periodStart"
               },
@@ -18508,7 +18488,6 @@
             "sourceSchema": "GLLine",
             "sourceRegister": "shillinq",
             "filter": {
-              "administrationId": "@self.administrationId",
               "fiscalYear": "@self.taxYear",
               "entryType": "credit",
               "accountType": "revenue"
@@ -18520,7 +18499,6 @@
             "sourceSchema": "GLLine",
             "sourceRegister": "shillinq",
             "filter": {
-              "administrationId": "@self.administrationId",
               "fiscalYear": "@self.taxYear",
               "entryType": "debit",
               "accountType": "expense"
@@ -18890,7 +18868,6 @@
             "operation": "sum",
             "field": "hours",
             "filter": {
-              "administrationId": "@self.administrationId",
               "personId": "@self.personId",
               "date": {
                 "gte": "@self.taxYear + '-01-01'",
@@ -18912,7 +18889,6 @@
             "operation": "sum",
             "field": "amount",
             "filter": {
-              "administrationId": "@self.administrationId",
               "fiscalYear": "@self.taxYear",
               "taxCategory": "self-employment-income"
             },

--- a/src/views/bookkeeping/dimensions/SegmentPnLDashboard.vue
+++ b/src/views/bookkeeping/dimensions/SegmentPnLDashboard.vue
@@ -183,6 +183,7 @@ export default {
 			activeSegment: 'costCenter',
 			rows: [],
 			analyticalDimensions: [],
+			administrationId: '',
 		}
 	},
 
@@ -226,6 +227,50 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Resolve the caller's active administration.
+		 *
+		 * These aggregations used to declare
+		 * `administrationId: "@self.administrationId"`. That is not a
+		 * placeholder OpenRegister implements — PlaceholderResolver only acts on
+		 * values beginning with `$` — so it was left LITERAL and the filter
+		 * matched nothing, which is why this dashboard returned zero rows over
+		 * live data (#1216, swept in #1255).
+		 *
+		 * An administration is a shillinq layer over OpenRegister's organisation
+		 * tenancy, so it is a normal property, and the scope comes from the
+		 * CALLER as a narrowing filter (openregister#2852) — which can add a
+		 * constraint but never relax one.
+		 *
+		 * Returns '' when the context cannot be read, and loadSegment() then
+		 * REFUSES to query. That matters more here than it looks: the declared
+		 * filter is gone, so an unscoped call would roll up EVERY
+		 * administration's P&L into one plausible-looking total.
+		 *
+		 * @return {Promise<string>} The active administration id, or ''.
+		 * @spec openspec/changes/bookkeeping-cost-centers-dimensions/tasks.md#task-14
+		 */
+		async resolveAdministrationId() {
+			try {
+				const { data } = await axios.get(
+					generateUrl('/apps/shillinq/api/administrations/context'),
+				)
+				return (
+					data?.activeAdministrationId
+					|| data?.administrations?.[0]?.administrationId
+					|| ''
+				)
+			} catch {
+				return ''
+			}
+		},
+
+		/**
+		 * Switch the dashboard to another segment and reload it.
+		 *
+		 * @param {string} segment One of SEGMENT_AGGREGATION's keys.
+		 * @spec openspec/changes/bookkeeping-cost-centers-dimensions/tasks.md#task-14
+		 */
 		selectSegment(segment) {
 			if (segment === this.activeSegment) {
 				return
@@ -234,7 +279,12 @@ export default {
 			this.loadSegment(segment)
 		},
 
-		/** @spec openspec/changes/bookkeeping-cost-centers-dimensions/tasks.md#task-14 */
+		/**
+		 * Load one segment's P&L roll-up, scoped to the caller's administration.
+		 *
+		 * @param {string} segment One of SEGMENT_AGGREGATION's keys.
+		 * @spec openspec/changes/bookkeeping-cost-centers-dimensions/tasks.md#task-14
+		 */
 		async loadSegment(segment) {
 			this.loading = true
 			this.errorMessage = ''
@@ -248,11 +298,26 @@ export default {
 			}
 
 			try {
+				this.administrationId = await this.resolveAdministrationId()
+				if (!this.administrationId) {
+					// Deliberately not a fallback to an unscoped call: the
+					// declaration no longer carries administrationId, so omitting
+					// it here would roll up every administration the register
+					// holds into one total that looks entirely reasonable.
+					this.errorMessage = this.t(
+						'shillinq',
+						'No active administration — cannot scope segment P&L.',
+					)
+					return
+				}
+
 				const url = generateUrl(
 					`/apps/openregister/api/objects/aggregations/${REGISTER_SLUG}/GLLine/`
 						+ encodeURIComponent(aggregationName),
 				)
-				const { data } = await axios.get(url)
+				const { data } = await axios.get(url, {
+					params: { 'filter[administrationId]': this.administrationId },
+				})
 				this.rows = this.normaliseRows(data, segment)
 			} catch (error) {
 				const status = error?.response?.status

--- a/tests/validate-registers.js
+++ b/tests/validate-registers.js
@@ -555,6 +555,119 @@ const AGGREGATION_REF_BASELINE = new Map([
 	],
 ])
 
+// `@`-prefixed placeholders in an aggregation's filter are NOT resolved.
+//
+// OpenRegister's PlaceholderResolver acts only on values beginning with `$`
+// (it implements `$currentUser` and the date expressions). A value starting
+// with `@` fails that test and is returned UNCHANGED, so the filter that runs
+// is a literal string comparison against `"@self.whatever"` — which matches
+// nothing. The aggregation then returns an empty result with HTTP 200, and the
+// page renders its own empty state over live data. That is issue #1216, and it
+// was found only by querying a real instance; every unit test and gate was
+// green throughout.
+//
+// TWO TIERS, deliberately:
+//
+//   1. `administrationId` / `organisationId` — ZERO tolerance. These are
+//      tenant scoping, and they have all been removed. An administration is a
+//      shillinq-specific layer over OpenRegister's organisation tenancy, so it
+//      is NOT `@self` metadata: it is a normal property, and the CALLER passes
+//      it as a narrowing filter (`?filter[administrationId]=...`), which
+//      openregister#2852 accepts and can never relax. A new one appearing means
+//      somebody re-introduced an aggregation that silently returns nothing.
+//
+//   2. every other `@self.*` — RATCHET. Those are a different intent ("this
+//      object's field", e.g. `@self.id`), and deleting them would widen the
+//      aggregation rather than fix it. They need the placeholder to be
+//      implemented, not removed. Tracked in #1255; the count may fall, never
+//      rise.
+const AGG_PLACEHOLDER_TENANT_KEYS = new Set(['administrationId', 'organisationId'])
+// Measured 2026-08-26 by this check, after removing 67 tenant placeholders
+// across 22 files. Counted BY THE GATE, not by a one-off script — an earlier
+// estimate of 73 came from a narrower hand-written predicate and was wrong.
+const AGG_PLACEHOLDER_BASELINE = 84
+
+function collectPlaceholders(node, path, out) {
+	if (node === null || node === undefined) return
+	if (typeof node === 'string') {
+		if (node.includes('@self.')) out.push({ path, value: node })
+		return
+	}
+	if (Array.isArray(node)) {
+		node.forEach((v, i) => collectPlaceholders(v, `${path}[${i}]`, out))
+		return
+	}
+	if (typeof node === 'object') {
+		for (const [k, v] of Object.entries(node)) {
+			collectPlaceholders(v, path ? `${path}.${k}` : k, out)
+		}
+	}
+}
+
+function checkAggregationPlaceholders(registry) {
+	const tenant = []
+	const others = []
+
+	for (const slug of Object.keys(registry).sort()) {
+		for (const { aggName, agg, file } of registry[slug].aggregations) {
+			const found = []
+			for (const key of ['filter', 'where', 'join', 'match']) {
+				collectPlaceholders(agg[key], key, found)
+			}
+			// NOT `path` — that shadows the `path` module this file already
+			// imports, and the shadow only bites on the failure branch.
+			for (const { path: at, value } of found) {
+				const leaf = at.split('.').pop().replace(/\[\d+\]$/, '')
+				const where = `${slug}.${aggName} ${at} = ${JSON.stringify(value)}`
+					+ ` (${path.relative(REPO_ROOT, file)})`
+				if (AGG_PLACEHOLDER_TENANT_KEYS.has(leaf)) tenant.push(where)
+				else others.push(where)
+			}
+		}
+	}
+
+	console.log(
+		`[validate-registers] aggregation @self placeholders: ${tenant.length} tenant, `
+			+ `${others.length} other (baseline ${AGG_PLACEHOLDER_BASELINE})`,
+	)
+
+	let ok = true
+
+	if (tenant.length > 0) {
+		console.error(
+			'[validate-registers] FAIL — an aggregation scopes a tenant with an `@self` placeholder, '
+				+ 'which OpenRegister does not resolve. The filter runs as a literal string, matches '
+				+ 'nothing, and the aggregation returns an empty result with HTTP 200 (#1216):',
+		)
+		for (const t of tenant) console.error(`  - ${t}`)
+		console.error('')
+		console.error(
+			'[validate-registers] Fix: remove the key from the declaration and have the CALLER pass it — '
+				+ '`?filter[administrationId]=<active>`. An administration is a normal property, not @self metadata.',
+		)
+		console.error(
+			'[validate-registers] Removing it WITHOUT a caller that supplies one turns "returns nothing" '
+				+ 'into "returns every administration", so change the caller first.',
+		)
+		ok = false
+	}
+
+	if (others.length > AGG_PLACEHOLDER_BASELINE) {
+		console.error(
+			`[validate-registers] FAIL — @self placeholders in aggregation filters rose to ${others.length}, `
+				+ `above the baseline of ${AGG_PLACEHOLDER_BASELINE}. These resolve to nothing (#1255).`,
+		)
+		ok = false
+	} else if (others.length < AGG_PLACEHOLDER_BASELINE) {
+		console.log(
+			`[validate-registers] ${AGG_PLACEHOLDER_BASELINE - others.length} better than baseline — `
+				+ `please lower AGG_PLACEHOLDER_BASELINE to ${others.length}.`,
+		)
+	}
+
+	return ok
+}
+
 function checkAggregationFieldRefs(registry) {
 	const problems = []
 	const baselined = []
@@ -670,12 +783,14 @@ function main() {
 	const slugsOk = checkSlugCaseCollisions(registry)
 	const sameSlugFullDefinitionOk = checkSameSlugFullDefinitionCollisions(registry)
 	const aggregationRefsOk = checkAggregationFieldRefs(registry)
+	const aggregationPlaceholdersOk = checkAggregationPlaceholders(registry)
 
 	if (offenders.length === 0) {
 		if (
 			slugsOk === false
 			|| sameSlugFullDefinitionOk === false
 			|| aggregationRefsOk === false
+			|| aggregationPlaceholdersOk === false
 		)
 			process.exit(1)
 		console.log(

--- a/tests/validate-registers.js
+++ b/tests/validate-registers.js
@@ -555,6 +555,70 @@ const AGGREGATION_REF_BASELINE = new Map([
 	],
 ])
 
+// An aggregation without `metric`/`metrics` cannot produce a value.
+//
+// AggregationRunner::run() reads exactly nine keys off a spec — measured from
+// its source, not from docs:
+//
+//   field  filter  from  groupBy  join  metric  metrics  select  where
+//
+// `source`, `sum`, `operation`, `operations`, `expression`, `sourceSchema` and
+// friends are read by NOTHING. A spec without metric/metrics comes back as
+// `{"metric":"","field":null,"groups":[]}` — an empty result with HTTP 200,
+// which every page renders as its own empty state and reads as "no data yet".
+//
+// This is #1216's FIRST layer, and it is still true of 265 of 268 declarations
+// (#1261). It is also why #1255's placeholder problem went unnoticed for so
+// long: these aggregations were already returning nothing for a second,
+// independent reason.
+//
+// A RATCHET, not a hard fail — 265 cannot be fixed in one pass, and each needs
+// its semantics checked against a live instance rather than pattern-matched.
+// The count may fall; it may never rise.
+const AGG_NO_METRIC_BASELINE = 265
+
+function checkAggregationMetrics(registry) {
+	const missing = []
+	for (const slug of Object.keys(registry).sort()) {
+		for (const { aggName, agg, file } of registry[slug].aggregations) {
+			if (agg === null || typeof agg !== 'object') continue
+			if ('metric' in agg || 'metrics' in agg) continue
+			missing.push(
+				`${slug}.${aggName} (${path.relative(REPO_ROOT, file)})`
+					+ ` — declares ${JSON.stringify(Object.keys(agg).filter((k) => k !== 'description'))}`,
+			)
+		}
+	}
+
+	console.log(
+		`[validate-registers] aggregations without metric/metrics: ${missing.length} `
+			+ `(baseline ${AGG_NO_METRIC_BASELINE}) — these return an empty result, see #1261`,
+	)
+
+	if (missing.length > AGG_NO_METRIC_BASELINE) {
+		console.error(
+			`[validate-registers] FAIL — aggregations that cannot compute a value rose to `
+				+ `${missing.length}, above the baseline of ${AGG_NO_METRIC_BASELINE}.`,
+		)
+		console.error(
+			'[validate-registers] The engine reads only: field filter from groupBy join metric '
+				+ 'metrics select where. `source`/`sum`/`operation` are read by nothing, and a spec '
+				+ 'without metric/metrics returns {"metric":"","field":null,"groups":[]} with HTTP 200.',
+		)
+		for (const m of missing.slice(-10)) console.error(`  - ${m}`)
+		return false
+	}
+
+	if (missing.length < AGG_NO_METRIC_BASELINE) {
+		console.log(
+			`[validate-registers] ${AGG_NO_METRIC_BASELINE - missing.length} better than baseline — `
+				+ `please lower AGG_NO_METRIC_BASELINE to ${missing.length}.`,
+		)
+	}
+
+	return true
+}
+
 // `@`-prefixed placeholders in an aggregation's filter are NOT resolved.
 //
 // OpenRegister's PlaceholderResolver acts only on values beginning with `$`
@@ -788,6 +852,7 @@ function main() {
 	const sameSlugFullDefinitionOk = checkSameSlugFullDefinitionCollisions(registry)
 	const aggregationRefsOk = checkAggregationFieldRefs(registry)
 	const aggregationPlaceholdersOk = checkAggregationPlaceholders(registry)
+	const aggregationMetricsOk = checkAggregationMetrics(registry)
 
 	if (offenders.length === 0) {
 		if (
@@ -795,6 +860,7 @@ function main() {
 			|| sameSlugFullDefinitionOk === false
 			|| aggregationRefsOk === false
 			|| aggregationPlaceholdersOk === false
+			|| aggregationMetricsOk === false
 		)
 			process.exit(1)
 		console.log(

--- a/tests/validate-registers.js
+++ b/tests/validate-registers.js
@@ -617,8 +617,12 @@ function checkAggregationPlaceholders(registry) {
 			// NOT `path` — that shadows the `path` module this file already
 			// imports, and the shadow only bites on the failure branch.
 			for (const { path: at, value } of found) {
-				const leaf = at.split('.').pop().replace(/\[\d+\]$/, '')
-				const where = `${slug}.${aggName} ${at} = ${JSON.stringify(value)}`
+				const leaf = at
+					.split('.')
+					.pop()
+					.replace(/\[\d+\]$/, '')
+				const where =
+					`${slug}.${aggName} ${at} = ${JSON.stringify(value)}`
 					+ ` (${path.relative(REPO_ROOT, file)})`
 				if (AGG_PLACEHOLDER_TENANT_KEYS.has(leaf)) tenant.push(where)
 				else others.push(where)


### PR DESCRIPTION
Closes #1255.

## 67 tenant placeholders across 22 fragments, every one matching nothing

`administrationId: "@self.administrationId"` is not a placeholder OpenRegister
implements. `PlaceholderResolver::resolve()` acts only on values beginning with
`$` — it implements `$currentUser` and the date expressions — so a value
starting with `@` fails `str_starts_with($value, '$')` and is **returned
unchanged**. The filter that ran was the literal string comparison
`administrationId = '@self.administrationId'`.

Measured on a live instance, against `GLLine` (which has rows):

| query | result |
|---|---|
| `objects/shillinq/GLLine?_limit=1` | **3 rows** |
| `objects/shillinq/GLLine?administrationId=@self.administrationId` | **0 rows** |
| `aggregations/shillinq/GLLine/byCostCenter` | `"groups": []` |

Nothing errors. A filter on a value nothing holds returns an empty set with HTTP
200, which renders as the page's own empty state and reads as "no data yet".
That is exactly how #1216 hid — and #1216 was closed by fixing **one**
aggregation while the identical defect sat in every other declaration that
scopes by administration.

## The design call

Administrations are a **shillinq-specific layer over OpenRegister's organisation
tenancy**. Being shillinq-specific, an administration is not `@self` metadata —
`@self` is OpenRegister's own envelope. It is a **normal property**, and the
caller passes it as a narrowing filter, which openregister#2852 accepts and can
never relax.

## The caller

`SegmentPnLDashboard.vue` is the one live caller, and it passed **no filter at
all**. It now resolves the active administration and *refuses to query* when it
cannot — deliberately not falling back to an unscoped call, because with the
declared filter gone that would roll every administration's P&L into one
plausible-looking total.

> Order matters and getting it backwards is a tenant leak. Today these return
> **nothing**, which is the safe direction; removing a declared filter without a
> caller that supplies one turns that into **everything**. Caller and
> declaration land in the same commit.

The other candidates turned out not to be callers at all. `TrialBalanceService`,
`TaxReportService`, `BudgetGridReader` and `VatReturnReportGenerator` each say
the declarative shape is *documented* on the schema while the service computes
it in PHP, and they already scope by a server-resolved `administrationId`.

## The join half comes free

15 of these also declare a `join` whose gap is `administrationId`, and the joined
schema declares it too. Nothing needs adding to `join.filter` — a tenant cannot
be hardcoded there, it varies per caller — because **openregister#2869** forwards
the caller's narrowing filter to the joined aggregate, restricted to keys the
joined schema declares.

## A gate holds the line, in two tiers

- **Zero tolerance** for `administrationId` / `organisationId` placeholders.
  Those are all gone; a new one means somebody re-introduced an aggregation that
  silently returns nothing. The failure message says what to do instead, *and*
  warns to change the caller first.
- **A ratchet at 84** for every other `@self.*`. Those are a different intent —
  "this object's field", e.g. `@self.id` — and deleting them would widen the
  aggregation rather than fix it. They need the placeholder **implemented**, not
  removed. Left in #1255.

Confirmed the gate can fail: re-introducing one tenant placeholder turns it red
with the right message, and the file was restored byte-identical afterwards
(md5 checked).

> The baseline is **84**, counted by the gate itself. An earlier hand-written
> predicate said 73 and was wrong — a number a check computes beats a number I
> derived beside it.

## Verified

- all 9 JS validators green, `eslint` clean, `vitest` 256 passed
- every edited file re-parsed and **tree-diffed against HEAD**: 67 removals, all
  inside `x-openregister-aggregations`, **0 unexpected differences**
- an earlier attempt over-matched (a 14-space pattern is a substring of a
  16-space line) and merged lines together; caught by that same tree diff,
  reverted, and redone with both newlines explicit. Final diff is 108 deletions
  against 204 insertions, the insertions being the gate and the caller.

## Not in scope, found on the way

Five aggregations are not placeholder bugs at all — `TaxEstimate.ytdByCategory`
declares its `filter` as a **SQL-like string**, and the four `SBRDocumentType`
ones use an invented vocabulary (`join.schema` + `join.condition`, a `check`
block) that the engine never reads. Those need redesign, not a deletion. Noted
in #1255.
