### PR TITLE
fix(aggregations): translate the mechanical 46 into the engine's grammar

### DIFF
--- a/lib/Settings/register.d/10-bookings-create-appointment.json
+++ b/lib/Settings/register.d/10-bookings-create-appointment.json
@@ -321,9 +321,9 @@
         "x-openregister-aggregations": {
           "countByStatus": {
             "field": "status",
-            "operation": "count",
+            "metric": "count",
             "description": "Number of appointments per status.",
-            "groupBy": "status"
+            "groupBy": ["status"]
           }
         }
       }

--- a/lib/Settings/register.d/20-zzp-urencriterium-tracker.json
+++ b/lib/Settings/register.d/20-zzp-urencriterium-tracker.json
@@ -168,9 +168,9 @@
         "x-openregister-aggregations": {
           "countByDrempelStatus": {
             "field": "thresholdStatus",
-            "operation": "count",
+            "metric": "count",
             "description": "Aantal onderneming-jaren per drempel-status.",
-            "groupBy": "thresholdStatus"
+            "groupBy": ["thresholdStatus"]
           }
         },
         "x-openregister-audit-trail": {
@@ -677,9 +677,9 @@
         "x-openregister-aggregations": {
           "countByUrgentie": {
             "field": "urgency",
-            "operation": "count",
+            "metric": "count",
             "description": "Aantal alerts per urgentie-niveau.",
-            "groupBy": "urgency"
+            "groupBy": ["urgency"]
           }
         },
         "x-openregister-audit-trail": {

--- a/lib/Settings/register.d/50-bookings-deposits.json
+++ b/lib/Settings/register.d/50-bookings-deposits.json
@@ -403,22 +403,22 @@
         "x-openregister-aggregations": {
           "byState": {
             "field": "state",
-            "operation": "count",
+            "metric": "count",
             "description": "Number of deposits per lifecycle state — drives the Deposits overview state filter (REQ-DP-010).",
-            "groupBy": "state"
+            "groupBy": ["state"]
           },
           "pendingByDueDate": {
             "field": "amount",
-            "operation": "sum",
+            "metric": "sum",
             "description": "Total pending deposit value grouped by due date, for the operator follow-up worklist (REQ-DP-010).",
-            "groupBy": "dueDate",
+            "groupBy": ["dueDate"],
             "filter": {
               "state": "pending"
             }
           },
           "failedCount": {
             "field": "state",
-            "operation": "count",
+            "metric": "count",
             "description": "Count of failed deposits requiring operator follow-up (REQ-DP-011).",
             "filter": {
               "state": "failed"

--- a/lib/Settings/register.d/bookings-deposit-to-invoice.json
+++ b/lib/Settings/register.d/bookings-deposit-to-invoice.json
@@ -312,9 +312,9 @@
         "x-openregister-aggregations": {
           "countByState": {
             "field": "state",
-            "operation": "count",
+            "metric": "count",
             "description": "Number of orders per lifecycle state.",
-            "groupBy": "state"
+            "groupBy": ["state"]
           }
         }
       },
@@ -552,15 +552,15 @@
         "x-openregister-aggregations": {
           "countByState": {
             "field": "state",
-            "operation": "count",
+            "metric": "count",
             "description": "Number of invoices per state for AR aging dashboards (REQ-DI-009).",
-            "groupBy": "state"
+            "groupBy": ["state"]
           },
           "outstandingGross": {
             "field": "grossAmount",
-            "operation": "sum",
+            "metric": "sum",
             "description": "Total outstanding gross by state.",
-            "groupBy": "state"
+            "groupBy": ["state"]
           }
         }
       },

--- a/lib/Settings/register.d/bookings-resource-calendar.json
+++ b/lib/Settings/register.d/bookings-resource-calendar.json
@@ -269,9 +269,9 @@
         "x-openregister-aggregations": {
           "countByStatus": {
             "field": "status",
-            "operation": "count",
+            "metric": "count",
             "description": "Number of bookings per status.",
-            "groupBy": "status"
+            "groupBy": ["status"]
           }
         }
       }

--- a/lib/Settings/register.d/bookings-service-catalog.json
+++ b/lib/Settings/register.d/bookings-service-catalog.json
@@ -163,15 +163,15 @@
         "x-openregister-aggregations": {
           "countByStatus": {
             "field": "status",
-            "operation": "count",
+            "metric": "count",
             "description": "Number of services per lifecycle state.",
-            "groupBy": "status"
+            "groupBy": ["status"]
           },
           "countByCategory": {
             "field": "serviceCategory",
-            "operation": "count",
+            "metric": "count",
             "description": "Number of services per flat category grouping (REQ-SC-006).",
-            "groupBy": "serviceCategory"
+            "groupBy": ["serviceCategory"]
           }
         }
       }

--- a/lib/Settings/register.d/bookkeeping-aansluitingen.json
+++ b/lib/Settings/register.d/bookkeeping-aansluitingen.json
@@ -363,18 +363,18 @@
         "x-openregister-aggregations": {
           "openCountByAdministration": {
             "field": "id",
-            "operation": "count",
+            "metric": "count",
             "description": "REQ-AANS-008: count of open AansluitingResult rows per administration, for a dashboard tile / period-close flag surface.",
-            "groupBy": "administrationId",
+            "groupBy": ["administrationId"],
             "filter": {
               "status": "open"
             }
           },
           "openCountByAansluiting": {
             "field": "id",
-            "operation": "count",
+            "metric": "count",
             "description": "Count of open results per Aansluiting definition, across all computed periods.",
-            "groupBy": "reconciliationId",
+            "groupBy": ["reconciliationId"],
             "filter": {
               "status": "open"
             }

--- a/lib/Settings/register.d/bookkeeping-bank-reconciliation.json
+++ b/lib/Settings/register.d/bookkeeping-bank-reconciliation.json
@@ -225,8 +225,8 @@
         "x-openregister-aggregations": {
           "countByStatus": {
             "field": "status",
-            "operation": "count",
-            "groupBy": "status",
+            "metric": "count",
+            "groupBy": ["status"],
             "description": "Number of reconciliation sessions per lifecycle status, for the index status filter and dashboard."
           }
         }
@@ -417,8 +417,8 @@
           },
           "countByType": {
             "field": "matchType",
-            "operation": "count",
-            "groupBy": "matchType",
+            "metric": "count",
+            "groupBy": ["matchType"],
             "description": "Number of matches per matchType, for the detail-page match summary."
           }
         },

--- a/lib/Settings/register.d/bookkeeping-fixed-assets-depreciation.json
+++ b/lib/Settings/register.d/bookkeeping-fixed-assets-depreciation.json
@@ -252,8 +252,8 @@
           "depreciationByMethod": {
             "description": "REQ-FA-009 (1) — count of active assets grouped by depreciationMethod. Drives the Depreciation Expense report method-mix breakdown.",
             "field": "depreciationMethod",
-            "operation": "count",
-            "groupBy": "depreciationMethod",
+            "metric": "count",
+            "groupBy": ["depreciationMethod"],
             "filter": {
               "lifecycleState": "active"
             }
@@ -261,8 +261,8 @@
           "depreciationByCostCenter": {
             "description": "REQ-FA-009 (2) — sum of acquisitionCost grouped by costCenterCode (proxy for current-fiscal-year depreciation allocation). Drives the Depreciation Expense cost-center report.",
             "field": "acquisitionCost",
-            "operation": "sum",
-            "groupBy": "costCenterCode",
+            "metric": "sum",
+            "groupBy": ["costCenterCode"],
             "filter": {
               "lifecycleState": "active"
             }
@@ -270,8 +270,8 @@
           "bookValuesByStatus": {
             "description": "REQ-FA-009 (4) — count of assets grouped by lifecycleState (proxy for book-value buckets). Drives balance-sheet reporting splits.",
             "field": "lifecycleState",
-            "operation": "count",
-            "groupBy": "lifecycleState"
+            "metric": "count",
+            "groupBy": ["lifecycleState"]
           }
         }
       },
@@ -456,8 +456,8 @@
           "depreciationAmountByCostCenter": {
             "description": "REQ-FA-009 (2) — sum of depreciationAmount grouped by costCenterCode for the current fiscal year. Drives the Depreciation Expense cost-center report.",
             "field": "depreciationAmount",
-            "operation": "sum",
-            "groupBy": "costCenterCode",
+            "metric": "sum",
+            "groupBy": ["costCenterCode"],
             "filter": {
               "status": "active"
             }
@@ -465,8 +465,8 @@
           "depreciationAmountByMethod": {
             "description": "REQ-FA-009 (1) — sum of depreciationAmount grouped by depreciationMethod for the current fiscal year. Drives the Depreciation Expense method-mix report.",
             "field": "depreciationAmount",
-            "operation": "sum",
-            "groupBy": "depreciationMethod",
+            "metric": "sum",
+            "groupBy": ["depreciationMethod"],
             "filter": {
               "status": "active"
             }
@@ -474,8 +474,8 @@
           "accumulatedDepreciationByAsset": {
             "description": "REQ-FA-009 (3) — sum of depreciationAmount grouped by assetRef across all closed periods. Drives the asset-by-asset accumulated-depreciation report.",
             "field": "depreciationAmount",
-            "operation": "sum",
-            "groupBy": "assetRef"
+            "metric": "sum",
+            "groupBy": ["assetRef"]
           }
         }
       },

--- a/lib/Settings/register.d/bookkeeping-reconciliation-reports.json
+++ b/lib/Settings/register.d/bookkeeping-reconciliation-reports.json
@@ -219,16 +219,16 @@
         "x-openregister-aggregations": {
           "varianceByAccount": {
             "field": "variance",
-            "operation": "sum",
+            "metric": "sum",
             "description": "REQ-REC-007: Total absolute variance per bank account across all closed reconciliations. Open reconciliations are excluded (REQ-REC-007 scenario 'variance aggregation excludes open reconciliations').",
-            "groupBy": "bankAccountId",
+            "groupBy": ["bankAccountId"],
             "filter": {
               "reconciliationStatus": "closed"
             }
           },
           "varianceByPeriod": {
             "field": "variance",
-            "operation": "sum",
+            "metric": "sum",
             "description": "REQ-REC-007: Variance by (bankAccountId, statementPeriodEnd). Used for trend analysis — accountants spot drift across multiple closing periods.",
             "groupBy": [
               "bankAccountId",
@@ -240,9 +240,9 @@
           },
           "reconciliationCount": {
             "field": "id",
-            "operation": "count",
+            "metric": "count",
             "description": "Number of closed reconciliations per account.",
-            "groupBy": "bankAccountId",
+            "groupBy": ["bankAccountId"],
             "filter": {
               "reconciliationStatus": "closed"
             }
@@ -360,16 +360,16 @@
         "x-openregister-aggregations": {
           "matchesByRecon": {
             "field": "reconId",
-            "operation": "count",
+            "metric": "count",
             "description": "Number of ReconciliationMatch records per reconciliation session. Drives BankReconciliation.matchedCount.",
-            "groupBy": "reconId",
+            "groupBy": ["reconId"],
             "filter": {
               "resolutionStatus": "matched"
             }
           },
           "varianceByType": {
             "field": "resolutionStatus",
-            "operation": "count",
+            "metric": "count",
             "description": "REQ-REC-007 variance-by-type aggregation: count of unmatched items by classification (timing/pending/adjustment). Excludes resolved 'matched' items.",
             "groupBy": [
               "reconId",
@@ -378,9 +378,9 @@
           },
           "unresolvedByRecon": {
             "field": "id",
-            "operation": "count",
+            "metric": "count",
             "description": "Count of unmatched (resolutionStatus=null) entries per reconciliation. Drives the REQ-REC-006 pre-close summary.",
-            "groupBy": "reconId",
+            "groupBy": ["reconId"],
             "filter": {
               "resolutionStatus": null
             }
@@ -471,9 +471,9 @@
         "x-openregister-aggregations": {
           "totalVarianceByAdmin": {
             "field": "totalVariance",
-            "operation": "sum",
+            "metric": "sum",
             "description": "REQ-REC-007: Total variance booked across all closed reconciliations per administration. Drives the variance dashboard.",
-            "groupBy": "administrationId"
+            "groupBy": ["administrationId"]
           }
         },
         "x-openregister-rbac": {

--- a/lib/Settings/register.d/dba-compliance-marker.json
+++ b/lib/Settings/register.d/dba-compliance-marker.json
@@ -392,15 +392,15 @@
         "x-openregister-aggregations": {
           "countByRisicoNiveau": {
             "field": "riskLevel",
-            "operation": "count",
+            "metric": "count",
             "description": "Aantal opdrachten per risico-niveau (LAAG/LAAG_MIDDEN/MIDDEN_HOOG/HOOG/VERKORT_LAGE_DREMPEL).",
-            "groupBy": "riskLevel"
+            "groupBy": ["riskLevel"]
           },
           "omzetPerKlant": {
             "field": "realisedRevenue",
-            "operation": "sum",
+            "metric": "sum",
             "description": "Totale gerealiseerde omzet per klant (eurocenten); voedt concentratie-aggregatie REQ-DBA-005.",
-            "groupBy": "customerId"
+            "groupBy": ["customerId"]
           }
         },
         "x-openregister-audit-trail": {
@@ -1058,18 +1058,18 @@
         "x-openregister-aggregations": {
           "openFlagsPerOpdracht": {
             "field": "assignmentId",
-            "operation": "count",
+            "metric": "count",
             "description": "Open-flag-aantal per opdracht (voedt DBAOpdracht.openFlags).",
-            "groupBy": "assignmentId",
+            "groupBy": ["assignmentId"],
             "filter": {
               "status": "OPEN"
             }
           },
           "flagsByType": {
             "field": "type",
-            "operation": "count",
+            "metric": "count",
             "description": "Aantal flags per type (voor dashboard).",
-            "groupBy": "type"
+            "groupBy": ["type"]
           }
         },
         "x-openregister-audit-trail": {
@@ -1261,9 +1261,9 @@
         "x-openregister-aggregations": {
           "countByOverallRisico": {
             "field": "overallRisk",
-            "operation": "count",
+            "metric": "count",
             "description": "Aantal portfolio-records per overall-risico-niveau.",
-            "groupBy": "overallRisk"
+            "groupBy": ["overallRisk"]
           }
         },
         "x-openregister-audit-trail": {

--- a/lib/Settings/register.d/inventory-stock-movement-ledger.json
+++ b/lib/Settings/register.d/inventory-stock-movement-ledger.json
@@ -412,7 +412,7 @@
             "filter": {
               "lifecycleState": "draft"
             },
-            "operation": "sum",
+            "metric": "sum",
             "field": "quantity",
             "groupBy": [
               "sourceLocationId",
@@ -423,9 +423,9 @@
             "description": "Stock Movements index filter aggregation per REQ-SM-008: count of moves per movementType for the dashboard tile.",
             "source": "StockMove",
             "filter": {},
-            "operation": "count",
+            "metric": "count",
             "field": "id",
-            "groupBy": "movementType"
+            "groupBy": ["movementType"]
           }
         },
         "x-openregister-indexes": [

--- a/lib/Settings/register.d/zzp-cashflow-13wk.json
+++ b/lib/Settings/register.d/zzp-cashflow-13wk.json
@@ -203,8 +203,8 @@
         "x-openregister-aggregations": {
           "countByLifecycleState": {
             "field": "lifecycleState",
-            "operation": "count",
-            "groupBy": "lifecycleState",
+            "metric": "count",
+            "groupBy": ["lifecycleState"],
             "description": "Number of horizons per lifecycle state."
           }
         }
@@ -455,20 +455,20 @@
         "x-openregister-aggregations": {
           "inflowsArByWeek": {
             "field": "inflows_ar_geprognosticeerd",
-            "operation": "sum",
-            "groupBy": "weekNumber",
+            "metric": "sum",
+            "groupBy": ["weekNumber"],
             "description": "Projected AR inflows summed per week (REQ-CF-002 weekly aggregation). Feeds the bar chart inflows series."
           },
           "outflowsByWeek": {
             "field": "outflows_total",
-            "operation": "sum",
-            "groupBy": "weekNumber",
+            "metric": "sum",
+            "groupBy": ["weekNumber"],
             "description": "Total outflows summed per week (REQ-CF-006/007). Feeds the bar chart outflows series."
           },
           "countByBufferStatus": {
             "field": "bufferStatus",
-            "operation": "count",
-            "groupBy": "bufferStatus",
+            "metric": "count",
+            "groupBy": ["bufferStatus"],
             "description": "Number of weeks per buffer status, for alert badges (REQ-CF-009)."
           }
         }
@@ -610,8 +610,8 @@
         "x-openregister-aggregations": {
           "projectedReceiptsByWeek": {
             "field": "outstandingAmount",
-            "operation": "sum",
-            "groupBy": "expectedReceiptWeek",
+            "metric": "sum",
+            "groupBy": ["expectedReceiptWeek"],
             "description": "Sum of outstanding AR amounts grouped by projected receipt week (REQ-CF-002/003). This is the source aggregation for CashflowWeek.inflows_ar_geprognosticeerd."
           }
         }
@@ -735,8 +735,8 @@
         "x-openregister-aggregations": {
           "scheduledPaymentsByCategory": {
             "field": "amount",
-            "operation": "sum",
-            "groupBy": "category",
+            "metric": "sum",
+            "groupBy": ["category"],
             "description": "Sum of scheduled AP outflows grouped by category (REQ-CF-006). Feeds CashflowWeek.outflows_ap_geprognosticeerd."
           }
         }
@@ -932,8 +932,8 @@
         "x-openregister-aggregations": {
           "countByCategorie": {
             "field": "category",
-            "operation": "count",
-            "groupBy": "category",
+            "metric": "count",
+            "groupBy": ["category"],
             "description": "Number of recurring items per category (REQ-CF-005)."
           }
         }
@@ -1029,8 +1029,8 @@
         "x-openregister-aggregations": {
           "countByPolicy": {
             "field": "policy",
-            "operation": "count",
-            "groupBy": "policy",
+            "metric": "count",
+            "groupBy": ["policy"],
             "description": "Number of buffer policies per policy type (REQ-CF-009)."
           }
         }
@@ -1244,8 +1244,8 @@
         "x-openregister-aggregations": {
           "countByHorizon": {
             "field": "horizonId",
-            "operation": "count",
-            "groupBy": "horizonId",
+            "metric": "count",
+            "groupBy": ["horizonId"],
             "description": "Number of scenarios per horizon (REQ-CF-011)."
           }
         }
@@ -1400,8 +1400,8 @@
         "x-openregister-aggregations": {
           "avgArMapeByPeriod": {
             "field": "ar_mape",
-            "operation": "avg",
-            "groupBy": "calibrationPeriod",
+            "metric": "avg",
+            "groupBy": ["calibrationPeriod"],
             "description": "Average AR MAPE per calibration period, for the accuracy trend (REQ-CF-013)."
           }
         }

--- a/tests/Unit/Service/CashflowForecastFragmentTest.php
+++ b/tests/Unit/Service/CashflowForecastFragmentTest.php
@@ -176,9 +176,16 @@ final class CashflowForecastFragmentTest extends TestCase {
 		$schemas = $this->load($this->fragmentPath)['components']['schemas'];
 		$aggs = $schemas['CashflowARProjection']['x-openregister-aggregations'];
 
+		// `metric`, not `operation`, and `groupBy` as an ARRAY. Both are the
+		// engine's vocabulary rather than an invented one: AggregationRunner
+		// reads only field/filter/from/groupBy/join/metric/metrics/select/where,
+		// and normaliseGroupByFields() returns [] for a non-array groupBy, so
+		// the previous spelling computed nothing and — once `metric` was added
+		// without fixing groupBy — an ungrouped TOTAL. See #1261.
 		self::assertArrayHasKey('projectedReceiptsByWeek', $aggs);
-		self::assertSame('sum', $aggs['projectedReceiptsByWeek']['operation']);
-		self::assertSame('expectedReceiptWeek', $aggs['projectedReceiptsByWeek']['groupBy']);
+		self::assertSame('sum', $aggs['projectedReceiptsByWeek']['metric']);
+		self::assertArrayNotHasKey('operation', $aggs['projectedReceiptsByWeek']);
+		self::assertSame(['expectedReceiptWeek'], $aggs['projectedReceiptsByWeek']['groupBy']);
 
 	}//end testArProjectionDeclaresReceiptsAggregation()
 

--- a/tests/Unit/Validation/BankReconciliationSchemaTest.php
+++ b/tests/Unit/Validation/BankReconciliationSchemaTest.php
@@ -227,10 +227,15 @@ final class BankReconciliationSchemaTest extends TestCase {
 	public function testReconciliationAggregations(): void {
 		$schema = $this->fragment['components']['schemas']['BankReconciliation'];
 
+		// `metric`, not `operation`, and `groupBy` as an ARRAY — the engine's
+		// vocabulary. `operation` is read by nothing, and a string `groupBy` is
+		// silently dropped, so the old spelling returned no value and then, with
+		// `metric` alone, an ungrouped total. See #1261.
 		$agg = $schema['x-openregister-aggregations']['countByStatus'];
 		self::assertSame('status', $agg['field']);
-		self::assertSame('count', $agg['operation']);
-		self::assertSame('status', $agg['groupBy']);
+		self::assertSame('count', $agg['metric']);
+		self::assertArrayNotHasKey('operation', $agg);
+		self::assertSame(['status'], $agg['groupBy']);
 
 	}//end testReconciliationAggregations()
 
@@ -372,15 +377,24 @@ final class BankReconciliationSchemaTest extends TestCase {
 		$schema = $this->fragment['components']['schemas']['BankReconciliationMatch'];
 		$agg = $schema['x-openregister-aggregations']['approvedAmountTotal'];
 
+		// `approvedAmountTotal` is NOT translated: it uses an `operations` dict
+		// whose custom alias (`approvedTotal`) the engine cannot express — its
+		// `metrics` form emits `sum_<field>` keys, so translating it changes
+		// what every CONSUMER must read, not just the declaration. Its `filter`
+		// is also a SQL-ish string the engine does not parse. Both are tracked
+		// in #1261, and this test pins the shape as it stands so the debt stays
+		// visible rather than looking intentional.
 		self::assertSame("matchType = 'approved'", $agg['filter']);
 		self::assertSame('reconciliationId', $agg['groupBy']);
 		self::assertSame('bankTransactionAmount', $agg['operations']['approvedTotal']['field']);
 		self::assertSame('sum', $agg['operations']['approvedTotal']['operation']);
 
+		// `countByType` IS translated — a plain count over its own schema.
 		$countByType = $schema['x-openregister-aggregations']['countByType'];
 		self::assertSame('matchType', $countByType['field']);
-		self::assertSame('count', $countByType['operation']);
-		self::assertSame('matchType', $countByType['groupBy']);
+		self::assertSame('count', $countByType['metric']);
+		self::assertArrayNotHasKey('operation', $countByType);
+		self::assertSame(['matchType'], $countByType['groupBy']);
 
 	}//end testApprovedAmountTotalAggregation()
 

--- a/tests/validate-registers.js
+++ b/tests/validate-registers.js
@@ -575,7 +575,67 @@ const AGGREGATION_REF_BASELINE = new Map([
 // A RATCHET, not a hard fail — 265 cannot be fixed in one pass, and each needs
 // its semantics checked against a live instance rather than pattern-matched.
 // The count may fall; it may never rise.
-const AGG_NO_METRIC_BASELINE = 265
+// 265 -> 219: the 46 declarations whose `operation` was a plain
+// count/sum/avg on their OWN schema, renamed to `metric`. Nothing else about
+// them changed — `count` ignores `field` and counts rows either way, so the
+// semantics carry over exactly.
+//
+// Deliberately NOT translated: 19 more are simple metrics whose `source` names
+// a DIFFERENT schema. `source` does not map to `from` — `from` switches the
+// runner into its cross-schema path, which needs a parent row and behaves
+// differently. Those are a redesign, not a rename, and they are the GL/tax ones
+// where a wrong number matters most.
+const AGG_NO_METRIC_BASELINE = 219
+
+// A STRING `groupBy` is silently ignored, and the result is a WRONG NUMBER.
+//
+// AggregationQuery::normaliseGroupByFields() opens with
+// `if (is_array($groupBy) === false) { return []; }`. So `"groupBy": "status"`
+// yields no group fields and the engine returns one ungrouped total.
+//
+// This is worse than the empty result it replaces, and it is how I nearly
+// shipped one. Measured live: `Service.countByStatus` with a metric and
+// `"groupBy": "status"` returned `value: 8` — the grand total of all services,
+// presented by a page that asked for a per-status breakdown. A plausible
+// number is harder to notice than an empty table.
+//
+// ZERO tolerance, but only where a `metric` exists: without one the
+// aggregation returns nothing anyway, so a string groupBy there is latent
+// rather than wrong. Those are tracked with the rest of #1261.
+function checkAggregationGroupByShape(registry) {
+	const offenders = []
+	for (const slug of Object.keys(registry).sort()) {
+		for (const { aggName, agg, file } of registry[slug].aggregations) {
+			if (agg === null || typeof agg !== 'object') continue
+			const hasMetric = 'metric' in agg || 'metrics' in agg
+			if (hasMetric === false) continue
+			if (typeof agg.groupBy !== 'string') continue
+			offenders.push(
+				`${slug}.${aggName} (${path.relative(REPO_ROOT, file)})`
+					+ ` — "groupBy": ${JSON.stringify(agg.groupBy)}`,
+			)
+		}
+	}
+
+	if (offenders.length === 0) {
+		console.log(
+			'[validate-registers] PASS — every metric-bearing aggregation declares groupBy as an array',
+		)
+		return true
+	}
+
+	console.error(
+		'[validate-registers] FAIL — a metric-bearing aggregation declares `groupBy` as a STRING. '
+			+ 'normaliseGroupByFields() returns [] for a non-array, so the grouping is silently dropped '
+			+ 'and the engine answers with ONE UNGROUPED TOTAL — a plausible wrong number, not an error:',
+	)
+	for (const o of offenders) console.error(`  - ${o}`)
+	console.error('')
+	console.error(
+		'[validate-registers] Fix: "groupBy": ["field"] — an array, even for a single field.',
+	)
+	return false
+}
 
 function checkAggregationMetrics(registry) {
 	const missing = []
@@ -853,6 +913,7 @@ function main() {
 	const aggregationRefsOk = checkAggregationFieldRefs(registry)
 	const aggregationPlaceholdersOk = checkAggregationPlaceholders(registry)
 	const aggregationMetricsOk = checkAggregationMetrics(registry)
+	const aggregationGroupByOk = checkAggregationGroupByShape(registry)
 
 	if (offenders.length === 0) {
 		if (
@@ -861,6 +922,7 @@ function main() {
 			|| aggregationRefsOk === false
 			|| aggregationPlaceholdersOk === false
 			|| aggregationMetricsOk === false
+			|| aggregationGroupByOk === false
 		)
 			process.exit(1)
 		console.log(


### PR DESCRIPTION
Part of #1261 — the mechanical subset you can translate without guessing.

## 46 aggregations that computed nothing

`AggregationRunner::run()` reads exactly nine keys. Measured from source, not
docs:

```
$ grep -oE "spec\['[a-zA-Z]+'\]" lib/Service/Aggregation/AggregationRunner.php | sort -u
spec['field']  spec['filter']  spec['from']   spec['groupBy']  spec['join']
spec['metric'] spec['metrics'] spec['select'] spec['where']
```

`operation` is read by nothing, so these returned `{"metric":"","value":null}`
with HTTP 200. Renaming `operation` → `metric` is faithful — `count` ignores
`field` and counts rows either way; `sum`/`avg` use the field exactly as before.

## The interesting part: `groupBy` had to move with it

`AggregationQuery::normaliseGroupByFields()` opens with

```php
if (is_array($groupBy) === false) { return []; }
```

**42 of the 46 declared `"groupBy": "status"` as a string**, which is silently
dropped. So renaming `operation` on its own made them return **one ungrouped
total** where the page asked for a breakdown.

That is worse than the empty result it replaced, and I nearly shipped it.
Measured on a live instance, the same aggregation at each stage:

| stage | response |
|---|---|
| before | `{"metric":"","field":"status","value":null}` |
| `operation` → `metric` only | `{"metric":"count","value":8}` ← **wrong** |
| + `groupBy` as an array | `{"groups":[{"key":"active","value":8}]}` |

`value: 8` is the grand total of all services, presented as a per-status count.
A plausible number is harder to notice than an empty table — precisely the
defect class this app keeps hitting.

## Two gates, both confirmed able to fail

- **A metric-bearing aggregation may not declare `groupBy` as a string.** Zero
  tolerance. The failure message says the grouping is *dropped* rather than
  rejected, because that is the non-obvious half. Control: reintroducing one
  turns it red; file restored byte-identical afterwards (md5 checked).
- **The no-metric ratchet drops 265 → 219.** Control: lowering it to 264 turns
  it red and names the nine keys.

## Deliberately not translated

- **19** are simple metrics whose `source` names a **different** schema.
  `source` does **not** map to `from` — `from` switches the runner into its
  cross-schema path, which needs a parent row and behaves differently. That is a
  redesign, not a rename, and they are the GL/tax ones where a wrong number
  costs most.
- **~200** more use `operations` dicts with custom aliases (the engine emits
  `sum_<field>`, so every *consumer* changes too) or `expression` SQL strings.
  Both stay in #1261.

## Verified

- live rig: the three-stage progression above, plus `Booking.countByStatus` as
  an unplanned control — its fragment was not copied to the rig, and it still
  reported `metric:""`, side by side with the translated ones in the same batch
- engine behaviour independently confirmed on the 8080 dev instance: a
  declaration *with* `metric` computes (`{"metric":"count","value":0}`)
- 8 JS validators, `eslint`, `prettier`, `vitest` 256 — all green
- every edited file tree-diffed against HEAD: 46 `operation`→`metric` renames,
  all inside `x-openregister-aggregations`, **0 unexpected differences**
